### PR TITLE
修复 deadline timer 线程创建失败 panic

### DIFF
--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -169,6 +169,7 @@ pub struct ExecutionContext {
 struct ExecutionShared {
     cancellation: CancellationToken,
     deadline: Option<Instant>,
+    deadline_timer_available: AtomicBool,
     timed_out: AtomicBool,
     timer_stop: Arc<TimerStop>,
     progress: Mutex<ProgressState>,
@@ -209,13 +210,29 @@ impl ExecutionContext {
     /// Construct a context from request controls and conversion limits.
     #[must_use]
     pub fn new(options: ExecutionOptions, limits: ResourceLimits) -> Self {
+        Self::new_with_timer_spawner(options, limits, std::thread::Builder::spawn)
+    }
+
+    fn new_with_timer_spawner<F>(
+        options: ExecutionOptions,
+        limits: ResourceLimits,
+        spawn: F,
+    ) -> Self
+    where
+        F: FnOnce(
+            std::thread::Builder,
+            Box<dyn FnOnce() + Send + 'static>,
+        ) -> io::Result<JoinHandle<()>>,
+    {
         let now = Instant::now();
         let deadline = options.timeout.and_then(|duration| now.checked_add(duration));
         let dispatcher = options.progress_listener.and_then(ProgressDispatcher::new);
         let timer_stop = Arc::new(TimerStop::default());
+        let timer_deadline = deadline.filter(|deadline| *deadline > now);
         let shared = Arc::new(ExecutionShared {
             cancellation: options.cancellation,
             deadline,
+            deadline_timer_available: AtomicBool::new(timer_deadline.is_none()),
             timed_out: AtomicBool::new(false),
             timer_stop: Arc::clone(&timer_stop),
             progress: Mutex::new(ProgressState::default()),
@@ -224,9 +241,9 @@ impl ExecutionContext {
             memory_bytes: AtomicU64::new(0),
             temporary_bytes: AtomicU64::new(0),
         });
-        if let Some(deadline) = deadline {
+        if let Some(deadline) = timer_deadline {
             let weak = Arc::downgrade(&shared);
-            std::thread::spawn(move || {
+            let task = Box::new(move || {
                 let now = Instant::now();
                 if deadline > now {
                     let wait = deadline.duration_since(now);
@@ -245,6 +262,11 @@ impl ExecutionContext {
                     shared.cancellation.wake_waiters();
                 }
             });
+            if spawn(std::thread::Builder::new().name("into-markdown-deadline".into()), task)
+                .is_ok()
+            {
+                shared.deadline_timer_available.store(true, Ordering::Release);
+            }
         }
         Self { shared }
     }
@@ -253,8 +275,16 @@ impl ExecutionContext {
     ///
     /// # Errors
     ///
-    /// Returns [`ConversionError::Cancelled`] or [`ConversionError::Timeout`].
+    /// Returns [`ConversionError::Cancelled`], [`ConversionError::Timeout`], or a
+    /// stable [`ConversionError::ComponentUnavailable`] when the process could
+    /// not start the deadline timer.
     pub fn checkpoint(&self) -> Result<(), ConversionError> {
+        if !self.shared.deadline_timer_available.load(Ordering::Acquire) {
+            return Err(ConversionError::ComponentUnavailable {
+                component: "deadline-timer".into(),
+                detail: "deadline timer could not be started".into(),
+            });
+        }
         if self.shared.cancellation.is_cancelled() {
             return Err(ConversionError::Cancelled);
         }
@@ -1048,6 +1078,83 @@ mod tests {
             poll_once(future.as_mut(), &wake),
             Poll::Ready(Err(ConversionError::Timeout))
         ));
+    }
+
+    #[test]
+    fn deadline_timer_spawn_failure_is_stable_for_clones_and_waiters() {
+        let cancellation = CancellationToken::new();
+        let context = ExecutionContext::new_with_timer_spawner(
+            ExecutionOptions {
+                cancellation: cancellation.clone(),
+                timeout: Some(Duration::from_hours(1)),
+                ..ExecutionOptions::default()
+            },
+            ResourceLimits::default(),
+            |_, _| Err(io::Error::other("injected deadline timer spawn failure")),
+        );
+        let clone = context.clone();
+        cancellation.cancel();
+
+        for candidate in [&context, &clone] {
+            let error = candidate.checkpoint().unwrap_err();
+            assert_eq!(error.code(), crate::ErrorCode::ComponentUnavailable);
+            match error {
+                ConversionError::ComponentUnavailable { component, detail } => {
+                    assert_eq!(component, "deadline-timer");
+                    assert_eq!(detail, "deadline timer could not be started");
+                }
+                other => panic!("unexpected timer startup error: {other:?}"),
+            }
+
+            let wake = Arc::new(CountingWake::default());
+            let mut future = Box::pin(candidate.run(Never));
+            assert!(matches!(
+                poll_once(future.as_mut(), &wake),
+                Poll::Ready(Err(ConversionError::ComponentUnavailable { ref component, .. }))
+                    if component == "deadline-timer"
+            ));
+        }
+        assert!(lock_unpoisoned(&context.shared.cancellation.state.waiters).is_empty());
+        assert_eq!(Arc::strong_count(&context.shared.timer_stop), 1);
+    }
+
+    #[test]
+    fn immediate_and_unrepresentable_deadlines_do_not_need_a_timer_thread() {
+        for timeout in [Duration::ZERO, Duration::MAX] {
+            let spawn_calls = AtomicUsize::new(0);
+            let context = ExecutionContext::new_with_timer_spawner(
+                ExecutionOptions { timeout: Some(timeout), ..ExecutionOptions::default() },
+                ResourceLimits::default(),
+                |_, _| {
+                    spawn_calls.fetch_add(1, Ordering::AcqRel);
+                    Err(io::Error::other("timer must not be spawned"))
+                },
+            );
+            assert_eq!(spawn_calls.load(Ordering::Acquire), 0);
+            if timeout.is_zero() {
+                assert!(matches!(context.checkpoint(), Err(ConversionError::Timeout)));
+            } else {
+                assert!(context.checkpoint().is_ok());
+            }
+        }
+    }
+
+    #[test]
+    fn timer_spawn_failure_releases_listener_when_context_is_dropped() {
+        let listener = Arc::new(EmptyListener);
+        let weak = Arc::downgrade(&listener);
+        let context = ExecutionContext::new_with_timer_spawner(
+            ExecutionOptions {
+                timeout: Some(Duration::from_hours(1)),
+                progress_listener: Some(listener.clone()),
+                ..ExecutionOptions::default()
+            },
+            ResourceLimits::default(),
+            |_, _| Err(io::Error::other("injected deadline timer spawn failure")),
+        );
+        drop(listener);
+        drop(context);
+        wait_until_released(&weak);
     }
 
     #[test]

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -138,6 +138,10 @@ target。其他平台若没有经过审计的 no-follow 策略，则返回 `comp
 取消不会改写已经完成的结果。
 library 的零 `Duration` 表示立即 deadline；CLI 和配置拒绝零值。若极大 `Duration`
 无法转换为平台 `Instant`，则饱和为无 deadline，不能回绕成立即 timeout。
+可表示且尚未到期的 deadline 使用独立 timer 唤醒所有已注册 waiter；timer 线程无法创建时，
+上下文及其所有 clone 的 checkpoint 和异步等待稳定返回
+`componentUnavailable`（component 为 `deadline-timer`），不会把请求伪装成无 deadline，
+也不会等待原 deadline 才暴露失败。该初始化错误优先于同一上下文随后观察到的显式取消。
 
 阶段进度使用 `ProgressEvent` 和对象安全的 `ProgressListener`。总体进度以 basis points
 表达并保持单调。OCR 与 AI 是转换期间可以交错出现的活动，而不是互斥的线性总体阶段。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,7 +107,10 @@ schema 1 读取迁移与 schema 2 aliases/path/ZIP 双向一致均为契约测�
 future 的取消和 deadline 唤醒、多 waiter 竞争、checked 预算累加，以及失败后临时
 产物清理。dispatcher 生命周期使用 barrier 确定性覆盖 worker wait 前后关闭、回调中
 释放最后一个 context、饱和 mailbox 接受 `Completed` 后 drain、线程创建失败降级和
-listener 最终释放。阻塞来源还要覆盖有界工作者过载、deadline 先于系统调用返回、增长
+listener 最终释放。deadline timer 使用作用域内 spawner 注入确定性覆盖线程创建失败、
+clone 一致错误、取消优先级、多 waiter 即时失败与 listener/timer 状态释放，不依赖耗尽
+系统线程额度；零 deadline 与不可表示的超长 deadline 不需要 timer 线程。阻塞来源还要
+覆盖有界工作者过载、deadline 先于系统调用返回、增长
 文件只读预算加一字节、Unix symlink 拒绝、Windows 设备 namespace/保留设备拒绝、磁盘
 句柄类型与权威句柄替换稳定性、source 分配前预留、scratch 退款后恰好双 payload 的 Vec
 到 Arc 峰值、跨 context handoff、旧 `ResolvedInput` literal 与默认 resolver 方法兼容、


### PR DESCRIPTION
## 变更

- 将 `ExecutionContext` deadline timer 改为 `std::thread::Builder::spawn` 可失败创建，保持现有公共构造 API
- timer 创建失败时在 context 及所有 clone 上稳定返回 `componentUnavailable`（component 为 `deadline-timer`），不静默丢弃 deadline，且该初始化错误优先于随后取消
- 零 timeout 保持立即 `timeout`；不可表示的超长 timeout 保持既有无 deadline 饱和语义，两者都不创建 timer
- 增加作用域内 spawner 故障注入，覆盖 clone、future waiter、取消优先级、timer 状态和 listener 释放，并补充接口及测试契约文档

## 验证

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo run --locked --offline -p license-check --bin license-check`
- `cargo run --locked --offline -p license-check --bin release-audit`
- `bazel test //tools/license-check:license_check`
- `bazel build //...`
- `bazel test //...`
- 三个 Cargo timer 关键路径分别非缓存循环 100 次
- `bazel test //crates/core:core_test --runs_per_test=100 --nocache_test_results`
- core crate 四个支持 target `--all-targets` 编译通过
- workspace 四个支持 target 编译通过

## 风险

由于兼容的 `ExecutionContext::new` 返回 `Self`，timer 初始化失败无法从构造签名同步返回；失败会在任何可执行工作前的 `checkpoint` 或 `run` 首次 poll 稳定暴露。未调用协作检查点的第三方代码无法自行观察该错误，这与现有取消/deadline 的协作式契约一致。

Closes #88