### PR TITLE
chore(ocr): sync post-merge fixture authority

### DIFF
--- a/models/ocr-merge-quality-authority.json
+++ b/models/ocr-merge-quality-authority.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "fixture_manifest_sha256": "36ce28da7c81d3ad760fa9556c223a7e04e0d1b437b692f2d846a41d0bb6c777",
+  "fixture_manifest_sha256": "c876fbc3daef755940a426cf6665b2eb855a85c90a20abbbbee038fb74331e04",
   "recognizer_authority_sha256": "bda342ad69b5add1846b5a7a5252d0479145284ad27eabf70f14f09d5df2b5c5",
   "fixture_license": "Apache-2.0",
   "fixture_provenance": "repository-generated",


### PR DESCRIPTION
## Summary

- synchronize the OCR merge quality authority with the post-merge fixture inventory after EPUB and MSG fixtures landed
- retain the existing recognizer authority and all per-language quality groups unchanged
- make no OCR algorithm, threshold, corpus, or golden changes

## Verification

- `cargo test -j2 -p into-markdown-ocr merge::tests::quality_authority::degraded_scan_quality_authority_is_hash_and_license_bound`
- `bazel --batch test --jobs=2 --local_resources=memory=4096 --repository_disable_download --lockfile_mode=error --nocache_test_results //crates/onnxruntime:ppocrv6_merge_quality`
- `cargo run -j2 -p license-check --bin license-check`
- `cargo run -j2 -p license-check --bin release-audit`

This is a post-merge fixture inventory authority sync only; it does not change OCR behavior.