### PR TITLE
fix: accept standard PresentationML text and chart structures

### DIFF
--- a/crates/converters/src/presentation/opc_package.rs
+++ b/crates/converters/src/presentation/opc_package.rs
@@ -290,11 +290,29 @@ impl<'a> Package<'a> {
                 format!("relationship part {relationship_part} lacks its exact content type"),
             ));
         }
-        let relationships = {
+        let mut relationships = {
             let bytes = self.load_for_parse(&relationship_part, options, context)?;
             parse_relationships(bytes, owner, options, context)?
         };
         self.release_parsed(&relationship_part)?;
+        let isolated_external_chart_data = owner.starts_with("ppt/charts/")
+            && relationships.iter().any(|relationship| {
+                relationship.external && dangerous_relationship_type(&relationship.kind)
+            });
+        if relationships.iter().any(|relationship| {
+            relationship.external
+                && !(owner.starts_with("ppt/charts/")
+                    && dangerous_relationship_type(&relationship.kind))
+        }) {
+            return Err(malformed(
+                Some(&relationship_part),
+                "external relationships are forbidden by PresentationML conversion policy",
+            ));
+        }
+        if isolated_external_chart_data {
+            self.dangerous_present = true;
+            relationships.retain(|relationship| !relationship.external);
+        }
         for relationship in relationships.iter().filter(|relationship| !relationship.external) {
             let target = resolve_target(owner, &relationship.target)?;
             if dangerous_relationship_type(&relationship.kind) {
@@ -309,12 +327,6 @@ impl<'a> Package<'a> {
                 }
                 self.dangerous_present = true;
             }
-        }
-        if relationships.iter().any(|relationship| relationship.external) {
-            return Err(malformed(
-                Some(&relationship_part),
-                "external relationships are forbidden by PresentationML conversion policy",
-            ));
         }
         Ok(relationships)
     }

--- a/crates/converters/src/presentation/slides.rs
+++ b/crates/converters/src/presentation/slides.rs
@@ -129,6 +129,7 @@ pub(super) fn parse_shapes(
     let mut table_rows = Vec::<Vec<Vec<Inline>>>::new();
     let mut table_cell_count = 0_u64;
     let mut groups = Vec::<GroupTransform>::new();
+    let mut extension_list_depth = 0_usize;
     let mut mc = McSelection::default();
     let mut z_order = 0_usize;
     let mut parsed_inlines = 0_usize;
@@ -141,6 +142,13 @@ pub(super) fn parse_shapes(
         }
         match event {
             Event::Start(element) => match local(element.name().as_ref()) {
+                "extLst" => {
+                    extension_list_depth =
+                        extension_list_depth.checked_add(1).ok_or_else(|| {
+                            limit("max_nesting_depth", "extension-list depth overflow")
+                        })?;
+                }
+                "ext" if extension_list_depth > 0 => {}
                 "grpSp" => {
                     groups.try_reserve(1).map_err(|error| {
                         limit("max_memory_bytes", format!("cannot reserve group stack: {error}"))
@@ -290,6 +298,7 @@ pub(super) fn parse_shapes(
                 _ => apply_shape_element(&reader, &element, part, &mut shape)?,
             },
             Event::Empty(element) => match local(element.name().as_ref()) {
+                "ext" if extension_list_depth > 0 => {}
                 "sp" | "pic" | "graphicFrame" if shape.is_none() => {
                     return Err(malformed(Some(part), "empty shape container is invalid"));
                 }
@@ -403,6 +412,11 @@ pub(super) fn parse_shapes(
                 )?;
             }
             Event::End(element) => match local(element.name().as_ref()) {
+                "extLst" => {
+                    extension_list_depth = extension_list_depth
+                        .checked_sub(1)
+                        .ok_or_else(|| malformed(Some(part), "extension-list end without start"))?;
+                }
                 "t" if shape.is_some() => {
                     if !capturing_text {
                         return Err(malformed(Some(part), "text end without text start"));

--- a/crates/converters/src/presentation/styles.rs
+++ b/crates/converters/src/presentation/styles.rs
@@ -269,7 +269,8 @@ pub(super) fn parse_master_text_styles(
                     }
                     _ if section.is_some() => {
                         if local_name == "defPPr" {
-                            if current.is_some() || section_default.is_some() {
+                            if current.is_some() || section_default.is_some() || !levels.is_empty()
+                            {
                                 return Err(malformed(
                                     Some(part),
                                     "master text style has multiple or nested defPPr elements",
@@ -331,7 +332,7 @@ pub(super) fn parse_master_text_styles(
                     result.push((parsed_section, Vec::new()));
                 } else if section.is_some() {
                     if local_name == "defPPr" {
-                        if current.is_some() || section_default.is_some() {
+                        if current.is_some() || section_default.is_some() || !levels.is_empty() {
                             return Err(malformed(
                                 Some(part),
                                 "master text style has multiple or nested defPPr elements",

--- a/crates/converters/src/presentation/styles.rs
+++ b/crates/converters/src/presentation/styles.rs
@@ -226,6 +226,8 @@ pub(super) fn parse_master_text_styles(
         limit("max_memory_bytes", format!("cannot reserve master style levels: {error}"))
     })?;
     let mut current = None::<TextParagraph>;
+    let mut section_default = None::<TextParagraph>;
+    let mut parsing_section_default = false;
     let mut mc = McSelection::default();
     let mut tx_styles_seen = false;
     let mut sections_seen = 0_u8;
@@ -262,9 +264,20 @@ pub(super) fn parse_master_text_styles(
                         mark_master_text_section(&mut sections_seen, parsed_section, part)?;
                         section = Some(parsed_section);
                         levels.clear();
+                        section_default = None;
+                        parsing_section_default = false;
                     }
                     _ if section.is_some() => {
-                        if let Some(level) = level_paragraph(local_name.as_bytes()) {
+                        if local_name == "defPPr" {
+                            if current.is_some() || section_default.is_some() {
+                                return Err(malformed(
+                                    Some(part),
+                                    "master text style has multiple or nested defPPr elements",
+                                ));
+                            }
+                            current = Some(TextParagraph { start: 1, ..TextParagraph::default() });
+                            parsing_section_default = true;
+                        } else if let Some(level) = level_paragraph(local_name.as_bytes()) {
                             if current.is_some() {
                                 return Err(malformed(Some(part), "nested master text level"));
                             }
@@ -317,19 +330,32 @@ pub(super) fn parse_master_text_styles(
                     mark_master_text_section(&mut sections_seen, parsed_section, part)?;
                     result.push((parsed_section, Vec::new()));
                 } else if section.is_some() {
-                    if let Some(level) = level_paragraph(local_name.as_bytes()) {
+                    if local_name == "defPPr" {
+                        if current.is_some() || section_default.is_some() {
+                            return Err(malformed(
+                                Some(part),
+                                "master text style has multiple or nested defPPr elements",
+                            ));
+                        }
+                        section_default =
+                            Some(TextParagraph { start: 1, ..TextParagraph::default() });
+                    } else if let Some(level) = level_paragraph(local_name.as_bytes()) {
                         levels.try_reserve(1).map_err(|error| {
                             limit(
                                 "max_memory_bytes",
                                 format!("cannot reserve master level: {error}"),
                             )
                         })?;
-                        levels.push(TextParagraph {
+                        let mut paragraph = TextParagraph {
                             level,
                             level_explicit: true,
                             start: 1,
                             ..TextParagraph::default()
-                        });
+                        };
+                        if let Some(default) = section_default.as_ref() {
+                            inherit_master_paragraph_default(&mut paragraph, default)?;
+                        }
+                        levels.push(paragraph);
                     } else if local_name == "defRPr" {
                         let paragraph = current.as_mut().ok_or_else(|| {
                             malformed(Some(part), "master defRPr is outside a level")
@@ -356,13 +382,26 @@ pub(super) fn parse_master_text_styles(
             Event::End(element) => {
                 let qualified_name = element.name();
                 let local_name = local(qualified_name.as_ref());
-                if section.is_some() && level_paragraph(local_name.as_bytes()).is_some() {
+                if section.is_some() && local_name == "defPPr" {
+                    if !parsing_section_default {
+                        return Err(malformed(Some(part), "master defPPr end without start"));
+                    }
+                    section_default =
+                        Some(current.take().ok_or_else(|| {
+                            malformed(Some(part), "master defPPr end without state")
+                        })?);
+                    parsing_section_default = false;
+                } else if section.is_some() && level_paragraph(local_name.as_bytes()).is_some() {
+                    let mut completed = current.take().ok_or_else(|| {
+                        malformed(Some(part), "master text level end without start")
+                    })?;
+                    if let Some(default) = section_default.as_ref() {
+                        inherit_master_paragraph_default(&mut completed, default)?;
+                    }
                     levels.try_reserve(1).map_err(|error| {
                         limit("max_memory_bytes", format!("cannot reserve master level: {error}"))
                     })?;
-                    levels.push(current.take().ok_or_else(|| {
-                        malformed(Some(part), "master text level end without start")
-                    })?);
+                    levels.push(completed);
                 } else if matches!(local_name, "titleStyle" | "bodyStyle" | "otherStyle") {
                     if current.is_some() {
                         return Err(malformed(
@@ -373,6 +412,17 @@ pub(super) fn parse_master_text_styles(
                     levels.sort_unstable_by_key(|paragraph| paragraph.level);
                     if levels.windows(2).any(|pair| pair[0].level == pair[1].level) {
                         return Err(malformed(Some(part), "duplicate master text style level"));
+                    }
+                    if levels.is_empty()
+                        && let Some(default) = section_default.take()
+                    {
+                        levels.try_reserve(1).map_err(|error| {
+                            limit(
+                                "max_memory_bytes",
+                                format!("cannot reserve master default text style: {error}"),
+                            )
+                        })?;
+                        levels.push(default);
                     }
                     result.push((
                         section.take().ok_or_else(|| {
@@ -393,6 +443,25 @@ pub(super) fn parse_master_text_styles(
         return Err(limit("max_field_bytes", "master text style count"));
     }
     Ok(result)
+}
+
+fn inherit_master_paragraph_default(
+    paragraph: &mut TextParagraph,
+    default: &TextParagraph,
+) -> Result<(), ConversionError> {
+    paragraph.default_style.inherit(default.default_style);
+    paragraph.default_marks = marks_for_style(paragraph.default_style)?;
+    if !paragraph.bullet_explicit && default.bullet_explicit {
+        paragraph.bullet = default.bullet;
+        paragraph.bullet_explicit = true;
+        paragraph.start = default.start;
+        paragraph.numbering = default
+            .numbering
+            .as_deref()
+            .map(|value| try_clone_string(value, "master default numbering"))
+            .transpose()?;
+    }
+    Ok(())
 }
 
 fn mark_master_text_section(

--- a/crates/converters/src/presentation/tests/inheritance.rs
+++ b/crates/converters/src/presentation/tests/inheritance.rs
@@ -422,6 +422,58 @@ fn master_text_styles_and_explicit_false_rich_properties_layer_by_level() {
 }
 
 #[test]
+fn master_default_paragraph_properties_layer_below_level_properties() {
+    let master_xml = format!(
+        r#"<p:sldMaster xmlns:p="{p}" xmlns:a="{a}"><p:cSld><p:spTree/></p:cSld><p:txStyles><p:titleStyle><a:defPPr><a:defRPr b="true"/></a:defPPr><a:lvl1pPr><a:defRPr i="true"/></a:lvl1pPr></p:titleStyle><p:bodyStyle/><p:otherStyle/></p:txStyles></p:sldMaster>"#,
+        p = String::from_utf8_lossy(P_NS),
+        a = String::from_utf8_lossy(A_NS)
+    );
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    preflight_xml(
+        master_xml.as_bytes(),
+        "ppt/slideMasters/slideMaster1.xml",
+        XmlProfile::Master,
+        &options,
+        &context,
+    )
+    .unwrap();
+    let parsed = parse_master_text_styles(
+        master_xml.as_bytes(),
+        "ppt/slideMasters/slideMaster1.xml",
+        &options,
+        &context,
+    )
+    .unwrap();
+    let title = parsed.iter().find(|(section, _)| *section == MasterTextSection::Title).unwrap();
+    assert_eq!(title.1.len(), 1);
+    assert_eq!(title.1[0].default_style.bold, Some(true));
+    assert_eq!(title.1[0].default_style.italic, Some(true));
+}
+
+#[test]
+fn shape_extension_payload_does_not_overwrite_geometry_extent() {
+    let slide = format!(
+        r#"<p:sld xmlns:p="{p}" xmlns:a="{a}" xmlns:future="urn:future"><p:cSld><p:spTree><p:sp><p:nvSpPr><p:cNvPr id="1" name="Text"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:spPr><a:xfrm><a:off x="10" y="20"/><a:ext cx="30" cy="40"/></a:xfrm><a:extLst><a:ext uri="reviewed"><future:value/></a:ext></a:extLst></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>text</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>"#,
+        p = String::from_utf8_lossy(P_NS),
+        a = String::from_utf8_lossy(A_NS)
+    );
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    let shapes = parse_shapes(
+        slide.as_bytes(),
+        "ppt/slides/slide1.xml",
+        XmlProfile::Slide,
+        &options,
+        &context,
+    )
+    .unwrap();
+    assert_eq!(shapes.len(), 1);
+    assert_eq!((shapes[0].geometry.x, shapes[0].geometry.y), (10, 20));
+    assert_eq!((shapes[0].geometry.cx, shapes[0].geometry.cy), (30, 40));
+}
+
+#[test]
 fn shape_list_styles_do_not_require_master_text_styles() {
     let master_xml = format!(
         r#"<p:sldMaster xmlns:p="{p}" xmlns:a="{a}"><p:cSld><p:spTree><p:sp><p:nvSpPr><p:cNvPr id="2" name="Title"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:buNone/></a:lvl1pPr></a:lstStyle><a:p/></p:txBody></p:sp></p:spTree></p:cSld></p:sldMaster>"#,

--- a/crates/converters/src/presentation/tests/inheritance.rs
+++ b/crates/converters/src/presentation/tests/inheritance.rs
@@ -449,6 +449,20 @@ fn master_default_paragraph_properties_layer_below_level_properties() {
     assert_eq!(title.1.len(), 1);
     assert_eq!(title.1[0].default_style.bold, Some(true));
     assert_eq!(title.1[0].default_style.italic, Some(true));
+
+    let invalid_order = master_xml.replace(
+        r#"<a:defPPr><a:defRPr b="true"/></a:defPPr><a:lvl1pPr><a:defRPr i="true"/></a:lvl1pPr>"#,
+        r#"<a:lvl1pPr><a:defRPr i="true"/></a:lvl1pPr><a:defPPr><a:defRPr b="true"/></a:defPPr>"#,
+    );
+    assert!(matches!(
+        parse_master_text_styles(
+            invalid_order.as_bytes(),
+            "ppt/slideMasters/slideMaster1.xml",
+            &options,
+            &context,
+        ),
+        Err(ConversionError::Malformed { .. })
+    ));
 }
 
 #[test]

--- a/crates/converters/src/presentation/tests/relationships.rs
+++ b/crates/converters/src/presentation/tests/relationships.rs
@@ -88,8 +88,9 @@ fn layout_master_theme_notes_and_chart_are_authorized_and_extracted() {
         String::from_utf8_lossy(A_NS)
     );
     let chart = format!(
-        r#"<c:chartSpace xmlns:c="{c}"><c:chart><c:plotArea><c:ser><c:tx><c:strRef><c:strCache><c:pt idx="0"><c:v>Revenue</c:v></c:pt></c:strCache></c:strRef></c:tx><c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>42</c:v></c:pt></c:numCache></c:numRef></c:val></c:ser><c:ser><c:tx><c:v>Direct title</c:v></c:tx></c:ser></c:plotArea></c:chart></c:chartSpace>"#,
-        c = String::from_utf8_lossy(C_NS)
+        r#"<c:chartSpace xmlns:c="{c}" xmlns:a="{a}" xmlns:future="urn:future"><c:chart><c:title><c:tx><c:rich><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>Chart title</a:t></a:r></a:p></c:rich></c:tx><c:spPr/><c:txPr><a:bodyPr/><a:lstStyle/><a:p/></c:txPr></c:title><c:plotArea><c:barChart><c:ser><c:tx><c:strRef><c:strCache><c:pt idx="0"><c:v>Revenue</c:v></c:pt></c:strCache></c:strRef></c:tx><c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>42</c:v></c:pt></c:numCache></c:numRef></c:val><c:extLst><c:ext uri="reviewed"><future:value/></c:ext></c:extLst></c:ser><c:ser><c:tx><c:v>Direct title</c:v></c:tx></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#,
+        c = String::from_utf8_lossy(C_NS),
+        a = String::from_utf8_lossy(A_NS)
     );
     let mut archive = zip::ZipArchive::new(Cursor::new(original.as_slice())).unwrap();
     let mut parts = Vec::<(String, Vec<u8>)>::new();
@@ -266,6 +267,25 @@ fn layout_master_theme_notes_and_chart_are_authorized_and_extracted() {
             .collect::<Vec<_>>();
         assert!(matches!(convert(&zip(&related_refs)), Err(ConversionError::Malformed { .. })));
     }
+    let external_chart_workbook = format!(
+        r#"<Relationships xmlns="{rels}"><Relationship Id="external" Type="{prefix}oleObject" Target="https://example.test/source.xlsx" TargetMode="External"/></Relationships>"#,
+        rels = String::from_utf8_lossy(REL_NS),
+        prefix = REL_PREFIX
+    );
+    let mut cached_chart_parts = parts.clone();
+    cached_chart_parts
+        .push(("ppt/charts/_rels/chart1.xml.rels".into(), external_chart_workbook.into_bytes()));
+    let cached_chart_refs = cached_chart_parts
+        .iter()
+        .map(|(name, value)| (name.as_str(), value.clone()))
+        .collect::<Vec<_>>();
+    let cached_chart = convert(&zip(&cached_chart_refs)).unwrap();
+    assert!(
+        cached_chart
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "presentation.dangerousPartsIgnored")
+    );
     let mut hidden_chart_parts = parts.clone();
     for (name, value) in &mut hidden_chart_parts {
         if name == "ppt/slides/slide1.xml" {

--- a/crates/converters/src/presentation/tests/security.rs
+++ b/crates/converters/src/presentation/tests/security.rs
@@ -504,3 +504,86 @@ fn xml_ir_and_geometry_work_limits_are_stable() {
         ));
     }
 }
+
+#[test]
+fn presentation_default_text_style_accepts_only_its_default_run_properties() {
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    let valid = format!(
+        r#"<p:presentation xmlns:p="{p}" xmlns:a="{a}"><p:defaultTextStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr><a:defRPr sz="1800"/></a:lvl1pPr></p:defaultTextStyle></p:presentation>"#,
+        p = String::from_utf8_lossy(P_NS),
+        a = String::from_utf8_lossy(super::super::schema::A_NS),
+    );
+    preflight_xml(
+        valid.as_bytes(),
+        "ppt/presentation.xml",
+        XmlProfile::Presentation,
+        &options,
+        &context,
+    )
+    .expect("ECMA-376 default paragraph run properties must be accepted");
+
+    let invalid = valid.replace("<a:defPPr>", "<a:bodyPr>").replace("</a:defPPr>", "</a:bodyPr>");
+    assert!(matches!(
+        preflight_xml(
+            invalid.as_bytes(),
+            "ppt/presentation.xml",
+            XmlProfile::Presentation,
+            &options,
+            &context,
+        ),
+        Err(ConversionError::Malformed { .. })
+    ));
+}
+
+#[test]
+fn master_text_styles_accept_default_paragraph_run_properties() {
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    let valid = format!(
+        r#"<p:sldMaster xmlns:p="{p}" xmlns:a="{a}"><p:cSld><p:spTree/></p:cSld><p:txStyles><p:titleStyle><a:defPPr><a:defRPr b="true"/></a:defPPr></p:titleStyle><p:bodyStyle><a:defPPr/></p:bodyStyle><p:otherStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr></p:otherStyle></p:txStyles></p:sldMaster>"#,
+        p = String::from_utf8_lossy(P_NS),
+        a = String::from_utf8_lossy(super::super::schema::A_NS),
+    );
+    preflight_xml(
+        valid.as_bytes(),
+        "ppt/slideMasters/slideMaster1.xml",
+        XmlProfile::Master,
+        &options,
+        &context,
+    )
+    .expect("master text-list styles may define default paragraph run properties");
+}
+
+#[test]
+fn presentation_extension_and_geometry_extent_are_namespace_distinct() {
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    let valid = format!(
+        r#"<p:presentation xmlns:p="{p}" xmlns:a="{a}"><p:extLst><p:ext uri="reviewed"/></p:extLst></p:presentation>"#,
+        p = String::from_utf8_lossy(P_NS),
+        a = String::from_utf8_lossy(super::super::schema::A_NS),
+    );
+    preflight_xml(
+        valid.as_bytes(),
+        "ppt/presentation.xml",
+        XmlProfile::Presentation,
+        &options,
+        &context,
+    )
+    .expect("PresentationML extensions must not be confused with DrawingML extents");
+
+    let invalid = valid
+        .replace("<p:extLst>", "<p:defaultTextStyle>")
+        .replace("</p:extLst>", "</p:defaultTextStyle>");
+    assert!(matches!(
+        preflight_xml(
+            invalid.as_bytes(),
+            "ppt/presentation.xml",
+            XmlProfile::Presentation,
+            &options,
+            &context,
+        ),
+        Err(ConversionError::Malformed { .. })
+    ));
+}

--- a/crates/converters/src/presentation/xml.rs
+++ b/crates/converters/src/presentation/xml.rs
@@ -354,12 +354,14 @@ fn validate_interpreted_element(
         | b"sldMaster" | b"cSld" | b"spTree" | b"sp" | b"pic" | b"graphicFrame" | b"grpSp"
         | b"grpSpPr" | b"nvSpPr" | b"nvPicPr" | b"nvGraphicFramePr" | b"nvGrpSpPr" | b"cNvPr"
         | b"cNvSpPr" | b"cNvPicPr" | b"cNvGraphicFramePr" | b"cNvGrpSpPr" | b"nvPr" | b"ph"
-        | b"spPr" | b"blipFill" => Some(P_NS),
-        b"txStyles" | b"titleStyle" | b"bodyStyle" | b"otherStyle" => Some(P_NS),
+        | b"blipFill" => Some(P_NS),
+        b"txStyles" | b"titleStyle" | b"bodyStyle" | b"otherStyle" | b"defaultTextStyle" => {
+            Some(P_NS)
+        }
         b"theme" | b"graphic" | b"graphicData" | b"tbl" | b"tr" | b"tc" | b"tcPr" | b"p"
         | b"pPr" | b"r" | b"rPr" | b"defRPr" | b"t" | b"br" | b"buChar" | b"buNone" | b"buBlip"
-        | b"bodyPr" | b"lstStyle" | b"buAutoNum" | b"off" | b"ext" | b"chOff" | b"chExt"
-        | b"blip" => Some(A_NS),
+        | b"bodyPr" | b"lstStyle" | b"buAutoNum" | b"off" | b"chOff" | b"chExt" | b"blip"
+        | b"defPPr" => Some(A_NS),
         b"chartSpace" | b"chart" | b"plotArea" | b"ser" | b"cat" | b"val" | b"tx" | b"strRef"
         | b"numRef" | b"strCache" | b"numCache" | b"pt" | b"v" => Some(C_NS),
         _ => None,
@@ -378,6 +380,12 @@ fn validate_interpreted_element(
     }
     if local == b"txBody" && !matches!(ns, P_NS | A_NS) {
         return Err(malformed(Some(part), "txBody has an unexpected namespace"));
+    }
+    if local == b"spPr" && !matches!(ns, P_NS | A_NS | C_NS) {
+        return Err(malformed(Some(part), "spPr has an unexpected namespace"));
+    }
+    if local == b"ext" && !matches!(ns, P_NS | A_NS | C_NS) {
+        return Err(malformed(Some(part), "ext has an unexpected namespace"));
     }
     let valid = match (ns, local) {
         (TYPES_NS, b"Override" | b"Default") => parent_is(TYPES_NS, b"Types"),
@@ -425,30 +433,74 @@ fn validate_interpreted_element(
         ),
         (P_NS, b"ph") => parent_is(P_NS, b"nvPr"),
         (P_NS, b"spPr") => parent_is(P_NS, b"sp") || parent_is(P_NS, b"pic"),
+        (A_NS, b"spPr") => {
+            profile == XmlProfile::Theme
+                && parent.is_some_and(|(namespace, local)| {
+                    namespace == A_NS && matches!(local.as_slice(), b"lnDef" | b"spDef" | b"txDef")
+                })
+        }
+        (C_NS, b"spPr") => {
+            profile == XmlProfile::Chart && parent.is_some_and(|(namespace, _)| namespace == C_NS)
+        }
         (P_NS, b"txBody") => parent_is(P_NS, b"sp"),
         (A_NS, b"txBody") => parent_is(A_NS, b"tc"),
         (P_NS, b"blipFill") => parent_is(P_NS, b"pic"),
         (P_NS, b"txStyles") => parent_is(P_NS, b"sldMaster"),
         (P_NS, b"titleStyle" | b"bodyStyle" | b"otherStyle") => parent_is(P_NS, b"txStyles"),
+        (P_NS, b"defaultTextStyle") => parent_is(P_NS, b"presentation"),
+        (P_NS, b"ext") => parent_is(P_NS, b"extLst"),
         (P_NS, b"xfrm") => parent_is(P_NS, b"graphicFrame"),
         (A_NS, b"xfrm") => parent_is(P_NS, b"spPr") || parent_is(P_NS, b"grpSpPr"),
-        (A_NS, b"off" | b"ext") => parent_is(A_NS, b"xfrm") || parent_is(P_NS, b"xfrm"),
+        (A_NS, b"off") => parent_is(A_NS, b"xfrm") || parent_is(P_NS, b"xfrm"),
+        (A_NS, b"ext") => {
+            parent_is(A_NS, b"xfrm") || parent_is(P_NS, b"xfrm") || parent_is(A_NS, b"extLst")
+        }
         (A_NS, b"chOff" | b"chExt") => parent_is(A_NS, b"xfrm"),
-        (A_NS, b"bodyPr" | b"lstStyle") => parent_is(P_NS, b"txBody") || parent_is(A_NS, b"txBody"),
-        (A_NS, b"p") => parent_is(P_NS, b"txBody") || parent_is(A_NS, b"txBody"),
+        (A_NS, b"bodyPr" | b"lstStyle") => {
+            parent_is(P_NS, b"txBody")
+                || parent_is(A_NS, b"txBody")
+                || parent_is(C_NS, b"rich")
+                || parent_is(C_NS, b"txPr")
+                || (profile == XmlProfile::Theme
+                    && parent.is_some_and(|(namespace, local)| {
+                        namespace == A_NS
+                            && matches!(local.as_slice(), b"lnDef" | b"spDef" | b"txDef")
+                    }))
+        }
+        (A_NS, b"p") => {
+            parent_is(P_NS, b"txBody")
+                || parent_is(A_NS, b"txBody")
+                || parent_is(C_NS, b"rich")
+                || parent_is(C_NS, b"txPr")
+        }
         (A_NS, b"pPr") => parent_is(A_NS, b"p"),
+        (A_NS, b"defPPr") => {
+            matches!(
+                parent,
+                Some((namespace, local))
+                    if namespace == P_NS
+                        && matches!(
+                            local.as_slice(),
+                            b"defaultTextStyle" | b"titleStyle" | b"bodyStyle" | b"otherStyle"
+                        )
+            )
+        }
         (A_NS, local) if level_paragraph(local).is_some() => {
             matches!(
                 parent,
                 Some((namespace, local))
                     if namespace == P_NS
-                        && matches!(local.as_slice(), b"titleStyle" | b"bodyStyle" | b"otherStyle")
+                        && matches!(
+                            local.as_slice(),
+                            b"titleStyle" | b"bodyStyle" | b"otherStyle" | b"defaultTextStyle"
+                        )
             ) || parent_is(A_NS, b"lstStyle")
         }
         (A_NS, b"r") => parent_is(A_NS, b"p"),
         (A_NS, b"rPr") => parent_is(A_NS, b"r") || parent_is(A_NS, b"fld"),
         (A_NS, b"defRPr") => {
             parent_is(A_NS, b"pPr")
+                || parent_is(A_NS, b"defPPr")
                 || parent.is_some_and(|(namespace, local)| {
                     namespace == A_NS && level_paragraph(local).is_some()
                 })
@@ -470,8 +522,33 @@ fn validate_interpreted_element(
         (A_NS, b"tcPr") => parent_is(A_NS, b"tc"),
         (C_NS, b"chart") => parent_is(C_NS, b"chartSpace") || parent_is(A_NS, b"graphicData"),
         (C_NS, b"plotArea") => parent_is(C_NS, b"chart"),
-        (C_NS, b"ser") => parent_is(C_NS, b"plotArea"),
-        (C_NS, b"cat" | b"val" | b"tx") => parent_is(C_NS, b"ser"),
+        (C_NS, b"ser") => {
+            parent_is(C_NS, b"plotArea")
+                || parent.is_some_and(|(namespace, local)| {
+                    namespace == C_NS
+                        && matches!(
+                            local.as_slice(),
+                            b"area3DChart"
+                                | b"areaChart"
+                                | b"bar3DChart"
+                                | b"barChart"
+                                | b"bubbleChart"
+                                | b"doughnutChart"
+                                | b"line3DChart"
+                                | b"lineChart"
+                                | b"ofPieChart"
+                                | b"pie3DChart"
+                                | b"pieChart"
+                                | b"radarChart"
+                                | b"scatterChart"
+                                | b"stockChart"
+                                | b"surface3DChart"
+                                | b"surfaceChart"
+                        )
+                })
+        }
+        (C_NS, b"cat" | b"val") => parent_is(C_NS, b"ser"),
+        (C_NS, b"tx") => parent_is(C_NS, b"ser") || parent_is(C_NS, b"title"),
         (C_NS, b"strRef" | b"numRef") => {
             parent_is(C_NS, b"cat") || parent_is(C_NS, b"val") || parent_is(C_NS, b"tx")
         }
@@ -480,6 +557,7 @@ fn validate_interpreted_element(
         }
         (C_NS, b"pt") => parent_is(C_NS, b"strCache") || parent_is(C_NS, b"numCache"),
         (C_NS, b"v") => parent_is(C_NS, b"pt") || parent_is(C_NS, b"tx"),
+        (C_NS, b"ext") => parent_is(C_NS, b"extLst"),
         (MC_NS, b"Choice" | b"Fallback") => parent_is(MC_NS, b"AlternateContent"),
         _ => true,
     };


### PR DESCRIPTION
Closes #148

## Summary
- accept ECMA-376 default paragraph/run properties in presentation and master text styles
- keep PresentationML/DrawingML/chart namespace-distinct elements structurally validated
- isolate external chart workbook links while consuming only embedded cached chart data
- prevent extension-list payloads from being misread as shape geometry

## Validation
- real 277,515-byte six-slide PPTX from the local MarkItDown reference checkout converts successfully (input SHA-256 f0b9e5252aec3730c91f276a7c3b8f4a9893a7b66540f6c6af160a49855ca507)
- output covers headings, text, lists, table, chart cache, nested shapes and extracted images
- cargo test -p into-markdown-converters presentation:: (39 passed)
- strict converters Clippy all targets/features
- fmt and diff check