### PR TITLE
Fix Bazel platform toolchain contracts

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,10 +2,14 @@ common --enable_bzlmod
 build --announce_rc
 build --incompatible_strict_action_env
 build --show_timestamps
+# Rust 1.97 mangles allocator symbols.  Use rules_rust's rust_static_library
+# bridge so Rust libraries remain linkable from native C++ without a target C++
+# compiler being needed merely to analyze a rejected foreign configuration.
+build --@rules_rust//rust/settings:experimental_use_allocator_libraries_with_mangled_symbols=true
 test --test_output=errors
 
 # This project intentionally supports Apple Silicon only on macOS.
-build:macos_arm64 --platforms=//:macos_arm64_platform
-build:linux_x86_64 --platforms=//:linux_x86_64_platform
-build:linux_arm64 --platforms=//:linux_arm64_platform
-build:windows_x86_64 --platforms=//:windows_x86_64_platform
+build:macos_arm64 --platforms=//:macos_arm64_platform --aspects=//toolchains:platform_contract.bzl%platform_contract_aspect
+build:linux_x86_64 --platforms=//:linux_x86_64_platform --aspects=//toolchains:platform_contract.bzl%platform_contract_aspect
+build:linux_arm64 --platforms=//:linux_arm64_platform --aspects=//toolchains:platform_contract.bzl%platform_contract_aspect
+build:windows_x86_64 --platforms=//:windows_x86_64_platform --aspects=//toolchains:platform_contract.bzl%platform_contract_aspect

--- a/.github/workflows/bazel-platform-toolchains.yml
+++ b/.github/workflows/bazel-platform-toolchains.yml
@@ -1,0 +1,146 @@
+name: Bazel platform toolchain contract
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  native-platform:
+    name: ${{ matrix.config }} native Rust + C++
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            config: macos_arm64
+            triple: aarch64-apple-darwin
+          - os: ubuntu-24.04
+            config: linux_x86_64
+            triple: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            config: linux_arm64
+            triple: aarch64-unknown-linux-gnu
+          - os: windows-2025
+            config: windows_x86_64
+            triple: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazelbuild/setup-bazel@v3
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}-${{ matrix.config }}
+          repository-cache: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
+          targets: ${{ matrix.triple }}
+      - name: Check Cargo target boundary with its native C toolchain
+        run: cargo check --locked --workspace --all-targets --target ${{ matrix.triple }}
+      - name: Resolve both toolchains and build public Rust products
+        run: >-
+          bazel build --config=${{ matrix.config }} --lockfile_mode=error
+          //toolchains:native_toolchain_contract
+          //crates/core:core
+          //tests/contracts:public_api_consumer
+      - name: Run the platform-independent core test
+        run: >-
+          bazel test --config=${{ matrix.config }} --lockfile_mode=error
+          //crates/core:core_test
+          //toolchains:allocator_bridge_test
+      - name: Prove the Rust-library allocator bridge is required
+        if: matrix.config == 'macos_arm64'
+        shell: bash
+        run: |
+          set +e
+          output=$(bazel build --config=macos_arm64 --lockfile_mode=error \
+            --@rules_rust//rust/settings:experimental_use_allocator_libraries_with_mangled_symbols=false \
+            //toolchains:allocator_bridge_test 2>&1)
+          exit_code=$?
+          set -e
+          printf '%s\n' "$output"
+          test "$exit_code" -ne 0
+          grep -F '__rust_alloc' <<<"$output"
+      - name: Reject every foreign public config at analysis entry
+        shell: bash
+        env:
+          NATIVE_CONFIG: ${{ matrix.config }}
+        run: |
+          assert_rejected() {
+            set +e
+            output=$(bazel build "$@" 2>&1)
+            exit_code=$?
+            set -e
+            printf '%s\n' "$output"
+            test "$exit_code" -ne 0
+            grep -F 'unsupported Bazel host/target combination' <<<"$output"
+            if grep -F 'No matching toolchains' <<<"$output"; then
+              echo "foreign config leaked a Bazel toolchain-resolution error" >&2
+              exit 1
+            fi
+            if grep -E 'undefined reference|unresolved external symbol|linker command failed' <<<"$output"; then
+              echo "foreign config leaked a raw linker error" >&2
+              exit 1
+            fi
+          }
+
+          for config in macos_arm64 linux_x86_64 linux_arm64 windows_x86_64; do
+            if [[ "$config" == "$NATIVE_CONFIG" ]]; then
+              continue
+            fi
+            for target in \
+              //crates/core:core \
+              //crates/core:core_test \
+              //tests/contracts:public_api_consumer \
+              //toolchains:native_toolchain_contract \
+              //toolchains:allocator_bridge_test \
+              //:documentation; do
+              assert_rejected --config="$config" --lockfile_mode=error --nobuild "$target"
+            done
+          done
+      - name: Reject foreign consumers even when the config aspect is bypassed
+        shell: bash
+        env:
+          NATIVE_CONFIG: ${{ matrix.config }}
+        run: |
+          assert_rejected() {
+            set +e
+            output=$(bazel build "$@" 2>&1)
+            exit_code=$?
+            set -e
+            printf '%s\n' "$output"
+            test "$exit_code" -ne 0
+            grep -F 'unsupported Bazel host/target combination' <<<"$output"
+            if grep -F 'No matching toolchains' <<<"$output"; then
+              echo "foreign bypass leaked a Bazel toolchain-resolution error" >&2
+              exit 1
+            fi
+            if grep -E 'undefined reference|unresolved external symbol|linker command failed' <<<"$output"; then
+              echo "foreign bypass leaked a raw linker error" >&2
+              exit 1
+            fi
+            if grep -F 'Build completed successfully' <<<"$output"; then
+              echo "foreign bypass incorrectly analyzed a toolchain consumer" >&2
+              exit 1
+            fi
+          }
+
+          for entry in \
+            'macos_arm64 //:macos_arm64_platform' \
+            'linux_x86_64 //:linux_x86_64_platform' \
+            'linux_arm64 //:linux_arm64_platform' \
+            'windows_x86_64 //:windows_x86_64_platform'; do
+            read -r config platform <<<"$entry"
+            if [[ "$config" == "$NATIVE_CONFIG" ]]; then
+              continue
+            fi
+            for target in //toolchains:allocator_bridge_test //crates/core:core_test; do
+              assert_rejected --platforms="$platform" --lockfile_mode=error --nobuild "$target"
+              assert_rejected --config="$config" --aspects= --lockfile_mode=error --nobuild "$target"
+            done
+          done

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ module(
 )
 
 bazel_dep(name = "rules_rust", version = "0.73.0")
+bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "platforms", version = "1.1.0")
 bazel_dep(name = "aspect_rules_js", version = "3.3.1")
 bazel_dep(name = "aspect_rules_ts", version = "3.9.2")
@@ -57,11 +58,22 @@ use_repo(rules_ts, "npm_typescript")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
+    # Every public Bazel platform has a matching rust_std component.  The
+    # compiler itself still executes natively; platform_contract.bzl rejects
+    # host -> target combinations for which this repository has no C++ linker.
+    allocator_library = "@rules_rust//rust/private/cc:empty",
     edition = "2024",
+    extra_target_triples = [
+        "aarch64-apple-darwin",
+        "aarch64-unknown-linux-gnu",
+        "x86_64-pc-windows-msvc",
+        "x86_64-unknown-linux-gnu",
+    ],
     versions = ["1.97.1"],
 )
 use_repo(rust, "rust_toolchains")
 register_toolchains("@rust_toolchains//:all")
+register_toolchains("//toolchains:all")
 
 crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
 crate.from_cargo(

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -169,6 +169,53 @@ snapshot；75,000-byte request memory 复现稳定返回 `resourceLimit`。Atom 
 去重键和 asset rewrite lookup 使用按真实 capacity 计费的线性 Vec，不依赖 allocator 节点容量不透明
 的树形或哈希容器。
 
+## Cargo target 检查与 Bazel 平台配置
+
+Cargo 和 Bazel 回答不同的问题，二者不能互相替代。Rust 1.97.1 的以下命令只做
+workspace 在目标 triple 下的 Rust 类型检查、`cfg` 分支和依赖选择检查；`cargo check`
+仍会运行 bundled SQLite 等依赖的 C build script，必须在 matching native runner 上执行。
+成功不证明 Bazel 工具链解析、Bazel action 或最终产品二进制：
+
+```shell
+cargo check --workspace --all-targets --target aarch64-apple-darwin
+cargo check --workspace --all-targets --target x86_64-unknown-linux-gnu
+cargo check --workspace --all-targets --target aarch64-unknown-linux-gnu
+cargo check --workspace --all-targets --target x86_64-pc-windows-msvc
+```
+
+四个公开 Bazel config 是严格的 **native host/exec → 同平台 target** 合约，不是任意
+交叉编译入口。每个 config 注册 rules_rust 1.97.1 的对应 target std，并要求 native
+C++ toolchain；CI 在匹配 runner 上实际构建 toolchain probe、`//crates/core:core` 和
+平台无关的 `//tests/contracts:public_api_consumer`，再运行 core 测试和真实的
+Rust-library-from-C++ 链接/执行测试。Rust 1.97 的 allocator symbol 由 rules_rust 在内部
+生成 empty `rust_static_library` bridge；`//toolchains:allocator_bridge_test` 的业务依赖是
+普通 `rust_library`，在 Rust 侧真实分配并释放 `Vec`，防止为了 foreign-config 分析而把
+C++ embedding 静默退化为空 allocator。关闭 mangled-symbol bridge 时同一链接会因缺失
+版本化 allocator symbol 而失败：
+
+```shell
+bazel build --config=macos_arm64 --lockfile_mode=error //toolchains:native_toolchain_contract //crates/core:core //tests/contracts:public_api_consumer
+bazel build --config=linux_x86_64 --lockfile_mode=error //toolchains:native_toolchain_contract //crates/core:core //tests/contracts:public_api_consumer
+bazel build --config=linux_arm64 --lockfile_mode=error //toolchains:native_toolchain_contract //crates/core:core //tests/contracts:public_api_consumer
+bazel build --config=windows_x86_64 --lockfile_mode=error //toolchains:native_toolchain_contract //crates/core:core //tests/contracts:public_api_consumer
+bazel test --config=<matching-config> --lockfile_mode=error //crates/core:core_test //toolchains:allocator_bridge_test
+```
+
+必须在与 config 匹配的原生 runner 上执行这些命令。比如 Apple Silicon macOS 请求
+`--config=linux_x86_64` 会在分析入口稳定失败为
+`unsupported Bazel host/target combination`；这比借用宿主 clang 或注册一个能完成分析、
+却不能产出目标二进制的伪 C++ provider 更诚实。该拒绝路径也由 CI 断言不得退化为
+`No matching toolchains`。为保证 mandatory C++ consumer 和 test target 也能得到同样稳定的
+边界错误，仓库为十二种 `exec != target` 组合注册拒绝型 C++ 与 test execution toolchain。
+它们不会转发宿主 C++ provider 或伪造 test runner，
+而是在被选择时直接终止分析，因此即使调用方使用裸 `--platforms` 或显式清空 config aspect，
+也不能让宿主 clang 伪装成 foreign compiler、生成 action 或得到分析成功；它也不会匹配四种
+native `exec == target` 组合。CI 在四个 native runner 上对其余三个 foreign config × core、
+core test、public consumer、probe、C++ embedding test 和普通聚合目标逐项检查 config 入口，
+覆盖全部十二种 host→foreign 组合；还单独绕过 aspect 验证 mandatory C++ 与 test consumer
+仍被 toolchain 自身拒绝。这些普通目标不引用 manual ONNX Runtime、PDFium、FFmpeg 或
+模型下载目标，因此四平台门禁不会获取其大型制品。
+
 仓库为对象安全 SPI、稳定错误码、确定性注册表校验、显式回退语义、默认
 离线、资源预算、模型清单校验、CLI 骨架和 GFM 渲染器提供契约测试。渲染器测试
 逐类覆盖全部 IR 节点，并覆盖恶意链接、HTML/Markdown 字符、动态围栏、表格换行、

--- a/toolchains/BUILD.bazel
+++ b/toolchains/BUILD.bazel
@@ -1,0 +1,60 @@
+load(":platform_contract.bzl", "foreign_rejecting_toolchains", "platform_contract", "toolchain_probe")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
+load("@rules_rust//rust:defs.bzl", "rust_library")
+
+package(default_visibility = ["//visibility:public"])
+
+toolchain_type(name = "platform_contract_type")
+
+foreign_rejecting_toolchains()
+
+platform_contract(name = "macos_arm64_impl", triple = "aarch64-apple-darwin")
+platform_contract(name = "linux_x86_64_impl", triple = "x86_64-unknown-linux-gnu")
+platform_contract(name = "linux_arm64_impl", triple = "aarch64-unknown-linux-gnu")
+platform_contract(name = "windows_x86_64_impl", triple = "x86_64-pc-windows-msvc")
+
+toolchain(
+    name = "macos_arm64",
+    exec_compatible_with = ["@platforms//os:osx", "@platforms//cpu:aarch64"],
+    toolchain = ":macos_arm64_impl",
+    toolchain_type = ":platform_contract_type",
+)
+
+toolchain(
+    name = "linux_x86_64",
+    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+    toolchain = ":linux_x86_64_impl",
+    toolchain_type = ":platform_contract_type",
+)
+
+toolchain(
+    name = "linux_arm64",
+    exec_compatible_with = ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+    toolchain = ":linux_arm64_impl",
+    toolchain_type = ":platform_contract_type",
+)
+
+toolchain(
+    name = "windows_x86_64",
+    exec_compatible_with = ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    toolchain = ":windows_x86_64_impl",
+    toolchain_type = ":platform_contract_type",
+)
+
+toolchain_probe(name = "native_toolchain_contract")
+
+# A real native C++ link/run regression for the Rust allocator-symbol bridge.
+# The Rust function allocates and drops a Vec, so an empty allocator CcInfo
+# would leave the link without the version-mangled allocator definitions.
+rust_library(
+    name = "allocator_bridge_rust",
+    srcs = ["allocator_bridge.rs"],
+    crate_name = "allocator_bridge",
+    edition = "2024",
+)
+
+cc_test(
+    name = "allocator_bridge_test",
+    srcs = ["allocator_bridge_test.cc"],
+    deps = [":allocator_bridge_rust"],
+)

--- a/toolchains/allocator_bridge.rs
+++ b/toolchains/allocator_bridge.rs
@@ -1,0 +1,5 @@
+#[unsafe(no_mangle)]
+pub extern "C" fn into_markdown_allocator_bridge() -> usize {
+    let values = Vec::from([2_usize, 3, 5, 7]);
+    values.into_iter().sum()
+}

--- a/toolchains/allocator_bridge_test.cc
+++ b/toolchains/allocator_bridge_test.cc
@@ -1,0 +1,5 @@
+#include <cstddef>
+
+extern "C" std::size_t into_markdown_allocator_bridge();
+
+int main() { return into_markdown_allocator_bridge() == 17 ? 0 : 1; }

--- a/toolchains/platform_contract.bzl
+++ b/toolchains/platform_contract.bzl
@@ -1,0 +1,149 @@
+"""Native Rust + C++ toolchain contract for the public Bazel configs."""
+
+PlatformContractInfo = provider(
+    doc = "The native target supported by one Bazel execution platform.",
+    fields = {"triple": "Canonical Rust target triple."},
+)
+
+def _platform_contract_impl(ctx):
+    return [platform_common.ToolchainInfo(
+        platform_contract = PlatformContractInfo(triple = ctx.attr.triple),
+    )]
+
+platform_contract = rule(
+    implementation = _platform_contract_impl,
+    attrs = {"triple": attr.string(mandatory = True)},
+)
+
+def _foreign_toolchain_rejector_impl(ctx):
+    # This target is selectable only when exec != target (see BUILD.bazel).
+    # Reject from the selected toolchain implementation itself: an aspect is a
+    # useful config-entry diagnostic, but callers can clear or bypass aspects
+    # with a direct --platforms flag.  Returning the host C++ provider here
+    # would let those callers analyze (and potentially execute) foreign actions
+    # with a native compiler masquerading as a cross toolchain.
+    fail((
+        "unsupported Bazel host/target combination: the selected target " +
+        "requires a foreign {kind} toolchain; use the matching native runner"
+    ).format(kind = ctx.attr.kind))
+
+foreign_toolchain_rejector = rule(
+    implementation = _foreign_toolchain_rejector_impl,
+    attrs = {"kind": attr.string(mandatory = True)},
+)
+
+def foreign_rejecting_toolchains():
+    platforms = {
+        "macos_arm64": ["@platforms//os:osx", "@platforms//cpu:aarch64"],
+        "linux_x86_64": ["@platforms//os:linux", "@platforms//cpu:x86_64"],
+        "linux_arm64": ["@platforms//os:linux", "@platforms//cpu:aarch64"],
+        "windows_x86_64": ["@platforms//os:windows", "@platforms//cpu:x86_64"],
+    }
+    # This implementation is selected through the registered toolchains, not
+    # built as a top-level product by //... expansion.
+    foreign_toolchain_rejector(
+        name = "foreign_cc_rejector_impl",
+        kind = "C++",
+        tags = ["manual"],
+    )
+    foreign_toolchain_rejector(
+        name = "foreign_test_rejector_impl",
+        kind = "test execution",
+        tags = ["manual"],
+    )
+    for exec_name, exec_constraints in platforms.items():
+        for target_name, target_constraints in platforms.items():
+            if exec_name == target_name:
+                continue
+            native.toolchain(
+                name = "foreign_cc_{}_to_{}".format(exec_name, target_name),
+                exec_compatible_with = exec_constraints,
+                target_compatible_with = target_constraints,
+                toolchain = ":foreign_cc_rejector_impl",
+                toolchain_type = "@bazel_tools//tools/cpp:toolchain_type",
+            )
+            native.toolchain(
+                name = "foreign_test_{}_to_{}".format(exec_name, target_name),
+                exec_compatible_with = exec_constraints,
+                target_compatible_with = target_constraints,
+                toolchain = ":foreign_test_rejector_impl",
+                toolchain_type = "@bazel_tools//tools/test:default_test_toolchain_type",
+            )
+
+def _target(ctx):
+    public_targets = [
+        (ctx.attr._osx, ctx.attr._aarch64, "aarch64-apple-darwin", "macos_arm64"),
+        (ctx.attr._linux, ctx.attr._x86_64, "x86_64-unknown-linux-gnu", "linux_x86_64"),
+        (ctx.attr._linux, ctx.attr._aarch64, "aarch64-unknown-linux-gnu", "linux_arm64"),
+        (ctx.attr._windows, ctx.attr._x86_64, "x86_64-pc-windows-msvc", "windows_x86_64"),
+    ]
+    for os_target, cpu_target, triple, config in public_targets:
+        os_constraint = os_target[platform_common.ConstraintValueInfo]
+        cpu_constraint = cpu_target[platform_common.ConstraintValueInfo]
+        if (ctx.target_platform_has_constraint(os_constraint) and
+            ctx.target_platform_has_constraint(cpu_constraint)):
+            return triple, config
+    return None, None
+
+def _guard(ctx):
+    target_triple, target_config = _target(ctx)
+    host_triple = ctx.toolchains["//toolchains:platform_contract_type"].platform_contract.triple
+    if target_triple == None:
+        fail("unsupported Bazel target platform: the public contract only covers macos_arm64, linux_x86_64, linux_arm64, and windows_x86_64")
+    if target_triple != host_triple:
+        fail((
+            "unsupported Bazel host/target combination: native exec platform {host} " +
+            "cannot build --config={config} ({target}); run this config on its matching " +
+            "native runner. Cargo target checks are a separate compile-analysis boundary."
+        ).format(host = host_triple, config = target_config, target = target_triple))
+
+def _platform_contract_aspect_impl(target, ctx):
+    _guard(ctx)
+    return []
+
+platform_contract_aspect = aspect(
+    implementation = _platform_contract_aspect_impl,
+    attrs = {
+        "_aarch64": attr.label(default = "@platforms//cpu:aarch64"),
+        "_linux": attr.label(default = "@platforms//os:linux"),
+        "_osx": attr.label(default = "@platforms//os:osx"),
+        "_windows": attr.label(default = "@platforms//os:windows"),
+        "_x86_64": attr.label(default = "@platforms//cpu:x86_64"),
+    },
+    toolchains = ["//toolchains:platform_contract_type"],
+)
+
+def _toolchain_probe_impl(ctx):
+    _guard(ctx)
+    rust = ctx.toolchains["@rules_rust//rust:toolchain_type"]
+    cc = ctx.toolchains["@bazel_tools//tools/cpp:toolchain_type"]
+    if rust == None:
+        fail("native Bazel platform contract is missing its Rust toolchain")
+    if cc == None:
+        fail("native Bazel platform contract is missing its C++ toolchain")
+    output = ctx.actions.declare_file(ctx.label.name + ".txt")
+    ctx.actions.write(
+        output,
+        "target={}\nrust={}\ncpp={}\n".format(
+            rust.target_triple.str,
+            rust.target_triple.str,
+            cc.cc.target_gnu_system_name,
+        ),
+    )
+    return [DefaultInfo(files = depset([output]))]
+
+toolchain_probe = rule(
+    implementation = _toolchain_probe_impl,
+    attrs = {
+        "_aarch64": attr.label(default = "@platforms//cpu:aarch64"),
+        "_linux": attr.label(default = "@platforms//os:linux"),
+        "_osx": attr.label(default = "@platforms//os:osx"),
+        "_windows": attr.label(default = "@platforms//os:windows"),
+        "_x86_64": attr.label(default = "@platforms//cpu:x86_64"),
+    },
+    toolchains = [
+        "//toolchains:platform_contract_type",
+        config_common.toolchain_type("@rules_rust//rust:toolchain_type", mandatory = False),
+        config_common.toolchain_type("@bazel_tools//tools/cpp:toolchain_type", mandatory = False),
+    ],
+)


### PR DESCRIPTION
Closes #99

## Exact revision
- Base: `64e28e6487e67bb5fb1219c2f2b932c6abba0291`
- Head: `c21d04d9fa20f21f1c0f8bdda342d0eaf9b55b00`
- Tree: `7e63563f2da23d9c1dcb21411447869e3052437c`

## Summary
- establish one auditable native host/exec-to-target contract for the four public Bazel configs using Rust 1.97.1 and each runner's real C++ toolchain
- reject all 12 unsupported host/target pairs during analysis, including mandatory C++, test-toolchain, allocator, bare `--platforms`, and cleared-aspect bypass paths, without forwarding a host compiler or leaking toolchain/linker errors
- exercise a real `rust_library` embedded in C++ so the rules_rust allocator-symbol bridge remains proven rather than silently disabled
- document the distinct Cargo target-check and Bazel native-build proof boundaries

## Scope boundary
This PR contains only the shared Bazel/Rust/C++ platform-toolchain contract. It does **not** implement or include any archive, native-runtime/binary packaging, installer, release artifact, or platform delivery work from #133, #134, or #135. The latest-main fixture corpus, runtime/model authorities, license inventories, `Cargo.lock`, and `MODULE.bazel.lock` remain unchanged.

## Local validation
- Rust 1.97.1: `cargo fmt`, locked offline workspace check, Clippy with `-D warnings`, and locked offline workspace tests
- Bazel 9.2.0: online/cache preparation followed by strict `--lockfile_mode=error --nofetch` `//...` build and 24-test suite
- macOS ARM64: native toolchain probe/core/public consumer build, core and allocator bridge tests, plus a bridge-disabled `__rust_alloc` link-failure counterexample
- macOS foreign matrix: 3 configs × 6 public targets and bare-platform/cleared-aspect C++ and core-test consumers; every case is intentional unsupported with no toolchain-resolution or raw-linker leakage
- Cargo and Bazel license/release audits in offline/no-fetch mode

## CI proof
The four-runner matrix uses macOS ARM64, Linux x86_64, Linux ARM64, and Windows x86_64 native runners. Each runner performs its matching Cargo/Bazel Rust+C++/allocator/core positive gates and rejects the other three configs, covering all 12 foreign host/target pairs.

Latest run [31770665231](https://github.com/coolplayagent/into-markdown/actions/runs/31770665231) was rejected by GitHub before checkout: all four jobs have zero steps and the platform annotation reports failed account payments or an insufficient spending limit. This is not a code-test result and does not count as the required native evidence. The PR remains Draft pending a successful rerun and independent maintainer review.
