### PR TITLE
feat: OCR embedded visuals across container formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,6 +1085,8 @@ dependencies = [
  "into-markdown-render-markdown",
  "into-markdown-task-store",
  "serde_json",
+ "sha2",
+ "tempfile",
  "zip 2.4.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1268,6 +1268,7 @@ dependencies = [
  "thiserror",
  "unicode-normalization",
  "url",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,7 @@ dependencies = [
 name = "into-markdown"
 version = "0.0.0"
 dependencies = [
+ "image",
  "into-markdown-ai",
  "into-markdown-converters",
  "into-markdown-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ tiff = "=0.10.3"
 unicode-normalization = "0.1.25"
 url = "2.5.4"
 winapi-util = "0.1.11"
-windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Security_Isolation", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_LibraryLoader", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading"] }
+windows-sys = { version = "0.61.2", features = ["Win32_Foundation", "Win32_Security", "Win32_Security_Authorization", "Win32_Security_Isolation", "Win32_Storage_FileSystem", "Win32_System_JobObjects", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemInformation", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
 zip = { version = "2.4.2", default-features = false, features = ["deflate"] }
 
 [workspace.lints.rust]

--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -310,6 +310,9 @@ fn run_models(
     _catalog: Catalog,
     context: &mut RunContext<'_>,
 ) -> Result<(), CliError> {
+    if matches!(&command, Some(ModelsCommand::Install { .. })) {
+        ensure_model_parent()?;
+    }
     let manager = model_manager()?;
     let execution = into_markdown::ExecutionContext::new(
         into_markdown::ExecutionOptions {
@@ -410,6 +413,23 @@ fn run_models(
             Ok(())
         }
     }
+}
+
+fn ensure_model_parent() -> Result<(), CliError> {
+    let data_dir = directories::ProjectDirs::from("", "", "into-markdown")
+        .map(|directories| directories.data_dir().to_path_buf())
+        .ok_or_else(|| {
+            CliError::new(
+                ExitClass::Io,
+                "modelDataDirectoryUnavailable",
+                "cannot determine the platform model data directory",
+            )
+        })?;
+    ensure_model_parent_at(&data_dir)
+}
+
+fn ensure_model_parent_at(data_dir: &Path) -> Result<(), CliError> {
+    fs::create_dir_all(data_dir).map_err(CliError::from)
 }
 
 fn model_manager() -> Result<into_markdown::ModelManager, CliError> {
@@ -2901,6 +2921,18 @@ mod tests {
     fn default_model_pipeline_is_explicitly_installable() {
         let manager = model_manager().unwrap();
         manager.require_installable(&manager.manifest().default_bundle).unwrap();
+    }
+
+    #[test]
+    fn first_model_install_creates_the_missing_product_data_parent() {
+        let temporary = tempfile::tempdir().unwrap();
+        let data_dir = temporary.path().join("missing").join("into-markdown");
+        assert!(!data_dir.exists());
+
+        ensure_model_parent_at(&data_dir).unwrap();
+
+        assert!(data_dir.is_dir());
+        assert!(!data_dir.join("models").exists());
     }
 
     #[test]

--- a/apps/cli/src/transaction.rs
+++ b/apps/cli/src/transaction.rs
@@ -937,14 +937,14 @@ impl SafeDir {
     }
 
     pub(crate) fn open_child_private(&self, _name: &OsStr) -> Result<Self, CliError> {
-        unsupported_safe_dir()
+        Err(transaction_platform_unavailable())
     }
 
     pub(crate) fn open_child_private_optional(
         &self,
         _name: &OsStr,
     ) -> Result<Option<Self>, CliError> {
-        unsupported_safe_dir()
+        Err(transaction_platform_unavailable())
     }
 
     pub(crate) fn create_regular(&self, _name: &OsStr) -> Result<File, CliError> {
@@ -1037,7 +1037,7 @@ impl SafeDir {
         Err(transaction_platform_unavailable())
     }
 
-    fn sync(&self) -> Result<(), CliError> {
+    pub(crate) fn sync(&self) -> Result<(), CliError> {
         Err(transaction_platform_unavailable())
     }
 }

--- a/crates/api/BUILD.bazel
+++ b/crates/api/BUILD.bazel
@@ -101,6 +101,8 @@ rust_test(
         "//crates/render-markdown:render_markdown",
         "//crates/task-store:task_store",
         "@crates//:serde_json",
+        "@crates//:sha2",
+        "@crates//:tempfile",
         "@crates//:zip",
     ],
 )

--- a/crates/api/BUILD.bazel
+++ b/crates/api/BUILD.bazel
@@ -100,6 +100,7 @@ rust_test(
         "//crates/ocr",
         "//crates/render-markdown:render_markdown",
         "//crates/task-store:task_store",
+        "@crates//:image",
         "@crates//:serde_json",
         "@crates//:sha2",
         "@crates//:tempfile",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -17,6 +17,7 @@ into-markdown-render-markdown = { path = "../render-markdown" }
 into-markdown-task-store = { path = "../task-store" }
 
 [dev-dependencies]
+image.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 tempfile.workspace = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -18,6 +18,8 @@ into-markdown-task-store = { path = "../task-store" }
 
 [dev-dependencies]
 serde_json.workspace = true
+sha2.workspace = true
+tempfile.workspace = true
 zip.workspace = true
 
 [lints]

--- a/crates/api/src/embedded_visual_ocr_tests.rs
+++ b/crates/api/src/embedded_visual_ocr_tests.rs
@@ -1,0 +1,357 @@
+use super::*;
+use sha2::{Digest, Sha256};
+use std::future::Future;
+use std::io::Write as _;
+use std::pin::pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::task::{Context, Poll, Waker};
+
+const TEST_PNG: &[u8] = &[
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x04, 0x00, 0x00, 0x00, 0xb5, 0x1c, 0x0c,
+    0x02, 0x00, 0x00, 0x00, 0x0b, 0x49, 0x44, 0x41, 0x54, 0x78, 0xda, 0x63, 0x64, 0xf8, 0x0f, 0x00,
+    0x01, 0x05, 0x01, 0x01, 0x27, 0x18, 0xe3, 0x66, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+    0xae, 0x42, 0x60, 0x82,
+];
+
+struct SourceBoundOcr(AtomicUsize);
+
+impl OcrEngine for SourceBoundOcr {
+    fn id(&self) -> &'static str {
+        "test.api.embedded-source-bound-ocr"
+    }
+
+    fn recognize<'a>(
+        &'a self,
+        _: OcrRequest<'a>,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+        Box::pin(async { unreachable!("embedded visuals require bound OCR") })
+    }
+
+    fn planned_bound_output(
+        &self,
+        _: OcrRequest<'_>,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new(16 * 1024, 1, 128)
+    }
+
+    fn recognize_bound<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        let identity = OcrInputIdentity::try_new(Sha256::digest(request.image).into(), 1, 1, 0);
+        Box::pin(async move {
+            context.checkpoint()?;
+            Ok(OcrRecognition::Bound(BoundOcrResult::try_new_for_input(
+                OcrResult {
+                    regions: vec![OcrRegion {
+                        text: "text from embedded picture".into(),
+                        polygon: [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)],
+                        confidence: 0.99,
+                    }],
+                    provider: "test.api.recognizer".into(),
+                },
+                vec![0.99],
+                vec![
+                    OcrEvidenceStep {
+                        stage: OcrEvidenceStage::Detection,
+                        provider: "test.api.detector".into(),
+                        model: Some("detector-sha256".into()),
+                    },
+                    OcrEvidenceStep {
+                        stage: OcrEvidenceStage::Recognition,
+                        provider: "test.api.recognizer".into(),
+                        model: Some("recognizer-sha256".into()),
+                    },
+                ],
+                identity?,
+            )?))
+        })
+    }
+}
+
+#[test]
+fn dynamically_created_docx_obeys_embedded_visual_ocr_and_asset_modes() {
+    let mut file = tempfile::Builder::new().suffix(".docx").tempfile().unwrap();
+    file.write_all(&docx_with_png()).unwrap();
+    file.flush().unwrap();
+
+    let ocr = Arc::new(SourceBoundOcr(AtomicUsize::new(0)));
+    for mode in [AssetMode::Extract, AssetMode::Embed, AssetMode::Omit] {
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let engine = default_engine_with_services(services).unwrap();
+        let mut request = ConversionRequest::new(InputRef::Path(file.path().to_path_buf()));
+        request.options.ocr.policy = OcrPolicy::Always;
+        request.options.output.asset_mode = mode;
+        let result = block_on(engine.convert(request)).unwrap();
+        assert!(result.markdown.contains("text from embedded picture"));
+        match mode {
+            AssetMode::Extract => {
+                assert!(result.markdown.contains("!["));
+                assert!(!result.markdown.contains("data:image/png;base64,"));
+            }
+            AssetMode::Embed => assert!(result.markdown.contains("data:image/png;base64,")),
+            AssetMode::Omit => assert!(!result.markdown.contains("![")),
+        }
+    }
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 3);
+
+    let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+    let engine = default_engine_with_services(services).unwrap();
+    let mut request = ConversionRequest::new(InputRef::Path(file.path().to_path_buf()));
+    request.options.ocr.policy = OcrPolicy::Off;
+    request.options.output.asset_mode = AssetMode::Omit;
+    let result = block_on(engine.convert(request)).unwrap();
+    assert!(!result.markdown.contains("text from embedded picture"));
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 3);
+}
+
+#[test]
+fn dynamically_created_rtf_and_notebook_images_use_embedded_ocr() {
+    let hex_png =
+        TEST_PNG.iter().fold(String::with_capacity(TEST_PNG.len() * 2), |mut output, byte| {
+            use std::fmt::Write as _;
+            write!(output, "{byte:02x}").unwrap();
+            output
+        });
+    let rtf = format!("{{\\rtf1\\ansi before\\par{{\\pict\\pngblip {hex_png}}}after\\par}}");
+    assert_dynamic_file_ocr(".rtf", rtf.as_bytes());
+
+    let notebook = serde_json::json!({
+        "cells": [{
+            "id": "embedded-image",
+            "cell_type": "raw",
+            "metadata": {},
+            "source": ["before and after"],
+            "attachments": {
+                "embedded.png": {
+                    "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+                }
+            }
+        }],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5
+    });
+    assert_dynamic_file_ocr(".ipynb", notebook.to_string().as_bytes());
+
+    assert_dynamic_file_ocr(".odt", &odf_with_png("text"));
+    assert_dynamic_file_ocr(".ods", &odf_with_png("spreadsheet"));
+    assert_dynamic_file_ocr(".odp", &odf_with_png("presentation"));
+    assert_dynamic_file_ocr(".epub", &epub_with_png());
+
+    let nested_docx = docx_with_png();
+    assert_dynamic_file_ocr(".zip", &zip_parts(&[("nested/document.docx", &nested_docx)]));
+}
+
+#[test]
+fn dynamically_created_pptx_and_xlsx_deduplicate_bytes_but_preserve_references() {
+    assert_dynamic_file_ocr_references(".pptx", &pptx_with_interleaved_picture_references(), 3);
+    assert_dynamic_file_ocr_references(".xlsx", &xlsx_with_two_picture_references(), 2);
+}
+
+#[test]
+fn dynamically_created_html_remote_image_is_not_fetched_or_ocr_guessed() {
+    let mut file = tempfile::Builder::new().suffix(".html").tempfile().unwrap();
+    file.write_all(
+        br#"<!doctype html><p>safe</p><img src="https://example.invalid/secret.png" alt="remote">"#,
+    )
+    .unwrap();
+    file.flush().unwrap();
+    let ocr = Arc::new(SourceBoundOcr(AtomicUsize::new(0)));
+    let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+    let engine = default_engine_with_services(services).unwrap();
+    let mut request = ConversionRequest::new(InputRef::Path(file.path().to_path_buf()));
+    request.options.ocr.policy = OcrPolicy::Always;
+    let result = block_on(engine.convert(request)).unwrap();
+    assert!(result.markdown.contains("remote"));
+    assert!(!result.markdown.contains("text from embedded picture"));
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 0);
+
+    assert_dynamic_file_ocr(
+        ".html",
+        br#"<!doctype html><p>before</p><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=" alt="local"><p>after</p>"#,
+    );
+}
+
+fn assert_dynamic_file_ocr(suffix: &str, bytes: &[u8]) {
+    assert_dynamic_file_ocr_references(suffix, bytes, 1);
+}
+
+fn assert_dynamic_file_ocr_references(suffix: &str, bytes: &[u8], references: usize) {
+    let mut file = tempfile::Builder::new().suffix(suffix).tempfile().unwrap();
+    file.write_all(bytes).unwrap();
+    file.flush().unwrap();
+    let ocr = Arc::new(SourceBoundOcr(AtomicUsize::new(0)));
+    let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+    let engine = default_engine_with_services(services).unwrap();
+    let mut request = ConversionRequest::new(InputRef::Path(file.path().to_path_buf()));
+    request.options.ocr.policy = OcrPolicy::Always;
+    request.options.output.asset_mode = AssetMode::Extract;
+    let result =
+        block_on(engine.convert(request)).unwrap_or_else(|error| panic!("{suffix}: {error}"));
+    assert_eq!(
+        result.markdown.matches("text from embedded picture").count(),
+        references,
+        "{suffix}"
+    );
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 1, "{suffix}");
+}
+
+fn zip_parts(parts: &[(&str, &[u8])]) -> Vec<u8> {
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut zip = zip::ZipWriter::new(cursor);
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (name, bytes) in parts {
+        zip.start_file(*name, options).unwrap();
+        zip.write_all(bytes).unwrap();
+    }
+    zip.finish().unwrap().into_inner()
+}
+
+fn odf_with_png(family: &str) -> Vec<u8> {
+    let (media_type, body) = match family {
+        "text" => (
+            "application/vnd.oasis.opendocument.text",
+            "<office:text><text:p>before</text:p><draw:frame><draw:image xlink:type='simple' xlink:href='Pictures/a.png'/></draw:frame><text:p>after</text:p></office:text>",
+        ),
+        "spreadsheet" => (
+            "application/vnd.oasis.opendocument.spreadsheet",
+            "<office:spreadsheet><table:table table:name='Data'><table:table-row><table:table-cell><text:p>before</text:p><draw:frame><draw:image xlink:type='simple' xlink:href='Pictures/a.png'/></draw:frame><text:p>after</text:p></table:table-cell></table:table-row></table:table></office:spreadsheet>",
+        ),
+        "presentation" => (
+            "application/vnd.oasis.opendocument.presentation",
+            "<office:presentation><draw:page draw:name='Slide 1'><draw:frame><draw:text-box><text:p>before</text:p></draw:text-box></draw:frame><draw:frame><draw:image xlink:type='simple' xlink:href='Pictures/a.png'/></draw:frame><draw:frame><draw:text-box><text:p>after</text:p></draw:text-box></draw:frame></draw:page></office:presentation>",
+        ),
+        _ => panic!("unsupported ODF family"),
+    };
+    let content = format!(
+        r#"<office:document-content xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:xlink="http://www.w3.org/1999/xlink"><office:body>{body}</office:body></office:document-content>"#
+    );
+    let manifest = format!(
+        r#"<manifest:manifest xmlns:manifest="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0" manifest:version="1.3"><manifest:file-entry manifest:full-path="/" manifest:media-type="{media_type}"/><manifest:file-entry manifest:full-path="content.xml" manifest:media-type="text/xml"/><manifest:file-entry manifest:full-path="Pictures/a.png" manifest:media-type="image/png"/></manifest:manifest>"#
+    );
+    zip_parts(&[
+        ("mimetype", media_type.as_bytes()),
+        ("content.xml", content.as_bytes()),
+        ("META-INF/manifest.xml", manifest.as_bytes()),
+        ("Pictures/a.png", TEST_PNG),
+    ])
+}
+
+fn epub_with_png() -> Vec<u8> {
+    const CONTAINER: &str = r#"<?xml version="1.0"?><container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/></rootfiles></container>"#;
+    const PACKAGE: &str = r#"<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="book"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier id="book">urn:test:embedded-ocr</dc:identifier><dc:title>Embedded OCR</dc:title><dc:language>en</dc:language><meta property="dcterms:modified">2026-08-17T00:00:00Z</meta></metadata><manifest><item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/><item id="image" href="image.png" media-type="image/png"/></manifest><spine><itemref idref="chapter"/></spine></package>"#;
+    const NAV: &str = r#"<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"><head><title>Contents</title></head><body><nav epub:type="toc"><ol><li><a href="chapter.xhtml">Chapter</a></li></ol></nav></body></html>"#;
+    const CHAPTER: &str = r#"<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"><head><title>Chapter</title></head><body><p>before</p><img src="image.png" alt="embedded"/><p>after</p></body></html>"#;
+    zip_parts(&[
+        ("mimetype", b"application/epub+zip"),
+        ("META-INF/container.xml", CONTAINER.as_bytes()),
+        ("EPUB/package.opf", PACKAGE.as_bytes()),
+        ("EPUB/nav.xhtml", NAV.as_bytes()),
+        ("EPUB/chapter.xhtml", CHAPTER.as_bytes()),
+        ("EPUB/image.png", TEST_PNG),
+    ])
+}
+
+fn pptx_with_interleaved_picture_references() -> Vec<u8> {
+    const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/><Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/></Types>"#;
+    const ROOT: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="root" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/></Relationships>"#;
+    const PRESENTATION: &str = r#"<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst><p:sldId id="256" r:id="slide"/></p:sldIdLst></p:presentation>"#;
+    const PRESENTATION_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="slide" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/></Relationships>"#;
+    const SLIDE: &str = r#"<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:cSld><p:spTree><p:pic><p:nvPicPr><p:cNvPr id="2" name="start"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="3" name="before-middle"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before middle</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="4" name="middle"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="5" name="before-end"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before end</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="6" name="end"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic></p:spTree></p:cSld></p:sld>"#;
+    const SLIDE_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/></Relationships>"#;
+    zip_parts(&[
+        ("[Content_Types].xml", TYPES.as_bytes()),
+        ("_rels/.rels", ROOT.as_bytes()),
+        ("ppt/presentation.xml", PRESENTATION.as_bytes()),
+        ("ppt/_rels/presentation.xml.rels", PRESENTATION_RELS.as_bytes()),
+        ("ppt/slides/slide1.xml", SLIDE.as_bytes()),
+        ("ppt/slides/_rels/slide1.xml.rels", SLIDE_RELS.as_bytes()),
+        ("ppt/media/image.png", TEST_PNG),
+    ])
+}
+
+fn xlsx_with_two_picture_references() -> Vec<u8> {
+    const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/><Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/></Types>"#;
+    const ROOT: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="root" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#;
+    const WORKBOOK: &str = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="sheet"/></sheets></workbook>"#;
+    const WORKBOOK_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="sheet" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="styles" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#;
+    const STYLES: &str = r#"<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fonts count="1"><font/></fonts><fills count="1"><fill><patternFill patternType="none"/></fill></fills><borders count="1"><border/></borders><cellStyleXfs count="1"><xf/></cellStyleXfs><cellXfs count="1"><xf/></cellXfs></styleSheet>"#;
+    const SHEET: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><dimension ref="C4"/><sheetData/><drawing r:id="drawing"/></worksheet>"#;
+    const SHEET_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="drawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#;
+    const DRAWING: &str = r#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:oneCellAnchor><xdr:from><xdr:col>0</xdr:col><xdr:row>0</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="1" name="first"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="image"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor><xdr:oneCellAnchor><xdr:from><xdr:col>2</xdr:col><xdr:row>3</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="2" name="second"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="image"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor></xdr:wsDr>"#;
+    const DRAWING_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/></Relationships>"#;
+    zip_parts(&[
+        ("[Content_Types].xml", TYPES.as_bytes()),
+        ("_rels/.rels", ROOT.as_bytes()),
+        ("xl/workbook.xml", WORKBOOK.as_bytes()),
+        ("xl/_rels/workbook.xml.rels", WORKBOOK_RELS.as_bytes()),
+        ("xl/styles.xml", STYLES.as_bytes()),
+        ("xl/worksheets/sheet1.xml", SHEET.as_bytes()),
+        ("xl/worksheets/_rels/sheet1.xml.rels", SHEET_RELS.as_bytes()),
+        ("xl/drawings/drawing1.xml", DRAWING.as_bytes()),
+        ("xl/drawings/_rels/drawing1.xml.rels", DRAWING_RELS.as_bytes()),
+        ("xl/media/image.png", TEST_PNG),
+    ])
+}
+
+fn docx_with_png() -> Vec<u8> {
+    const PNG: &[u8] = &[
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+        0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x04, 0x00, 0x00, 0x00, 0xb5,
+        0x1c, 0x0c, 0x02, 0x00, 0x00, 0x00, 0x0b, 0x49, 0x44, 0x41, 0x54, 0x78, 0xda, 0x63, 0x64,
+        0xf8, 0x0f, 0x00, 0x01, 0x05, 0x01, 0x01, 0x27, 0x18, 0xe3, 0x66, 0x00, 0x00, 0x00, 0x00,
+        0x49, 0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ];
+    const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#;
+    const ROOT_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rDocument" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+    const DOCUMENT_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image.png"/></Relationships>"#;
+
+    let mut document = String::from(
+        r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><w:body>"#,
+    );
+    for paragraph in 0..256 {
+        use std::fmt::Write as _;
+        write!(document, "<w:p><w:r><w:t>normal volume paragraph {paragraph}</w:t></w:r></w:p>")
+            .unwrap();
+    }
+    document.push_str(
+        r#"<w:p><w:r><w:drawing><a:blip r:embed="rImage"/></w:drawing></w:r></w:p></w:body></w:document>"#,
+    );
+
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut zip = zip::ZipWriter::new(cursor);
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (name, bytes) in [
+        ("[Content_Types].xml", TYPES.as_bytes()),
+        ("_rels/.rels", ROOT_RELS.as_bytes()),
+        ("word/document.xml", document.as_bytes()),
+        ("word/_rels/document.xml.rels", DOCUMENT_RELS.as_bytes()),
+        ("word/media/image.png", PNG),
+    ] {
+        zip.start_file(name, options).unwrap();
+        zip.write_all(bytes).unwrap();
+    }
+    zip.finish().unwrap().into_inner()
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = pin!(future);
+    let waker = Waker::noop();
+    let mut context = Context::from_waker(waker);
+    loop {
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(output) => return output,
+            Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}

--- a/crates/api/src/embedded_visual_ocr_tests.rs
+++ b/crates/api/src/embedded_visual_ocr_tests.rs
@@ -56,29 +56,43 @@ impl OcrEngine for PdfGeometryOcr {
         request: OcrRequest<'a>,
         context: &'a ExecutionContext,
     ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
-        let ordinal = self.0.fetch_add(1, Ordering::SeqCst);
+        self.0.fetch_add(1, Ordering::SeqCst);
         let dimensions = normalized_png_dimensions(request.image);
         let digest = Sha256::digest(request.image).into();
-        let text = if ordinal == 0 { "native words" } else { "embedded second" };
         Box::pin(async move {
             context.checkpoint()?;
             let (width, height) = dimensions?;
+            let is_page_render = width > 10 && height > 10;
+            let regions = (!is_page_render)
+                .then(|| OcrRegion {
+                    text: "embedded second".into(),
+                    polygon: [
+                        (0.0, 0.0),
+                        (width as f32, 0.0),
+                        (width as f32, height as f32),
+                        (0.0, height as f32),
+                    ],
+                    confidence: 0.99,
+                })
+                .into_iter()
+                .collect();
+            let confidences = if is_page_render { Vec::new() } else { vec![0.99] };
             let identity = OcrInputIdentity::try_new(digest, width, height, 0);
             Ok(OcrRecognition::Bound(BoundOcrResult::try_new_for_input(
-                OcrResult {
-                    regions: vec![OcrRegion {
-                        text: text.into(),
-                        polygon: [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)],
-                        confidence: 0.99,
-                    }],
-                    provider: "test.api.pdf-geometry-ocr".into(),
-                },
-                vec![0.99],
-                vec![OcrEvidenceStep {
-                    stage: OcrEvidenceStage::Recognition,
-                    provider: "test.api.pdf-geometry-ocr".into(),
-                    model: Some("source-bound-test".into()),
-                }],
+                OcrResult { regions, provider: "test.api.pdf-geometry-ocr".into() },
+                confidences,
+                vec![
+                    OcrEvidenceStep {
+                        stage: OcrEvidenceStage::Detection,
+                        provider: "test.api.pdf-geometry-ocr".into(),
+                        model: Some("source-bound-detector".into()),
+                    },
+                    OcrEvidenceStep {
+                        stage: OcrEvidenceStage::Recognition,
+                        provider: "test.api.pdf-geometry-ocr".into(),
+                        model: Some("source-bound-recognizer".into()),
+                    },
+                ],
                 identity?,
             )?))
         })
@@ -283,6 +297,36 @@ fn dynamically_created_html_remote_image_is_not_fetched_or_ocr_guessed() {
 }
 
 #[test]
+fn dynamically_created_epub_external_and_traversal_images_never_enter_embedded_ocr() {
+    let ocr = Arc::new(SourceBoundOcr(AtomicUsize::new(0)));
+    let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+    let engine = default_engine_with_services(services).unwrap();
+
+    let mut request = ConversionRequest::new(InputRef::bytes(
+        epub_with_unsafe_image("https://example.invalid/secret.png", None),
+        Some("external-image.epub"),
+    ));
+    request.options.ocr.policy = OcrPolicy::Always;
+    let result = block_on(engine.convert(request)).unwrap();
+    assert!(result.markdown.contains("remote image"));
+    assert!(!result.markdown.contains("text from embedded picture"));
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 0, "external EPUB image must not reach OCR");
+    assert!(result.assets.iter().all(|asset| asset.bytes.is_empty()));
+
+    let mut request = ConversionRequest::new(InputRef::bytes(
+        epub_with_unsafe_image("../../../escape.png", Some("../../../escape.png")),
+        Some("traversal-image.epub"),
+    ));
+    request.options.ocr.policy = OcrPolicy::Always;
+    assert!(matches!(block_on(engine.convert(request)), Err(ConversionError::Malformed { .. })));
+    assert_eq!(
+        ocr.0.load(Ordering::SeqCst),
+        0,
+        "path-confined EPUB rejection must happen before embedded OCR"
+    );
+}
+
+#[test]
 #[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
 fn dynamically_created_pdf_merges_native_and_embedded_ocr_geometry_and_deduplicates() {
     assert!(std::env::var_os("PDFIUM_LIBRARY").is_some());
@@ -295,9 +339,11 @@ fn dynamically_created_pdf_merges_native_and_embedded_ocr_geometry_and_deduplica
     ));
     request.options.ocr.policy = OcrPolicy::Always;
     let result = block_on(engine.convert(request)).unwrap();
-    assert_eq!(ocr.0.load(Ordering::SeqCst), 2);
+    // One request is the PDF page OCR pass. The embedded stage makes one request
+    // for red and one for green; the second green drawing reuses that result.
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 3);
     assert_eq!(result.markdown.matches("native words").count(), 1);
-    assert_eq!(result.markdown.matches("embedded second").count(), 2);
+    assert_eq!(result.markdown.matches("embedded second").count(), 3);
     assert!(
         result.markdown.find("native words").unwrap()
             < result.markdown.find("embedded second").unwrap()
@@ -312,11 +358,10 @@ fn pdf_with_native_text_and_two_images() -> Vec<u8> {
     let objects = [
         b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
         b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
-        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /Font << /F1 5 0 R >> /XObject << /Im1 6 0 R /Im2 7 0 R /Im3 8 0 R >> >> /Contents 4 0 R >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /Font << /F1 5 0 R >> /XObject << /Im1 6 0 R /Im2 7 0 R /Im3 7 0 R >> >> /Contents 4 0 R >>".to_vec(),
         content,
         b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec(),
         pdf_stream("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[255, 0, 0]),
-        pdf_stream("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[0, 255, 0]),
         pdf_stream("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[0, 255, 0]),
     ];
     assemble_pdf(&objects)
@@ -533,6 +578,27 @@ fn epub_with_png() -> Vec<u8> {
         ("EPUB/nav.xhtml", NAV.as_bytes()),
         ("EPUB/chapter.xhtml", CHAPTER.as_bytes()),
         ("EPUB/image.png", TEST_PNG),
+    ])
+}
+
+fn epub_with_unsafe_image(source: &str, manifest_image: Option<&str>) -> Vec<u8> {
+    const CONTAINER: &str = r#"<?xml version="1.0"?><container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0"><rootfiles><rootfile full-path="EPUB/package.opf" media-type="application/oebps-package+xml"/></rootfiles></container>"#;
+    const NAV: &str = r#"<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"><head><title>Contents</title></head><body><nav epub:type="toc"><ol><li><a href="chapter.xhtml">Chapter</a></li></ol></nav></body></html>"#;
+    let image_item = manifest_image.map_or_else(String::new, |href| {
+        format!(r#"<item id="image" href="{href}" media-type="image/png"/>"#)
+    });
+    let package = format!(
+        r#"<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="book"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier id="book">urn:test:unsafe-embedded-ocr</dc:identifier><dc:title>Unsafe Embedded OCR</dc:title><dc:language>en</dc:language><meta property="dcterms:modified">2026-08-17T00:00:00Z</meta></metadata><manifest><item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/>{image_item}</manifest><spine><itemref idref="chapter"/></spine></package>"#
+    );
+    let chapter = format!(
+        r#"<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"><head><title>Chapter</title></head><body><p>safe text</p><img src="{source}" alt="remote image"/></body></html>"#
+    );
+    zip_owned(vec![
+        ("mimetype".into(), b"application/epub+zip".to_vec()),
+        ("META-INF/container.xml".into(), CONTAINER.as_bytes().to_vec()),
+        ("EPUB/package.opf".into(), package.into_bytes()),
+        ("EPUB/nav.xhtml".into(), NAV.as_bytes().to_vec()),
+        ("EPUB/chapter.xhtml".into(), chapter.into_bytes()),
     ])
 }
 

--- a/crates/api/src/embedded_visual_ocr_tests.rs
+++ b/crates/api/src/embedded_visual_ocr_tests.rs
@@ -17,6 +17,87 @@ const TEST_PNG: &[u8] = &[
 
 struct SourceBoundOcr(AtomicUsize);
 
+struct PdfGeometryOcr(AtomicUsize);
+
+impl OcrEngine for PdfGeometryOcr {
+    fn id(&self) -> &'static str {
+        "test.api.pdf-geometry-ocr"
+    }
+
+    fn recognize<'a>(
+        &'a self,
+        _: OcrRequest<'a>,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+        Box::pin(async { unreachable!("embedded visuals require bound OCR") })
+    }
+
+    fn planned_bound_output(
+        &self,
+        _: OcrRequest<'_>,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new(16 * 1024, 1, 128)
+    }
+
+    fn planned_normalized_png_output(
+        &self,
+        _: u32,
+        _: u32,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new(16 * 1024, 1, 128)
+    }
+
+    fn recognize_bound<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+        let ordinal = self.0.fetch_add(1, Ordering::SeqCst);
+        let dimensions = normalized_png_dimensions(request.image);
+        let digest = Sha256::digest(request.image).into();
+        let text = if ordinal == 0 { "native words" } else { "embedded second" };
+        Box::pin(async move {
+            context.checkpoint()?;
+            let (width, height) = dimensions?;
+            let identity = OcrInputIdentity::try_new(digest, width, height, 0);
+            Ok(OcrRecognition::Bound(BoundOcrResult::try_new_for_input(
+                OcrResult {
+                    regions: vec![OcrRegion {
+                        text: text.into(),
+                        polygon: [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)],
+                        confidence: 0.99,
+                    }],
+                    provider: "test.api.pdf-geometry-ocr".into(),
+                },
+                vec![0.99],
+                vec![OcrEvidenceStep {
+                    stage: OcrEvidenceStage::Recognition,
+                    provider: "test.api.pdf-geometry-ocr".into(),
+                    model: Some("source-bound-test".into()),
+                }],
+                identity?,
+            )?))
+        })
+    }
+}
+
+fn normalized_png_dimensions(bytes: &[u8]) -> Result<(u32, u32), ConversionError> {
+    if bytes.len() < 24 || &bytes[..8] != b"\x89PNG\r\n\x1a\n" {
+        return Err(ConversionError::Ocr {
+            provider: "test.api.pdf-geometry-ocr".into(),
+            detail: "test provider expected normalized PNG input".into(),
+        });
+    }
+    Ok((
+        u32::from_be_bytes(bytes[16..20].try_into().unwrap()),
+        u32::from_be_bytes(bytes[20..24].try_into().unwrap()),
+    ))
+}
+
 impl OcrEngine for SourceBoundOcr {
     fn id(&self) -> &'static str {
         "test.api.embedded-source-bound-ocr"
@@ -39,25 +120,41 @@ impl OcrEngine for SourceBoundOcr {
         OcrOutputPlan::try_new(16 * 1024, 1, 128)
     }
 
+    fn planned_normalized_png_output(
+        &self,
+        _: u32,
+        _: u32,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new(16 * 1024, 1, 128)
+    }
+
     fn recognize_bound<'a>(
         &'a self,
         request: OcrRequest<'a>,
         context: &'a ExecutionContext,
     ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
         self.0.fetch_add(1, Ordering::SeqCst);
+        let no_text = image::load_from_memory(request.image)
+            .is_ok_and(|image| image.to_rgba8().pixels().all(|pixel| pixel.0[..3] == [255, 0, 0]));
         let identity = OcrInputIdentity::try_new(Sha256::digest(request.image).into(), 1, 1, 0);
         Box::pin(async move {
             context.checkpoint()?;
             Ok(OcrRecognition::Bound(BoundOcrResult::try_new_for_input(
                 OcrResult {
-                    regions: vec![OcrRegion {
-                        text: "text from embedded picture".into(),
-                        polygon: [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)],
-                        confidence: 0.99,
-                    }],
+                    regions: if no_text {
+                        Vec::new()
+                    } else {
+                        vec![OcrRegion {
+                            text: "text from embedded picture".into(),
+                            polygon: [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)],
+                            confidence: 0.99,
+                        }]
+                    },
                     provider: "test.api.recognizer".into(),
                 },
-                vec![0.99],
+                if no_text { Vec::new() } else { vec![0.99] },
                 vec![
                     OcrEvidenceStep {
                         stage: OcrEvidenceStage::Detection,
@@ -90,7 +187,7 @@ fn dynamically_created_docx_obeys_embedded_visual_ocr_and_asset_modes() {
         request.options.ocr.policy = OcrPolicy::Always;
         request.options.output.asset_mode = mode;
         let result = block_on(engine.convert(request)).unwrap();
-        assert!(result.markdown.contains("text from embedded picture"));
+        assert_eq!(result.markdown.matches("text from embedded picture").count(), 3);
         match mode {
             AssetMode::Extract => {
                 assert!(result.markdown.contains("!["));
@@ -100,7 +197,7 @@ fn dynamically_created_docx_obeys_embedded_visual_ocr_and_asset_modes() {
             AssetMode::Omit => assert!(!result.markdown.contains("![")),
         }
     }
-    assert_eq!(ocr.0.load(Ordering::SeqCst), 3);
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 6);
 
     let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
     let engine = default_engine_with_services(services).unwrap();
@@ -109,7 +206,7 @@ fn dynamically_created_docx_obeys_embedded_visual_ocr_and_asset_modes() {
     request.options.output.asset_mode = AssetMode::Omit;
     let result = block_on(engine.convert(request)).unwrap();
     assert!(!result.markdown.contains("text from embedded picture"));
-    assert_eq!(ocr.0.load(Ordering::SeqCst), 3);
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 6);
 }
 
 #[test]
@@ -147,13 +244,18 @@ fn dynamically_created_rtf_and_notebook_images_use_embedded_ocr() {
     assert_dynamic_file_ocr(".epub", &epub_with_png());
 
     let nested_docx = docx_with_png();
-    assert_dynamic_file_ocr(".zip", &zip_parts(&[("nested/document.docx", &nested_docx)]));
+    assert_dynamic_file_ocr_references(
+        ".zip",
+        &zip_parts(&[("nested/document.docx", &nested_docx)]),
+        3,
+        2,
+    );
 }
 
 #[test]
 fn dynamically_created_pptx_and_xlsx_deduplicate_bytes_but_preserve_references() {
-    assert_dynamic_file_ocr_references(".pptx", &pptx_with_interleaved_picture_references(), 3);
-    assert_dynamic_file_ocr_references(".xlsx", &xlsx_with_two_picture_references(), 2);
+    assert_dynamic_file_ocr_references(".pptx", &pptx_with_interleaved_picture_references(), 3, 2);
+    assert_dynamic_file_ocr_references(".xlsx", &xlsx_with_two_picture_references(), 2, 2);
 }
 
 #[test]
@@ -180,11 +282,88 @@ fn dynamically_created_html_remote_image_is_not_fetched_or_ocr_guessed() {
     );
 }
 
-fn assert_dynamic_file_ocr(suffix: &str, bytes: &[u8]) {
-    assert_dynamic_file_ocr_references(suffix, bytes, 1);
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn dynamically_created_pdf_merges_native_and_embedded_ocr_geometry_and_deduplicates() {
+    assert!(std::env::var_os("PDFIUM_LIBRARY").is_some());
+    let ocr = Arc::new(PdfGeometryOcr(AtomicUsize::new(0)));
+    let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+    let engine = default_engine_with_services(services).unwrap();
+    let mut request = ConversionRequest::new(InputRef::bytes(
+        pdf_with_native_text_and_two_images(),
+        Some("dynamic-embedded.pdf"),
+    ));
+    request.options.ocr.policy = OcrPolicy::Always;
+    let result = block_on(engine.convert(request)).unwrap();
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 2);
+    assert_eq!(result.markdown.matches("native words").count(), 1);
+    assert_eq!(result.markdown.matches("embedded second").count(), 1);
+    assert!(
+        result.markdown.find("native words").unwrap()
+            < result.markdown.find("embedded second").unwrap()
+    );
 }
 
-fn assert_dynamic_file_ocr_references(suffix: &str, bytes: &[u8], references: usize) {
+fn pdf_with_native_text_and_two_images() -> Vec<u8> {
+    let content = pdf_stream(
+        "",
+        b"BT /F1 12 Tf 10 60 Td (native words) Tj ET\nq 20 0 0 12 10 55 cm /Im1 Do Q\nq 20 0 0 12 10 10 cm /Im2 Do Q\n",
+    );
+    let objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /Font << /F1 5 0 R >> /XObject << /Im1 6 0 R /Im2 7 0 R >> >> /Contents 4 0 R >>".to_vec(),
+        content,
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec(),
+        pdf_stream("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[255, 0, 0]),
+        pdf_stream("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[0, 255, 0]),
+    ];
+    assemble_pdf(&objects)
+}
+
+fn pdf_stream(dictionary: &str, bytes: &[u8]) -> Vec<u8> {
+    let mut object = format!("<< {dictionary} /Length {} >>\nstream\n", bytes.len()).into_bytes();
+    object.extend_from_slice(bytes);
+    object.extend_from_slice(b"\nendstream");
+    object
+}
+
+fn assemble_pdf(objects: &[Vec<u8>]) -> Vec<u8> {
+    let mut pdf = b"%PDF-1.4\n%\x80\x80\x80\x80\n".to_vec();
+    let mut offsets = Vec::new();
+    for (index, object) in objects.iter().enumerate() {
+        offsets.push(pdf.len());
+        pdf.extend_from_slice(format!("{} 0 obj\n", index + 1).as_bytes());
+        pdf.extend_from_slice(object);
+        pdf.extend_from_slice(b"\nendobj\n");
+    }
+    let xref = pdf.len();
+    pdf.extend_from_slice(
+        format!("xref\n0 {}\n0000000000 65535 f \n", objects.len() + 1).as_bytes(),
+    );
+    for offset in offsets {
+        pdf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
+    }
+    pdf.extend_from_slice(
+        format!(
+            "trailer\n<< /Size {} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n",
+            objects.len() + 1
+        )
+        .as_bytes(),
+    );
+    pdf
+}
+
+fn assert_dynamic_file_ocr(suffix: &str, bytes: &[u8]) {
+    assert_dynamic_file_ocr_references(suffix, bytes, 1, 1);
+}
+
+fn assert_dynamic_file_ocr_references(
+    suffix: &str,
+    bytes: &[u8],
+    references: usize,
+    recognized_assets: usize,
+) {
     let mut file = tempfile::Builder::new().suffix(suffix).tempfile().unwrap();
     file.write_all(bytes).unwrap();
     file.flush().unwrap();
@@ -201,7 +380,66 @@ fn assert_dynamic_file_ocr_references(suffix: &str, bytes: &[u8], references: us
         references,
         "{suffix}"
     );
-    assert_eq!(ocr.0.load(Ordering::SeqCst), 1, "{suffix}");
+    if suffix == ".pptx" {
+        let ocr_positions = result
+            .markdown
+            .match_indices("text from embedded picture")
+            .map(|(offset, _)| offset)
+            .collect::<Vec<_>>();
+        let middle = result.markdown.find("before middle").unwrap();
+        let end = result.markdown.find("before end").unwrap();
+        assert!(
+            ocr_positions[0] < middle
+                && middle < ocr_positions[1]
+                && ocr_positions[1] < end
+                && end < ocr_positions[2],
+            "PPTX OCR must retain start/middle/end text-image reading order"
+        );
+    }
+    assert_eq!(ocr.0.load(Ordering::SeqCst), recognized_assets, "{suffix}");
+    let mut ocr_nodes = Vec::new();
+    collect_ocr_nodes(&result.document.blocks, &mut ocr_nodes);
+    assert_eq!(ocr_nodes.len(), references, "{suffix}: OCR IR reference count");
+    for node in ocr_nodes {
+        assert_eq!(node.provenance.kind, ProvenanceKind::LocalOcr, "{suffix}");
+        assert_eq!(node.provenance.provider, "test.api.recognizer", "{suffix}");
+        assert!(node.provenance.confidence.is_some(), "{suffix}");
+        assert!(node.id.0.contains("::ocr::"), "{suffix}");
+        if suffix == ".pptx" {
+            assert_eq!(node.provenance.locator.slide, Some(1));
+            assert_eq!(node.provenance.locator.part.as_deref(), Some("ppt/slides/slide1.xml"));
+        } else if suffix == ".xlsx" {
+            assert_eq!(node.provenance.locator.sheet.as_deref(), Some("Start"));
+            assert_eq!(node.provenance.locator.part.as_deref(), Some("xl/drawings/drawing1.xml"));
+        }
+    }
+}
+
+fn collect_ocr_nodes<'a>(nodes: &'a [BlockNode], output: &mut Vec<&'a BlockNode>) {
+    for node in nodes {
+        if node.provenance.kind == ProvenanceKind::LocalOcr {
+            output.push(node);
+        }
+        match &node.block {
+            Block::List { items, .. } => {
+                for item in items {
+                    collect_ocr_nodes(&item.blocks, output);
+                }
+            }
+            Block::Table { rows, .. } => {
+                for row in rows {
+                    for cell in &row.cells {
+                        collect_ocr_nodes(&cell.blocks, output);
+                    }
+                }
+            }
+            Block::Footnote { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => collect_ocr_nodes(blocks, output),
+            _ => {}
+        }
+    }
 }
 
 fn zip_parts(parts: &[(&str, &[u8])]) -> Vec<u8> {
@@ -214,6 +452,25 @@ fn zip_parts(parts: &[(&str, &[u8])]) -> Vec<u8> {
         zip.write_all(bytes).unwrap();
     }
     zip.finish().unwrap().into_inner()
+}
+
+fn zip_owned(parts: Vec<(String, Vec<u8>)>) -> Vec<u8> {
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut zip = zip::ZipWriter::new(cursor);
+    let options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    for (name, bytes) in parts {
+        zip.start_file(name, options).unwrap();
+        zip.write_all(&bytes).unwrap();
+    }
+    zip.finish().unwrap().into_inner()
+}
+
+fn blank_png() -> Vec<u8> {
+    let pixels = image::RgbaImage::from_pixel(1, 1, image::Rgba([255, 0, 0, 255]));
+    let mut cursor = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgba8(pixels).write_to(&mut cursor, image::ImageFormat::Png).unwrap();
+    cursor.into_inner()
 }
 
 fn odf_with_png(family: &str) -> Vec<u8> {
@@ -262,33 +519,60 @@ fn epub_with_png() -> Vec<u8> {
 }
 
 fn pptx_with_interleaved_picture_references() -> Vec<u8> {
-    const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/><Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/></Types>"#;
     const ROOT: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="root" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/></Relationships>"#;
-    const PRESENTATION: &str = r#"<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst><p:sldId id="256" r:id="slide"/></p:sldIdLst></p:presentation>"#;
-    const PRESENTATION_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="slide" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/></Relationships>"#;
-    const SLIDE: &str = r#"<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:cSld><p:spTree><p:pic><p:nvPicPr><p:cNvPr id="2" name="start"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="3" name="before-middle"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before middle</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="4" name="middle"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="5" name="before-end"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before end</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="6" name="end"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic></p:spTree></p:cSld></p:sld>"#;
-    const SLIDE_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/></Relationships>"#;
-    zip_parts(&[
-        ("[Content_Types].xml", TYPES.as_bytes()),
-        ("_rels/.rels", ROOT.as_bytes()),
-        ("ppt/presentation.xml", PRESENTATION.as_bytes()),
-        ("ppt/_rels/presentation.xml.rels", PRESENTATION_RELS.as_bytes()),
-        ("ppt/slides/slide1.xml", SLIDE.as_bytes()),
-        ("ppt/slides/_rels/slide1.xml.rels", SLIDE_RELS.as_bytes()),
-        ("ppt/media/image.png", TEST_PNG),
-    ])
+    const SLIDE: &str = r#"<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:cSld><p:spTree><p:pic><p:nvPicPr><p:cNvPr id="2" name="start"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="3" name="before-middle"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before middle</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="4" name="middle"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:pic><p:nvPicPr><p:cNvPr id="7" name="blank-no-text"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="blank"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="5" name="before-end"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before end</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="6" name="end"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic></p:spTree></p:cSld></p:sld>"#;
+    const SLIDE_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/><Relationship Id="blank" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/blank.png"/></Relationships>"#;
+    let mut overrides = String::new();
+    let mut slide_ids = String::new();
+    let mut relationships = String::new();
+    let mut parts = vec![
+        ("_rels/.rels".into(), ROOT.as_bytes().to_vec()),
+        ("ppt/media/image.png".into(), TEST_PNG.to_vec()),
+        ("ppt/media/blank.png".into(), blank_png()),
+    ];
+    for slide in 1..=6 {
+        use std::fmt::Write as _;
+        write!(overrides, "<Override PartName=\"/ppt/slides/slide{slide}.xml\" ContentType=\"application/vnd.openxmlformats-officedocument.presentationml.slide+xml\"/>").unwrap();
+        write!(slide_ids, "<p:sldId id=\"{}\" r:id=\"slide{slide}\"/>", 255 + slide).unwrap();
+        write!(relationships, "<Relationship Id=\"slide{slide}\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide\" Target=\"slides/slide{slide}.xml\"/>").unwrap();
+        let body = if slide == 1 {
+            SLIDE.to_owned()
+        } else {
+            format!(
+                r#"<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><p:cSld><p:spTree><p:sp><p:nvSpPr><p:cNvPr id="2" name="normal-{slide}"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>normal volume slide {slide}</a:t></a:r></a:p></p:txBody></p:sp></p:spTree></p:cSld></p:sld>"#
+            )
+        };
+        parts.push((format!("ppt/slides/slide{slide}.xml"), body.into_bytes()));
+        if slide == 1 {
+            parts.push(("ppt/slides/_rels/slide1.xml.rels".into(), SLIDE_RELS.as_bytes().to_vec()));
+        }
+    }
+    let types = format!(
+        r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>{overrides}</Types>"#
+    );
+    let presentation = format!(
+        r#"<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst>{slide_ids}</p:sldIdLst></p:presentation>"#
+    );
+    let presentation_rels = format!(
+        r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">{relationships}</Relationships>"#
+    );
+    parts.push(("[Content_Types].xml".into(), types.into_bytes()));
+    parts.push(("ppt/presentation.xml".into(), presentation.into_bytes()));
+    parts.push(("ppt/_rels/presentation.xml.rels".into(), presentation_rels.into_bytes()));
+    zip_owned(parts)
 }
 
 fn xlsx_with_two_picture_references() -> Vec<u8> {
-    const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/><Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/></Types>"#;
+    const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/worksheets/sheet3.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/><Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/></Types>"#;
     const ROOT: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="root" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#;
-    const WORKBOOK: &str = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Sheet1" sheetId="1" r:id="sheet"/></sheets></workbook>"#;
-    const WORKBOOK_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="sheet" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="styles" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#;
+    const WORKBOOK: &str = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Start" sheetId="1" r:id="sheet1"/><sheet name="Middle" sheetId="2" r:id="sheet2"/><sheet name="End" sheetId="3" r:id="sheet3"/></sheets></workbook>"#;
+    const WORKBOOK_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="sheet1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="sheet2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/><Relationship Id="sheet3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet3.xml"/><Relationship Id="styles" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#;
     const STYLES: &str = r#"<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fonts count="1"><font/></fonts><fills count="1"><fill><patternFill patternType="none"/></fill></fills><borders count="1"><border/></borders><cellStyleXfs count="1"><xf/></cellStyleXfs><cellXfs count="1"><xf/></cellXfs></styleSheet>"#;
     const SHEET: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><dimension ref="C4"/><sheetData/><drawing r:id="drawing"/></worksheet>"#;
+    const VOLUME_SHEET: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><dimension ref="A1"/><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>normal volume sheet</t></is></c></row></sheetData></worksheet>"#;
     const SHEET_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="drawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#;
-    const DRAWING: &str = r#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:oneCellAnchor><xdr:from><xdr:col>0</xdr:col><xdr:row>0</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="1" name="first"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="image"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor><xdr:oneCellAnchor><xdr:from><xdr:col>2</xdr:col><xdr:row>3</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="2" name="second"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="image"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor></xdr:wsDr>"#;
-    const DRAWING_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/></Relationships>"#;
+    const DRAWING: &str = r#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:oneCellAnchor><xdr:from><xdr:col>0</xdr:col><xdr:row>0</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="1" name="first"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="image"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor><xdr:oneCellAnchor><xdr:from><xdr:col>1</xdr:col><xdr:row>2</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="3" name="blank-no-text"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="blank"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor><xdr:oneCellAnchor><xdr:from><xdr:col>2</xdr:col><xdr:row>3</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="2" name="second"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="image"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor></xdr:wsDr>"#;
+    const DRAWING_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/><Relationship Id="blank" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/blank.png"/></Relationships>"#;
     zip_parts(&[
         ("[Content_Types].xml", TYPES.as_bytes()),
         ("_rels/.rels", ROOT.as_bytes()),
@@ -296,10 +580,13 @@ fn xlsx_with_two_picture_references() -> Vec<u8> {
         ("xl/_rels/workbook.xml.rels", WORKBOOK_RELS.as_bytes()),
         ("xl/styles.xml", STYLES.as_bytes()),
         ("xl/worksheets/sheet1.xml", SHEET.as_bytes()),
+        ("xl/worksheets/sheet2.xml", VOLUME_SHEET.as_bytes()),
+        ("xl/worksheets/sheet3.xml", VOLUME_SHEET.as_bytes()),
         ("xl/worksheets/_rels/sheet1.xml.rels", SHEET_RELS.as_bytes()),
         ("xl/drawings/drawing1.xml", DRAWING.as_bytes()),
         ("xl/drawings/_rels/drawing1.xml.rels", DRAWING_RELS.as_bytes()),
         ("xl/media/image.png", TEST_PNG),
+        ("xl/media/blank.png", blank_png().as_slice()),
     ])
 }
 
@@ -313,19 +600,29 @@ fn docx_with_png() -> Vec<u8> {
     ];
     const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#;
     const ROOT_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rDocument" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
-    const DOCUMENT_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image.png"/></Relationships>"#;
+    const DOCUMENT_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rImage" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image.png"/><Relationship Id="rBlank" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/blank.png"/></Relationships>"#;
+    const IMAGE: &str =
+        r#"<w:p><w:r><w:drawing><a:blip r:embed="rImage"/></w:drawing></w:r></w:p>"#;
+    const BLANK: &str =
+        r#"<w:p><w:r><w:drawing><a:blip r:embed="rBlank"/></w:drawing></w:r></w:p>"#;
 
     let mut document = String::from(
         r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"><w:body>"#,
     );
+    document.push_str(IMAGE);
     for paragraph in 0..256 {
         use std::fmt::Write as _;
         write!(document, "<w:p><w:r><w:t>normal volume paragraph {paragraph}</w:t></w:r></w:p>")
             .unwrap();
+        if paragraph == 127 {
+            document.push_str(IMAGE);
+            document.push_str(BLANK);
+        }
     }
-    document.push_str(
-        r#"<w:p><w:r><w:drawing><a:blip r:embed="rImage"/></w:drawing></w:r></w:p></w:body></w:document>"#,
-    );
+    document.push_str(IMAGE);
+    document.push_str("</w:body></w:document>");
+
+    let blank = blank_png();
 
     let cursor = std::io::Cursor::new(Vec::new());
     let mut zip = zip::ZipWriter::new(cursor);
@@ -337,6 +634,7 @@ fn docx_with_png() -> Vec<u8> {
         ("word/document.xml", document.as_bytes()),
         ("word/_rels/document.xml.rels", DOCUMENT_RELS.as_bytes()),
         ("word/media/image.png", PNG),
+        ("word/media/blank.png", blank.as_slice()),
     ] {
         zip.start_file(name, options).unwrap();
         zip.write_all(bytes).unwrap();

--- a/crates/api/src/embedded_visual_ocr_tests.rs
+++ b/crates/api/src/embedded_visual_ocr_tests.rs
@@ -254,8 +254,8 @@ fn dynamically_created_rtf_and_notebook_images_use_embedded_ocr() {
 
 #[test]
 fn dynamically_created_pptx_and_xlsx_deduplicate_bytes_but_preserve_references() {
-    assert_dynamic_file_ocr_references(".pptx", &pptx_with_interleaved_picture_references(), 3, 2);
-    assert_dynamic_file_ocr_references(".xlsx", &xlsx_with_two_picture_references(), 2, 2);
+    assert_dynamic_file_ocr_references(".pptx", &pptx_with_interleaved_picture_references(), 4, 2);
+    assert_dynamic_file_ocr_references(".xlsx", &xlsx_with_two_picture_references(), 4, 2);
 }
 
 #[test]
@@ -297,7 +297,7 @@ fn dynamically_created_pdf_merges_native_and_embedded_ocr_geometry_and_deduplica
     let result = block_on(engine.convert(request)).unwrap();
     assert_eq!(ocr.0.load(Ordering::SeqCst), 2);
     assert_eq!(result.markdown.matches("native words").count(), 1);
-    assert_eq!(result.markdown.matches("embedded second").count(), 1);
+    assert_eq!(result.markdown.matches("embedded second").count(), 2);
     assert!(
         result.markdown.find("native words").unwrap()
             < result.markdown.find("embedded second").unwrap()
@@ -307,15 +307,16 @@ fn dynamically_created_pdf_merges_native_and_embedded_ocr_geometry_and_deduplica
 fn pdf_with_native_text_and_two_images() -> Vec<u8> {
     let content = pdf_stream(
         "",
-        b"BT /F1 12 Tf 10 60 Td (native words) Tj ET\nq 20 0 0 12 10 55 cm /Im1 Do Q\nq 20 0 0 12 10 10 cm /Im2 Do Q\n",
+        b"BT /F1 12 Tf 10 60 Td (native words) Tj ET\nq 20 0 0 12 10 55 cm /Im1 Do Q\nq 20 0 0 12 10 30 cm /Im2 Do Q\nq 20 0 0 12 10 10 cm /Im3 Do Q\n",
     );
     let objects = [
         b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
         b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_vec(),
-        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /Font << /F1 5 0 R >> /XObject << /Im1 6 0 R /Im2 7 0 R >> >> /Contents 4 0 R >>".to_vec(),
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 100 100] /Resources << /Font << /F1 5 0 R >> /XObject << /Im1 6 0 R /Im2 7 0 R /Im3 8 0 R >> >> /Contents 4 0 R >>".to_vec(),
         content,
         b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_vec(),
         pdf_stream("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[255, 0, 0]),
+        pdf_stream("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[0, 255, 0]),
         pdf_stream("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[0, 255, 0]),
     ];
     assemble_pdf(&objects)
@@ -381,6 +382,8 @@ fn assert_dynamic_file_ocr_references(
         "{suffix}"
     );
     if suffix == ".pptx" {
+        assert!(result.markdown.contains("table cell"), "PPTX table content must survive");
+        assert!(result.markdown.contains("chart series"), "PPTX chart cache must survive");
         let ocr_positions = result
             .markdown
             .match_indices("text from embedded picture")
@@ -400,6 +403,7 @@ fn assert_dynamic_file_ocr_references(
     let mut ocr_nodes = Vec::new();
     collect_ocr_nodes(&result.document.blocks, &mut ocr_nodes);
     assert_eq!(ocr_nodes.len(), references, "{suffix}: OCR IR reference count");
+    let mut xlsx_locators = Vec::new();
     for node in ocr_nodes {
         assert_eq!(node.provenance.kind, ProvenanceKind::LocalOcr, "{suffix}");
         assert_eq!(node.provenance.provider, "test.api.recognizer", "{suffix}");
@@ -409,9 +413,23 @@ fn assert_dynamic_file_ocr_references(
             assert_eq!(node.provenance.locator.slide, Some(1));
             assert_eq!(node.provenance.locator.part.as_deref(), Some("ppt/slides/slide1.xml"));
         } else if suffix == ".xlsx" {
-            assert_eq!(node.provenance.locator.sheet.as_deref(), Some("Start"));
-            assert_eq!(node.provenance.locator.part.as_deref(), Some("xl/drawings/drawing1.xml"));
+            xlsx_locators.push((
+                node.provenance.locator.sheet.as_deref().unwrap().to_owned(),
+                node.provenance.locator.part.as_deref().unwrap().to_owned(),
+            ));
         }
+    }
+    if suffix == ".xlsx" {
+        assert_eq!(
+            xlsx_locators,
+            [
+                ("Start".into(), "xl/drawings/drawing1.xml".into()),
+                ("Start".into(), "xl/drawings/drawing1.xml".into()),
+                ("Middle".into(), "xl/drawings/drawing2.xml".into()),
+                ("End".into(), "xl/drawings/drawing3.xml".into()),
+            ],
+            "XLSX OCR locators must retain workbook sheet order"
+        );
     }
 }
 
@@ -520,8 +538,9 @@ fn epub_with_png() -> Vec<u8> {
 
 fn pptx_with_interleaved_picture_references() -> Vec<u8> {
     const ROOT: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="root" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/></Relationships>"#;
-    const SLIDE: &str = r#"<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:cSld><p:spTree><p:pic><p:nvPicPr><p:cNvPr id="2" name="start"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="3" name="before-middle"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before middle</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="4" name="middle"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:pic><p:nvPicPr><p:cNvPr id="7" name="blank-no-text"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="blank"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="5" name="before-end"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before end</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="6" name="end"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic></p:spTree></p:cSld></p:sld>"#;
-    const SLIDE_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/><Relationship Id="blank" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/blank.png"/></Relationships>"#;
+    const SLIDE: &str = r#"<p:sld xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:cSld><p:spTree><p:pic><p:nvPicPr><p:cNvPr id="2" name="start"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="3" name="before-middle"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before middle</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="4" name="middle"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:pic><p:nvPicPr><p:cNvPr id="7" name="blank-no-text"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="blank"/></p:blipFill><p:spPr/></p:pic><p:sp><p:nvSpPr><p:cNvPr id="5" name="before-end"/><p:cNvSpPr/><p:nvPr/></p:nvSpPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>before end</a:t></a:r></a:p></p:txBody></p:sp><p:pic><p:nvPicPr><p:cNvPr id="6" name="end"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic><p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="8" name="Table"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr><a:graphic><a:graphicData><a:tbl><a:tr><a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:r><a:t>table cell</a:t></a:r></a:p></a:txBody></a:tc></a:tr></a:tbl></a:graphicData></a:graphic></p:graphicFrame><p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="9" name="Chart"/><p:cNvGraphicFramePr/><p:nvPr/></p:nvGraphicFramePr><a:graphic><a:graphicData><c:chart r:id="chart"/></a:graphicData></a:graphic></p:graphicFrame><p:grpSp><p:nvGrpSpPr><p:cNvPr id="10" name="Nested group"/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="914400" cy="914400"/><a:chOff x="0" y="0"/><a:chExt cx="914400" cy="914400"/></a:xfrm></p:grpSpPr><p:pic><p:nvPicPr><p:cNvPr id="11" name="nested image"/><p:cNvPicPr/><p:nvPr/></p:nvPicPr><p:blipFill><a:blip r:embed="image"/></p:blipFill><p:spPr/></p:pic></p:grpSp></p:spTree></p:cSld></p:sld>"#;
+    const SLIDE_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/><Relationship Id="blank" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/blank.png"/><Relationship Id="chart" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/chart" Target="../charts/chart1.xml"/></Relationships>"#;
+    const CHART: &str = r#"<c:chartSpace xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart"><c:chart><c:plotArea><c:barChart><c:ser><c:tx><c:strRef><c:strCache><c:pt idx="0"><c:v>chart series</c:v></c:pt></c:strCache></c:strRef></c:tx><c:val><c:numRef><c:numCache><c:pt idx="0"><c:v>42</c:v></c:pt></c:numCache></c:numRef></c:val></c:ser></c:barChart></c:plotArea></c:chart></c:chartSpace>"#;
     let mut overrides = String::new();
     let mut slide_ids = String::new();
     let mut relationships = String::new();
@@ -529,6 +548,7 @@ fn pptx_with_interleaved_picture_references() -> Vec<u8> {
         ("_rels/.rels".into(), ROOT.as_bytes().to_vec()),
         ("ppt/media/image.png".into(), TEST_PNG.to_vec()),
         ("ppt/media/blank.png".into(), blank_png()),
+        ("ppt/charts/chart1.xml".into(), CHART.as_bytes().to_vec()),
     ];
     for slide in 1..=6 {
         use std::fmt::Write as _;
@@ -548,7 +568,7 @@ fn pptx_with_interleaved_picture_references() -> Vec<u8> {
         }
     }
     let types = format!(
-        r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>{overrides}</Types>"#
+        r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/><Override PartName="/ppt/charts/chart1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawingml.chart+xml"/>{overrides}</Types>"#
     );
     let presentation = format!(
         r#"<p:presentation xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><p:sldIdLst>{slide_ids}</p:sldIdLst></p:presentation>"#
@@ -563,16 +583,17 @@ fn pptx_with_interleaved_picture_references() -> Vec<u8> {
 }
 
 fn xlsx_with_two_picture_references() -> Vec<u8> {
-    const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/worksheets/sheet3.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/><Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/></Types>"#;
+    const TYPES: &str = r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Default Extension="png" ContentType="image/png"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/worksheets/sheet3.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/><Override PartName="/xl/drawings/drawing1.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/><Override PartName="/xl/drawings/drawing2.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/><Override PartName="/xl/drawings/drawing3.xml" ContentType="application/vnd.openxmlformats-officedocument.drawing+xml"/></Types>"#;
     const ROOT: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="root" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#;
     const WORKBOOK: &str = r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Start" sheetId="1" r:id="sheet1"/><sheet name="Middle" sheetId="2" r:id="sheet2"/><sheet name="End" sheetId="3" r:id="sheet3"/></sheets></workbook>"#;
     const WORKBOOK_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="sheet1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="sheet2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/><Relationship Id="sheet3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet3.xml"/><Relationship Id="styles" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#;
     const STYLES: &str = r#"<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><fonts count="1"><font/></fonts><fills count="1"><fill><patternFill patternType="none"/></fill></fills><borders count="1"><border/></borders><cellStyleXfs count="1"><xf/></cellStyleXfs><cellXfs count="1"><xf/></cellXfs></styleSheet>"#;
     const SHEET: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><dimension ref="C4"/><sheetData/><drawing r:id="drawing"/></worksheet>"#;
-    const VOLUME_SHEET: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><dimension ref="A1"/><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>normal volume sheet</t></is></c></row></sheetData></worksheet>"#;
-    const SHEET_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="drawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#;
+    const VOLUME_SHEET: &str = r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><dimension ref="A1"/><sheetData><row r="1"><c r="A1" t="inlineStr"><is><t>normal volume sheet</t></is></c></row></sheetData><drawing r:id="drawing"/></worksheet>"#;
     const DRAWING: &str = r#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:oneCellAnchor><xdr:from><xdr:col>0</xdr:col><xdr:row>0</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="1" name="first"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="image"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor><xdr:oneCellAnchor><xdr:from><xdr:col>1</xdr:col><xdr:row>2</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="3" name="blank-no-text"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="blank"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor><xdr:oneCellAnchor><xdr:from><xdr:col>2</xdr:col><xdr:row>3</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="2" name="second"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="image"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor></xdr:wsDr>"#;
     const DRAWING_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/><Relationship Id="blank" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/blank.png"/></Relationships>"#;
+    const DRAWING_SINGLE: &str = r#"<xdr:wsDr xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><xdr:oneCellAnchor><xdr:from><xdr:col>0</xdr:col><xdr:row>0</xdr:row></xdr:from><xdr:pic><xdr:nvPicPr><xdr:cNvPr id="1" name="cross-sheet image"/></xdr:nvPicPr><xdr:blipFill><a:blip r:embed="image"/></xdr:blipFill></xdr:pic><xdr:clientData/></xdr:oneCellAnchor></xdr:wsDr>"#;
+    const DRAWING_SINGLE_RELS: &str = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="image" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image.png"/></Relationships>"#;
     zip_parts(&[
         ("[Content_Types].xml", TYPES.as_bytes()),
         ("_rels/.rels", ROOT.as_bytes()),
@@ -582,9 +603,15 @@ fn xlsx_with_two_picture_references() -> Vec<u8> {
         ("xl/worksheets/sheet1.xml", SHEET.as_bytes()),
         ("xl/worksheets/sheet2.xml", VOLUME_SHEET.as_bytes()),
         ("xl/worksheets/sheet3.xml", VOLUME_SHEET.as_bytes()),
-        ("xl/worksheets/_rels/sheet1.xml.rels", SHEET_RELS.as_bytes()),
+        ("xl/worksheets/_rels/sheet1.xml.rels", br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="drawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing1.xml"/></Relationships>"#),
+        ("xl/worksheets/_rels/sheet2.xml.rels", br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="drawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing2.xml"/></Relationships>"#),
+        ("xl/worksheets/_rels/sheet3.xml.rels", br#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="drawing" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/drawing" Target="../drawings/drawing3.xml"/></Relationships>"#),
         ("xl/drawings/drawing1.xml", DRAWING.as_bytes()),
         ("xl/drawings/_rels/drawing1.xml.rels", DRAWING_RELS.as_bytes()),
+        ("xl/drawings/drawing2.xml", DRAWING_SINGLE.as_bytes()),
+        ("xl/drawings/_rels/drawing2.xml.rels", DRAWING_SINGLE_RELS.as_bytes()),
+        ("xl/drawings/drawing3.xml", DRAWING_SINGLE.as_bytes()),
+        ("xl/drawings/_rels/drawing3.xml.rels", DRAWING_SINGLE_RELS.as_bytes()),
         ("xl/media/image.png", TEST_PNG),
         ("xl/media/blank.png", blank_png().as_slice()),
     ])

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -7,6 +7,9 @@ mod ocr_service;
 #[cfg(test)]
 mod image_ai_tests;
 
+#[cfg(test)]
+mod embedded_visual_ocr_tests;
+
 pub use into_markdown_ai::{
     AiProviderDescriptor, GenerationEndpoint, GenerationInput, GenerationRequest, GenerationResult,
     OpenAiCompatibleClient, OpenAiCompatibleConfig, OpenAiImageDescriptionProvider, ProviderConfig,
@@ -61,6 +64,7 @@ pub fn default_engine_builder() -> EngineBuilder {
 pub fn default_engine_builder_with_services(services: Services) -> EngineBuilder {
     let mut builder = EngineBuilder::new()
         .renderer(Arc::new(into_markdown_render_markdown::GfmRenderer))
+        .enricher(Arc::new(into_markdown_converters::EmbeddedVisualOcrEnricher))
         .services(services);
     if let Err(error) = into_markdown_converters::register_core_components(builder.registry_mut()) {
         builder.registry_mut().record_validation_error(error.to_string());

--- a/crates/api/tests/ppocrv6_image_quality.rs
+++ b/crates/api/tests/ppocrv6_image_quality.rs
@@ -73,9 +73,10 @@ mod quality {
             "1e13b22717b1edd89d4cde4fda272b6c17d5b505c97c2baea99da1a3a2d54b29"
         );
         let dictionary = fs::read(runfiles.join("_main/models/ppocrv6_tiny_dict.txt")).unwrap();
-        let model_root = tempfile::tempdir().unwrap();
+        let model_parent = tempfile::tempdir().unwrap();
+        let model_root = model_parent.path().join("models");
         let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
-        let manager = ModelManager::embedded(model_root.path().to_path_buf(), None).unwrap();
+        let manager = ModelManager::embedded(model_root.clone(), None).unwrap();
         let fetcher = QualityFetcher { detector, recognizer, dictionary };
         let status = manager.install("pp-ocrv6-tiny-zh-en", &fetcher, &context).unwrap();
         assert_eq!(status.state, "installed");
@@ -96,7 +97,7 @@ mod quality {
         options.ocr.policy = OcrPolicy::Always;
         options.ocr.minimum_confidence = 0.0;
         let service_config = InstalledOcrConfig {
-            writable_model_root: model_root.path().to_path_buf(),
+            writable_model_root: model_root,
             bundled_model_root: None,
             runtime_trusted_root: runtime_root,
             runtime_library,

--- a/crates/converters/src/docx.rs
+++ b/crates/converters/src/docx.rs
@@ -1312,6 +1312,17 @@ fn parse_word_part(
                         return Err(malformed(Some(part), "run is outside a paragraph"));
                     }
                     marks.clear();
+                } else if name == "docPr" {
+                    if let Some(p) = &mut paragraph {
+                        p.pending_alt = attr(&e, b"descr", part)?.or(attr(&e, b"title", part)?);
+                    }
+                } else if matches!(name.as_str(), "blip" | "imagedata") {
+                    if let Some(p) = &mut paragraph
+                        && let Some(id) =
+                            attr_local(&e, "embed", part)?.or(attr_local(&e, "id", part)?)
+                    {
+                        p.images.push((id, p.pending_alt.take()));
+                    }
                 } else if name == "vMerge" {
                     return Err(malformed(Some(part), "vertical table merges are unsupported"));
                 } else if matches!(
@@ -4243,6 +4254,28 @@ mod tests {
         let output = succeeds(high).unwrap();
         assert_eq!(output.assets.len(), 1);
         assert_eq!(output.assets[0].bytes.len(), image.len());
+    }
+
+    #[test]
+    fn producer_style_non_empty_blip_preserves_the_image_reference() {
+        let document = format!(
+            r#"<w:document xmlns:w="{WORD}" xmlns:r="{OFFICE_REL}" xmlns:a="{DRAWING}"><w:body><w:p><w:r><w:drawing><a:blip r:embed="rImage"><a:extLst><a:ext uri="{{producer-extension}}"/></a:extLst></a:blip></w:drawing></w:r></w:p></w:body></w:document>"#
+        );
+        let rels = format!(
+            r#"<Relationships xmlns="{PACKAGE_REL}"><Relationship Id="rImage" Type="{REL_TYPE_PREFIX}image" Target="media/producer.png"/></Relationships>"#
+        );
+        let image = valid_png(256);
+        let bytes = base(
+            document.as_bytes(),
+            &[
+                ("word/_rels/document.xml.rels", rels.as_bytes()),
+                ("word/media/producer.png", image.as_slice()),
+            ],
+        );
+
+        let output = convert_docx(&bytes, &ConversionOptions::default(), &context()).unwrap();
+        assert_eq!(output.assets.len(), 1);
+        assert_eq!(output.assets[0].bytes.as_slice(), image.as_slice());
     }
 
     #[test]

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -204,76 +204,91 @@ fn plan_enrichment(
     {
         return Ok(EnrichmentPlan::Skip);
     }
-    let mut raster_references = 0_u32;
+    // Inventory references once. Candidate envelope parsing and hashing below
+    // are then performed once per referenced AssetId, never once per node.
+    let mut reference_counts = BTreeMap::<AssetId, u64>::new();
     for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
-        let Some(asset) = find_asset(&output.assets, asset_id, context)? else {
+        if find_asset(&output.assets, asset_id, context)?.is_none() {
             return Err(ConversionError::Internal {
                 detail: format!("image node references missing asset {}", asset_id.0),
             });
-        };
-        if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
-            return Ok(());
         }
-        if auto_excluded_raster(asset, options, context)? {
-            return Ok(());
-        }
-        raster_references = raster_references.checked_add(1).ok_or_else(|| {
+        let count = reference_counts.entry(asset_id.clone()).or_default();
+        *count = count.checked_add(1).ok_or_else(|| {
             resource("max_archive_entries", "embedded visual reference count is not representable")
         })?;
-        if raster_references > options.limits.max_archive_entries {
+        Ok(())
+    })?;
+    if reference_counts.is_empty() {
+        return Ok(EnrichmentPlan::Skip);
+    }
+    if options.ocr.policy == OcrPolicy::Always {
+        let mut supported_references = 0_u64;
+        for asset in &output.assets {
+            if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
+                continue;
+            }
+            supported_references = supported_references
+                .checked_add(reference_counts.get(&asset.id).copied().unwrap_or(0))
+                .ok_or_else(|| {
+                    resource(
+                        "max_archive_entries",
+                        "embedded visual reference count is not representable",
+                    )
+                })?;
+        }
+        if supported_references > u64::from(options.limits.max_archive_entries) {
             return Err(resource(
                 "max_archive_entries",
                 "embedded visual references exceed the request limit",
             ));
         }
-        Ok(())
-    })?;
-    if raster_references == 0 {
-        return Ok(EnrichmentPlan::Skip);
     }
-    let mut references = 0_u32;
-    let mut total = 0_u64;
-    for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
-        let Some(asset) = find_asset(&output.assets, asset_id, context)? else {
-            return Err(ConversionError::Internal {
-                detail: format!("image node references missing asset {}", asset_id.0),
-            });
-        };
-        if asset.bytes.is_empty()
-            || asset.external_uri.is_some()
-            || !supported_raster(asset)
-            || candidate_dimensions_for_policy(asset, options, context)?.is_none()
-        {
-            return Ok(());
-        }
-        references = references.checked_add(1).ok_or_else(|| {
-            resource("max_archive_entries", "eligible visual reference count is not representable")
-        })?;
-        // Each eligible reference can clone OCR IR, evidence, and diagnostics,
-        // even when its source bytes share one provider request.
-        checked_add(&mut total, 128 * 1024, "embedded OCR reference plan overflow")?;
-        Ok(())
-    })?;
-    if references == 0 {
-        return Ok(EnrichmentPlan::Skip);
-    }
-    let mut candidates = 0_u32;
+
+    // (asset index, reference count, dimensions, exact-byte digest)
+    let mut candidates = Vec::<(usize, u64, (u32, u32), [u8; 32])>::new();
+    let mut references = 0_u64;
     let mut candidate_bytes = 0_u64;
-    let existing_nodes = count_document_nodes(&output.document.blocks, context)?;
-    let mut planned_added_nodes = 0_usize;
-    let mut provider_working_peak = 0_u64;
+    let mut total = 0_u64;
+    for asset in &output.assets {
+        context.checkpoint()?;
+        checked_add(
+            &mut total,
+            u64::try_from(asset.id.0.len())
+                .unwrap_or(u64::MAX)
+                .checked_add(128)
+                .ok_or_else(|| resource("max_memory_bytes", "asset index plan overflow"))?,
+            "asset index plan overflow",
+        )?;
+    }
     for (index, asset) in output.assets.iter().enumerate() {
         context.checkpoint()?;
-        if asset.bytes.is_empty()
-            || asset.external_uri.is_some()
-            || !supported_raster(asset)
-            || !has_visual_reference(&output.document.blocks, &asset.id, context)?
-        {
+        let Some(reference_count) = reference_counts.get(&asset.id).copied() else { continue };
+        if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
             continue;
         }
-        if candidate_dimensions_for_policy(asset, options, context)?.is_none() {
+        if auto_excluded_raster(asset, options, context)? {
             continue;
         }
+        references = references.checked_add(reference_count).ok_or_else(|| {
+            resource("max_archive_entries", "eligible visual reference count is not representable")
+        })?;
+        if references > u64::from(options.limits.max_archive_entries) {
+            return Err(resource(
+                "max_archive_entries",
+                "embedded visual references exceed the request limit",
+            ));
+        }
+        let Some(dimensions) = candidate_dimensions_for_policy(asset, options, context)? else {
+            continue;
+        };
+        checked_add(
+            &mut total,
+            reference_count.checked_mul(128 * 1024).ok_or_else(|| {
+                resource("max_memory_bytes", "embedded OCR reference plan overflow")
+            })?,
+            "embedded OCR reference plan overflow",
+        )?;
         candidate_bytes = candidate_bytes
             .checked_add(u64::try_from(asset.bytes.len()).map_err(|_| {
                 resource("max_total_asset_bytes", "embedded visual byte count is not representable")
@@ -285,84 +300,99 @@ fn plan_enrichment(
                 "embedded visual bytes exceed the request limit",
             ));
         }
-        if first_referenced_asset_with_bytes(output, index, context)? {
-            candidates = candidates
-                .checked_add(1)
-                .ok_or_else(|| resource("max_pages", "embedded OCR candidate count overflow"))?;
-            if candidates > options.limits.max_pages {
-                return Err(resource(
-                    "max_pages",
-                    "embedded OCR candidate requests exceed the request limit",
-                ));
-            }
-        }
-    }
-    if candidates == 0 {
-        return Ok(EnrichmentPlan::Skip);
-    }
-
-    // Only consult provider plans after every knowable input count and envelope
-    // bound has passed, so a provider cannot observe a request that preflight
-    // must reject.
-    // Account hash/map work once per eligible AssetId, but normalization and
-    // provider output once per unique byte identity.
-    for (index, asset) in output.assets.iter().enumerate() {
-        context.checkpoint()?;
-        if asset.bytes.is_empty()
-            || asset.external_uri.is_some()
-            || !supported_raster(asset)
-            || !has_visual_reference(&output.document.blocks, &asset.id, context)?
-        {
-            continue;
-        }
         checked_add(
             &mut total,
             u64::try_from(asset.bytes.len())
                 .map_err(|_| resource("max_memory_bytes", "hash/cache plan overflow"))?,
             "hash/cache plan overflow",
         )?;
-        if !first_referenced_asset_with_bytes(output, index, context)? {
+        candidates.push((
+            index,
+            reference_count,
+            dimensions,
+            checkpointed_sha256(&asset.bytes, context)?,
+        ));
+    }
+    if references == 0 {
+        return Ok(EnrichmentPlan::Skip);
+    }
+    let mut unique = Vec::<usize>::new();
+    for candidate_index in 0..candidates.len() {
+        context.checkpoint()?;
+        let candidate = &candidates[candidate_index];
+        if unique.iter().any(|prior_index| {
+            let prior = &candidates[*prior_index];
+            prior.3 == candidate.3
+                && output.assets[prior.0].bytes == output.assets[candidate.0].bytes
+        }) {
             continue;
         }
-        let dimensions = candidate_dimensions_for_policy(asset, options, context)?;
-        let normalized_peak = if let Some((width, height)) = dimensions {
-            u64::from(width)
-                .checked_mul(u64::from(height))
-                .and_then(|pixels| pixels.checked_mul(32))
-                .and_then(|bytes| bytes.checked_add(64 * 1024))
-                .ok_or_else(|| resource("max_memory_bytes", "normalization plan overflow"))?
-        } else {
-            64 * 1024
-        };
+        unique.push(candidate_index);
+    }
+    let unique_count = u32::try_from(unique.len())
+        .map_err(|_| resource("max_pages", "embedded OCR candidate count overflow"))?;
+    if unique_count > options.limits.max_pages {
+        return Err(resource(
+            "max_pages",
+            "embedded OCR candidate requests exceed the request limit",
+        ));
+    }
+
+    let existing_nodes = count_document_nodes(&output.document.blocks, context)?;
+    let mut planned_added_nodes = 0_usize;
+    let mut provider_working_peak = 0_u64;
+    // Only consult provider plans after every knowable input count and envelope
+    // bound has passed, so a provider cannot observe a request that preflight
+    // must reject.
+    // Account hash/map work once per eligible AssetId, but normalization and
+    // provider output once per unique byte identity.
+    for candidate_index in unique {
+        context.checkpoint()?;
+        let candidate = &candidates[candidate_index];
+        let asset = &output.assets[candidate.0];
+        let (width, height) = candidate.2;
+        let normalized_peak = u64::from(width)
+            .checked_mul(u64::from(height))
+            .and_then(|pixels| pixels.checked_mul(32))
+            .and_then(|bytes| bytes.checked_add(64 * 1024))
+            .ok_or_else(|| resource("max_memory_bytes", "normalization plan overflow"))?;
         checked_add(&mut total, normalized_peak, "normalization working-set plan overflow")?;
-        let (provider_bound, provider_working, provider_regions) =
-            match (services.ocr.as_deref(), dimensions) {
-                (_, None) => (0, 0, 0),
-                (Some(engine), Some((width, height))) => {
-                    match engine.planned_normalized_png_output(width, height, options, context) {
-                        Ok(plan) => (
-                            plan.max_retained_bytes(),
-                            plan.max_working_bytes(),
-                            plan.max_regions(),
-                        ),
-                        Err(ConversionError::ComponentUnavailable { .. })
-                            if options.ocr.policy == OcrPolicy::Auto =>
-                        {
-                            (0, 0, 0)
-                        }
-                        Err(error) => return Err(error),
+        let (provider_bound, provider_working, provider_regions) = match services.ocr.as_deref() {
+            Some(engine) => {
+                match engine.planned_normalized_png_output(width, height, options, context) {
+                    Ok(plan) => {
+                        (plan.max_retained_bytes(), plan.max_working_bytes(), plan.max_regions())
                     }
+                    Err(ConversionError::ComponentUnavailable { .. })
+                        if options.ocr.policy == OcrPolicy::Auto =>
+                    {
+                        (0, 0, 0)
+                    }
+                    Err(error) => return Err(error),
                 }
-                (None, Some(_)) if options.ocr.policy == OcrPolicy::Auto => (0, 0, 0),
-                (None, Some(_)) => {
-                    return Err(ConversionError::ComponentUnavailable {
-                        component: "ocr".into(),
-                        detail: "no OCR engine is configured".into(),
-                    });
-                }
-            };
+            }
+            None if options.ocr.policy == OcrPolicy::Auto => (0, 0, 0),
+            None => {
+                return Err(ConversionError::ComponentUnavailable {
+                    component: "ocr".into(),
+                    detail: "no OCR engine is configured".into(),
+                });
+            }
+        };
         provider_working_peak = provider_working_peak.max(provider_working);
-        let reference_copies = visual_reference_count_for_bytes(output, &asset.bytes, context)?;
+        let (reference_copies, asset_copies) = candidates
+            .iter()
+            .filter(|other| other.3 == candidate.3 && output.assets[other.0].bytes == asset.bytes)
+            .try_fold((0_u64, 0_u64), |values, other| {
+                Ok::<_, ConversionError>((
+                    values.0.checked_add(other.1).ok_or_else(|| {
+                        resource("max_memory_bytes", "OCR reference-copy count overflow")
+                    })?,
+                    values.1.checked_add(1).ok_or_else(|| {
+                        resource("max_memory_bytes", "OCR asset-copy count overflow")
+                    })?,
+                ))
+            })?;
         let added_nodes = usize::try_from(provider_regions)
             .unwrap_or(usize::MAX)
             .checked_mul(usize::try_from(reference_copies).unwrap_or(usize::MAX))
@@ -380,7 +410,6 @@ fn plan_enrichment(
                 "embedded OCR output can exceed the document node limit",
             ));
         }
-        let asset_copies = referenced_asset_count_for_bytes(output, &asset.bytes, context)?;
         let retained_copies = reference_copies
             .checked_add(asset_copies)
             .and_then(|value| value.checked_add(1))
@@ -433,6 +462,7 @@ fn auto_excluded_raster(
     // the request deliberately set those OCR-stage limits low.
     let mut classification_options = options.clone();
     classification_options.limits.max_archive_entries = u32::MAX;
+    classification_options.limits.max_pages = u32::MAX;
     Ok(candidate_dimensions_for_policy(asset, &classification_options, context)?.is_none())
 }
 
@@ -480,54 +510,6 @@ fn count_document_nodes(
             .ok_or_else(|| resource("documentNodes", "document node count overflow"))?;
     }
     Ok(total)
-}
-
-fn visual_reference_count_for_bytes(
-    output: &ConverterOutput,
-    bytes: &[u8],
-    context: &ExecutionContext,
-) -> Result<u64, ConversionError> {
-    let mut count = 0_u64;
-    for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
-        let Some(asset) = find_asset(&output.assets, asset_id, context)? else {
-            return Err(ConversionError::Internal {
-                detail: format!("image node references missing asset {}", asset_id.0),
-            });
-        };
-        if !asset.bytes.is_empty()
-            && asset.external_uri.is_none()
-            && supported_raster(asset)
-            && asset.bytes == bytes
-        {
-            count = count.checked_add(1).ok_or_else(|| {
-                resource("max_archive_entries", "embedded visual reference count overflow")
-            })?;
-        }
-        Ok(())
-    })?;
-    Ok(count)
-}
-
-fn referenced_asset_count_for_bytes(
-    output: &ConverterOutput,
-    bytes: &[u8],
-    context: &ExecutionContext,
-) -> Result<u64, ConversionError> {
-    let mut count = 0_u64;
-    for asset in &output.assets {
-        context.checkpoint()?;
-        if asset.bytes == bytes
-            && !asset.bytes.is_empty()
-            && asset.external_uri.is_none()
-            && supported_raster(asset)
-            && has_visual_reference(&output.document.blocks, &asset.id, context)?
-        {
-            count = count.checked_add(1).ok_or_else(|| {
-                resource("max_archive_entries", "embedded visual asset count overflow")
-            })?;
-        }
-    }
-    Ok(count)
 }
 
 fn planned_node_id_working_set(
@@ -603,44 +585,6 @@ fn planned_node_id_inventory(
         maximum = maximum.max(nested.1);
     }
     Ok((total, maximum))
-}
-
-fn has_visual_reference(
-    nodes: &[BlockNode],
-    asset_id: &AssetId,
-    context: &ExecutionContext,
-) -> Result<bool, ConversionError> {
-    let mut found = false;
-    for_each_visual_reference(nodes, context, &mut |candidate| {
-        if candidate == asset_id {
-            found = true;
-        }
-        Ok(())
-    })?;
-    Ok(found)
-}
-
-/// Returns true for the first referenced eligible `AssetId` carrying these exact
-/// bytes. Exact byte equality is the OCR input identity; no set allocation is
-/// needed before the engine reserves the enrichment plan.
-fn first_referenced_asset_with_bytes(
-    output: &ConverterOutput,
-    index: usize,
-    context: &ExecutionContext,
-) -> Result<bool, ConversionError> {
-    let asset = &output.assets[index];
-    for prior in &output.assets[..index] {
-        context.checkpoint()?;
-        if prior.bytes == asset.bytes
-            && !prior.bytes.is_empty()
-            && prior.external_uri.is_none()
-            && supported_raster(prior)
-            && has_visual_reference(&output.document.blocks, &prior.id, context)?
-        {
-            return Ok(false);
-        }
-    }
-    Ok(true)
 }
 
 fn validated_candidate_dimensions(
@@ -803,27 +747,46 @@ async fn enrich(
         return Ok(output);
     }
 
+    // Keep only stable indices here. Cloning `Asset` would duplicate every
+    // payload, including excluded and unreferenced assets outside the plan.
     let mut assets = BTreeMap::new();
     for (index, asset) in output.assets.iter().enumerate() {
         if index % 256 == 0 {
             context.checkpoint()?;
         }
-        assets.insert(asset.id.clone(), asset.clone());
+        assets.insert(asset.id.clone(), index);
+    }
+    let mut eligible_assets = BTreeSet::new();
+    let mut classified_assets = BTreeSet::new();
+    for reference in &references {
+        if !classified_assets.insert(reference.asset.clone()) {
+            continue;
+        }
+        let Some(asset_index) = assets.get(&reference.asset) else {
+            return Err(ConversionError::Internal {
+                detail: format!("image node references missing asset {}", reference.asset.0),
+            });
+        };
+        let asset = &output.assets[*asset_index];
+        if !asset.bytes.is_empty()
+            && asset.external_uri.is_none()
+            && supported_raster(asset)
+            && !auto_excluded_raster(asset, options, context)?
+        {
+            eligible_assets.insert(reference.asset.clone());
+        }
     }
     let mut eligible_reference_count = 0_u32;
     for (index, reference) in references.iter().enumerate() {
         if index % 256 == 0 {
             context.checkpoint()?;
         }
-        let Some(asset) = assets.get(&reference.asset) else {
+        if !assets.contains_key(&reference.asset) {
             return Err(ConversionError::Internal {
                 detail: format!("image node references missing asset {}", reference.asset.0),
             });
-        };
-        if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
-            continue;
         }
-        if auto_excluded_raster(asset, options, context)? {
+        if !eligible_assets.contains(&reference.asset) {
             continue;
         }
         eligible_reference_count = eligible_reference_count.checked_add(1).ok_or_else(|| {
@@ -844,15 +807,13 @@ async fn enrich(
         if index % 256 == 0 {
             context.checkpoint()?;
         }
-        let Some(asset) = assets.get(&reference.asset) else {
+        let Some(asset_index) = assets.get(&reference.asset) else {
             return Err(ConversionError::Internal {
                 detail: format!("image node references missing asset {}", reference.asset.0),
             });
         };
-        if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
-            continue;
-        }
-        if auto_excluded_raster(asset, options, context)? {
+        let asset = &output.assets[*asset_index];
+        if !eligible_assets.contains(&reference.asset) {
             continue;
         }
         if !referenced_assets.insert(reference.asset.clone()) {
@@ -883,9 +844,10 @@ async fn enrich(
     let mut cache = BTreeMap::<[u8; 32], CachedContribution>::new();
     for (ordinal, (digest, asset_id)) in unique.into_iter().enumerate() {
         context.checkpoint()?;
-        let asset = assets.get(&asset_id).ok_or_else(|| ConversionError::Internal {
+        let asset_index = assets.get(&asset_id).ok_or_else(|| ConversionError::Internal {
             detail: "embedded OCR asset inventory changed during enrichment".into(),
         })?;
+        let asset = &output.assets[*asset_index];
         let normalized = match normalize(asset, options, context) {
             Ok(value) => value,
             Err(error)
@@ -1007,6 +969,8 @@ fn auto_skippable_raster(error: &ConversionError) -> bool {
         ConversionError::Unsupported { detail }
             if detail == "animated or multi-page embedded raster is not eligible for OCR"
                 || detail == "animated embedded GIF is not eligible for OCR"
+                || detail == "fully transparent embedded raster is not eligible for OCR"
+                || detail == "fully transparent embedded GIF is not eligible for OCR"
     )
 }
 
@@ -1137,21 +1101,22 @@ fn normalize_gif(
         context,
     )?;
     let memory = context.reserve_memory(working)?;
-    let decoder = image::codecs::gif::GifDecoder::new(Cursor::new(bytes)).map_err(|error| {
+    let gif_reader = image::codecs::gif::GifDecoder::new(Cursor::new(bytes)).map_err(|error| {
         ConversionError::Malformed { part: None, detail: format!("invalid embedded GIF: {error}") }
     })?;
-    if decoder.dimensions() != (width, height) {
+    if gif_reader.dimensions() != (width, height) {
         return Err(ConversionError::Malformed {
             part: None,
             detail: "GIF decoder dimensions disagree with the header".into(),
         });
     }
-    let frames = decoder.into_frames().take(2).collect::<Result<Vec<_>, _>>().map_err(|error| {
-        ConversionError::Malformed {
-            part: None,
-            detail: format!("invalid embedded GIF frames: {error}"),
-        }
-    })?;
+    let frames =
+        gif_reader.into_frames().take(2).collect::<Result<Vec<_>, _>>().map_err(|error| {
+            ConversionError::Malformed {
+                part: None,
+                detail: format!("invalid embedded GIF frames: {error}"),
+            }
+        })?;
     if frames.len() != 1 {
         return Err(ConversionError::Unsupported {
             detail: "animated embedded GIF is not eligible for OCR".into(),
@@ -1481,10 +1446,12 @@ mod tests {
         OcrResult, ProvenanceKind,
     };
     use std::future::Future;
+    use std::io::Cursor;
     use std::pin::pin;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::task::{Context, Poll, Waker};
+    use tiff::encoder::{TiffEncoder, colortype};
 
     struct SourceBoundOcr {
         calls: AtomicUsize,
@@ -1688,6 +1655,23 @@ mod tests {
         bytes
     }
 
+    fn transparent_png() -> Vec<u8> {
+        let pixels = RgbaImage::from_pixel(2, 2, Rgba([1, 2, 3, 0]));
+        let mut cursor = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(pixels).write_to(&mut cursor, ImageFormat::Png).unwrap();
+        cursor.into_inner()
+    }
+
+    fn multi_tiff() -> Vec<u8> {
+        let mut bytes = Cursor::new(Vec::new());
+        {
+            let mut encoder = TiffEncoder::new(&mut bytes).unwrap();
+            encoder.write_image::<colortype::Gray8>(1, 1, &[0]).unwrap();
+            encoder.write_image::<colortype::Gray8>(1, 1, &[255]).unwrap();
+        }
+        bytes.into_inner()
+    }
+
     #[test]
     fn big_tiff_dimensions_are_read_from_long8_ifd_entries() {
         let mut bytes = Vec::new();
@@ -1866,6 +1850,55 @@ mod tests {
             plan_enrichment(&source, InputFormat::Docx, &options, &services, &context),
             Err(ConversionError::Unsupported { .. })
         ));
+    }
+
+    #[test]
+    fn auto_policy_preserves_transparent_png_without_calling_provider() {
+        let ocr = source_bound_ocr(false);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut source = output();
+        let transparent = transparent_png();
+        for asset in &mut source.assets {
+            asset.bytes = transparent.clone();
+        }
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let expected_assets: Vec<_> =
+            source.assets.iter().map(|asset| asset.bytes.clone()).collect();
+
+        let enriched =
+            block_on(enrich(source, InputFormat::Docx, &options, &services, &context)).unwrap();
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(
+            enriched.assets.iter().map(|asset| asset.bytes.clone()).collect::<Vec<_>>(),
+            expected_assets
+        );
+        assert_eq!(enriched.diagnostics.len(), 2);
+    }
+
+    #[test]
+    fn auto_multipage_tiff_classification_ignores_ocr_page_limit() {
+        let ocr = source_bound_ocr(false);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut source = output();
+        let bytes = multi_tiff();
+        for asset in &mut source.assets {
+            asset.bytes = bytes.clone();
+            asset.filename = Some(format!("{}.tiff", asset.id.0));
+            asset.media_type = "image/tiff".into();
+        }
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        options.limits.max_pages = 1;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+
+        assert_eq!(
+            plan_enrichment(&source, InputFormat::Docx, &options, &services, &context).unwrap(),
+            EnrichmentPlan::Skip
+        );
+        assert_eq!(ocr.plans.load(Ordering::SeqCst), 0);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -4,9 +4,9 @@ use crate::image_converter::{decode, encode, envelope, format};
 use image::{AnimationDecoder, ImageDecoder};
 use into_markdown_core::{
     AssetId, Block, BlockNode, BoxFuture, ConversionError, ConversionOptions, ConverterOutput,
-    Diagnostic, DiagnosticSeverity, ExecutionContext, Inline, InputFormat, NodeId,
+    Diagnostic, DiagnosticSeverity, EnrichmentPlan, ExecutionContext, Inline, InputFormat, NodeId,
     OcrInputIdentity, OcrPolicy, OutputEnricher, Provenance, ResourceReservation, Services,
-    SourceLocator,
+    SourceLocator, estimate_validation_working_set,
 };
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -24,6 +24,18 @@ impl OutputEnricher for EmbeddedVisualOcrEnricher {
         PROVIDER
     }
 
+    fn planned_enrichment_bytes(
+        &self,
+        output: &ConverterOutput,
+        _converter_id: &str,
+        input_format: InputFormat,
+        options: &ConversionOptions,
+        services: &Services,
+        context: &ExecutionContext,
+    ) -> Result<EnrichmentPlan, ConversionError> {
+        plan_enrichment(output, input_format, options, services, context)
+    }
+
     fn enrich<'a>(
         &'a self,
         output: ConverterOutput,
@@ -35,6 +47,249 @@ impl OutputEnricher for EmbeddedVisualOcrEnricher {
     ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
         Box::pin(async move { enrich(output, format, options, services, context).await })
     }
+}
+
+fn checked_add(total: &mut u64, bytes: u64, detail: &'static str) -> Result<(), ConversionError> {
+    *total = total.checked_add(bytes).ok_or_else(|| resource("max_memory_bytes", detail))?;
+    Ok(())
+}
+
+fn image_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") && bytes.len() >= 24 {
+        return Some((
+            u32::from_be_bytes(bytes[16..20].try_into().ok()?),
+            u32::from_be_bytes(bytes[20..24].try_into().ok()?),
+        ));
+    }
+    if (bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a")) && bytes.len() >= 10 {
+        return Some((
+            u32::from(u16::from_le_bytes([bytes[6], bytes[7]])),
+            u32::from(u16::from_le_bytes([bytes[8], bytes[9]])),
+        ));
+    }
+    if bytes.starts_with(b"BM") && bytes.len() >= 26 {
+        let width = i32::from_le_bytes(bytes[18..22].try_into().ok()?).unsigned_abs();
+        let height = i32::from_le_bytes(bytes[22..26].try_into().ok()?).unsigned_abs();
+        return Some((width, height));
+    }
+    if bytes.starts_with(b"RIFF") && bytes.get(8..12) == Some(b"WEBP") {
+        match bytes.get(12..16)? {
+            b"VP8X" if bytes.len() >= 30 => {
+                let width = u32::from_le_bytes([bytes[24], bytes[25], bytes[26], 0]) + 1;
+                let height = u32::from_le_bytes([bytes[27], bytes[28], bytes[29], 0]) + 1;
+                return Some((width, height));
+            }
+            b"VP8L" if bytes.len() >= 25 && bytes[20] == 0x2f => {
+                let width = 1 + u32::from(bytes[21]) + (u32::from(bytes[22] & 0x3f) << 8);
+                let height = 1
+                    + u32::from(bytes[22] >> 6)
+                    + (u32::from(bytes[23]) << 2)
+                    + (u32::from(bytes[24] & 0x0f) << 10);
+                return Some((width, height));
+            }
+            b"VP8 " if bytes.len() >= 30 && bytes[23..26] == [0x9d, 0x01, 0x2a] => {
+                let width = u32::from(u16::from_le_bytes([bytes[26], bytes[27]]) & 0x3fff);
+                let height = u32::from(u16::from_le_bytes([bytes[28], bytes[29]]) & 0x3fff);
+                return Some((width, height));
+            }
+            _ => {}
+        }
+    }
+    if bytes.starts_with(&[0xff, 0xd8]) {
+        let mut offset = 2_usize;
+        while offset.checked_add(9)? <= bytes.len() {
+            if bytes[offset] != 0xff {
+                offset += 1;
+                continue;
+            }
+            let marker = bytes[offset + 1];
+            offset += 2;
+            if matches!(marker, 0xd8 | 0xd9 | 0x01) {
+                continue;
+            }
+            let length =
+                usize::from(u16::from_be_bytes(bytes.get(offset..offset + 2)?.try_into().ok()?));
+            if length < 2 || offset.checked_add(length)? > bytes.len() {
+                return None;
+            }
+            if matches!(marker, 0xc0..=0xc3 | 0xc5..=0xc7 | 0xc9..=0xcb | 0xcd..=0xcf) {
+                let height =
+                    u32::from(u16::from_be_bytes(bytes[offset + 3..offset + 5].try_into().ok()?));
+                let width =
+                    u32::from(u16::from_be_bytes(bytes[offset + 5..offset + 7].try_into().ok()?));
+                return Some((width, height));
+            }
+            offset += length;
+        }
+    }
+    tiff_dimensions(bytes)
+}
+
+fn tiff_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
+    let little = match bytes.get(..4)? {
+        b"II*\0" => true,
+        b"MM\0*" => false,
+        _ => return None,
+    };
+    let read_u16 = |slice: &[u8]| {
+        let value: [u8; 2] = slice.try_into().ok()?;
+        Some(if little { u16::from_le_bytes(value) } else { u16::from_be_bytes(value) })
+    };
+    let read_u32 = |slice: &[u8]| {
+        let value: [u8; 4] = slice.try_into().ok()?;
+        Some(if little { u32::from_le_bytes(value) } else { u32::from_be_bytes(value) })
+    };
+    let ifd = usize::try_from(read_u32(bytes.get(4..8)?)?).ok()?;
+    let entries = usize::from(read_u16(bytes.get(ifd..ifd.checked_add(2)?)?)?);
+    let mut width = None;
+    let mut height = None;
+    for index in 0..entries {
+        let start = ifd.checked_add(2)?.checked_add(index.checked_mul(12)?)?;
+        let entry = bytes.get(start..start.checked_add(12)?)?;
+        let tag = read_u16(&entry[..2])?;
+        if !matches!(tag, 256 | 257) {
+            continue;
+        }
+        let kind = read_u16(&entry[2..4])?;
+        let count = read_u32(&entry[4..8])?;
+        if count != 1 {
+            return None;
+        }
+        let value = match kind {
+            3 => u32::from(read_u16(&entry[8..10])?),
+            4 => read_u32(&entry[8..12])?,
+            _ => return None,
+        };
+        if tag == 256 {
+            width = Some(value);
+        } else {
+            height = Some(value);
+        }
+    }
+    Some((width?, height?))
+}
+
+/// Allocation-free with respect to image pixels: only envelope dimensions and
+/// provider-declared bounds are inspected before the engine reserves this peak.
+fn plan_enrichment(
+    output: &ConverterOutput,
+    input_format: InputFormat,
+    options: &ConversionOptions,
+    services: &Services,
+    context: &ExecutionContext,
+) -> Result<EnrichmentPlan, ConversionError> {
+    if options.ocr.policy == OcrPolicy::Off
+        || input_format == InputFormat::Image
+        || !eligible_container(input_format)
+    {
+        return Ok(EnrichmentPlan::Skip);
+    }
+    let mut total = 0_u64;
+    let mut candidates = 0_u32;
+    for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
+        let Some(asset) = output.assets.iter().find(|asset| asset.id == *asset_id) else {
+            return Err(ConversionError::Internal {
+                detail: format!("image node references missing asset {}", asset_id.0),
+            });
+        };
+        if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
+            return Ok(());
+        }
+        candidates = candidates.checked_add(1).ok_or_else(|| {
+            resource("max_archive_entries", "embedded OCR candidate count overflow")
+        })?;
+        // Treat every reference as unique. This is deliberately conservative:
+        // duplicate identities save inference work but still clone IR/evidence.
+        checked_add(&mut total, 128 * 1024, "embedded OCR reference plan overflow")?;
+        let dimensions = image_dimensions(&asset.bytes);
+        let normalized_peak = if let Some((width, height)) = dimensions {
+            u64::from(width)
+                .checked_mul(u64::from(height))
+                .and_then(|pixels| pixels.checked_mul(32))
+                .and_then(|bytes| bytes.checked_add(64 * 1024))
+                .ok_or_else(|| resource("max_memory_bytes", "normalization plan overflow"))?
+        } else {
+            64 * 1024
+        };
+        checked_add(&mut total, normalized_peak, "normalization working-set plan overflow")?;
+        checked_add(
+            &mut total,
+            u64::try_from(asset.bytes.len())
+                .map_err(|_| resource("max_memory_bytes", "hash/cache plan overflow"))?,
+            "hash/cache plan overflow",
+        )?;
+        let provider_bound = match (services.ocr.as_deref(), dimensions) {
+            (_, None) => 0,
+            (Some(engine), Some((width, height))) => {
+                match engine.planned_normalized_png_output(width, height, options, context) {
+                    Ok(plan) => plan.max_retained_bytes(),
+                    Err(ConversionError::ComponentUnavailable { .. })
+                        if options.ocr.policy == OcrPolicy::Auto =>
+                    {
+                        0
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            (None, Some(_)) if options.ocr.policy == OcrPolicy::Auto => 0,
+            (None, Some(_)) => {
+                return Err(ConversionError::ComponentUnavailable {
+                    component: "ocr".into(),
+                    detail: "no OCR engine is configured".into(),
+                });
+            }
+        };
+        checked_add(
+            &mut total,
+            provider_bound
+                .checked_mul(2)
+                .ok_or_else(|| resource("max_memory_bytes", "OCR output plan overflow"))?,
+            "OCR output plan overflow",
+        )?;
+        Ok(())
+    })?;
+    if candidates == 0 {
+        return Ok(EnrichmentPlan::Skip);
+    }
+    checked_add(
+        &mut total,
+        estimate_validation_working_set(&output.document, &output.assets, &output.diagnostics)?,
+        "embedded OCR validation plan overflow",
+    )?;
+    Ok(EnrichmentPlan::Reserve(total))
+}
+
+fn for_each_visual_reference(
+    nodes: &[BlockNode],
+    context: &ExecutionContext,
+    visit: &mut impl FnMut(&AssetId) -> Result<(), ConversionError>,
+) -> Result<(), ConversionError> {
+    for node in nodes {
+        context.checkpoint()?;
+        match &node.block {
+            Block::Image { asset, .. } => visit(asset)?,
+            Block::List { items, .. } => {
+                for item in items {
+                    for_each_visual_reference(&item.blocks, context, visit)?;
+                }
+            }
+            Block::Table { rows, .. } => {
+                for row in rows {
+                    for cell in &row.cells {
+                        for_each_visual_reference(&cell.blocks, context, visit)?;
+                    }
+                }
+            }
+            Block::Footnote { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => {
+                for_each_visual_reference(blocks, context, visit)?;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 #[derive(Clone)]
@@ -139,7 +394,10 @@ async fn enrich(
         })?;
         let normalized = match normalize(asset, options, context) {
             Ok(value) => value,
-            Err(error) if options.ocr.policy == OcrPolicy::Auto => {
+            Err(error)
+                if options.ocr.policy == OcrPolicy::Auto
+                    && auto_degradable_normalization(&error) =>
+            {
                 cache.insert(
                     digest,
                     CachedContribution {
@@ -157,6 +415,35 @@ async fn enrich(
             normalized.height,
             0,
         )?;
+        let normalized_plan = match services.ocr.as_deref() {
+            Some(engine) => engine.planned_normalized_png_output(
+                normalized.width,
+                normalized.height,
+                options,
+                context,
+            ),
+            None => Err(ConversionError::ComponentUnavailable {
+                component: "ocr".into(),
+                detail: "no OCR engine is configured".into(),
+            }),
+        };
+        match normalized_plan {
+            Ok(_) => {}
+            Err(error)
+                if options.ocr.policy == OcrPolicy::Auto
+                    && matches!(error, ConversionError::ComponentUnavailable { .. }) =>
+            {
+                cache.insert(
+                    digest,
+                    CachedContribution {
+                        nodes: Vec::new(),
+                        diagnostics: vec![visual_diagnostic(None, error.to_string())],
+                    },
+                );
+                continue;
+            }
+            Err(error) => return Err(error),
+        }
         let mut contribution = crate::image_converter::ocr::recognize_for_input(
             &normalized.bytes,
             u32::try_from(ordinal + 1)
@@ -184,9 +471,12 @@ async fn enrich(
             contributions_by_asset.insert(asset, contribution.clone());
         }
     }
+    let mut occupied_ids = BTreeSet::new();
+    collect_node_ids(&output.document.blocks, &mut occupied_ids);
     output.document.blocks = rebuild_nodes(
         std::mem::take(&mut output.document.blocks),
         &contributions_by_asset,
+        &mut occupied_ids,
         context,
     )?;
     for reference in &references {
@@ -202,6 +492,10 @@ async fn enrich(
         output = crate::pdf_ocr::reconstruct_enriched_pdf(output, context)?;
     }
     Ok(output)
+}
+
+fn auto_degradable_normalization(error: &ConversionError) -> bool {
+    matches!(error, ConversionError::ComponentUnavailable { .. })
 }
 
 fn eligible_container(format: InputFormat) -> bool {
@@ -227,17 +521,18 @@ fn eligible_container(format: InputFormat) -> bool {
 }
 
 fn supported_raster(asset: &into_markdown_core::Asset) -> bool {
-    matches!(
-        asset.media_type.to_ascii_lowercase().as_str(),
-        "image/png"
-            | "image/jpeg"
-            | "image/jpg"
-            | "image/gif"
-            | "image/webp"
-            | "image/bmp"
-            | "image/tiff"
-            | "image/x-tiff"
-    )
+    [
+        "image/png",
+        "image/jpeg",
+        "image/jpg",
+        "image/gif",
+        "image/webp",
+        "image/bmp",
+        "image/tiff",
+        "image/x-tiff",
+    ]
+    .iter()
+    .any(|candidate| asset.media_type.eq_ignore_ascii_case(candidate))
 }
 
 fn normalize(
@@ -409,6 +704,7 @@ fn collect_references(
 fn rebuild_nodes(
     nodes: Vec<BlockNode>,
     cache: &BTreeMap<AssetId, CachedContribution>,
+    occupied_ids: &mut BTreeSet<NodeId>,
     context: &ExecutionContext,
 ) -> Result<Vec<BlockNode>, ConversionError> {
     let mut rebuilt = Vec::new();
@@ -419,14 +715,23 @@ fn rebuild_nodes(
         match &mut node.block {
             Block::List { items, .. } => {
                 for item in items {
-                    item.blocks = rebuild_nodes(std::mem::take(&mut item.blocks), cache, context)?;
+                    item.blocks = rebuild_nodes(
+                        std::mem::take(&mut item.blocks),
+                        cache,
+                        occupied_ids,
+                        context,
+                    )?;
                 }
             }
             Block::Table { rows, .. } => {
                 for row in rows {
                     for cell in &mut row.cells {
-                        cell.blocks =
-                            rebuild_nodes(std::mem::take(&mut cell.blocks), cache, context)?;
+                        cell.blocks = rebuild_nodes(
+                            std::mem::take(&mut cell.blocks),
+                            cache,
+                            occupied_ids,
+                            context,
+                        )?;
                     }
                 }
             }
@@ -434,7 +739,7 @@ fn rebuild_nodes(
             | Block::Page { blocks, .. }
             | Block::Slide { blocks, .. }
             | Block::Sheet { blocks, .. } => {
-                *blocks = rebuild_nodes(std::mem::take(blocks), cache, context)?;
+                *blocks = rebuild_nodes(std::mem::take(blocks), cache, occupied_ids, context)?;
             }
             _ => {}
         }
@@ -447,20 +752,25 @@ fn rebuild_nodes(
         rebuilt.push(node);
         if let Some(contribution) = contribution {
             for (ocr_index, template) in contribution.nodes.into_iter().enumerate() {
-                rebuilt.push(remap_ocr_node(template, &source_id, &source_provenance, ocr_index));
+                let mut suffix = ocr_index + 1;
+                let fresh_id = loop {
+                    let candidate = NodeId(format!("{}::ocr::{suffix}", source_id.0));
+                    if occupied_ids.insert(candidate.clone()) {
+                        break candidate;
+                    }
+                    suffix = suffix.checked_add(1).ok_or_else(|| {
+                        resource("max_archive_entries", "OCR node ID suffix overflow")
+                    })?;
+                };
+                rebuilt.push(remap_ocr_node(template, fresh_id, &source_provenance));
             }
         }
     }
     Ok(rebuilt)
 }
 
-fn remap_ocr_node(
-    mut node: BlockNode,
-    source_id: &NodeId,
-    source: &Provenance,
-    index: usize,
-) -> BlockNode {
-    node.id = NodeId(format!("{}::ocr::{}", source_id.0, index + 1));
+fn remap_ocr_node(mut node: BlockNode, fresh_id: NodeId, source: &Provenance) -> BlockNode {
+    node.id = fresh_id;
     let ocr_locator = node.provenance.locator.clone();
     node.provenance.locator = remapped_ocr_locator(&source.locator, &ocr_locator);
     if let Block::Paragraph(inlines) = &mut node.block {
@@ -484,6 +794,31 @@ fn remap_ocr_node(
         }
     }
     node
+}
+
+fn collect_node_ids(nodes: &[BlockNode], output: &mut BTreeSet<NodeId>) {
+    for node in nodes {
+        output.insert(node.id.clone());
+        match &node.block {
+            Block::List { items, .. } => {
+                for item in items {
+                    collect_node_ids(&item.blocks, output);
+                }
+            }
+            Block::Table { rows, .. } => {
+                for row in rows {
+                    for cell in &row.cells {
+                        collect_node_ids(&cell.blocks, output);
+                    }
+                }
+            }
+            Block::Footnote { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => collect_node_ids(blocks, output),
+            _ => {}
+        }
+    }
 }
 
 fn coordinate_frame(
@@ -569,6 +904,44 @@ mod tests {
         corrupt_identity: bool,
     }
 
+    struct LegacyBoundOcr(AtomicUsize);
+
+    impl OcrEngine for LegacyBoundOcr {
+        fn id(&self) -> &'static str {
+            "test.ocr.legacy-bound"
+        }
+
+        fn recognize<'a>(
+            &'a self,
+            _: OcrRequest<'a>,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+            Box::pin(async {
+                unreachable!("provider without normalized preflight must be skipped")
+            })
+        }
+
+        fn planned_bound_output(
+            &self,
+            _: OcrRequest<'_>,
+            _: &ConversionOptions,
+            _: &ExecutionContext,
+        ) -> Result<OcrOutputPlan, ConversionError> {
+            OcrOutputPlan::try_new(1024 * 1024, 1, 128)
+        }
+
+        fn recognize_bound<'a>(
+            &'a self,
+            _: OcrRequest<'a>,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async {
+                unreachable!("provider without normalized preflight must be skipped")
+            })
+        }
+    }
+
     impl OcrEngine for SourceBoundOcr {
         fn id(&self) -> &'static str {
             "test.ocr.source-bound"
@@ -585,6 +958,16 @@ mod tests {
         fn planned_bound_output(
             &self,
             _: OcrRequest<'_>,
+            _: &ConversionOptions,
+            _: &ExecutionContext,
+        ) -> Result<OcrOutputPlan, ConversionError> {
+            OcrOutputPlan::try_new(16 * 1024, 1, 128)
+        }
+
+        fn planned_normalized_png_output(
+            &self,
+            _: u32,
+            _: u32,
             _: &ConversionOptions,
             _: &ExecutionContext,
         ) -> Result<OcrOutputPlan, ConversionError> {
@@ -782,6 +1165,62 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_references_increase_the_preflight_plan() {
+        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let services = Services { ocr: Some(ocr), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let duplicate = output();
+        let mut single = output();
+        let Block::Page { blocks, .. } = &mut single.document.blocks[0].block else {
+            panic!("page expected")
+        };
+        blocks.truncate(1);
+        let EnrichmentPlan::Reserve(single_plan) =
+            plan_enrichment(&single, InputFormat::Docx, &options, &services, &context).unwrap()
+        else {
+            panic!("active plan expected")
+        };
+        let EnrichmentPlan::Reserve(duplicate_plan) =
+            plan_enrichment(&duplicate, InputFormat::Docx, &options, &services, &context).unwrap()
+        else {
+            panic!("active plan expected")
+        };
+        assert!(duplicate_plan >= single_plan + 16 * 1024 + 4 * 1024);
+    }
+
+    #[test]
+    fn generated_ocr_ids_are_stable_and_never_collide() {
+        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let services = Services { ocr: Some(ocr), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        let mut source = output();
+        let Block::Page { blocks, .. } = &mut source.document.blocks[0].block else {
+            panic!("page expected")
+        };
+        blocks.insert(
+            0,
+            BlockNode {
+                id: NodeId("image-a::ocr::1".into()),
+                block: Block::Rule,
+                provenance: provenance("existing"),
+            },
+        );
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let enriched =
+            block_on(enrich(source, InputFormat::Docx, &options, &services, &context)).unwrap();
+        let Block::Page { blocks, .. } = &enriched.document.blocks[0].block else {
+            panic!("page expected")
+        };
+        let ids = blocks.iter().map(|node| node.id.0.as_str()).collect::<BTreeSet<_>>();
+        assert_eq!(ids.len(), blocks.len());
+        assert!(ids.contains("image-a::ocr::1"));
+        assert!(ids.contains("image-a::ocr::2"));
+    }
+
+    #[test]
     fn off_and_non_container_formats_are_exact_no_ops() {
         let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
         let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
@@ -874,12 +1313,17 @@ mod tests {
             block_on(enrich(remote, InputFormat::Html, &options, &services, &context)).unwrap();
         assert_eq!(after.document, expected);
 
-        let mut mismatched = output();
-        mismatched.assets[0].media_type = "image/jpeg".into();
-        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
-        let error = block_on(enrich(mismatched, InputFormat::Docx, &options, &services, &context))
-            .unwrap_err();
-        assert!(matches!(error, ConversionError::Malformed { .. }));
+        for policy in [OcrPolicy::Always, OcrPolicy::Auto] {
+            let mut mismatched = output();
+            mismatched.assets[0].media_type = "image/jpeg".into();
+            options.ocr.policy = policy;
+            let context =
+                ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+            let error =
+                block_on(enrich(mismatched, InputFormat::Docx, &options, &services, &context))
+                    .unwrap_err();
+            assert!(matches!(error, ConversionError::Malformed { .. }), "{policy:?}");
+        }
         assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
     }
 
@@ -923,6 +1367,81 @@ mod tests {
             .unwrap_err();
         assert_eq!(error.code(), into_markdown_core::ErrorCode::Cancelled);
         assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn auto_propagates_normalization_limits_cancellation_and_timeout() {
+        let services = Services::default();
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        options.limits.max_decompressed_bytes = 1;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let error = block_on(enrich(output(), InputFormat::Docx, &options, &services, &context))
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ConversionError::ResourceLimit { limit: "max_decompressed_bytes", .. }
+        ));
+
+        let bytes = png();
+        let asset = Asset {
+            id: AssetId("direct".into()),
+            filename: Some("direct.png".into()),
+            media_type: "image/png".into(),
+            bytes,
+            external_uri: None,
+        };
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let cancelled = ExecutionContext::new(
+            ExecutionOptions { cancellation, ..ExecutionOptions::default() },
+            ConversionOptions::default().limits,
+        );
+        assert!(matches!(
+            normalize(&asset, &ConversionOptions::default(), &cancelled),
+            Err(ConversionError::Cancelled)
+        ));
+
+        let timed_out = ExecutionContext::new(
+            ExecutionOptions {
+                timeout: Some(std::time::Duration::ZERO),
+                ..ExecutionOptions::default()
+            },
+            ConversionOptions::default().limits,
+        );
+        assert!(matches!(
+            normalize(&asset, &ConversionOptions::default(), &timed_out),
+            Err(ConversionError::Timeout)
+        ));
+    }
+
+    #[test]
+    fn auto_degrades_missing_normalized_provider_plan_but_always_fails() {
+        let ocr = Arc::new(LegacyBoundOcr(AtomicUsize::new(0)));
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        assert!(matches!(
+            plan_enrichment(&output(), InputFormat::Docx, &options, &services, &context).unwrap(),
+            EnrichmentPlan::Reserve(_)
+        ));
+        let enriched =
+            block_on(enrich(output(), InputFormat::Docx, &options, &services, &context)).unwrap();
+        assert_eq!(ocr.0.load(Ordering::SeqCst), 0);
+        assert!(
+            enriched
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("normalized-PNG output bound"))
+        );
+
+        options.ocr.policy = OcrPolicy::Always;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        assert!(matches!(
+            plan_enrichment(&output(), InputFormat::Docx, &options, &services, &context),
+            Err(ConversionError::ComponentUnavailable { .. })
+        ));
     }
 
     fn block_on<F: Future>(future: F) -> F::Output {

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -126,9 +126,11 @@ fn image_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
 }
 
 fn tiff_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
-    let little = match bytes.get(..4)? {
-        b"II*\0" => true,
-        b"MM\0*" => false,
+    let (little, big_tiff) = match bytes.get(..4)? {
+        b"II*\0" => (true, false),
+        b"MM\0*" => (false, false),
+        b"II+\0" => (true, true),
+        b"MM\0+" => (false, true),
         _ => return None,
     };
     let read_u16 = |slice: &[u8]| {
@@ -139,25 +141,42 @@ fn tiff_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
         let value: [u8; 4] = slice.try_into().ok()?;
         Some(if little { u32::from_le_bytes(value) } else { u32::from_be_bytes(value) })
     };
-    let ifd = usize::try_from(read_u32(bytes.get(4..8)?)?).ok()?;
-    let entries = usize::from(read_u16(bytes.get(ifd..ifd.checked_add(2)?)?)?);
+    let read_u64 = |slice: &[u8]| {
+        let value: [u8; 8] = slice.try_into().ok()?;
+        Some(if little { u64::from_le_bytes(value) } else { u64::from_be_bytes(value) })
+    };
+    let (ifd, entries, entries_start, entry_size) = if big_tiff {
+        if read_u16(bytes.get(4..6)?)? != 8 || read_u16(bytes.get(6..8)?)? != 0 {
+            return None;
+        }
+        let ifd = usize::try_from(read_u64(bytes.get(8..16)?)?).ok()?;
+        let entries = usize::try_from(read_u64(bytes.get(ifd..ifd.checked_add(8)?)?)?).ok()?;
+        (ifd, entries, 8_usize, 20_usize)
+    } else {
+        let ifd = usize::try_from(read_u32(bytes.get(4..8)?)?).ok()?;
+        let entries = usize::from(read_u16(bytes.get(ifd..ifd.checked_add(2)?)?)?);
+        (ifd, entries, 2_usize, 12_usize)
+    };
     let mut width = None;
     let mut height = None;
     for index in 0..entries {
-        let start = ifd.checked_add(2)?.checked_add(index.checked_mul(12)?)?;
-        let entry = bytes.get(start..start.checked_add(12)?)?;
+        let start = ifd.checked_add(entries_start)?.checked_add(index.checked_mul(entry_size)?)?;
+        let entry = bytes.get(start..start.checked_add(entry_size)?)?;
         let tag = read_u16(&entry[..2])?;
         if !matches!(tag, 256 | 257) {
             continue;
         }
         let kind = read_u16(&entry[2..4])?;
-        let count = read_u32(&entry[4..8])?;
+        let count =
+            if big_tiff { read_u64(&entry[4..12])? } else { u64::from(read_u32(&entry[4..8])?) };
         if count != 1 {
             return None;
         }
-        let value = match kind {
-            3 => u32::from(read_u16(&entry[8..10])?),
-            4 => read_u32(&entry[8..12])?,
+        let value_offset = if big_tiff { 12 } else { 8 };
+        let value = match (kind, big_tiff) {
+            (3, _) => u32::from(read_u16(&entry[value_offset..value_offset + 2])?),
+            (4, _) => read_u32(&entry[value_offset..value_offset + 4])?,
+            (16, true) => u32::try_from(read_u64(&entry[value_offset..value_offset + 8])?).ok()?,
             _ => return None,
         };
         if tag == 256 {
@@ -185,8 +204,7 @@ fn plan_enrichment(
     {
         return Ok(EnrichmentPlan::Skip);
     }
-    let mut references = 0_u32;
-    let mut total = 0_u64;
+    let mut raster_references = 0_u32;
     for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
         let Some(asset) = find_asset(&output.assets, asset_id, context)? else {
             return Err(ConversionError::Internal {
@@ -196,15 +214,41 @@ fn plan_enrichment(
         if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
             return Ok(());
         }
-        references = references.checked_add(1).ok_or_else(|| {
+        if auto_excluded_raster(asset, options, context)? {
+            return Ok(());
+        }
+        raster_references = raster_references.checked_add(1).ok_or_else(|| {
             resource("max_archive_entries", "embedded visual reference count is not representable")
         })?;
-        if references > options.limits.max_archive_entries {
+        if raster_references > options.limits.max_archive_entries {
             return Err(resource(
                 "max_archive_entries",
                 "embedded visual references exceed the request limit",
             ));
         }
+        Ok(())
+    })?;
+    if raster_references == 0 {
+        return Ok(EnrichmentPlan::Skip);
+    }
+    let mut references = 0_u32;
+    let mut total = 0_u64;
+    for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
+        let Some(asset) = find_asset(&output.assets, asset_id, context)? else {
+            return Err(ConversionError::Internal {
+                detail: format!("image node references missing asset {}", asset_id.0),
+            });
+        };
+        if asset.bytes.is_empty()
+            || asset.external_uri.is_some()
+            || !supported_raster(asset)
+            || candidate_dimensions_for_policy(asset, options, context)?.is_none()
+        {
+            return Ok(());
+        }
+        references = references.checked_add(1).ok_or_else(|| {
+            resource("max_archive_entries", "eligible visual reference count is not representable")
+        })?;
         // Each eligible reference can clone OCR IR, evidence, and diagnostics,
         // even when its source bytes share one provider request.
         checked_add(&mut total, 128 * 1024, "embedded OCR reference plan overflow")?;
@@ -213,9 +257,10 @@ fn plan_enrichment(
     if references == 0 {
         return Ok(EnrichmentPlan::Skip);
     }
-
     let mut candidates = 0_u32;
     let mut candidate_bytes = 0_u64;
+    let existing_nodes = count_document_nodes(&output.document.blocks, context)?;
+    let mut planned_added_nodes = 0_usize;
     for (index, asset) in output.assets.iter().enumerate() {
         context.checkpoint()?;
         if asset.bytes.is_empty()
@@ -223,6 +268,9 @@ fn plan_enrichment(
             || !supported_raster(asset)
             || !has_visual_reference(&output.document.blocks, &asset.id, context)?
         {
+            continue;
+        }
+        if candidate_dimensions_for_policy(asset, options, context)?.is_none() {
             continue;
         }
         candidate_bytes = candidate_bytes
@@ -236,7 +284,6 @@ fn plan_enrichment(
                 "embedded visual bytes exceed the request limit",
             ));
         }
-        validated_candidate_dimensions(asset, options, context)?;
         if first_referenced_asset_with_bytes(output, index, context)? {
             candidates = candidates
                 .checked_add(1)
@@ -248,6 +295,9 @@ fn plan_enrichment(
                 ));
             }
         }
+    }
+    if candidates == 0 {
+        return Ok(EnrichmentPlan::Skip);
     }
 
     // Only consult provider plans after every knowable input count and envelope
@@ -273,7 +323,7 @@ fn plan_enrichment(
         if !first_referenced_asset_with_bytes(output, index, context)? {
             continue;
         }
-        let dimensions = image_dimensions(&asset.bytes);
+        let dimensions = candidate_dimensions_for_policy(asset, options, context)?;
         let normalized_peak = if let Some((width, height)) = dimensions {
             u64::from(width)
                 .checked_mul(u64::from(height))
@@ -284,20 +334,20 @@ fn plan_enrichment(
             64 * 1024
         };
         checked_add(&mut total, normalized_peak, "normalization working-set plan overflow")?;
-        let provider_bound = match (services.ocr.as_deref(), dimensions) {
-            (_, None) => 0,
+        let (provider_bound, provider_regions) = match (services.ocr.as_deref(), dimensions) {
+            (_, None) => (0, 0),
             (Some(engine), Some((width, height))) => {
                 match engine.planned_normalized_png_output(width, height, options, context) {
-                    Ok(plan) => plan.max_retained_bytes(),
+                    Ok(plan) => (plan.max_retained_bytes(), plan.max_regions()),
                     Err(ConversionError::ComponentUnavailable { .. })
                         if options.ocr.policy == OcrPolicy::Auto =>
                     {
-                        0
+                        (0, 0)
                     }
                     Err(error) => return Err(error),
                 }
             }
-            (None, Some(_)) if options.ocr.policy == OcrPolicy::Auto => 0,
+            (None, Some(_)) if options.ocr.policy == OcrPolicy::Auto => (0, 0),
             (None, Some(_)) => {
                 return Err(ConversionError::ComponentUnavailable {
                     component: "ocr".into(),
@@ -306,6 +356,23 @@ fn plan_enrichment(
             }
         };
         let reference_copies = visual_reference_count_for_bytes(output, &asset.bytes, context)?;
+        let added_nodes = usize::try_from(provider_regions)
+            .unwrap_or(usize::MAX)
+            .checked_mul(usize::try_from(reference_copies).unwrap_or(usize::MAX))
+            .ok_or_else(|| resource("documentNodes", "embedded OCR node preflight overflow"))?;
+        planned_added_nodes = planned_added_nodes
+            .checked_add(added_nodes)
+            .ok_or_else(|| resource("documentNodes", "embedded OCR node preflight overflow"))?;
+        if existing_nodes
+            .checked_add(planned_added_nodes)
+            .ok_or_else(|| resource("documentNodes", "embedded OCR node preflight overflow"))?
+            > into_markdown_core::MAX_DOCUMENT_NODES
+        {
+            return Err(resource(
+                "documentNodes",
+                "embedded OCR output can exceed the document node limit",
+            ));
+        }
         let asset_copies = referenced_asset_count_for_bytes(output, &asset.bytes, context)?;
         let retained_copies = reference_copies
             .checked_add(asset_copies)
@@ -329,6 +396,82 @@ fn plan_enrichment(
         "embedded OCR validation plan overflow",
     )?;
     Ok(EnrichmentPlan::Reserve(total))
+}
+
+fn candidate_dimensions_for_policy(
+    asset: &into_markdown_core::Asset,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+) -> Result<Option<(u32, u32)>, ConversionError> {
+    match validated_candidate_dimensions(asset, options, context) {
+        Ok(dimensions) => Ok(Some(dimensions)),
+        Err(error) if options.ocr.policy == OcrPolicy::Auto && auto_skippable_raster(&error) => {
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn auto_excluded_raster(
+    asset: &into_markdown_core::Asset,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+) -> Result<bool, ConversionError> {
+    if options.ocr.policy != OcrPolicy::Auto {
+        return Ok(false);
+    }
+    // Classification must not consume OCR reference limits: otherwise an
+    // animated/multi-page raster that Auto excludes could fail merely because
+    // the request deliberately set those OCR-stage limits low.
+    let mut classification_options = options.clone();
+    classification_options.limits.max_archive_entries = u32::MAX;
+    Ok(candidate_dimensions_for_policy(asset, &classification_options, context)?.is_none())
+}
+
+fn count_document_nodes(
+    nodes: &[BlockNode],
+    context: &ExecutionContext,
+) -> Result<usize, ConversionError> {
+    let mut total = 0_usize;
+    for node in nodes {
+        context.checkpoint()?;
+        total = total
+            .checked_add(1)
+            .ok_or_else(|| resource("documentNodes", "document node count overflow"))?;
+        let nested = match &node.block {
+            Block::List { items, .. } => {
+                let mut count = 0_usize;
+                for item in items {
+                    count = count
+                        .checked_add(count_document_nodes(&item.blocks, context)?)
+                        .ok_or_else(|| resource("documentNodes", "document node count overflow"))?;
+                }
+                count
+            }
+            Block::Table { rows, .. } => {
+                let mut count = 0_usize;
+                for row in rows {
+                    for cell in &row.cells {
+                        count = count
+                            .checked_add(count_document_nodes(&cell.blocks, context)?)
+                            .ok_or_else(|| {
+                                resource("documentNodes", "document node count overflow")
+                            })?;
+                    }
+                }
+                count
+            }
+            Block::Footnote { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => count_document_nodes(blocks, context)?,
+            _ => 0,
+        };
+        total = total
+            .checked_add(nested)
+            .ok_or_else(|| resource("documentNodes", "document node count overflow"))?;
+    }
+    Ok(total)
 }
 
 fn visual_reference_count_for_bytes(
@@ -517,7 +660,7 @@ fn validated_candidate_dimensions(
         }
         let decoded_bytes = u64::from(width)
             .checked_mul(u64::from(height))
-            .and_then(|pixels| pixels.checked_mul(20))
+            .and_then(|pixels| pixels.checked_mul(4))
             .ok_or_else(|| resource("max_decompressed_bytes", "GIF pixel size overflow"))?;
         if width == 0 || height == 0 || decoded_bytes > options.limits.max_decompressed_bytes {
             return Err(resource("max_decompressed_bytes", "GIF dimensions exceed request limits"));
@@ -672,6 +815,9 @@ async fn enrich(
         if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
             continue;
         }
+        if auto_excluded_raster(asset, options, context)? {
+            continue;
+        }
         eligible_reference_count = eligible_reference_count.checked_add(1).ok_or_else(|| {
             resource("max_archive_entries", "embedded visual reference count is not representable")
         })?;
@@ -690,15 +836,18 @@ async fn enrich(
         if index % 256 == 0 {
             context.checkpoint()?;
         }
-        if !referenced_assets.insert(reference.asset.clone()) {
-            continue;
-        }
         let Some(asset) = assets.get(&reference.asset) else {
             return Err(ConversionError::Internal {
                 detail: format!("image node references missing asset {}", reference.asset.0),
             });
         };
         if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
+            continue;
+        }
+        if auto_excluded_raster(asset, options, context)? {
+            continue;
+        }
+        if !referenced_assets.insert(reference.asset.clone()) {
             continue;
         }
         compressed_bytes = compressed_bytes
@@ -835,13 +984,22 @@ async fn enrich(
         }
     }
     if input_format == InputFormat::Pdf && !contributions_by_asset.is_empty() {
-        output = crate::pdf_ocr::reconstruct_enriched_pdf(output, context)?;
+        output = crate::pdf_ocr::reconstruct_enriched_pdf(output, options, context)?;
     }
     Ok(output)
 }
 
 fn auto_degradable_normalization(error: &ConversionError) -> bool {
-    matches!(error, ConversionError::ComponentUnavailable { .. })
+    matches!(error, ConversionError::ComponentUnavailable { .. }) || auto_skippable_raster(error)
+}
+
+fn auto_skippable_raster(error: &ConversionError) -> bool {
+    matches!(
+        error,
+        ConversionError::Unsupported { detail }
+            if detail == "animated or multi-page embedded raster is not eligible for OCR"
+                || detail == "animated embedded GIF is not eligible for OCR"
+    )
 }
 
 fn eligible_container(format: InputFormat) -> bool {
@@ -953,12 +1111,15 @@ fn normalize_gif(
         .checked_mul(u64::from(height))
         .and_then(|pixels| pixels.checked_mul(20))
         .ok_or_else(|| resource("max_memory_bytes", "GIF working set overflow"))?;
-    if width == 0
-        || height == 0
-        || working > options.limits.max_decompressed_bytes
-        || working > options.limits.max_memory_bytes
-    {
+    let decoded = u64::from(width)
+        .checked_mul(u64::from(height))
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| resource("max_decompressed_bytes", "GIF decoded size overflow"))?;
+    if width == 0 || height == 0 || decoded > options.limits.max_decompressed_bytes {
         return Err(resource("max_decompressed_bytes", "GIF dimensions exceed request limits"));
+    }
+    if working > options.limits.max_memory_bytes {
+        return Err(resource("max_memory_bytes", "GIF working set exceeds request limits"));
     }
     crate::epub::image::validate(
         bytes,
@@ -1271,7 +1432,7 @@ fn resource(limit: &'static str, detail: impl Into<String>) -> ConversionError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+    use image::{DynamicImage, Frame, ImageFormat, Rgba, RgbaImage, codecs::gif::GifEncoder};
     use into_markdown_core::{
         Asset, BoundOcrResult, CancellationToken, Document, ExecutionOptions, OcrEngine,
         OcrEvidenceStage, OcrEvidenceStep, OcrOutputPlan, OcrRecognition, OcrRegion, OcrRequest,
@@ -1295,6 +1456,7 @@ mod tests {
     struct EntryGuardOcr {
         plans: AtomicUsize,
         calls: AtomicUsize,
+        regions: u32,
     }
 
     impl OcrEngine for EntryGuardOcr {
@@ -1328,7 +1490,7 @@ mod tests {
             _: &ExecutionContext,
         ) -> Result<OcrOutputPlan, ConversionError> {
             self.plans.fetch_add(1, Ordering::SeqCst);
-            OcrOutputPlan::try_new(16 * 1024, 1, 128)
+            OcrOutputPlan::try_new(u64::from(self.regions) * 256 + 128, self.regions, 128)
         }
 
         fn recognize_bound<'a>(
@@ -1462,6 +1624,65 @@ mod tests {
         cursor.into_inner()
     }
 
+    fn gif(frame_count: usize) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        let mut encoder = GifEncoder::new(&mut bytes);
+        for value in 0..frame_count {
+            encoder
+                .encode_frame(Frame::new(RgbaImage::from_pixel(
+                    1,
+                    1,
+                    Rgba([u8::try_from(value).unwrap(), 2, 3, 255]),
+                )))
+                .unwrap();
+        }
+        drop(encoder);
+        bytes
+    }
+
+    #[test]
+    fn big_tiff_dimensions_are_read_from_long8_ifd_entries() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"II+\0");
+        bytes.extend_from_slice(&8_u16.to_le_bytes());
+        bytes.extend_from_slice(&0_u16.to_le_bytes());
+        bytes.extend_from_slice(&16_u64.to_le_bytes());
+        bytes.extend_from_slice(&2_u64.to_le_bytes());
+        for (tag, value) in [(256_u16, 640_u64), (257_u16, 480_u64)] {
+            bytes.extend_from_slice(&tag.to_le_bytes());
+            bytes.extend_from_slice(&16_u16.to_le_bytes());
+            bytes.extend_from_slice(&1_u64.to_le_bytes());
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        assert_eq!(tiff_dimensions(&bytes), Some((640, 480)));
+    }
+
+    #[test]
+    fn gif_decoded_limit_uses_rgba_bytes_and_memory_uses_working_set() {
+        let bytes = gif(1);
+        let mut options = ConversionOptions::default();
+        options.limits.max_decompressed_bytes = 4;
+        options.limits.max_memory_bytes = 1024 * 1024;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let normalized = normalize_gif(&bytes, Some("one.gif"), &options, &context).unwrap();
+        assert_eq!((normalized.width, normalized.height), (1, 1));
+
+        options.limits.max_decompressed_bytes = 3;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        assert!(matches!(
+            normalize_gif(&bytes, Some("one.gif"), &options, &context),
+            Err(ConversionError::ResourceLimit { limit: "max_decompressed_bytes", .. })
+        ));
+
+        options.limits.max_decompressed_bytes = 4;
+        options.limits.max_memory_bytes = 19;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        assert!(matches!(
+            normalize_gif(&bytes, Some("one.gif"), &options, &context),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
+    }
+
     fn source_bound_ocr(corrupt_identity: bool) -> Arc<SourceBoundOcr> {
         source_bound_ocr_with_plan(corrupt_identity, 16 * 1024)
     }
@@ -1551,6 +1772,93 @@ mod tests {
             ],
             vec![],
         )
+    }
+
+    #[test]
+    fn auto_policy_skips_animated_gif_before_provider_planning() {
+        let ocr = Arc::new(EntryGuardOcr {
+            plans: AtomicUsize::new(0),
+            calls: AtomicUsize::new(0),
+            regions: 1,
+        });
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut source = output();
+        let animated = gif(2);
+        for asset in &mut source.assets {
+            asset.bytes = animated.clone();
+            asset.filename = Some(format!("{}.gif", asset.id.0));
+            asset.media_type = "image/gif".into();
+        }
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        options.limits.max_archive_entries = 0;
+        options.limits.max_total_asset_bytes = 0;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+
+        assert!(matches!(
+            plan_enrichment(&source, InputFormat::Docx, &options, &services, &context).unwrap(),
+            EnrichmentPlan::Skip
+        ));
+        assert_eq!(ocr.plans.load(Ordering::SeqCst), 0);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+
+        options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        assert!(matches!(
+            plan_enrichment(&source, InputFormat::Docx, &options, &services, &context),
+            Err(ConversionError::Unsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn auto_policy_excluded_raster_does_not_consume_enrichment_limits() {
+        let ocr = source_bound_ocr(false);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let eligible = png();
+        let excluded = gif(2);
+        let mut source = output();
+        let Block::Page { blocks, .. } = &mut source.document.blocks[0].block else {
+            panic!("page expected")
+        };
+        blocks.truncate(1);
+        for index in 0..16 {
+            blocks.push(image_node(
+                &format!("excluded-{index}"),
+                "asset-b",
+                "word/media/animated.gif",
+            ));
+        }
+        source.assets[0].bytes = eligible.clone();
+        source.assets[1].bytes = excluded;
+        source.assets[1].filename = Some("animated.gif".into());
+        source.assets[1].media_type = "image/gif".into();
+
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        options.limits.max_archive_entries = 8;
+        options.limits.max_total_asset_bytes = u64::try_from(eligible.len()).unwrap();
+        options.limits.max_pages = 1;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+
+        let enriched =
+            block_on(enrich(source, InputFormat::Docx, &options, &services, &context)).unwrap();
+        assert_eq!(ocr.plans.load(Ordering::SeqCst), 1);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 1);
+        assert!(enriched.diagnostics.is_empty());
+        let Block::Page { blocks, .. } = &enriched.document.blocks[0].block else {
+            panic!("page expected")
+        };
+        assert_eq!(blocks.len(), 18);
+        assert_eq!(
+            blocks
+                .iter()
+                .filter(
+                    |node| matches!(&node.block, Block::Image { asset, .. } if asset.0 == "asset-b")
+                )
+                .count(),
+            16
+        );
     }
 
     #[test]
@@ -1699,8 +2007,11 @@ mod tests {
 
     #[test]
     fn reference_limit_fails_during_preflight_without_provider_or_leases() {
-        let ocr =
-            Arc::new(EntryGuardOcr { plans: AtomicUsize::new(0), calls: AtomicUsize::new(0) });
+        let ocr = Arc::new(EntryGuardOcr {
+            plans: AtomicUsize::new(0),
+            calls: AtomicUsize::new(0),
+            regions: 1,
+        });
         let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
         let mut options = ConversionOptions::default();
         options.ocr.policy = OcrPolicy::Always;
@@ -1710,11 +2021,32 @@ mod tests {
         let error = plan_enrichment(&output(), InputFormat::Docx, &options, &services, &context)
             .unwrap_err();
 
-        assert!(matches!(
-            error,
-            ConversionError::ResourceLimit { limit: "max_archive_entries", .. }
-        ));
+        assert!(
+            matches!(&error, ConversionError::ResourceLimit { limit: "max_archive_entries", .. }),
+            "{error:?}"
+        );
         assert_eq!(ocr.plans.load(Ordering::SeqCst), 0);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn provider_region_bound_is_multiplied_by_eligible_references_before_recognition() {
+        let ocr = Arc::new(EntryGuardOcr {
+            plans: AtomicUsize::new(0),
+            calls: AtomicUsize::new(0),
+            regions: u32::try_from(into_markdown_core::MAX_DOCUMENT_NODES / 2).unwrap(),
+        });
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+
+        let error = plan_enrichment(&output(), InputFormat::Docx, &options, &services, &context)
+            .unwrap_err();
+
+        assert!(matches!(error, ConversionError::ResourceLimit { limit: "documentNodes", .. }));
+        assert_eq!(ocr.plans.load(Ordering::SeqCst), 1);
         assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
         assert_eq!(context.reserved_memory_bytes(), 0);
     }
@@ -1738,8 +2070,11 @@ mod tests {
                     as fn(&mut ConversionOptions),
             ),
         ] {
-            let ocr =
-                Arc::new(EntryGuardOcr { plans: AtomicUsize::new(0), calls: AtomicUsize::new(0) });
+            let ocr = Arc::new(EntryGuardOcr {
+                plans: AtomicUsize::new(0),
+                calls: AtomicUsize::new(0),
+                regions: 1,
+            });
             let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
             let mut options = ConversionOptions::default();
             options.ocr.policy = OcrPolicy::Always;

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -171,6 +171,7 @@ fn tiff_dimensions(bytes: &[u8]) -> Option<(u32, u32)> {
 
 /// Allocation-free with respect to image pixels: only envelope dimensions and
 /// provider-declared bounds are inspected before the engine reserves this peak.
+#[allow(clippy::too_many_lines)]
 fn plan_enrichment(
     output: &ConverterOutput,
     input_format: InputFormat,
@@ -184,10 +185,10 @@ fn plan_enrichment(
     {
         return Ok(EnrichmentPlan::Skip);
     }
+    let mut references = 0_u32;
     let mut total = 0_u64;
-    let mut candidates = 0_u32;
     for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
-        let Some(asset) = output.assets.iter().find(|asset| asset.id == *asset_id) else {
+        let Some(asset) = find_asset(&output.assets, asset_id, context)? else {
             return Err(ConversionError::Internal {
                 detail: format!("image node references missing asset {}", asset_id.0),
             });
@@ -195,12 +196,83 @@ fn plan_enrichment(
         if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
             return Ok(());
         }
-        candidates = candidates.checked_add(1).ok_or_else(|| {
-            resource("max_archive_entries", "embedded OCR candidate count overflow")
+        references = references.checked_add(1).ok_or_else(|| {
+            resource("max_archive_entries", "embedded visual reference count is not representable")
         })?;
-        // Treat every reference as unique. This is deliberately conservative:
-        // duplicate identities save inference work but still clone IR/evidence.
+        if references > options.limits.max_archive_entries {
+            return Err(resource(
+                "max_archive_entries",
+                "embedded visual references exceed the request limit",
+            ));
+        }
+        // Each eligible reference can clone OCR IR, evidence, and diagnostics,
+        // even when its source bytes share one provider request.
         checked_add(&mut total, 128 * 1024, "embedded OCR reference plan overflow")?;
+        Ok(())
+    })?;
+    if references == 0 {
+        return Ok(EnrichmentPlan::Skip);
+    }
+
+    let mut candidates = 0_u32;
+    let mut candidate_bytes = 0_u64;
+    for (index, asset) in output.assets.iter().enumerate() {
+        context.checkpoint()?;
+        if asset.bytes.is_empty()
+            || asset.external_uri.is_some()
+            || !supported_raster(asset)
+            || !has_visual_reference(&output.document.blocks, &asset.id, context)?
+        {
+            continue;
+        }
+        candidate_bytes = candidate_bytes
+            .checked_add(u64::try_from(asset.bytes.len()).map_err(|_| {
+                resource("max_total_asset_bytes", "embedded visual byte count is not representable")
+            })?)
+            .ok_or_else(|| resource("max_total_asset_bytes", "embedded visual bytes overflow"))?;
+        if candidate_bytes > options.limits.max_total_asset_bytes {
+            return Err(resource(
+                "max_total_asset_bytes",
+                "embedded visual bytes exceed the request limit",
+            ));
+        }
+        validated_candidate_dimensions(asset, options, context)?;
+        if first_referenced_asset_with_bytes(output, index, context)? {
+            candidates = candidates
+                .checked_add(1)
+                .ok_or_else(|| resource("max_pages", "embedded OCR candidate count overflow"))?;
+            if candidates > options.limits.max_pages {
+                return Err(resource(
+                    "max_pages",
+                    "embedded OCR candidate requests exceed the request limit",
+                ));
+            }
+        }
+    }
+
+    // Only consult provider plans after every knowable input count and envelope
+    // bound has passed, so a provider cannot observe a request that preflight
+    // must reject.
+    // Account hash/map work once per eligible AssetId, but normalization and
+    // provider output once per unique byte identity.
+    for (index, asset) in output.assets.iter().enumerate() {
+        context.checkpoint()?;
+        if asset.bytes.is_empty()
+            || asset.external_uri.is_some()
+            || !supported_raster(asset)
+            || !has_visual_reference(&output.document.blocks, &asset.id, context)?
+        {
+            continue;
+        }
+        checked_add(
+            &mut total,
+            u64::try_from(asset.bytes.len())
+                .map_err(|_| resource("max_memory_bytes", "hash/cache plan overflow"))?,
+            "hash/cache plan overflow",
+        )?;
+        if !first_referenced_asset_with_bytes(output, index, context)? {
+            continue;
+        }
         let dimensions = image_dimensions(&asset.bytes);
         let normalized_peak = if let Some((width, height)) = dimensions {
             u64::from(width)
@@ -212,12 +284,6 @@ fn plan_enrichment(
             64 * 1024
         };
         checked_add(&mut total, normalized_peak, "normalization working-set plan overflow")?;
-        checked_add(
-            &mut total,
-            u64::try_from(asset.bytes.len())
-                .map_err(|_| resource("max_memory_bytes", "hash/cache plan overflow"))?,
-            "hash/cache plan overflow",
-        )?;
         let provider_bound = match (services.ocr.as_deref(), dimensions) {
             (_, None) => 0,
             (Some(engine), Some((width, height))) => {
@@ -239,24 +305,279 @@ fn plan_enrichment(
                 });
             }
         };
+        let reference_copies = visual_reference_count_for_bytes(output, &asset.bytes, context)?;
+        let asset_copies = referenced_asset_count_for_bytes(output, &asset.bytes, context)?;
+        let retained_copies = reference_copies
+            .checked_add(asset_copies)
+            .and_then(|value| value.checked_add(1))
+            .ok_or_else(|| resource("max_memory_bytes", "OCR retained-copy count overflow"))?;
         checked_add(
             &mut total,
             provider_bound
-                .checked_mul(2)
+                .checked_mul(retained_copies)
                 .ok_or_else(|| resource("max_memory_bytes", "OCR output plan overflow"))?,
             "OCR output plan overflow",
         )?;
-        Ok(())
-    })?;
-    if candidates == 0 {
-        return Ok(EnrichmentPlan::Skip);
     }
+    let (occupied_id_bytes, collision_scratch) =
+        planned_node_id_working_set(&output.document.blocks, context)?;
+    checked_add(&mut total, occupied_id_bytes, "occupied OCR node ID plan overflow")?;
+    checked_add(&mut total, collision_scratch, "OCR node ID collision scratch overflow")?;
     checked_add(
         &mut total,
         estimate_validation_working_set(&output.document, &output.assets, &output.diagnostics)?,
         "embedded OCR validation plan overflow",
     )?;
     Ok(EnrichmentPlan::Reserve(total))
+}
+
+fn visual_reference_count_for_bytes(
+    output: &ConverterOutput,
+    bytes: &[u8],
+    context: &ExecutionContext,
+) -> Result<u64, ConversionError> {
+    let mut count = 0_u64;
+    for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
+        let Some(asset) = find_asset(&output.assets, asset_id, context)? else {
+            return Err(ConversionError::Internal {
+                detail: format!("image node references missing asset {}", asset_id.0),
+            });
+        };
+        if !asset.bytes.is_empty()
+            && asset.external_uri.is_none()
+            && supported_raster(asset)
+            && asset.bytes == bytes
+        {
+            count = count.checked_add(1).ok_or_else(|| {
+                resource("max_archive_entries", "embedded visual reference count overflow")
+            })?;
+        }
+        Ok(())
+    })?;
+    Ok(count)
+}
+
+fn referenced_asset_count_for_bytes(
+    output: &ConverterOutput,
+    bytes: &[u8],
+    context: &ExecutionContext,
+) -> Result<u64, ConversionError> {
+    let mut count = 0_u64;
+    for asset in &output.assets {
+        context.checkpoint()?;
+        if asset.bytes == bytes
+            && !asset.bytes.is_empty()
+            && asset.external_uri.is_none()
+            && supported_raster(asset)
+            && has_visual_reference(&output.document.blocks, &asset.id, context)?
+        {
+            count = count.checked_add(1).ok_or_else(|| {
+                resource("max_archive_entries", "embedded visual asset count overflow")
+            })?;
+        }
+    }
+    Ok(count)
+}
+
+fn planned_node_id_working_set(
+    nodes: &[BlockNode],
+    context: &ExecutionContext,
+) -> Result<(u64, u64), ConversionError> {
+    let (total, maximum) = planned_node_id_inventory(nodes, context)?;
+    Ok((
+        total,
+        maximum
+            .checked_add(64)
+            .ok_or_else(|| resource("max_memory_bytes", "OCR node ID scratch plan overflow"))?,
+    ))
+}
+
+fn planned_node_id_inventory(
+    nodes: &[BlockNode],
+    context: &ExecutionContext,
+) -> Result<(u64, u64), ConversionError> {
+    let mut total = 0_u64;
+    let mut maximum = 0_u64;
+    for node in nodes {
+        context.checkpoint()?;
+        let length = u64::try_from(node.id.0.len())
+            .map_err(|_| resource("max_memory_bytes", "node ID length is not representable"))?;
+        checked_add(
+            &mut total,
+            length.checked_add(128).ok_or_else(|| {
+                resource("max_memory_bytes", "occupied node ID entry plan overflow")
+            })?,
+            "occupied node ID set plan overflow",
+        )?;
+        maximum = maximum.max(length);
+        let nested = match &node.block {
+            Block::List { items, .. } => {
+                let mut nested_total = 0_u64;
+                let mut nested_max = 0_u64;
+                for item in items {
+                    let (item_total, item_max) = planned_node_id_inventory(&item.blocks, context)?;
+                    checked_add(
+                        &mut nested_total,
+                        item_total,
+                        "occupied node ID set plan overflow",
+                    )?;
+                    nested_max = nested_max.max(item_max);
+                }
+                (nested_total, nested_max)
+            }
+            Block::Table { rows, .. } => {
+                let mut nested_total = 0_u64;
+                let mut nested_max = 0_u64;
+                for row in rows {
+                    for cell in &row.cells {
+                        let (cell_total, cell_max) =
+                            planned_node_id_inventory(&cell.blocks, context)?;
+                        checked_add(
+                            &mut nested_total,
+                            cell_total,
+                            "occupied node ID set plan overflow",
+                        )?;
+                        nested_max = nested_max.max(cell_max);
+                    }
+                }
+                (nested_total, nested_max)
+            }
+            Block::Footnote { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => planned_node_id_inventory(blocks, context)?,
+            _ => (0, 0),
+        };
+        checked_add(&mut total, nested.0, "occupied node ID set plan overflow")?;
+        maximum = maximum.max(nested.1);
+    }
+    Ok((total, maximum))
+}
+
+fn has_visual_reference(
+    nodes: &[BlockNode],
+    asset_id: &AssetId,
+    context: &ExecutionContext,
+) -> Result<bool, ConversionError> {
+    let mut found = false;
+    for_each_visual_reference(nodes, context, &mut |candidate| {
+        if candidate == asset_id {
+            found = true;
+        }
+        Ok(())
+    })?;
+    Ok(found)
+}
+
+/// Returns true for the first referenced eligible `AssetId` carrying these exact
+/// bytes. Exact byte equality is the OCR input identity; no set allocation is
+/// needed before the engine reserves the enrichment plan.
+fn first_referenced_asset_with_bytes(
+    output: &ConverterOutput,
+    index: usize,
+    context: &ExecutionContext,
+) -> Result<bool, ConversionError> {
+    let asset = &output.assets[index];
+    for prior in &output.assets[..index] {
+        context.checkpoint()?;
+        if prior.bytes == asset.bytes
+            && !prior.bytes.is_empty()
+            && prior.external_uri.is_none()
+            && supported_raster(prior)
+            && has_visual_reference(&output.document.blocks, &prior.id, context)?
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+fn validated_candidate_dimensions(
+    asset: &into_markdown_core::Asset,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+) -> Result<(u32, u32), ConversionError> {
+    if asset.bytes.starts_with(b"GIF87a") || asset.bytes.starts_with(b"GIF89a") {
+        if !asset.media_type.eq_ignore_ascii_case("image/gif") {
+            return Err(ConversionError::Malformed {
+                part: asset.filename.clone(),
+                detail: "embedded raster media type disagrees with its GIF envelope".into(),
+            });
+        }
+        let ((width, height), frames) = crate::epub::image::preflight_info(
+            &asset.bytes,
+            "image/gif",
+            asset.filename.as_deref().unwrap_or("embedded GIF"),
+            context,
+        )?;
+        if frames != 1 {
+            return Err(ConversionError::Unsupported {
+                detail: "animated or multi-page embedded raster is not eligible for OCR".into(),
+            });
+        }
+        let decoded_bytes = u64::from(width)
+            .checked_mul(u64::from(height))
+            .and_then(|pixels| pixels.checked_mul(20))
+            .ok_or_else(|| resource("max_decompressed_bytes", "GIF pixel size overflow"))?;
+        if width == 0 || height == 0 || decoded_bytes > options.limits.max_decompressed_bytes {
+            return Err(resource("max_decompressed_bytes", "GIF dimensions exceed request limits"));
+        }
+        return Ok((width, height));
+    }
+    let raster =
+        format::detect(&asset.bytes, context)?.ok_or_else(|| ConversionError::Malformed {
+            part: asset.filename.clone(),
+            detail: "declared raster asset has an unrecognized envelope".into(),
+        })?;
+    let declared_matches = asset.media_type.eq_ignore_ascii_case(raster.media_type())
+        || raster == format::RasterFormat::Jpeg
+            && asset.media_type.eq_ignore_ascii_case("image/jpg")
+        || raster == format::RasterFormat::Tiff
+            && asset.media_type.eq_ignore_ascii_case("image/x-tiff");
+    if !declared_matches {
+        return Err(ConversionError::Malformed {
+            part: asset.filename.clone(),
+            detail: "embedded raster media type disagrees with its byte envelope".into(),
+        });
+    }
+    let summary = envelope::preflight_validate(raster, &asset.bytes, &options.limits, context)?;
+    if summary.frames != 1 || summary.animated {
+        return Err(ConversionError::Unsupported {
+            detail: "animated or multi-page embedded raster is not eligible for OCR".into(),
+        });
+    }
+    let (width, height) =
+        image_dimensions(&asset.bytes).ok_or_else(|| ConversionError::Malformed {
+            part: asset.filename.clone(),
+            detail: "embedded raster dimensions are unavailable".into(),
+        })?;
+    let decoded_bytes = u64::from(width)
+        .checked_mul(u64::from(height))
+        .and_then(|pixels| pixels.checked_mul(4))
+        .ok_or_else(|| resource("max_decompressed_bytes", "embedded visual pixel size overflow"))?;
+    if decoded_bytes > options.limits.max_decompressed_bytes {
+        return Err(resource(
+            "max_decompressed_bytes",
+            "embedded visual pixels exceed the request limit",
+        ));
+    }
+    Ok((width, height))
+}
+
+fn find_asset<'a>(
+    assets: &'a [into_markdown_core::Asset],
+    asset_id: &AssetId,
+    context: &ExecutionContext,
+) -> Result<Option<&'a into_markdown_core::Asset>, ConversionError> {
+    for (index, asset) in assets.iter().enumerate() {
+        if index % 256 == 0 {
+            context.checkpoint()?;
+        }
+        if asset.id == *asset_id {
+            return Ok(Some(asset));
+        }
+    }
+    Ok(None)
 }
 
 fn for_each_visual_reference(
@@ -330,21 +651,37 @@ async fn enrich(
     if references.is_empty() {
         return Ok(output);
     }
-    let reference_count = u32::try_from(references.len()).map_err(|_| {
-        resource("max_archive_entries", "embedded visual reference count is not representable")
-    })?;
-    if reference_count > options.limits.max_archive_entries {
-        return Err(resource(
-            "max_archive_entries",
-            "embedded visual references exceed the request limit",
-        ));
-    }
 
-    let assets = output
-        .assets
-        .iter()
-        .map(|asset| (asset.id.clone(), asset.clone()))
-        .collect::<BTreeMap<_, _>>();
+    let mut assets = BTreeMap::new();
+    for (index, asset) in output.assets.iter().enumerate() {
+        if index % 256 == 0 {
+            context.checkpoint()?;
+        }
+        assets.insert(asset.id.clone(), asset.clone());
+    }
+    let mut eligible_reference_count = 0_u32;
+    for (index, reference) in references.iter().enumerate() {
+        if index % 256 == 0 {
+            context.checkpoint()?;
+        }
+        let Some(asset) = assets.get(&reference.asset) else {
+            return Err(ConversionError::Internal {
+                detail: format!("image node references missing asset {}", reference.asset.0),
+            });
+        };
+        if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
+            continue;
+        }
+        eligible_reference_count = eligible_reference_count.checked_add(1).ok_or_else(|| {
+            resource("max_archive_entries", "embedded visual reference count is not representable")
+        })?;
+        if eligible_reference_count > options.limits.max_archive_entries {
+            return Err(resource(
+                "max_archive_entries",
+                "embedded visual references exceed the request limit",
+            ));
+        }
+    }
     let mut hashes_by_asset = BTreeMap::new();
     let mut unique = BTreeMap::<[u8; 32], AssetId>::new();
     let mut referenced_assets = BTreeSet::new();
@@ -466,22 +803,31 @@ async fn enrich(
     }
 
     let mut contributions_by_asset = BTreeMap::new();
-    for (asset, digest) in hashes_by_asset {
+    for (index, (asset, digest)) in hashes_by_asset.into_iter().enumerate() {
+        if index % 256 == 0 {
+            context.checkpoint()?;
+        }
         if let Some(contribution) = cache.get(&digest) {
             contributions_by_asset.insert(asset, contribution.clone());
         }
     }
     let mut occupied_ids = BTreeSet::new();
-    collect_node_ids(&output.document.blocks, &mut occupied_ids);
+    collect_node_ids(&output.document.blocks, &mut occupied_ids, context)?;
     output.document.blocks = rebuild_nodes(
         std::mem::take(&mut output.document.blocks),
         &contributions_by_asset,
         &mut occupied_ids,
         context,
     )?;
-    for reference in &references {
+    for (reference_index, reference) in references.iter().enumerate() {
+        if reference_index % 256 == 0 {
+            context.checkpoint()?;
+        }
         if let Some(contribution) = contributions_by_asset.get(&reference.asset) {
-            for diagnostic in &contribution.diagnostics {
+            for (diagnostic_index, diagnostic) in contribution.diagnostics.iter().enumerate() {
+                if diagnostic_index % 256 == 0 {
+                    context.checkpoint()?;
+                }
                 let mut diagnostic = diagnostic.clone();
                 diagnostic.locator = Some(remapped_locator(&reference.provenance.locator));
                 output.diagnostics.push(diagnostic);
@@ -752,29 +1098,55 @@ fn rebuild_nodes(
         rebuilt.push(node);
         if let Some(contribution) = contribution {
             for (ocr_index, template) in contribution.nodes.into_iter().enumerate() {
-                let mut suffix = ocr_index + 1;
-                let fresh_id = loop {
-                    let candidate = NodeId(format!("{}::ocr::{suffix}", source_id.0));
-                    if occupied_ids.insert(candidate.clone()) {
-                        break candidate;
-                    }
-                    suffix = suffix.checked_add(1).ok_or_else(|| {
-                        resource("max_archive_entries", "OCR node ID suffix overflow")
-                    })?;
-                };
-                rebuilt.push(remap_ocr_node(template, fresh_id, &source_provenance));
+                if ocr_index % 256 == 0 {
+                    context.checkpoint()?;
+                }
+                let fresh_id = fresh_ocr_node_id(&source_id, ocr_index + 1, occupied_ids, context)?;
+                rebuilt.push(remap_ocr_node(template, fresh_id, &source_provenance, context)?);
             }
         }
     }
     Ok(rebuilt)
 }
 
-fn remap_ocr_node(mut node: BlockNode, fresh_id: NodeId, source: &Provenance) -> BlockNode {
+fn fresh_ocr_node_id(
+    source_id: &NodeId,
+    mut suffix: usize,
+    occupied_ids: &mut BTreeSet<NodeId>,
+    context: &ExecutionContext,
+) -> Result<NodeId, ConversionError> {
+    let mut collisions = 0_u64;
+    loop {
+        if collisions.is_multiple_of(256) {
+            context.checkpoint()?;
+        }
+        let candidate = NodeId(format!("{}::ocr::{suffix}", source_id.0));
+        if occupied_ids.insert(candidate.clone()) {
+            return Ok(candidate);
+        }
+        collisions = collisions.checked_add(1).ok_or_else(|| {
+            resource("max_archive_entries", "OCR node ID collision count overflow")
+        })?;
+        suffix = suffix
+            .checked_add(1)
+            .ok_or_else(|| resource("max_archive_entries", "OCR node ID suffix overflow"))?;
+    }
+}
+
+fn remap_ocr_node(
+    mut node: BlockNode,
+    fresh_id: NodeId,
+    source: &Provenance,
+    context: &ExecutionContext,
+) -> Result<BlockNode, ConversionError> {
     node.id = fresh_id;
     let ocr_locator = node.provenance.locator.clone();
     node.provenance.locator = remapped_ocr_locator(&source.locator, &ocr_locator);
     if let Block::Paragraph(inlines) = &mut node.block {
-        for inline in inlines {
+        for (inline_index, inline) in inlines.iter_mut().enumerate() {
+            if inline_index % 256 == 0 {
+                context.checkpoint()?;
+            }
             if let Inline::OcrText { provenance, evidence, .. } = inline {
                 let inline_locator = provenance.locator.clone();
                 provenance.locator = remapped_ocr_locator(&source.locator, &inline_locator);
@@ -782,8 +1154,14 @@ fn remap_ocr_node(mut node: BlockNode, fresh_id: NodeId, source: &Provenance) ->
                 if let Some((source_bounds, image_width, image_height)) =
                     coordinate_frame(&source.locator, &inline_locator)
                 {
-                    for region in &mut evidence.regions {
-                        for point in &mut region.polygon {
+                    for (region_index, region) in evidence.regions.iter_mut().enumerate() {
+                        if region_index % 256 == 0 {
+                            context.checkpoint()?;
+                        }
+                        for (point_index, point) in region.polygon.iter_mut().enumerate() {
+                            if point_index % 256 == 0 {
+                                context.checkpoint()?;
+                            }
                             point.x = source_bounds.x + point.x * source_bounds.width / image_width;
                             point.y =
                                 source_bounds.y + point.y * source_bounds.height / image_height;
@@ -793,32 +1171,38 @@ fn remap_ocr_node(mut node: BlockNode, fresh_id: NodeId, source: &Provenance) ->
             }
         }
     }
-    node
+    Ok(node)
 }
 
-fn collect_node_ids(nodes: &[BlockNode], output: &mut BTreeSet<NodeId>) {
+fn collect_node_ids(
+    nodes: &[BlockNode],
+    output: &mut BTreeSet<NodeId>,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
     for node in nodes {
+        context.checkpoint()?;
         output.insert(node.id.clone());
         match &node.block {
             Block::List { items, .. } => {
                 for item in items {
-                    collect_node_ids(&item.blocks, output);
+                    collect_node_ids(&item.blocks, output, context)?;
                 }
             }
             Block::Table { rows, .. } => {
                 for row in rows {
                     for cell in &row.cells {
-                        collect_node_ids(&cell.blocks, output);
+                        collect_node_ids(&cell.blocks, output, context)?;
                     }
                 }
             }
             Block::Footnote { blocks, .. }
             | Block::Page { blocks, .. }
             | Block::Slide { blocks, .. }
-            | Block::Sheet { blocks, .. } => collect_node_ids(blocks, output),
+            | Block::Sheet { blocks, .. } => collect_node_ids(blocks, output, context)?,
             _ => {}
         }
     }
+    Ok(())
 }
 
 fn coordinate_frame(
@@ -901,10 +1285,61 @@ mod tests {
 
     struct SourceBoundOcr {
         calls: AtomicUsize,
+        plans: AtomicUsize,
+        planned_bytes: u64,
         corrupt_identity: bool,
     }
 
     struct LegacyBoundOcr(AtomicUsize);
+
+    struct EntryGuardOcr {
+        plans: AtomicUsize,
+        calls: AtomicUsize,
+    }
+
+    impl OcrEngine for EntryGuardOcr {
+        fn id(&self) -> &'static str {
+            "test.ocr.entry-guard"
+        }
+
+        fn recognize<'a>(
+            &'a self,
+            _: OcrRequest<'a>,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { unreachable!("rejected preflight must not recognize") })
+        }
+
+        fn planned_bound_output(
+            &self,
+            _: OcrRequest<'_>,
+            _: &ConversionOptions,
+            _: &ExecutionContext,
+        ) -> Result<OcrOutputPlan, ConversionError> {
+            unreachable!("embedded OCR uses the normalized-PNG plan")
+        }
+
+        fn planned_normalized_png_output(
+            &self,
+            _: u32,
+            _: u32,
+            _: &ConversionOptions,
+            _: &ExecutionContext,
+        ) -> Result<OcrOutputPlan, ConversionError> {
+            self.plans.fetch_add(1, Ordering::SeqCst);
+            OcrOutputPlan::try_new(16 * 1024, 1, 128)
+        }
+
+        fn recognize_bound<'a>(
+            &'a self,
+            _: OcrRequest<'a>,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async { unreachable!("rejected preflight must not recognize") })
+        }
+    }
 
     impl OcrEngine for LegacyBoundOcr {
         fn id(&self) -> &'static str {
@@ -971,7 +1406,8 @@ mod tests {
             _: &ConversionOptions,
             _: &ExecutionContext,
         ) -> Result<OcrOutputPlan, ConversionError> {
-            OcrOutputPlan::try_new(16 * 1024, 1, 128)
+            self.plans.fetch_add(1, Ordering::SeqCst);
+            OcrOutputPlan::try_new(self.planned_bytes, 1, 128)
         }
 
         fn recognize_bound<'a>(
@@ -1024,6 +1460,22 @@ mod tests {
         let mut cursor = Cursor::new(Vec::new());
         DynamicImage::ImageRgba8(pixels).write_to(&mut cursor, ImageFormat::Png).unwrap();
         cursor.into_inner()
+    }
+
+    fn source_bound_ocr(corrupt_identity: bool) -> Arc<SourceBoundOcr> {
+        source_bound_ocr_with_plan(corrupt_identity, 16 * 1024)
+    }
+
+    fn source_bound_ocr_with_plan(
+        corrupt_identity: bool,
+        planned_bytes: u64,
+    ) -> Arc<SourceBoundOcr> {
+        Arc::new(SourceBoundOcr {
+            calls: AtomicUsize::new(0),
+            plans: AtomicUsize::new(0),
+            planned_bytes,
+            corrupt_identity,
+        })
     }
 
     fn provenance(part: &str) -> Provenance {
@@ -1103,7 +1555,7 @@ mod tests {
 
     #[test]
     fn duplicate_bytes_are_recognized_once_and_remapped_per_reference() {
-        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let ocr = source_bound_ocr(false);
         let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
         let mut options = ConversionOptions::default();
         options.ocr.policy = OcrPolicy::Always;
@@ -1166,7 +1618,7 @@ mod tests {
 
     #[test]
     fn duplicate_references_increase_the_preflight_plan() {
-        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let ocr = source_bound_ocr(false);
         let services = Services { ocr: Some(ocr), ..Services::default() };
         let mut options = ConversionOptions::default();
         options.ocr.policy = OcrPolicy::Always;
@@ -1191,8 +1643,214 @@ mod tests {
     }
 
     #[test]
+    fn repeated_references_share_page_limit_and_provider_request() {
+        let ocr = source_bound_ocr_with_plan(false, 512 * 1024);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut source = output();
+        let Block::Page { blocks, .. } = &mut source.document.blocks[0].block else {
+            panic!("page expected")
+        };
+        *blocks = (0..64)
+            .map(|index| {
+                image_node(
+                    &format!("repeated-{index}"),
+                    "asset-a",
+                    &format!("word/media/repeated-{index}.png"),
+                )
+            })
+            .collect();
+        let asset_bytes = u64::try_from(source.assets[0].bytes.len()).unwrap();
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        options.limits.max_archive_entries = 64;
+        options.limits.max_pages = 1;
+        options.limits.max_total_asset_bytes = asset_bytes;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+
+        let EnrichmentPlan::Reserve(plan) =
+            plan_enrichment(&source, InputFormat::Docx, &options, &services, &context).unwrap()
+        else {
+            panic!("active plan expected")
+        };
+        assert_eq!(ocr.plans.load(Ordering::SeqCst), 1);
+        assert!(plan >= 512 * 1024 * 66);
+        let low_context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            into_markdown_core::ResourceLimits {
+                max_memory_bytes: plan - 1,
+                ..options.limits.clone()
+            },
+        );
+        let error = low_context.reserve_memory(plan).unwrap_err();
+        assert!(matches!(error, ConversionError::ResourceLimit { limit: "max_memory_bytes", .. }));
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(low_context.reserved_memory_bytes(), 0);
+        let enriched =
+            block_on(enrich(source, InputFormat::Docx, &options, &services, &context)).unwrap();
+
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 1);
+        let Block::Page { blocks, .. } = &enriched.document.blocks[0].block else {
+            panic!("page expected")
+        };
+        assert_eq!(blocks.len(), 128);
+        drop(enriched);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn reference_limit_fails_during_preflight_without_provider_or_leases() {
+        let ocr =
+            Arc::new(EntryGuardOcr { plans: AtomicUsize::new(0), calls: AtomicUsize::new(0) });
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        options.limits.max_archive_entries = 1;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+
+        let error = plan_enrichment(&output(), InputFormat::Docx, &options, &services, &context)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ConversionError::ResourceLimit { limit: "max_archive_entries", .. }
+        ));
+        assert_eq!(ocr.plans.load(Ordering::SeqCst), 0);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn all_known_input_limits_fail_before_provider_planning_or_leases() {
+        for (expected, configure) in [
+            (
+                "max_total_asset_bytes",
+                (|options: &mut ConversionOptions| options.limits.max_total_asset_bytes = 1)
+                    as fn(&mut ConversionOptions),
+            ),
+            (
+                "max_pages",
+                (|options: &mut ConversionOptions| options.limits.max_pages = 0)
+                    as fn(&mut ConversionOptions),
+            ),
+            (
+                "max_decompressed_bytes",
+                (|options: &mut ConversionOptions| options.limits.max_decompressed_bytes = 1)
+                    as fn(&mut ConversionOptions),
+            ),
+        ] {
+            let ocr =
+                Arc::new(EntryGuardOcr { plans: AtomicUsize::new(0), calls: AtomicUsize::new(0) });
+            let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+            let mut options = ConversionOptions::default();
+            options.ocr.policy = OcrPolicy::Always;
+            configure(&mut options);
+            let context =
+                ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+
+            let error =
+                plan_enrichment(&output(), InputFormat::Docx, &options, &services, &context)
+                    .unwrap_err();
+
+            assert!(
+                matches!(error, ConversionError::ResourceLimit { limit, .. } if limit == expected),
+                "expected {expected}, got {error}"
+            );
+            assert_eq!(ocr.plans.load(Ordering::SeqCst), 0, "{expected}");
+            assert_eq!(ocr.calls.load(Ordering::SeqCst), 0, "{expected}");
+            assert_eq!(context.reserved_memory_bytes(), 0, "{expected}");
+        }
+    }
+
+    #[test]
+    fn node_id_preprocess_propagates_cancel_and_timeout_without_partial_state() {
+        let nested = vec![BlockNode {
+            id: NodeId("large-page".into()),
+            block: Block::Page {
+                number: 1,
+                blocks: (0..1_024)
+                    .map(|index| BlockNode {
+                        id: NodeId(format!("nested-{index}")),
+                        block: Block::Rule,
+                        provenance: provenance("large/document.xml"),
+                    })
+                    .collect(),
+            },
+            provenance: provenance("large/document.xml"),
+        }];
+        let original = nested.clone();
+
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let cancelled = ExecutionContext::new(
+            ExecutionOptions { cancellation, ..ExecutionOptions::default() },
+            ConversionOptions::default().limits,
+        );
+        let mut cancelled_ids = BTreeSet::new();
+        assert!(matches!(
+            collect_node_ids(&nested, &mut cancelled_ids, &cancelled),
+            Err(ConversionError::Cancelled)
+        ));
+        assert!(cancelled_ids.is_empty());
+        assert_eq!(nested, original);
+        assert_eq!(cancelled.reserved_memory_bytes(), 0);
+
+        let timed_out = ExecutionContext::new(
+            ExecutionOptions {
+                timeout: Some(std::time::Duration::ZERO),
+                ..ExecutionOptions::default()
+            },
+            ConversionOptions::default().limits,
+        );
+        let mut timed_out_ids = BTreeSet::new();
+        assert!(matches!(
+            collect_node_ids(&nested, &mut timed_out_ids, &timed_out),
+            Err(ConversionError::Timeout)
+        ));
+        assert!(timed_out_ids.is_empty());
+        assert_eq!(nested, original);
+        assert_eq!(timed_out.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn node_id_collision_scan_propagates_cancel_and_timeout_transactionally() {
+        let source = NodeId("crowded".into());
+        let occupied = (1..=1_024)
+            .map(|suffix| NodeId(format!("crowded::ocr::{suffix}")))
+            .collect::<BTreeSet<_>>();
+
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let cancelled = ExecutionContext::new(
+            ExecutionOptions { cancellation, ..ExecutionOptions::default() },
+            ConversionOptions::default().limits,
+        );
+        let mut cancelled_ids = occupied.clone();
+        assert!(matches!(
+            fresh_ocr_node_id(&source, 1, &mut cancelled_ids, &cancelled),
+            Err(ConversionError::Cancelled)
+        ));
+        assert_eq!(cancelled_ids, occupied);
+        assert_eq!(cancelled.reserved_memory_bytes(), 0);
+
+        let timed_out = ExecutionContext::new(
+            ExecutionOptions {
+                timeout: Some(std::time::Duration::ZERO),
+                ..ExecutionOptions::default()
+            },
+            ConversionOptions::default().limits,
+        );
+        let mut timed_out_ids = occupied.clone();
+        assert!(matches!(
+            fresh_ocr_node_id(&source, 1, &mut timed_out_ids, &timed_out),
+            Err(ConversionError::Timeout)
+        ));
+        assert_eq!(timed_out_ids, occupied);
+        assert_eq!(timed_out.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
     fn generated_ocr_ids_are_stable_and_never_collide() {
-        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let ocr = source_bound_ocr(false);
         let services = Services { ocr: Some(ocr), ..Services::default() };
         let mut options = ConversionOptions::default();
         options.ocr.policy = OcrPolicy::Always;
@@ -1222,7 +1880,7 @@ mod tests {
 
     #[test]
     fn off_and_non_container_formats_are_exact_no_ops() {
-        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let ocr = source_bound_ocr(false);
         let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
         for (format, policy) in
             [(InputFormat::Docx, OcrPolicy::Off), (InputFormat::Json, OcrPolicy::Always)]
@@ -1263,7 +1921,7 @@ mod tests {
             InputFormat::Zip,
             InputFormat::OutlookMsg,
         ];
-        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let ocr = source_bound_ocr(false);
         let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
         let mut options = ConversionOptions::default();
         options.ocr.policy = OcrPolicy::Always;
@@ -1282,7 +1940,7 @@ mod tests {
 
     #[test]
     fn arbitrary_data_formats_and_non_local_assets_are_never_guessed() {
-        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let ocr = source_bound_ocr(false);
         let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
         let mut options = ConversionOptions::default();
         options.ocr.policy = OcrPolicy::Always;
@@ -1308,6 +1966,23 @@ mod tests {
         remote.assets[0].bytes.clear();
         remote.assets[1].media_type = "image/svg+xml".into();
         let expected = remote.document.clone();
+        let mut no_candidate_options = options.clone();
+        no_candidate_options.limits.max_archive_entries = 0;
+        no_candidate_options.limits.max_pages = 0;
+        no_candidate_options.limits.max_total_asset_bytes = 0;
+        let no_candidate_context =
+            ExecutionContext::new(ExecutionOptions::default(), no_candidate_options.limits.clone());
+        assert_eq!(
+            plan_enrichment(
+                &remote,
+                InputFormat::Html,
+                &no_candidate_options,
+                &services,
+                &no_candidate_context,
+            )
+            .unwrap(),
+            EnrichmentPlan::Skip
+        );
         let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
         let after =
             block_on(enrich(remote, InputFormat::Html, &options, &services, &context)).unwrap();
@@ -1329,7 +2004,7 @@ mod tests {
 
     #[test]
     fn ocr_result_is_rejected_when_it_is_bound_to_different_image_bytes() {
-        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: true });
+        let ocr = source_bound_ocr(true);
         let services = Services { ocr: Some(ocr), ..Services::default() };
         let mut options = ConversionOptions::default();
         options.ocr.policy = OcrPolicy::Always;
@@ -1342,7 +2017,7 @@ mod tests {
 
     #[test]
     fn resource_limits_and_cancellation_stop_before_ocr_publication() {
-        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let ocr = source_bound_ocr(false);
         let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
         let mut options = ConversionOptions::default();
         options.ocr.policy = OcrPolicy::Always;

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -1,0 +1,939 @@
+//! Unified embedded-visual OCR between container conversion and Markdown rendering.
+
+use crate::image_converter::{decode, encode, envelope, format};
+use image::{AnimationDecoder, ImageDecoder};
+use into_markdown_core::{
+    AssetId, Block, BlockNode, BoxFuture, ConversionError, ConversionOptions, ConverterOutput,
+    Diagnostic, DiagnosticSeverity, ExecutionContext, Inline, InputFormat, NodeId,
+    OcrInputIdentity, OcrPolicy, OutputEnricher, Provenance, ResourceReservation, Services,
+    SourceLocator,
+};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::io::Cursor;
+
+const PROVIDER: &str = "builtin.enricher.embedded-visual-ocr";
+const UNSUPPORTED_CODE: &str = "embeddedVisualOcr.unsupportedVisual";
+
+/// Default post-converter enrichment for locally extracted raster assets.
+#[derive(Debug, Default)]
+pub struct EmbeddedVisualOcrEnricher;
+
+impl OutputEnricher for EmbeddedVisualOcrEnricher {
+    fn id(&self) -> &'static str {
+        PROVIDER
+    }
+
+    fn enrich<'a>(
+        &'a self,
+        output: ConverterOutput,
+        _converter_id: &'a str,
+        format: InputFormat,
+        options: &'a ConversionOptions,
+        services: &'a Services,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        Box::pin(async move { enrich(output, format, options, services, context).await })
+    }
+}
+
+#[derive(Clone)]
+struct VisualRef {
+    asset: AssetId,
+    provenance: Provenance,
+}
+
+#[derive(Clone, Default)]
+struct CachedContribution {
+    nodes: Vec<BlockNode>,
+    diagnostics: Vec<Diagnostic>,
+}
+
+struct NormalizedImage {
+    bytes: Vec<u8>,
+    width: u32,
+    height: u32,
+    _leases: Vec<ResourceReservation>,
+}
+
+#[allow(clippy::too_many_lines)] // Discovery, OCR, and publication share one transaction.
+async fn enrich(
+    mut output: ConverterOutput,
+    input_format: InputFormat,
+    options: &ConversionOptions,
+    services: &Services,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    if options.ocr.policy == OcrPolicy::Off
+        || input_format == InputFormat::Image
+        || !eligible_container(input_format)
+    {
+        return Ok(output);
+    }
+    let mut references = Vec::new();
+    collect_references(&output.document.blocks, &mut references, context)?;
+    if references.is_empty() {
+        return Ok(output);
+    }
+    let reference_count = u32::try_from(references.len()).map_err(|_| {
+        resource("max_archive_entries", "embedded visual reference count is not representable")
+    })?;
+    if reference_count > options.limits.max_archive_entries {
+        return Err(resource(
+            "max_archive_entries",
+            "embedded visual references exceed the request limit",
+        ));
+    }
+
+    let assets = output
+        .assets
+        .iter()
+        .map(|asset| (asset.id.clone(), asset.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut hashes_by_asset = BTreeMap::new();
+    let mut unique = BTreeMap::<[u8; 32], AssetId>::new();
+    let mut referenced_assets = BTreeSet::new();
+    let mut compressed_bytes = 0_u64;
+    for (index, reference) in references.iter().enumerate() {
+        if index % 256 == 0 {
+            context.checkpoint()?;
+        }
+        if !referenced_assets.insert(reference.asset.clone()) {
+            continue;
+        }
+        let Some(asset) = assets.get(&reference.asset) else {
+            return Err(ConversionError::Internal {
+                detail: format!("image node references missing asset {}", reference.asset.0),
+            });
+        };
+        if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
+            continue;
+        }
+        compressed_bytes = compressed_bytes
+            .checked_add(u64::try_from(asset.bytes.len()).map_err(|_| {
+                resource("max_total_asset_bytes", "embedded visual byte count is not representable")
+            })?)
+            .ok_or_else(|| resource("max_total_asset_bytes", "embedded visual bytes overflow"))?;
+        if compressed_bytes > options.limits.max_total_asset_bytes {
+            return Err(resource(
+                "max_total_asset_bytes",
+                "embedded visual bytes exceed the request limit",
+            ));
+        }
+        let digest = checkpointed_sha256(&asset.bytes, context)?;
+        hashes_by_asset.insert(reference.asset.clone(), digest);
+        unique.entry(digest).or_insert_with(|| reference.asset.clone());
+    }
+
+    let unique_count = u32::try_from(unique.len())
+        .map_err(|_| resource("max_pages", "OCR request count is not representable"))?;
+    if unique_count > options.limits.max_pages {
+        return Err(resource("max_pages", "embedded OCR requests exceed the request limit"));
+    }
+
+    let mut cache = BTreeMap::<[u8; 32], CachedContribution>::new();
+    for (ordinal, (digest, asset_id)) in unique.into_iter().enumerate() {
+        context.checkpoint()?;
+        let asset = assets.get(&asset_id).ok_or_else(|| ConversionError::Internal {
+            detail: "embedded OCR asset inventory changed during enrichment".into(),
+        })?;
+        let normalized = match normalize(asset, options, context) {
+            Ok(value) => value,
+            Err(error) if options.ocr.policy == OcrPolicy::Auto => {
+                cache.insert(
+                    digest,
+                    CachedContribution {
+                        nodes: Vec::new(),
+                        diagnostics: vec![visual_diagnostic(None, error.to_string())],
+                    },
+                );
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
+        let identity = OcrInputIdentity::try_new(
+            Sha256::digest(&normalized.bytes).into(),
+            normalized.width,
+            normalized.height,
+            0,
+        )?;
+        let mut contribution = crate::image_converter::ocr::recognize_for_input(
+            &normalized.bytes,
+            u32::try_from(ordinal + 1)
+                .map_err(|_| resource("max_pages", "OCR page ordinal overflow"))?,
+            normalized.width,
+            normalized.height,
+            identity,
+            options,
+            services,
+            context,
+        )
+        .await?;
+        if let Some(memory) = contribution.memory.take() {
+            output.attach_memory_reservation(context, memory)?;
+        }
+        cache.insert(
+            digest,
+            CachedContribution { nodes: contribution.nodes, diagnostics: contribution.diagnostics },
+        );
+    }
+
+    let mut contributions_by_asset = BTreeMap::new();
+    for (asset, digest) in hashes_by_asset {
+        if let Some(contribution) = cache.get(&digest) {
+            contributions_by_asset.insert(asset, contribution.clone());
+        }
+    }
+    output.document.blocks = rebuild_nodes(
+        std::mem::take(&mut output.document.blocks),
+        &contributions_by_asset,
+        context,
+    )?;
+    for reference in &references {
+        if let Some(contribution) = contributions_by_asset.get(&reference.asset) {
+            for diagnostic in &contribution.diagnostics {
+                let mut diagnostic = diagnostic.clone();
+                diagnostic.locator = Some(remapped_locator(&reference.provenance.locator));
+                output.diagnostics.push(diagnostic);
+            }
+        }
+    }
+    if input_format == InputFormat::Pdf && !contributions_by_asset.is_empty() {
+        output = crate::pdf_ocr::reconstruct_enriched_pdf(output, context)?;
+    }
+    Ok(output)
+}
+
+fn eligible_container(format: InputFormat) -> bool {
+    matches!(
+        format,
+        InputFormat::Pdf
+            | InputFormat::Doc
+            | InputFormat::Docx
+            | InputFormat::Ppt
+            | InputFormat::Pptx
+            | InputFormat::Xls
+            | InputFormat::Xlsx
+            | InputFormat::Odt
+            | InputFormat::Ods
+            | InputFormat::Odp
+            | InputFormat::Rtf
+            | InputFormat::Epub
+            | InputFormat::Html
+            | InputFormat::Ipynb
+            | InputFormat::Zip
+            | InputFormat::OutlookMsg
+    )
+}
+
+fn supported_raster(asset: &into_markdown_core::Asset) -> bool {
+    matches!(
+        asset.media_type.to_ascii_lowercase().as_str(),
+        "image/png"
+            | "image/jpeg"
+            | "image/jpg"
+            | "image/gif"
+            | "image/webp"
+            | "image/bmp"
+            | "image/tiff"
+            | "image/x-tiff"
+    )
+}
+
+fn normalize(
+    asset: &into_markdown_core::Asset,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+) -> Result<NormalizedImage, ConversionError> {
+    if asset.bytes.starts_with(b"GIF87a") || asset.bytes.starts_with(b"GIF89a") {
+        if asset.media_type.eq_ignore_ascii_case("image/gif") {
+            return normalize_gif(&asset.bytes, asset.filename.as_deref(), options, context);
+        }
+        return Err(ConversionError::Malformed {
+            part: asset.filename.clone(),
+            detail: "embedded raster media type disagrees with its GIF envelope".into(),
+        });
+    }
+    let raster =
+        format::detect(&asset.bytes, context)?.ok_or_else(|| ConversionError::Malformed {
+            part: asset.filename.clone(),
+            detail: "declared raster asset has an unrecognized envelope".into(),
+        })?;
+    let declared = asset.media_type.to_ascii_lowercase();
+    let declared = match declared.as_str() {
+        "image/jpg" => "image/jpeg",
+        "image/x-tiff" => "image/tiff",
+        value => value,
+    };
+    if raster.media_type() != declared {
+        return Err(ConversionError::Malformed {
+            part: asset.filename.clone(),
+            detail: "embedded raster media type disagrees with its byte envelope".into(),
+        });
+    }
+    let summary = envelope::validate(raster, &asset.bytes, &options.limits, context)?;
+    if summary.frames != 1 || summary.animated {
+        return Err(ConversionError::Unsupported {
+            detail: "animated or multi-page embedded raster is not eligible for OCR".into(),
+        });
+    }
+    let decoded = decode::decode(raster, &asset.bytes, summary, &options.limits, context)?;
+    let frame = decoded.frames.first().ok_or_else(|| ConversionError::Malformed {
+        part: asset.filename.clone(),
+        detail: "embedded raster decoder returned no frame".into(),
+    })?;
+    if frame.pixels.pixels().all(|pixel| pixel.0[3] == 0) {
+        return Err(ConversionError::Unsupported {
+            detail: "fully transparent embedded raster is not eligible for OCR".into(),
+        });
+    }
+    let width = frame.pixels.width();
+    let height = frame.pixels.height();
+    let encoded = encode::png(&frame.pixels, true, &options.limits, context)?;
+    let (bytes, memory) = encoded.into_parts();
+    Ok(NormalizedImage { bytes, width, height, _leases: vec![memory] })
+}
+
+fn normalize_gif(
+    bytes: &[u8],
+    part: Option<&str>,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+) -> Result<NormalizedImage, ConversionError> {
+    if bytes.len() < 10 {
+        return Err(ConversionError::Malformed {
+            part: None,
+            detail: "embedded GIF header is truncated".into(),
+        });
+    }
+    let width = u32::from(u16::from_le_bytes([bytes[6], bytes[7]]));
+    let height = u32::from(u16::from_le_bytes([bytes[8], bytes[9]]));
+    let working = u64::from(width)
+        .checked_mul(u64::from(height))
+        .and_then(|pixels| pixels.checked_mul(20))
+        .ok_or_else(|| resource("max_memory_bytes", "GIF working set overflow"))?;
+    if width == 0
+        || height == 0
+        || working > options.limits.max_decompressed_bytes
+        || working > options.limits.max_memory_bytes
+    {
+        return Err(resource("max_decompressed_bytes", "GIF dimensions exceed request limits"));
+    }
+    crate::epub::image::validate(
+        bytes,
+        "image/gif",
+        part.unwrap_or("embedded GIF"),
+        &options.limits,
+        context,
+    )?;
+    let memory = context.reserve_memory(working)?;
+    let decoder = image::codecs::gif::GifDecoder::new(Cursor::new(bytes)).map_err(|error| {
+        ConversionError::Malformed { part: None, detail: format!("invalid embedded GIF: {error}") }
+    })?;
+    if decoder.dimensions() != (width, height) {
+        return Err(ConversionError::Malformed {
+            part: None,
+            detail: "GIF decoder dimensions disagree with the header".into(),
+        });
+    }
+    let frames = decoder.into_frames().take(2).collect::<Result<Vec<_>, _>>().map_err(|error| {
+        ConversionError::Malformed {
+            part: None,
+            detail: format!("invalid embedded GIF frames: {error}"),
+        }
+    })?;
+    if frames.len() != 1 {
+        return Err(ConversionError::Unsupported {
+            detail: "animated embedded GIF is not eligible for OCR".into(),
+        });
+    }
+    let pixels = frames.into_iter().next().expect("one frame").into_buffer();
+    if pixels.pixels().all(|pixel| pixel.0[3] == 0) {
+        return Err(ConversionError::Unsupported {
+            detail: "fully transparent embedded GIF is not eligible for OCR".into(),
+        });
+    }
+    let encoded = encode::png(&pixels, true, &options.limits, context)?;
+    let (bytes, png_memory) = encoded.into_parts();
+    Ok(NormalizedImage { bytes, width, height, _leases: vec![memory, png_memory] })
+}
+
+fn checkpointed_sha256(
+    bytes: &[u8],
+    context: &ExecutionContext,
+) -> Result<[u8; 32], ConversionError> {
+    let mut digest = Sha256::new();
+    for chunk in bytes.chunks(4096) {
+        context.checkpoint()?;
+        digest.update(chunk);
+    }
+    Ok(digest.finalize().into())
+}
+
+fn collect_references(
+    nodes: &[BlockNode],
+    output: &mut Vec<VisualRef>,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    for (index, node) in nodes.iter().enumerate() {
+        if index % 256 == 0 {
+            context.checkpoint()?;
+        }
+        match &node.block {
+            Block::Image { asset, .. } => {
+                output
+                    .push(VisualRef { asset: asset.clone(), provenance: node.provenance.clone() });
+            }
+            Block::List { items, .. } => {
+                for item in items {
+                    collect_references(&item.blocks, output, context)?;
+                }
+            }
+            Block::Table { rows, .. } => {
+                for row in rows {
+                    for cell in &row.cells {
+                        collect_references(&cell.blocks, output, context)?;
+                    }
+                }
+            }
+            Block::Footnote { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => collect_references(blocks, output, context)?,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn rebuild_nodes(
+    nodes: Vec<BlockNode>,
+    cache: &BTreeMap<AssetId, CachedContribution>,
+    context: &ExecutionContext,
+) -> Result<Vec<BlockNode>, ConversionError> {
+    let mut rebuilt = Vec::new();
+    for (index, mut node) in nodes.into_iter().enumerate() {
+        if index % 256 == 0 {
+            context.checkpoint()?;
+        }
+        match &mut node.block {
+            Block::List { items, .. } => {
+                for item in items {
+                    item.blocks = rebuild_nodes(std::mem::take(&mut item.blocks), cache, context)?;
+                }
+            }
+            Block::Table { rows, .. } => {
+                for row in rows {
+                    for cell in &mut row.cells {
+                        cell.blocks =
+                            rebuild_nodes(std::mem::take(&mut cell.blocks), cache, context)?;
+                    }
+                }
+            }
+            Block::Footnote { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => {
+                *blocks = rebuild_nodes(std::mem::take(blocks), cache, context)?;
+            }
+            _ => {}
+        }
+        let contribution = match &node.block {
+            Block::Image { asset, .. } => cache.get(asset).cloned(),
+            _ => None,
+        };
+        let source_id = node.id.clone();
+        let source_provenance = node.provenance.clone();
+        rebuilt.push(node);
+        if let Some(contribution) = contribution {
+            for (ocr_index, template) in contribution.nodes.into_iter().enumerate() {
+                rebuilt.push(remap_ocr_node(template, &source_id, &source_provenance, ocr_index));
+            }
+        }
+    }
+    Ok(rebuilt)
+}
+
+fn remap_ocr_node(
+    mut node: BlockNode,
+    source_id: &NodeId,
+    source: &Provenance,
+    index: usize,
+) -> BlockNode {
+    node.id = NodeId(format!("{}::ocr::{}", source_id.0, index + 1));
+    let ocr_locator = node.provenance.locator.clone();
+    node.provenance.locator = remapped_ocr_locator(&source.locator, &ocr_locator);
+    if let Block::Paragraph(inlines) = &mut node.block {
+        for inline in inlines {
+            if let Inline::OcrText { provenance, evidence, .. } = inline {
+                let inline_locator = provenance.locator.clone();
+                provenance.locator = remapped_ocr_locator(&source.locator, &inline_locator);
+                evidence.page = source.locator.page.or(source.locator.slide).unwrap_or(1);
+                if let Some((source_bounds, image_width, image_height)) =
+                    coordinate_frame(&source.locator, &inline_locator)
+                {
+                    for region in &mut evidence.regions {
+                        for point in &mut region.polygon {
+                            point.x = source_bounds.x + point.x * source_bounds.width / image_width;
+                            point.y =
+                                source_bounds.y + point.y * source_bounds.height / image_height;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    node
+}
+
+fn coordinate_frame(
+    source: &SourceLocator,
+    ocr: &SourceLocator,
+) -> Option<(into_markdown_core::Rect, f32, f32)> {
+    let bounds = source.bounds?;
+    let width = ocr.page_width?;
+    let height = ocr.page_height?;
+    (bounds.x.is_finite()
+        && bounds.y.is_finite()
+        && bounds.width.is_finite()
+        && bounds.height.is_finite()
+        && bounds.width > 0.0
+        && bounds.height > 0.0
+        && width.is_finite()
+        && height.is_finite()
+        && width > 0.0
+        && height > 0.0)
+        .then_some((bounds, width, height))
+}
+
+fn remapped_ocr_locator(source: &SourceLocator, ocr: &SourceLocator) -> SourceLocator {
+    let mut locator = remapped_locator(source);
+    locator.page = source.page.or(source.slide).or(Some(1));
+    if let (Some((frame, width, height)), Some(bounds)) =
+        (coordinate_frame(source, ocr), ocr.bounds)
+    {
+        locator.page_width = source.page_width.or(ocr.page_width);
+        locator.page_height = source.page_height.or(ocr.page_height);
+        locator.bounds = Some(into_markdown_core::Rect {
+            x: frame.x + bounds.x * frame.width / width,
+            y: frame.y + bounds.y * frame.height / height,
+            width: bounds.width * frame.width / width,
+            height: bounds.height * frame.height / height,
+        });
+    } else {
+        locator.page_width = ocr.page_width;
+        locator.page_height = ocr.page_height;
+        locator.bounds = ocr.bounds;
+    }
+    locator
+}
+
+fn remapped_locator(source: &SourceLocator) -> SourceLocator {
+    let mut locator = source.clone();
+    locator.byte_start = None;
+    locator.byte_end = None;
+    locator.character_index = None;
+    locator
+}
+
+fn visual_diagnostic(locator: Option<SourceLocator>, detail: String) -> Diagnostic {
+    Diagnostic {
+        code: UNSUPPORTED_CODE.into(),
+        severity: DiagnosticSeverity::Warning,
+        message: detail,
+        locator,
+    }
+}
+
+fn resource(limit: &'static str, detail: impl Into<String>) -> ConversionError {
+    ConversionError::ResourceLimit { limit, detail: detail.into() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+    use into_markdown_core::{
+        Asset, BoundOcrResult, CancellationToken, Document, ExecutionOptions, OcrEngine,
+        OcrEvidenceStage, OcrEvidenceStep, OcrOutputPlan, OcrRecognition, OcrRegion, OcrRequest,
+        OcrResult, ProvenanceKind,
+    };
+    use std::future::Future;
+    use std::pin::pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll, Waker};
+
+    struct SourceBoundOcr {
+        calls: AtomicUsize,
+        corrupt_identity: bool,
+    }
+
+    impl OcrEngine for SourceBoundOcr {
+        fn id(&self) -> &'static str {
+            "test.ocr.source-bound"
+        }
+
+        fn recognize<'a>(
+            &'a self,
+            _: OcrRequest<'a>,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+            Box::pin(async { unreachable!("embedded OCR requires a bound result") })
+        }
+
+        fn planned_bound_output(
+            &self,
+            _: OcrRequest<'_>,
+            _: &ConversionOptions,
+            _: &ExecutionContext,
+        ) -> Result<OcrOutputPlan, ConversionError> {
+            OcrOutputPlan::try_new(16 * 1024, 1, 128)
+        }
+
+        fn recognize_bound<'a>(
+            &'a self,
+            request: OcrRequest<'a>,
+            context: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let mut digest: [u8; 32] = Sha256::digest(request.image).into();
+            if self.corrupt_identity {
+                digest[0] ^= 0xff;
+            }
+            let image = image::load_from_memory(request.image).expect("normalized PNG");
+            let identity = OcrInputIdentity::try_new(digest, image.width(), image.height(), 0);
+            Box::pin(async move {
+                context.checkpoint()?;
+                let bound = BoundOcrResult::try_new_for_input(
+                    OcrResult {
+                        regions: vec![OcrRegion {
+                            text: "embedded words".into(),
+                            polygon: [(0.0, 0.0), (2.0, 0.0), (2.0, 1.0), (0.0, 1.0)],
+                            confidence: 0.97,
+                        }],
+                        provider: "test.ocr.recognizer".into(),
+                    },
+                    vec![0.98],
+                    vec![
+                        OcrEvidenceStep {
+                            stage: OcrEvidenceStage::Detection,
+                            provider: "test.ocr.detector".into(),
+                            model: Some("detector-sha256".into()),
+                        },
+                        OcrEvidenceStep {
+                            stage: OcrEvidenceStage::Recognition,
+                            provider: "test.ocr.recognizer".into(),
+                            model: Some("recognizer-sha256".into()),
+                        },
+                    ],
+                    identity?,
+                )?;
+                Ok(OcrRecognition::Bound(bound))
+            })
+        }
+    }
+
+    fn png() -> Vec<u8> {
+        let pixels = RgbaImage::from_fn(3, 2, |x, y| {
+            Rgba([u8::try_from(x * 40).unwrap(), u8::try_from(y * 80).unwrap(), 30, 255])
+        });
+        let mut cursor = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(pixels).write_to(&mut cursor, ImageFormat::Png).unwrap();
+        cursor.into_inner()
+    }
+
+    fn provenance(part: &str) -> Provenance {
+        Provenance {
+            kind: ProvenanceKind::NativeParser,
+            provider: "test.converter".into(),
+            locator: SourceLocator {
+                page: Some(2),
+                part: Some(part.into()),
+                bounds: Some(into_markdown_core::Rect {
+                    x: 10.0,
+                    y: 20.0,
+                    width: 30.0,
+                    height: 20.0,
+                }),
+                page_width: Some(600.0),
+                page_height: Some(800.0),
+                byte_start: Some(4),
+                byte_end: Some(12),
+                ..SourceLocator::default()
+            },
+            confidence: Some(1.0),
+        }
+    }
+
+    fn image_node(id: &str, asset: &str, part: &str) -> BlockNode {
+        let mut source = provenance(part);
+        if id.ends_with('b') {
+            source.locator.bounds =
+                Some(into_markdown_core::Rect { x: 10.0, y: 60.0, width: 30.0, height: 20.0 });
+        }
+        BlockNode {
+            id: NodeId(id.into()),
+            block: Block::Image { asset: AssetId(asset.into()), alt: None },
+            provenance: source,
+        }
+    }
+
+    fn output() -> ConverterOutput {
+        let bytes = png();
+        let mut page_provenance = provenance("word/document.xml");
+        page_provenance.provider = "builtin.converter.pdfium".into();
+        ConverterOutput::new(
+            Document {
+                blocks: vec![BlockNode {
+                    id: NodeId("page-2".into()),
+                    block: Block::Page {
+                        number: 2,
+                        blocks: vec![
+                            image_node("image-a", "asset-a", "word/media/a.png"),
+                            image_node("image-b", "asset-b", "word/media/b.png"),
+                        ],
+                    },
+                    provenance: page_provenance,
+                }],
+                ..Document::default()
+            },
+            vec![
+                Asset {
+                    id: AssetId("asset-a".into()),
+                    filename: Some("a.png".into()),
+                    media_type: "image/png".into(),
+                    bytes: bytes.clone(),
+                    external_uri: None,
+                },
+                Asset {
+                    id: AssetId("asset-b".into()),
+                    filename: Some("b.png".into()),
+                    media_type: "image/png".into(),
+                    bytes,
+                    external_uri: None,
+                },
+            ],
+            vec![],
+        )
+    }
+
+    #[test]
+    fn duplicate_bytes_are_recognized_once_and_remapped_per_reference() {
+        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let enriched =
+            block_on(enrich(output(), InputFormat::Pdf, &options, &services, &context)).unwrap();
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 1);
+        let Block::Page { blocks, .. } = &enriched.document.blocks[0].block else {
+            panic!("page expected")
+        };
+        assert_eq!(blocks.len(), 4);
+        let first = blocks
+            .iter()
+            .find(|node| {
+                matches!(
+                    &node.block,
+                    Block::Paragraph(inlines)
+                        if inlines.iter().any(|inline| matches!(inline,
+                            Inline::OcrText { provenance, .. }
+                                if provenance.locator.part.as_deref() == Some("word/media/a.png")))
+                )
+            })
+            .unwrap();
+        let second = blocks
+            .iter()
+            .find(|node| {
+                matches!(
+                    &node.block,
+                    Block::Paragraph(inlines)
+                        if inlines.iter().any(|inline| matches!(inline,
+                            Inline::OcrText { provenance, .. }
+                                if provenance.locator.part.as_deref() == Some("word/media/b.png")))
+                )
+            })
+            .unwrap();
+        let Block::Paragraph(inlines) = &first.block else { panic!("OCR paragraph expected") };
+        let Inline::OcrText { value, evidence, provenance, .. } = &inlines[0] else {
+            panic!("OCR inline expected")
+        };
+        assert_eq!(provenance.locator.part.as_deref(), Some("word/media/a.png"));
+        assert_eq!(provenance.locator.byte_start, None);
+        let Block::Paragraph(second_inlines) = &second.block else {
+            panic!("OCR paragraph expected")
+        };
+        let Inline::OcrText { provenance: second_provenance, .. } = &second_inlines[0] else {
+            panic!("OCR inline expected")
+        };
+        assert_eq!(second_provenance.locator.part.as_deref(), Some("word/media/b.png"));
+        assert_eq!(value, "embedded words");
+        assert_eq!(evidence.page, 2);
+        assert_eq!(
+            evidence.regions[0].polygon[2],
+            into_markdown_core::SourcePoint { x: 30.0, y: 30.0 }
+        );
+        assert_eq!(
+            provenance.locator.bounds,
+            Some(into_markdown_core::Rect { x: 10.0, y: 20.0, width: 20.0, height: 10.0 })
+        );
+    }
+
+    #[test]
+    fn off_and_non_container_formats_are_exact_no_ops() {
+        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        for (format, policy) in
+            [(InputFormat::Docx, OcrPolicy::Off), (InputFormat::Json, OcrPolicy::Always)]
+        {
+            let before = output();
+            let expected_document = before.document.clone();
+            let expected_assets = before.assets.clone();
+            let expected_diagnostics = before.diagnostics.clone();
+            let mut options = ConversionOptions::default();
+            options.ocr.policy = policy;
+            let context =
+                ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+            let after = block_on(enrich(before, format, &options, &services, &context)).unwrap();
+            assert_eq!(after.document, expected_document);
+            assert_eq!(after.assets, expected_assets);
+            assert_eq!(after.diagnostics, expected_diagnostics);
+        }
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn every_supported_container_uses_the_same_source_bound_stage() {
+        let formats = [
+            InputFormat::Pdf,
+            InputFormat::Doc,
+            InputFormat::Docx,
+            InputFormat::Ppt,
+            InputFormat::Pptx,
+            InputFormat::Xls,
+            InputFormat::Xlsx,
+            InputFormat::Odt,
+            InputFormat::Ods,
+            InputFormat::Odp,
+            InputFormat::Rtf,
+            InputFormat::Epub,
+            InputFormat::Html,
+            InputFormat::Ipynb,
+            InputFormat::Zip,
+            InputFormat::OutlookMsg,
+        ];
+        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        for format in formats {
+            let context =
+                ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+            let enriched = block_on(enrich(output(), format, &options, &services, &context))
+                .unwrap_or_else(|error| panic!("{format:?}: {error}"));
+            let Block::Page { blocks, .. } = &enriched.document.blocks[0].block else {
+                panic!("{format:?}: page expected")
+            };
+            assert_eq!(blocks.len(), 4, "{format:?}");
+        }
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), formats.len());
+    }
+
+    #[test]
+    fn arbitrary_data_formats_and_non_local_assets_are_never_guessed() {
+        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        for format in [
+            InputFormat::Csv,
+            InputFormat::Json,
+            InputFormat::Xml,
+            InputFormat::Text,
+            InputFormat::Feed,
+            InputFormat::Markdown,
+            InputFormat::Image,
+        ] {
+            let context =
+                ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+            let before = output();
+            let expected = before.document.clone();
+            let after = block_on(enrich(before, format, &options, &services, &context)).unwrap();
+            assert_eq!(after.document, expected, "{format:?}");
+        }
+
+        let mut remote = output();
+        remote.assets[0].external_uri = Some("https://example.invalid/image.png".into());
+        remote.assets[0].bytes.clear();
+        remote.assets[1].media_type = "image/svg+xml".into();
+        let expected = remote.document.clone();
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let after =
+            block_on(enrich(remote, InputFormat::Html, &options, &services, &context)).unwrap();
+        assert_eq!(after.document, expected);
+
+        let mut mismatched = output();
+        mismatched.assets[0].media_type = "image/jpeg".into();
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let error = block_on(enrich(mismatched, InputFormat::Docx, &options, &services, &context))
+            .unwrap_err();
+        assert!(matches!(error, ConversionError::Malformed { .. }));
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn ocr_result_is_rejected_when_it_is_bound_to_different_image_bytes() {
+        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: true });
+        let services = Services { ocr: Some(ocr), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let error = block_on(enrich(output(), InputFormat::Docx, &options, &services, &context))
+            .unwrap_err();
+        assert_eq!(error.code(), into_markdown_core::ErrorCode::Ocr);
+        assert!(error.to_string().contains("does not match the normalized source image"));
+    }
+
+    #[test]
+    fn resource_limits_and_cancellation_stop_before_ocr_publication() {
+        let ocr = Arc::new(SourceBoundOcr { calls: AtomicUsize::new(0), corrupt_identity: false });
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        options.limits.max_total_asset_bytes = 1;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let error = block_on(enrich(output(), InputFormat::Docx, &options, &services, &context))
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            ConversionError::ResourceLimit { limit: "max_total_asset_bytes", .. }
+        ));
+
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let context = ExecutionContext::new(
+            ExecutionOptions { cancellation, ..ExecutionOptions::default() },
+            options.limits.clone(),
+        );
+        let error = block_on(enrich(output(), InputFormat::Docx, &options, &services, &context))
+            .unwrap_err();
+        assert_eq!(error.code(), into_markdown_core::ErrorCode::Cancelled);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        let mut future = pin!(future);
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        loop {
+            match future.as_mut().poll(&mut context) {
+                Poll::Ready(output) => return output,
+                Poll::Pending => std::thread::yield_now(),
+            }
+        }
+    }
+}

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -261,6 +261,7 @@ fn plan_enrichment(
     let mut candidate_bytes = 0_u64;
     let existing_nodes = count_document_nodes(&output.document.blocks, context)?;
     let mut planned_added_nodes = 0_usize;
+    let mut provider_working_peak = 0_u64;
     for (index, asset) in output.assets.iter().enumerate() {
         context.checkpoint()?;
         if asset.bytes.is_empty()
@@ -334,27 +335,33 @@ fn plan_enrichment(
             64 * 1024
         };
         checked_add(&mut total, normalized_peak, "normalization working-set plan overflow")?;
-        let (provider_bound, provider_regions) = match (services.ocr.as_deref(), dimensions) {
-            (_, None) => (0, 0),
-            (Some(engine), Some((width, height))) => {
-                match engine.planned_normalized_png_output(width, height, options, context) {
-                    Ok(plan) => (plan.max_retained_bytes(), plan.max_regions()),
-                    Err(ConversionError::ComponentUnavailable { .. })
-                        if options.ocr.policy == OcrPolicy::Auto =>
-                    {
-                        (0, 0)
+        let (provider_bound, provider_working, provider_regions) =
+            match (services.ocr.as_deref(), dimensions) {
+                (_, None) => (0, 0, 0),
+                (Some(engine), Some((width, height))) => {
+                    match engine.planned_normalized_png_output(width, height, options, context) {
+                        Ok(plan) => (
+                            plan.max_retained_bytes(),
+                            plan.max_working_bytes(),
+                            plan.max_regions(),
+                        ),
+                        Err(ConversionError::ComponentUnavailable { .. })
+                            if options.ocr.policy == OcrPolicy::Auto =>
+                        {
+                            (0, 0, 0)
+                        }
+                        Err(error) => return Err(error),
                     }
-                    Err(error) => return Err(error),
                 }
-            }
-            (None, Some(_)) if options.ocr.policy == OcrPolicy::Auto => (0, 0),
-            (None, Some(_)) => {
-                return Err(ConversionError::ComponentUnavailable {
-                    component: "ocr".into(),
-                    detail: "no OCR engine is configured".into(),
-                });
-            }
-        };
+                (None, Some(_)) if options.ocr.policy == OcrPolicy::Auto => (0, 0, 0),
+                (None, Some(_)) => {
+                    return Err(ConversionError::ComponentUnavailable {
+                        component: "ocr".into(),
+                        detail: "no OCR engine is configured".into(),
+                    });
+                }
+            };
+        provider_working_peak = provider_working_peak.max(provider_working);
         let reference_copies = visual_reference_count_for_bytes(output, &asset.bytes, context)?;
         let added_nodes = usize::try_from(provider_regions)
             .unwrap_or(usize::MAX)
@@ -386,6 +393,7 @@ fn plan_enrichment(
             "OCR output plan overflow",
         )?;
     }
+    checked_add(&mut total, provider_working_peak, "OCR provider working-set plan overflow")?;
     let (occupied_id_bytes, collision_scratch) =
         planned_node_id_working_set(&output.document.blocks, context)?;
     checked_add(&mut total, occupied_id_bytes, "occupied OCR node ID plan overflow")?;
@@ -1329,10 +1337,44 @@ fn remap_ocr_node(
                         }
                     }
                 }
+                provenance.locator.bounds = evidence_bounds(&evidence.regions);
             }
         }
     }
     Ok(node)
+}
+
+fn evidence_bounds(
+    regions: &[into_markdown_core::OcrSourceRegion],
+) -> Option<into_markdown_core::Rect> {
+    (!regions.is_empty()).then(|| {
+        let minimum_x = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.x)
+            .fold(f32::INFINITY, f32::min);
+        let minimum_y = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.y)
+            .fold(f32::INFINITY, f32::min);
+        let maximum_x = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.x)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let maximum_y = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.y)
+            .fold(f32::NEG_INFINITY, f32::max);
+        into_markdown_core::Rect {
+            x: minimum_x,
+            y: minimum_y,
+            width: maximum_x - minimum_x,
+            height: maximum_y - minimum_y,
+        }
+    })
 }
 
 fn collect_node_ids(
@@ -1448,6 +1490,7 @@ mod tests {
         calls: AtomicUsize,
         plans: AtomicUsize,
         planned_bytes: u64,
+        planned_working_bytes: u64,
         corrupt_identity: bool,
     }
 
@@ -1569,7 +1612,12 @@ mod tests {
             _: &ExecutionContext,
         ) -> Result<OcrOutputPlan, ConversionError> {
             self.plans.fetch_add(1, Ordering::SeqCst);
-            OcrOutputPlan::try_new(self.planned_bytes, 1, 128)
+            OcrOutputPlan::try_new_with_working(
+                self.planned_bytes,
+                self.planned_working_bytes,
+                1,
+                128,
+            )
         }
 
         fn recognize_bound<'a>(
@@ -1691,10 +1739,19 @@ mod tests {
         corrupt_identity: bool,
         planned_bytes: u64,
     ) -> Arc<SourceBoundOcr> {
+        source_bound_ocr_with_working_plan(corrupt_identity, planned_bytes, 0)
+    }
+
+    fn source_bound_ocr_with_working_plan(
+        corrupt_identity: bool,
+        planned_bytes: u64,
+        planned_working_bytes: u64,
+    ) -> Arc<SourceBoundOcr> {
         Arc::new(SourceBoundOcr {
             calls: AtomicUsize::new(0),
             plans: AtomicUsize::new(0),
             planned_bytes,
+            planned_working_bytes,
             corrupt_identity,
         })
     }
@@ -1925,6 +1982,36 @@ mod tests {
     }
 
     #[test]
+    fn remapped_locator_bounds_are_derived_from_the_published_evidence_points() {
+        let regions = vec![into_markdown_core::OcrSourceRegion {
+            source_index: 0,
+            polygon: [
+                into_markdown_core::SourcePoint { x: 0.1, y: 7.3 },
+                into_markdown_core::SourcePoint { x: 9.7, y: 1.2 },
+                into_markdown_core::SourcePoint { x: 8.4, y: 11.9 },
+                into_markdown_core::SourcePoint { x: 0.3, y: 10.1 },
+            ],
+            detection_confidence: 0.9,
+            recognition_confidence: 0.8,
+        }];
+        let bounds = evidence_bounds(&regions).unwrap();
+        let points = regions[0].polygon;
+        let minimum_x = points.iter().map(|point| point.x).fold(f32::INFINITY, f32::min);
+        let minimum_y = points.iter().map(|point| point.y).fold(f32::INFINITY, f32::min);
+        let maximum_x = points.iter().map(|point| point.x).fold(f32::NEG_INFINITY, f32::max);
+        let maximum_y = points.iter().map(|point| point.y).fold(f32::NEG_INFINITY, f32::max);
+        assert_eq!(
+            bounds,
+            into_markdown_core::Rect {
+                x: minimum_x,
+                y: minimum_y,
+                width: maximum_x - minimum_x,
+                height: maximum_y - minimum_y,
+            }
+        );
+    }
+
+    #[test]
     fn duplicate_references_increase_the_preflight_plan() {
         let ocr = source_bound_ocr(false);
         let services = Services { ocr: Some(ocr), ..Services::default() };
@@ -2003,6 +2090,36 @@ mod tests {
         assert_eq!(blocks.len(), 128);
         drop(enriched);
         assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn provider_working_peak_is_reserved_once_before_recognition() {
+        let retained = 64 * 1024;
+        let working = 8 * 1024 * 1024;
+        let ocr = source_bound_ocr_with_working_plan(false, retained, working);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let EnrichmentPlan::Reserve(plan) =
+            plan_enrichment(&output(), InputFormat::Docx, &options, &services, &context).unwrap()
+        else {
+            panic!("active plan expected")
+        };
+        assert!(plan >= working + retained * 2);
+
+        let low_context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            into_markdown_core::ResourceLimits {
+                max_memory_bytes: plan - 1,
+                ..options.limits.clone()
+            },
+        );
+        assert!(matches!(
+            low_context.reserve_memory(plan),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
     }
 
     #[test]

--- a/crates/converters/src/epub/image.rs
+++ b/crates/converters/src/epub/image.rs
@@ -12,6 +12,17 @@ struct RasterInfo {
     frames: u64,
 }
 
+/// Allocation-free raster envelope information for request preflight.
+pub(crate) fn preflight_info(
+    bytes: &[u8],
+    media_type: &str,
+    part: &str,
+    context: &ExecutionContext,
+) -> Result<((u32, u32), u64), ConversionError> {
+    let info = envelope_info(bytes, format(media_type)?, part, context)?;
+    Ok((info.dimensions, info.frames))
+}
+
 #[allow(clippy::too_many_lines)] // Decode budget and complete payload checks share one transaction.
 pub(crate) fn validate(
     bytes: &[u8],

--- a/crates/converters/src/epub/image.rs
+++ b/crates/converters/src/epub/image.rs
@@ -13,7 +13,7 @@ struct RasterInfo {
 }
 
 #[allow(clippy::too_many_lines)] // Decode budget and complete payload checks share one transaction.
-pub(super) fn validate(
+pub(crate) fn validate(
     bytes: &[u8],
     media_type: &str,
     part: &str,

--- a/crates/converters/src/epub/mod.rs
+++ b/crates/converters/src/epub/mod.rs
@@ -3,7 +3,7 @@
 mod budget;
 mod container;
 mod encryption;
-mod image;
+pub(crate) mod image;
 #[cfg(test)]
 mod image_tests;
 mod merge;

--- a/crates/converters/src/html.rs
+++ b/crates/converters/src/html.rs
@@ -1,5 +1,6 @@
 //! Offline HTML5 parsing and deterministic semantic extraction.
 
+use base64::Engine as _;
 use html5ever::interface::tree_builder::{ElementFlags, NodeOrText, QuirksMode, TreeSink};
 use html5ever::tendril::{StrTendril, TendrilSink};
 use html5ever::{Attribute, ParseOpts, QualName, parse_document};
@@ -1885,6 +1886,8 @@ struct Builder<'a, 'budget> {
     max_table_rows: u64,
     max_table_columns: u64,
     max_table_cells: u64,
+    limits: into_markdown_core::ResourceLimits,
+    total_asset_bytes: u64,
     feed_budget: Option<&'budget mut FeedHtmlBudget>,
 }
 
@@ -1961,6 +1964,8 @@ impl<'a, 'budget> Builder<'a, 'budget> {
             max_table_rows: options.limits.max_table_rows,
             max_table_columns: options.limits.max_table_columns,
             max_table_cells: options.limits.max_table_cells,
+            limits: options.limits.clone(),
+            total_asset_bytes: 0,
             feed_budget,
         }
     }
@@ -2591,6 +2596,10 @@ impl<'a, 'budget> Builder<'a, 'budget> {
                 None => Ok(None),
             };
         }
+        if src.get(..5).is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:")) {
+            let data_uri = src.to_owned();
+            return self.build_data_image(&data_uri, alt);
+        }
         let resolved = {
             Url::parse(src).ok().or_else(|| self.base.as_ref().and_then(|base| base.join(src).ok()))
         };
@@ -2659,6 +2668,141 @@ impl<'a, 'budget> Builder<'a, 'budget> {
             external_uri: Some(uri),
         });
         Ok(Some(Block::Image { asset: block_asset_id, alt }))
+    }
+
+    #[allow(clippy::too_many_lines)] // Canonical decoding and complete raster audit are one boundary.
+    fn build_data_image(
+        &mut self,
+        src: &str,
+        alt: Option<String>,
+    ) -> Result<Option<Block>, ConversionError> {
+        // Feed conversion owns a separate aggregate-memory model. Keeping data
+        // images out of nested feed HTML avoids charging their bytes twice.
+        if self.feed_budget.is_some() {
+            self.push_warning(
+                "html.imageUriRejected",
+                "data image was retained only as alternative text in nested feed HTML",
+            )?;
+            return self.image_alt_fallback(alt);
+        }
+        let Some((header, payload)) = src.split_once(',') else {
+            self.push_warning("html.dataImageRejected", "data image URI has no payload")?;
+            return self.image_alt_fallback(alt);
+        };
+        let media_type = header
+            .get(5..)
+            .and_then(|value| value.strip_suffix(";base64"))
+            .map(str::to_ascii_lowercase);
+        let Some(media_type) = media_type.filter(|value| {
+            matches!(
+                value.as_str(),
+                "image/png"
+                    | "image/jpeg"
+                    | "image/gif"
+                    | "image/webp"
+                    | "image/bmp"
+                    | "image/tiff"
+            )
+        }) else {
+            self.push_warning(
+                "html.dataImageRejected",
+                "data image must use an explicitly supported raster media type and base64 encoding",
+            )?;
+            return self.image_alt_fallback(alt);
+        };
+        let estimated = payload.len().saturating_add(3) / 4 * 3;
+        if u64::try_from(estimated).unwrap_or(u64::MAX) > self.limits.max_asset_bytes {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_asset_bytes",
+                detail: "HTML data image exceeds the per-asset byte budget".into(),
+            });
+        }
+        let bytes = match base64::engine::general_purpose::STANDARD.decode(payload) {
+            Ok(bytes) if base64::engine::general_purpose::STANDARD.encode(&bytes) == payload => {
+                bytes
+            }
+            _ => {
+                self.push_warning(
+                    "html.dataImageRejected",
+                    "data image payload is not canonical base64",
+                )?;
+                return self.image_alt_fallback(alt);
+            }
+        };
+        let byte_count = u64::try_from(bytes.len()).unwrap_or(u64::MAX);
+        if byte_count > self.limits.max_asset_bytes {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_asset_bytes",
+                detail: "HTML data image exceeds the per-asset byte budget".into(),
+            });
+        }
+        let format = crate::image_converter::format::detect(&bytes, self.context)?;
+        let declared_matches = if media_type == "image/gif" {
+            bytes.starts_with(b"GIF87a") || bytes.starts_with(b"GIF89a")
+        } else {
+            format.is_some_and(|format| format.media_type() == media_type)
+        };
+        if !declared_matches {
+            self.push_warning(
+                "html.dataImageRejected",
+                "data image bytes do not match the declared raster media type",
+            )?;
+            return self.image_alt_fallback(alt);
+        }
+        let extension = if media_type == "image/gif" {
+            crate::epub::image::validate(
+                &bytes,
+                &media_type,
+                "HTML data image",
+                &self.limits,
+                self.context,
+            )?;
+            "gif"
+        } else {
+            let format = format.expect("checked above");
+            crate::image_converter::envelope::validate(format, &bytes, &self.limits, self.context)?;
+            format.extension()
+        };
+        if let Some(asset) = self.assets.iter().find(|asset| {
+            asset.external_uri.is_none() && asset.media_type == media_type && asset.bytes == bytes
+        }) {
+            return Ok(Some(Block::Image { asset: asset.id.clone(), alt }));
+        }
+        self.total_asset_bytes =
+            self.total_asset_bytes.checked_add(byte_count).ok_or_else(|| {
+                ConversionError::ResourceLimit {
+                    limit: "max_total_asset_bytes",
+                    detail: "HTML data image byte total overflowed".into(),
+                }
+            })?;
+        if self.total_asset_bytes > self.limits.max_total_asset_bytes {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_total_asset_bytes",
+                detail: "HTML data images exceed the aggregate asset byte budget".into(),
+            });
+        }
+        let asset = AssetId(format!("html-data-image-{:06}", self.assets.len() + 1));
+        self.assets.push(Asset {
+            id: asset.clone(),
+            filename: Some(format!("embedded.{extension}")),
+            media_type,
+            bytes,
+            external_uri: None,
+        });
+        Ok(Some(Block::Image { asset, alt }))
+    }
+
+    fn image_alt_fallback(
+        &mut self,
+        alt: Option<String>,
+    ) -> Result<Option<Block>, ConversionError> {
+        match alt {
+            Some(value) => {
+                self.reserve_inline()?;
+                Ok(Some(Block::Paragraph(vec![Inline::Text { value, marks: Vec::new() }])))
+            }
+            None => Ok(None),
+        }
     }
 
     fn inline_children(&mut self, id: usize) -> Result<Vec<Inline>, ConversionError> {
@@ -3309,6 +3453,7 @@ pub(crate) fn safe_link_target(value: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use image::{Frame, RgbaImage, codecs::gif::GifEncoder};
     use into_markdown_core::{ExecutionOptions, ResourceLimits, SourceMetadata};
     use std::sync::Arc;
 
@@ -3612,6 +3757,37 @@ mod tests {
             Some("https://example.invalid/docs/a.png")
         );
         assert!(output.assets[0].bytes.is_empty());
+    }
+
+    #[test]
+    fn standalone_data_gif_is_fully_audited_and_trailing_bytes_are_rejected() {
+        let mut gif = Vec::new();
+        GifEncoder::new(&mut gif)
+            .encode_frame(Frame::new(RgbaImage::from_pixel(1, 1, image::Rgba([1, 2, 3, 255]))))
+            .unwrap();
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&gif);
+        let output = convert(&format!(
+            "<main><img src='data:image/gif;base64,{encoded}' alt='safe'></main>"
+        ));
+        assert_eq!(output.assets.len(), 1);
+        assert_eq!(output.assets[0].media_type, "image/gif");
+        assert_eq!(output.assets[0].bytes, gif);
+
+        let mut trailing = output.assets[0].bytes.clone();
+        trailing.push(0);
+        let encoded = base64::engine::general_purpose::STANDARD.encode(trailing);
+        let source =
+            format!("<main><img src='data:image/gif;base64,{encoded}' alt='fallback'></main>");
+        let error = convert_html(
+            &ResolvedInput {
+                bytes: Arc::from(source.as_bytes()),
+                metadata: SourceMetadata::default(),
+            },
+            &ConversionOptions::default(),
+            &context(),
+        )
+        .unwrap_err();
+        assert!(matches!(error, ConversionError::Malformed { .. }));
     }
 
     #[test]

--- a/crates/converters/src/html.rs
+++ b/crates/converters/src/html.rs
@@ -2710,7 +2710,18 @@ impl<'a, 'budget> Builder<'a, 'budget> {
             )?;
             return self.image_alt_fallback(alt);
         };
-        let estimated = payload.len().saturating_add(3) / 4 * 3;
+        let canonical_padding = if payload.len() % 4 == 0 {
+            if payload.ends_with("==") {
+                2
+            } else if payload.ends_with('=') {
+                1
+            } else {
+                0
+            }
+        } else {
+            0
+        };
+        let estimated = payload.len().saturating_add(3) / 4 * 3 - canonical_padding;
         if u64::try_from(estimated).unwrap_or(u64::MAX) > self.limits.max_asset_bytes {
             return Err(ConversionError::ResourceLimit {
                 limit: "max_asset_bytes",
@@ -3788,6 +3799,38 @@ mod tests {
         )
         .unwrap_err();
         assert!(matches!(error, ConversionError::Malformed { .. }));
+    }
+
+    #[test]
+    fn canonical_base64_padding_is_not_counted_as_decoded_asset_bytes() {
+        let gif = (1..=8)
+            .find_map(|width| {
+                let mut bytes = Vec::new();
+                GifEncoder::new(&mut bytes)
+                    .encode_frame(Frame::new(RgbaImage::from_pixel(
+                        width,
+                        1,
+                        image::Rgba([1, 2, 3, 255]),
+                    )))
+                    .unwrap();
+                let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+                encoded.ends_with('=').then_some((bytes, encoded))
+            })
+            .expect("a small GIF with canonical base64 padding");
+        let source = format!("<main><img src='data:image/gif;base64,{}' alt='safe'></main>", gif.1);
+        let mut options = ConversionOptions::default();
+        options.limits.max_asset_bytes = u64::try_from(gif.0.len()).unwrap();
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let output = convert_html(
+            &ResolvedInput {
+                bytes: Arc::from(source.as_bytes()),
+                metadata: SourceMetadata::default(),
+            },
+            &options,
+            &context,
+        )
+        .unwrap();
+        assert_eq!(output.assets[0].bytes, gif.0);
     }
 
     #[test]

--- a/crates/converters/src/image_converter/decode.rs
+++ b/crates/converters/src/image_converter/decode.rs
@@ -17,19 +17,19 @@ std::thread_local! {
 
 const MAX_DIMENSION: u32 = 32_768;
 
-pub(super) struct DecodedSet {
-    pub(super) frames: Vec<DecodedFrame>,
+pub(crate) struct DecodedSet {
+    pub(crate) frames: Vec<DecodedFrame>,
     pub(super) color: String,
     pub(super) orientation: u8,
     _memory: ResourceReservation,
 }
 
-pub(super) struct DecodedFrame {
-    pub(super) pixels: RgbaImage,
+pub(crate) struct DecodedFrame {
+    pub(crate) pixels: RgbaImage,
     pub(super) has_alpha: bool,
 }
 
-pub(super) fn decode(
+pub(crate) fn decode(
     format: RasterFormat,
     bytes: &[u8],
     summary: Summary,

--- a/crates/converters/src/image_converter/encode.rs
+++ b/crates/converters/src/image_converter/encode.rs
@@ -4,18 +4,18 @@ use image::codecs::png::{CompressionType, FilterType, PngEncoder};
 use image::{ExtendedColorType, ImageEncoder, RgbaImage};
 use into_markdown_core::{ConversionError, ExecutionContext, ResourceLimits, ResourceReservation};
 
-pub(super) struct EncodedImage {
+pub(crate) struct EncodedImage {
     pub(super) bytes: Vec<u8>,
     memory: ResourceReservation,
 }
 
 impl EncodedImage {
-    pub(super) fn into_parts(self) -> (Vec<u8>, ResourceReservation) {
+    pub(crate) fn into_parts(self) -> (Vec<u8>, ResourceReservation) {
         (self.bytes, self.memory)
     }
 }
 
-pub(super) fn png(
+pub(crate) fn png(
     pixels: &RgbaImage,
     composite_white: bool,
     limits: &ResourceLimits,

--- a/crates/converters/src/image_converter/envelope/mod.rs
+++ b/crates/converters/src/image_converter/envelope/mod.rs
@@ -12,12 +12,12 @@ use super::format::RasterFormat;
 use into_markdown_core::{ConversionError, ExecutionContext, ResourceLimits};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct Summary {
-    pub(super) frames: u32,
-    pub(super) animated: bool,
+pub(crate) struct Summary {
+    pub(crate) frames: u32,
+    pub(crate) animated: bool,
 }
 
-pub(super) fn validate(
+pub(crate) fn validate(
     format: RasterFormat,
     bytes: &[u8],
     limits: &ResourceLimits,

--- a/crates/converters/src/image_converter/envelope/mod.rs
+++ b/crates/converters/src/image_converter/envelope/mod.rs
@@ -40,6 +40,32 @@ pub(crate) fn validate(
     Ok(summary)
 }
 
+/// Allocation-free envelope and frame-count preflight used before an
+/// enrichment plan has been reserved. Complete BMP interval validation is
+/// deliberately deferred to [`validate`], under the caller's reserved credit.
+pub(crate) fn preflight_validate(
+    format: RasterFormat,
+    bytes: &[u8],
+    limits: &ResourceLimits,
+    context: &ExecutionContext,
+) -> Result<Summary, ConversionError> {
+    context.checkpoint()?;
+    let summary = match format {
+        RasterFormat::Png => png::validate(bytes, limits, context)?,
+        RasterFormat::Jpeg => jpeg::validate(bytes, limits, context)?,
+        RasterFormat::WebP => webp::validate(bytes, limits, context)?,
+        RasterFormat::Tiff => tiff::preflight_validate(bytes, limits.max_pages, context)?,
+        RasterFormat::Bmp => Summary { frames: 1, animated: false },
+    };
+    if summary.frames == 0 || summary.frames > limits.max_pages {
+        return Err(limit(
+            "max_pages",
+            format!("{} image frame(s) > {}", summary.frames, limits.max_pages),
+        ));
+    }
+    Ok(summary)
+}
+
 pub(super) fn malformed(detail: impl Into<String>) -> ConversionError {
     ConversionError::Malformed { part: Some("image".into()), detail: detail.into() }
 }

--- a/crates/converters/src/image_converter/envelope/tiff.rs
+++ b/crates/converters/src/image_converter/envelope/tiff.rs
@@ -157,6 +157,34 @@ pub(super) fn validate(
     Ok(Summary { frames, animated: frames > 1 })
 }
 
+/// Validate the TIFF directory chain and count frames without constructing the
+/// interval graph used by complete validation. This is safe before an engine
+/// reserves the enrichment plan.
+pub(super) fn preflight_validate(
+    bytes: &[u8],
+    max_pages: u32,
+    context: &ExecutionContext,
+) -> Result<Summary, ConversionError> {
+    let (little, layout, mut ifd) = header(bytes)?;
+    scan_all(bytes, context)?;
+    if ifd == 0 {
+        return Err(malformed("TIFF has no image file directory"));
+    }
+    validate_ifd_chain(bytes, layout, little, ifd, max_pages, context)?;
+    let mut frames = 0_u32;
+    while ifd != 0 {
+        context.checkpoint()?;
+        if frames >= max_pages {
+            return Err(limit("max_pages", "TIFF image directory count exceeds max_pages"));
+        }
+        ifd = next_ifd(bytes, layout, little, ifd)?;
+        frames = frames
+            .checked_add(1)
+            .ok_or_else(|| limit("max_pages", "TIFF image directory count overflow"))?;
+    }
+    Ok(Summary { frames, animated: frames > 1 })
+}
+
 #[derive(Debug, Clone, Copy)]
 enum Layout {
     Classic,

--- a/crates/converters/src/image_converter/format.rs
+++ b/crates/converters/src/image_converter/format.rs
@@ -4,7 +4,7 @@ use into_markdown_core::{ConversionError, ExecutionContext};
 
 /// Audited raster codecs accepted by the image converter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum RasterFormat {
+pub(crate) enum RasterFormat {
     Png,
     Jpeg,
     Tiff,
@@ -13,7 +13,7 @@ pub(super) enum RasterFormat {
 }
 
 impl RasterFormat {
-    pub(super) const fn media_type(self) -> &'static str {
+    pub(crate) const fn media_type(self) -> &'static str {
         match self {
             Self::Png => "image/png",
             Self::Jpeg => "image/jpeg",
@@ -23,7 +23,7 @@ impl RasterFormat {
         }
     }
 
-    pub(super) const fn extension(self) -> &'static str {
+    pub(crate) const fn extension(self) -> &'static str {
         match self {
             Self::Png => "png",
             Self::Jpeg => "jpg",
@@ -44,7 +44,7 @@ impl RasterFormat {
     }
 }
 
-pub(super) fn detect(
+pub(crate) fn detect(
     bytes: &[u8],
     context: &ExecutionContext,
 ) -> Result<Option<RasterFormat>, ConversionError> {

--- a/crates/converters/src/image_converter/mod.rs
+++ b/crates/converters/src/image_converter/mod.rs
@@ -1,12 +1,12 @@
 //! Safe raster-image conversion with bounded local OCR and optional image description.
 
 mod ai;
-mod decode;
-mod encode;
-mod envelope;
-mod format;
+pub(crate) mod decode;
+pub(crate) mod encode;
+pub(crate) mod envelope;
+pub(crate) mod format;
 mod metadata;
-mod ocr;
+pub(crate) mod ocr;
 
 use decode::DecodedFrame;
 use format::RasterFormat;

--- a/crates/converters/src/image_converter/ocr.rs
+++ b/crates/converters/src/image_converter/ocr.rs
@@ -3,9 +3,9 @@
 use into_markdown_core::{
     Asset, Block, BlockNode, ConversionError, ConversionOptions, Diagnostic, DiagnosticSeverity,
     Document, ExecutionContext, Inline, NodeId, OcrEvidence, OcrEvidenceStage, OcrEvidenceStep,
-    OcrOutputPlan, OcrPolicy, OcrRecognition, OcrRequest, OcrResult, OcrSourceRegion, Provenance,
-    ProvenanceKind, ResourceReservation, Services, SourceLocator, SourcePoint,
-    estimate_retained_output,
+    OcrInputIdentity, OcrOutputPlan, OcrPolicy, OcrRecognition, OcrRequest, OcrResult,
+    OcrSourceRegion, Provenance, ProvenanceKind, ResourceReservation, Services, SourceLocator,
+    SourcePoint, estimate_retained_output,
 };
 
 const MERGE_PROVIDER: &str = "builtin.converter.image.ocr-merge";
@@ -13,11 +13,11 @@ const INSTALL_HINT: &str =
     "install local OCR models with `into-md models install pp-ocrv6-tiny-zh-en`";
 
 #[derive(Debug)]
-pub(super) struct OcrContribution {
-    pub(super) nodes: Vec<BlockNode>,
-    pub(super) diagnostics: Vec<Diagnostic>,
+pub(crate) struct OcrContribution {
+    pub(crate) nodes: Vec<BlockNode>,
+    pub(crate) diagnostics: Vec<Diagnostic>,
     pub(super) accepted_text: bool,
-    pub(super) memory: Option<ResourceReservation>,
+    pub(crate) memory: Option<ResourceReservation>,
 }
 
 pub(super) async fn recognize(
@@ -25,6 +25,34 @@ pub(super) async fn recognize(
     page: u32,
     width: u32,
     height: u32,
+    options: &ConversionOptions,
+    services: &Services,
+    context: &ExecutionContext,
+) -> Result<OcrContribution, ConversionError> {
+    recognize_inner(image, page, width, height, None, options, services, context).await
+}
+
+#[allow(clippy::too_many_arguments)] // Source identity is intentionally explicit at this boundary.
+pub(crate) async fn recognize_for_input(
+    image: &[u8],
+    page: u32,
+    width: u32,
+    height: u32,
+    identity: OcrInputIdentity,
+    options: &ConversionOptions,
+    services: &Services,
+    context: &ExecutionContext,
+) -> Result<OcrContribution, ConversionError> {
+    recognize_inner(image, page, width, height, Some(identity), options, services, context).await
+}
+
+#[allow(clippy::too_many_arguments)] // Shared adapter retains the public OCR request fields.
+async fn recognize_inner(
+    image: &[u8],
+    page: u32,
+    width: u32,
+    height: u32,
+    expected_identity: Option<OcrInputIdentity>,
     options: &ConversionOptions,
     services: &Services,
     context: &ExecutionContext,
@@ -68,6 +96,14 @@ pub(super) async fn recognize(
             "the configured OCR engine returned legacy output without bound detector/model evidence",
         );
     };
+    if let Some(expected) = expected_identity
+        && bound.input_identity() != Some(expected)
+    {
+        return Err(ConversionError::Ocr {
+            provider: engine.id().into(),
+            detail: "bound OCR result does not match the normalized source image".into(),
+        });
+    }
     let (result, detection_confidences, mut chain) = bound.into_parts();
     validate_bound_payload(
         &result,
@@ -157,7 +193,7 @@ fn materialize_nodes(
         if region.text.trim().is_empty() || confidence < materialize.options.ocr.minimum_confidence
         {
             diagnostics.push(Diagnostic {
-                code: "image.ocrLowConfidence".into(),
+                code: "ocr.lowConfidence".into(),
                 severity: DiagnosticSeverity::Info,
                 message: format!("OCR region {index} was omitted below the configured confidence"),
                 locator: Some(page_locator(

--- a/crates/converters/src/image_converter/ocr.rs
+++ b/crates/converters/src/image_converter/ocr.rs
@@ -46,7 +46,7 @@ pub(crate) async fn recognize_for_input(
     recognize_inner(image, page, width, height, Some(identity), options, services, context).await
 }
 
-#[allow(clippy::too_many_arguments)] // Shared adapter retains the public OCR request fields.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)] // Shared adapter retains the public OCR request fields.
 async fn recognize_inner(
     image: &[u8],
     page: u32,
@@ -72,8 +72,20 @@ async fn recognize_inner(
         Err(error) => return preflight_unavailable(options.ocr.policy, page, engine.id(), error),
     };
     validate_plan(plan, options, context)?;
-    let planned_bytes = plan.max_retained_bytes();
-    let mut memory = context.reserve_memory(planned_bytes)?;
+    let planned_bytes = plan
+        .max_retained_bytes()
+        .checked_add(plan.max_working_bytes())
+        .ok_or_else(|| ConversionError::ResourceLimit {
+            limit: "max_memory_bytes",
+            detail: "OCR provider memory plan overflow".into(),
+        })?;
+    // An enclosing converter/enricher credit already reserved the complete
+    // provider peak. In that case retain only the output allowance here and
+    // let the provider charge its real working set to the enclosing credit.
+    // Reserving the working allowance again would double-charge that peak.
+    let reservation_bytes =
+        if context.has_memory_credit() { plan.max_retained_bytes() } else { planned_bytes };
+    let mut memory = context.reserve_memory(reservation_bytes)?;
     let credited = (!context.has_memory_credit())
         .then(|| context.with_memory_credit(&mut memory))
         .transpose()?;
@@ -137,14 +149,14 @@ async fn recognize_inner(
     let (document, diagnostics) = materialize_nodes(result, detection_confidences, &materialize)?;
     let assets = Vec::<Asset>::new();
     let retained = estimate_retained_output(&document, &assets, &diagnostics)?;
-    if retained > planned_bytes {
+    if retained > plan.max_retained_bytes() {
         return Err(ConversionError::Ocr {
             provider: engine.id().into(),
             detail: format!("structured OCR retained {retained} bytes beyond its plan"),
         });
     }
-    if retained < planned_bytes {
-        memory.shrink(planned_bytes - retained)?;
+    if retained < reservation_bytes {
+        memory.shrink(reservation_bytes - retained)?;
     }
     Ok(OcrContribution {
         accepted_text: !document.blocks.is_empty(),
@@ -260,9 +272,14 @@ fn validate_plan(
             detail: "OCR output plan exceeds the request text limit".into(),
         });
     }
-    if plan.max_retained_bytes() > options.limits.max_memory_bytes
-        || plan.max_retained_bytes() > context.available_memory_bytes()
-    {
+    let total =
+        plan.max_retained_bytes().checked_add(plan.max_working_bytes()).ok_or_else(|| {
+            ConversionError::ResourceLimit {
+                limit: "max_memory_bytes",
+                detail: "OCR provider memory plan overflow".into(),
+            }
+        })?;
+    if total > options.limits.max_memory_bytes || total > context.available_memory_bytes() {
         return Err(ConversionError::ResourceLimit {
             limit: "max_memory_bytes",
             detail: "OCR output plan exceeds the request memory limit".into(),

--- a/crates/converters/src/image_converter/tests.rs
+++ b/crates/converters/src/image_converter/tests.rs
@@ -548,6 +548,76 @@ fn cancelled_large_envelope_returns_cancelled_without_a_lease() {
 
 struct BoundOcr;
 
+struct WorkingSetOcr;
+
+impl OcrEngine for WorkingSetOcr {
+    fn id(&self) -> &'static str {
+        "test.ocr.working-set"
+    }
+
+    fn recognize<'a>(
+        &'a self,
+        _: OcrRequest<'a>,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+        Box::pin(async { unreachable!("working-set provider must use recognize_bound") })
+    }
+
+    fn planned_bound_output(
+        &self,
+        _: OcrRequest<'_>,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new_with_working(4096, 8192, 1, 32)
+    }
+
+    fn recognize_bound<'a>(
+        &'a self,
+        _: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+        Box::pin(async move {
+            let _working = context.reserve_memory(8192)?;
+            let bound = BoundOcrResult::try_new(
+                OcrResult { regions: vec![], provider: "test.ocr.recognizer".into() },
+                vec![],
+                vec![
+                    OcrEvidenceStep {
+                        stage: OcrEvidenceStage::Detection,
+                        provider: "test.ocr.detector".into(),
+                        model: Some("detector-sha256".into()),
+                    },
+                    OcrEvidenceStep {
+                        stage: OcrEvidenceStage::Recognition,
+                        provider: "test.ocr.recognizer".into(),
+                        model: Some("recognizer-sha256".into()),
+                    },
+                ],
+            )?;
+            Ok(OcrRecognition::Bound(bound))
+        })
+    }
+}
+
+#[test]
+fn enclosing_credit_does_not_double_charge_provider_working_memory() {
+    let mut options = options();
+    options.ocr.policy = OcrPolicy::Always;
+    options.limits.max_memory_bytes = 12_288;
+    let root = context(&options);
+    let mut parent = root.reserve_memory(12_288).unwrap();
+    let credit = root.with_memory_credit(&mut parent).unwrap();
+    let services = Services { ocr: Some(Arc::new(WorkingSetOcr)), ..Services::default() };
+
+    let contribution =
+        block_on(ocr::recognize(b"opaque-png", 1, 3, 2, &options, &services, &credit)).unwrap();
+
+    assert!(contribution.memory.is_some());
+    drop(contribution);
+    assert_eq!(credit.reserved_memory_bytes(), 0);
+}
+
 impl OcrEngine for BoundOcr {
     fn id(&self) -> &'static str {
         "test.ocr.pipeline"

--- a/crates/converters/src/lib.rs
+++ b/crates/converters/src/lib.rs
@@ -6,6 +6,7 @@ mod core_catalog;
 mod core_catalog_authority;
 mod delimited;
 mod docx;
+mod embedded_visual_ocr;
 mod epub;
 mod feed;
 mod html;
@@ -38,6 +39,7 @@ pub use core_catalog::{
 };
 pub use delimited::DelimitedTextConverter;
 pub use docx::DocxConverter;
+pub use embedded_visual_ocr::EmbeddedVisualOcrEnricher;
 pub use epub::EpubConverter;
 pub use feed::FeedConverter;
 pub use html::HtmlConverter;

--- a/crates/converters/src/pdf/mod.rs
+++ b/crates/converters/src/pdf/mod.rs
@@ -20,12 +20,14 @@ use budget::{
 use count::checked_count;
 use coverage::PageCoverage;
 use error::{malformed, map_pdfium_error, resource};
-use geometry::{normalize_rect, page_locator, render_dimensions, safe_link_target};
+use geometry::{
+    displayed_dimensions, normalize_rect, page_locator, render_dimensions, safe_link_target,
+};
 use ir::{allocation_capacity_bound, character_working_set_bytes, provenance, text_block};
 use runtime::lock_pdf_conversion;
 
 #[cfg(test)]
-use geometry::{displayed_dimensions, normalize_point};
+use geometry::normalize_point;
 #[cfg(test)]
 use ir::character_ir_allocation_bytes;
 
@@ -454,6 +456,7 @@ fn convert_pdf(
             || (options.ocr.policy == OcrPolicy::Auto && scanned);
         if render_requested {
             let (width, height) = render_dimensions(&info)?;
+            let (page_width, page_height) = displayed_dimensions(&info);
             let render_bytes = u64::from(width)
                 .checked_mul(u64::from(height))
                 .and_then(|pixels| pixels.checked_mul(4))
@@ -496,7 +499,12 @@ fn convert_pdf(
             blocks.push(BlockNode {
                 id: NodeId(format!("pdf-page-{page_number}-ocr-render")),
                 block: Block::Image { asset: AssetId(id), alt: Some("page render for OCR".into()) },
-                provenance: provenance(page_number, None, None, &info)?,
+                provenance: provenance(
+                    page_number,
+                    Some(Rect { x: 0.0, y: 0.0, width: page_width, height: page_height }),
+                    None,
+                    &info,
+                )?,
             });
         }
         if scanned {

--- a/crates/converters/src/pdf_ocr.rs
+++ b/crates/converters/src/pdf_ocr.rs
@@ -1,6 +1,6 @@
 //! PDF-side orchestration of the generic OCR merge and final page layout.
 
-use into_markdown_core::{ConversionError, ConverterOutput, ExecutionContext};
+use into_markdown_core::{ConversionError, ConversionOptions, ConverterOutput, ExecutionContext};
 use into_markdown_ocr::{MergeConfig, OcrPageInput};
 use into_markdown_pdf_layout::{LayoutConfig, reconstruct_document};
 
@@ -49,11 +49,23 @@ pub fn merge_pdf_ocr(
 /// becoming a second, order-dependent text stream.
 pub(crate) fn reconstruct_enriched_pdf(
     mut source: ConverterOutput,
+    options: &ConversionOptions,
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
     context.checkpoint()?;
     let document = std::mem::take(&mut source.document);
-    let layout = reconstruct_document(document, &LayoutConfig::default(), context)?;
+    let layout_config = LayoutConfig {
+        limits: into_markdown_pdf_layout::LayoutLimits {
+            max_table_columns: usize::try_from(options.limits.max_table_columns)
+                .unwrap_or(usize::MAX)
+                .min(into_markdown_core::MAX_TABLE_COLUMNS),
+            max_table_cells: usize::try_from(options.limits.max_table_cells)
+                .unwrap_or(usize::MAX)
+                .min(into_markdown_core::MAX_DOCUMENT_NODES),
+            ..into_markdown_pdf_layout::LayoutLimits::default()
+        },
+    };
+    let layout = reconstruct_document(document, &layout_config, context)?;
     let (document, reservation) = layout.into_parts();
     source.document = document;
     if let Some(reservation) = reservation {
@@ -139,5 +151,25 @@ mod tests {
         assert!(output.leased_memory_for(&context) > 0);
         drop(output);
         assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn enriched_relayout_preserves_request_table_limits() {
+        for configure in [
+            (|options: &mut ConversionOptions| options.limits.max_table_columns = 0)
+                as fn(&mut ConversionOptions),
+            (|options: &mut ConversionOptions| options.limits.max_table_cells = 0)
+                as fn(&mut ConversionOptions),
+        ] {
+            let mut options = ConversionOptions::default();
+            configure(&mut options);
+            let context =
+                ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+            let source = ConverterOutput::new(Document::default(), Vec::new(), Vec::new());
+            assert!(matches!(
+                reconstruct_enriched_pdf(source, &options, &context),
+                Err(ConversionError::ResourceLimit { limit: "pdfLayoutConfig", .. })
+            ));
+        }
     }
 }

--- a/crates/converters/src/pdf_ocr.rs
+++ b/crates/converters/src/pdf_ocr.rs
@@ -44,6 +44,24 @@ pub fn merge_pdf_ocr(
     source.account_retained(context)
 }
 
+/// Reconstruct an already-enriched PDF output through the same native/OCR
+/// coordinate merge used by page OCR. This keeps embedded-image OCR from
+/// becoming a second, order-dependent text stream.
+pub(crate) fn reconstruct_enriched_pdf(
+    mut source: ConverterOutput,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    context.checkpoint()?;
+    let document = std::mem::take(&mut source.document);
+    let layout = reconstruct_document(document, &LayoutConfig::default(), context)?;
+    let (document, reservation) = layout.into_parts();
+    source.document = document;
+    if let Some(reservation) = reservation {
+        source.attach_memory_reservation(context, reservation)?;
+    }
+    Ok(source)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/converters/src/workbook/extras/metadata.rs
+++ b/crates/converters/src/workbook/extras/metadata.rs
@@ -2,7 +2,9 @@ use crate::workbook::budget::checked_field_bytes;
 use crate::workbook::cell::parse_cell_ref;
 use crate::workbook::error::{limit, malformed};
 use crate::workbook::model::CellCoordinate;
-use crate::workbook::opc::relationships::{decode_attr, require_spreadsheet_namespace};
+use crate::workbook::opc::relationships::{
+    decode_attr, is_spreadsheet_namespace, require_spreadsheet_namespace,
+};
 use crate::workbook::schema::{MAX_EXCEL_COLUMNS, MAX_EXCEL_ROWS};
 use into_markdown_core::{ConversionError, ConversionOptions, ExecutionContext, InlineMark};
 use quick_xml::events::Event;
@@ -23,7 +25,12 @@ pub(super) fn parse_cell_styles(
         context.checkpoint()?;
         match reader.read_resolved_event() {
             Ok((namespace, Event::Start(event))) => {
-                require_spreadsheet_namespace(&namespace, part)?;
+                if event.local_name().as_ref() == b"styleSheet" {
+                    require_spreadsheet_namespace(&namespace, part)?;
+                }
+                if !is_spreadsheet_namespace(&namespace) {
+                    continue;
+                }
                 match event.local_name().as_ref() {
                     b"font" => current_font = Some(Vec::new()),
                     b"cellXfs" => in_cell_xfs = true,
@@ -39,7 +46,9 @@ pub(super) fn parse_cell_styles(
                 }
             }
             Ok((namespace, Event::Empty(event))) => {
-                require_spreadsheet_namespace(&namespace, part)?;
+                if !is_spreadsheet_namespace(&namespace) {
+                    continue;
+                }
                 match event.local_name().as_ref() {
                     b"font" => fonts.push(Vec::new()),
                     b"xf" if in_cell_xfs => styles.push(style_marks(&event, &fonts, part)?),
@@ -51,18 +60,20 @@ pub(super) fn parse_cell_styles(
                     _ => {}
                 }
             }
-            Ok((_, Event::End(event))) => match event.local_name().as_ref() {
-                b"font" => {
-                    let mut marks = current_font
-                        .take()
-                        .ok_or_else(|| malformed(Some(part), "font end without start"))?;
-                    marks.sort_unstable();
-                    marks.dedup();
-                    fonts.push(marks);
+            Ok((namespace, Event::End(event))) if is_spreadsheet_namespace(&namespace) => {
+                match event.local_name().as_ref() {
+                    b"font" => {
+                        let mut marks = current_font
+                            .take()
+                            .ok_or_else(|| malformed(Some(part), "font end without start"))?;
+                        marks.sort_unstable();
+                        marks.dedup();
+                        fonts.push(marks);
+                    }
+                    b"cellXfs" => in_cell_xfs = false,
+                    _ => {}
                 }
-                b"cellXfs" => in_cell_xfs = false,
-                _ => {}
-            },
+            }
             Ok((_, Event::Eof)) => break,
             Err(error) => {
                 return Err(malformed(Some(part), format!("invalid styles XML: {error}")));

--- a/crates/converters/src/workbook/opc/relationships.rs
+++ b/crates/converters/src/workbook/opc/relationships.rs
@@ -204,3 +204,11 @@ pub(in crate::workbook) fn require_spreadsheet_namespace(
         _ => Err(malformed(Some(part), "invalid SpreadsheetML namespace")),
     }
 }
+
+pub(in crate::workbook) fn is_spreadsheet_namespace(namespace: &ResolveResult<'_>) -> bool {
+    matches!(
+        namespace,
+        ResolveResult::Bound(value)
+            if value.as_ref() == SPREADSHEET_NS || value.as_ref() == SPREADSHEET_STRICT_NS
+    )
+}

--- a/crates/converters/src/workbook/tests/extras.rs
+++ b/crates/converters/src/workbook/tests/extras.rs
@@ -1,5 +1,6 @@
 use super::support::{
-    context, convert, image_xlsx, push_xlsb_record, push_xlsb_string, xlsx, xlsx_with_parts,
+    context, convert, image_xlsx, push_xlsb_record, push_xlsb_string, rewrite_package, xlsx,
+    xlsx_with_parts,
 };
 use crate::workbook::calamine_adapter::{append_sheet_extras_for_test, validate_extras_fields};
 use crate::workbook::extras::metadata::{display_ranges, push_compact_range};
@@ -15,6 +16,18 @@ use into_markdown_core::{
     Block, CellRef, ConversionError, ConversionOptions, ExecutionContext, Inline,
 };
 use std::collections::BTreeMap;
+
+#[test]
+fn producer_extension_namespaces_in_styles_are_ignored() {
+    let base = xlsx(
+        r#"<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><dimension ref="A1"/><sheetData><row r="1"><c r="A1"><v>7</v></c></row></sheetData></worksheet>"#,
+    );
+    let styles = r#"<?xml version="1.0"?><styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac"><fonts count="1" x14ac:knownFonts="1"><font><b/></font></fonts><fills count="1"><fill><patternFill patternType="none"/></fill></fills><borders count="1"><border/></borders><cellStyleXfs count="1"><xf numFmtId="0"/></cellStyleXfs><cellXfs count="1"><xf numFmtId="0" fontId="0"/></cellXfs><extLst><x14ac:ext uri="{producer-extension}"/></extLst></styleSheet>"#;
+    let bytes = rewrite_package(&base, &[("xl/styles.xml", styles.to_owned())], &[]);
+
+    let output = convert(&bytes, &ConversionOptions::default()).unwrap();
+    assert!(!output.document.blocks.is_empty());
+}
 
 #[test]
 fn xlsb_comments_require_complete_unique_containers_and_required_richstr_form() {

--- a/crates/converters/src/workbook/xlsx/tables.rs
+++ b/crates/converters/src/workbook/xlsx/tables.rs
@@ -1,6 +1,8 @@
 use crate::workbook::error::{limit, malformed};
 use crate::workbook::model::WorkbookInventory;
-use crate::workbook::opc::relationships::{decode_attr, require_spreadsheet_namespace};
+use crate::workbook::opc::relationships::{
+    decode_attr, is_spreadsheet_namespace, require_spreadsheet_namespace,
+};
 use into_markdown_core::{ConversionError, ConversionOptions, ExecutionContext};
 use quick_xml::events::Event;
 use std::collections::BTreeSet;
@@ -168,6 +170,7 @@ pub(in crate::workbook) fn scan_xml_style_counts(
     let mut declared_xfs = None;
     let mut declared_num_formats = None;
     let mut declared_fonts = None;
+    let mut foreign_depth = 0_u16;
     let mut output = WorkbookInventory::default();
     loop {
         context.checkpoint()?;
@@ -175,6 +178,23 @@ pub(in crate::workbook) fn scan_xml_style_counts(
             Ok((namespace, raw_event @ (Event::Start(_) | Event::Empty(_)))) => {
                 let is_empty = matches!(raw_event, Event::Empty(_));
                 let (Event::Start(event) | Event::Empty(event)) = raw_event else { unreachable!() };
+                if foreign_depth > 0 || !is_spreadsheet_namespace(&namespace) {
+                    if !saw_root || ended_root || depth == 0 {
+                        return Err(malformed(Some(part), "extension is outside styleSheet"));
+                    }
+                    if !is_empty {
+                        depth = depth.checked_add(1).ok_or_else(|| {
+                            limit("max_nesting_depth", "styleSheet depth overflow")
+                        })?;
+                        foreign_depth = foreign_depth.checked_add(1).ok_or_else(|| {
+                            limit("max_nesting_depth", "styleSheet extension depth overflow")
+                        })?;
+                        if depth > options.limits.max_nesting_depth {
+                            return Err(limit("max_nesting_depth", "styleSheet is too deep"));
+                        }
+                    }
+                    continue;
+                }
                 require_spreadsheet_namespace(&namespace, part)?;
                 let local = event.local_name();
                 if local.as_ref() == b"styleSheet" {
@@ -251,6 +271,14 @@ pub(in crate::workbook) fn scan_xml_style_counts(
                 }
             }
             Ok((namespace, Event::End(event))) => {
+                if foreign_depth > 0 {
+                    if depth == 0 {
+                        return Err(malformed(Some(part), "unbalanced styleSheet extension"));
+                    }
+                    depth -= 1;
+                    foreign_depth -= 1;
+                    continue;
+                }
                 require_spreadsheet_namespace(&namespace, part)?;
                 if depth == 0 {
                     return Err(malformed(Some(part), "unbalanced styleSheet element"));

--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -441,6 +441,13 @@ impl ExecutionContext {
         }
     }
 
+    /// Return the immutable request resource envelope carried by this context.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn resource_limits(&self) -> &ResourceLimits {
+        &self.shared.limits
+    }
+
     /// Whether this context already spends from an enclosing preflight credit.
     #[doc(hidden)]
     #[must_use]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,7 +43,9 @@ pub use ir::{
     TableRow, TimeRange, ValidationLimits,
 };
 pub use nested::{NestedConversionRequest, NestedConversionService};
-pub use ocr_binding::{BoundOcrResult, OcrOutputPlan, OcrRecognition, OcrRegion, OcrResult};
+pub use ocr_binding::{
+    BoundOcrResult, OcrInputIdentity, OcrOutputPlan, OcrRecognition, OcrRegion, OcrResult,
+};
 pub use options::{
     AiMode, AiOptions, AssetMode, ConversionOptions, DelimitedTextOptions, NetworkOptions,
     OcrOptions, OcrPolicy, OutputOptions, RaggedRowsMode, ResourceLimits, TableHeaderMode,
@@ -52,9 +54,9 @@ pub use options::{
 pub use spi::{
     AiCapability, AiInput, AiOutput, AiProvider, AiRequest, BoxFuture, ConversionRequest,
     ConversionResult, Converter, ConverterOutput, DetectionRequest, DetectionResult, DocumentPatch,
-    FormatDetector, MarkdownRenderer, OcrEngine, OcrRequest, PatchOperation, ProbeOutcome,
-    Services, SourceResolver, Tensor, TensorRuntime, Transcriber, TranscriptionRequest,
-    TranscriptionResult,
+    FormatDetector, MarkdownRenderer, OcrEngine, OcrRequest, OutputEnricher, PatchOperation,
+    ProbeOutcome, Services, SourceResolver, Tensor, TensorRuntime, Transcriber,
+    TranscriptionRequest, TranscriptionResult,
 };
 #[doc(hidden)]
 pub use spi::{

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -54,8 +54,8 @@ pub use options::{
 pub use spi::{
     AiCapability, AiInput, AiOutput, AiProvider, AiRequest, BoxFuture, ConversionRequest,
     ConversionResult, Converter, ConverterOutput, DetectionRequest, DetectionResult, DocumentPatch,
-    FormatDetector, MarkdownRenderer, OcrEngine, OcrRequest, OutputEnricher, PatchOperation,
-    ProbeOutcome, Services, SourceResolver, Tensor, TensorRuntime, Transcriber,
+    EnrichmentPlan, FormatDetector, MarkdownRenderer, OcrEngine, OcrRequest, OutputEnricher,
+    PatchOperation, ProbeOutcome, Services, SourceResolver, Tensor, TensorRuntime, Transcriber,
     TranscriptionRequest, TranscriptionResult,
 };
 #[doc(hidden)]

--- a/crates/core/src/ocr_binding.rs
+++ b/crates/core/src/ocr_binding.rs
@@ -98,6 +98,62 @@ pub struct BoundOcrResult {
     result: OcrResult,
     detection_confidences: Vec<f32>,
     evidence_chain: Vec<OcrEvidenceStep>,
+    input_identity: Option<OcrInputIdentity>,
+}
+
+/// Cryptographic identity of the exact normalized image accepted by an OCR provider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct OcrInputIdentity {
+    sha256: [u8; 32],
+    width: u32,
+    height: u32,
+    frame: u32,
+}
+
+impl OcrInputIdentity {
+    /// Construct an identity for one normalized image frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns an OCR error when either image dimension is zero.
+    pub fn try_new(
+        sha256: [u8; 32],
+        width: u32,
+        height: u32,
+        frame: u32,
+    ) -> Result<Self, ConversionError> {
+        if width == 0 || height == 0 {
+            return Err(ConversionError::Ocr {
+                provider: "ocr-binding".into(),
+                detail: "OCR input identity dimensions must be non-zero".into(),
+            });
+        }
+        Ok(Self { sha256, width, height, frame })
+    }
+
+    /// SHA-256 of the exact normalized encoded bytes supplied to OCR.
+    #[must_use]
+    pub const fn sha256(self) -> [u8; 32] {
+        self.sha256
+    }
+
+    /// Normalized image width.
+    #[must_use]
+    pub const fn width(self) -> u32 {
+        self.width
+    }
+
+    /// Normalized image height.
+    #[must_use]
+    pub const fn height(self) -> u32 {
+        self.height
+    }
+
+    /// Zero-based frame ordinal.
+    #[must_use]
+    pub const fn frame(self) -> u32 {
+        self.frame
+    }
 }
 
 impl BoundOcrResult {
@@ -152,7 +208,23 @@ impl BoundOcrResult {
                 detail: "OCR result provider does not match the bound recognition provider".into(),
             });
         }
-        Ok(Self { result, detection_confidences, evidence_chain })
+        Ok(Self { result, detection_confidences, evidence_chain, input_identity: None })
+    }
+
+    /// Bind validated OCR evidence to the exact normalized input image.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same validation errors as [`Self::try_new`].
+    pub fn try_new_for_input(
+        result: OcrResult,
+        detection_confidences: Vec<f32>,
+        evidence_chain: Vec<OcrEvidenceStep>,
+        input_identity: OcrInputIdentity,
+    ) -> Result<Self, ConversionError> {
+        let mut bound = Self::try_new(result, detection_confidences, evidence_chain)?;
+        bound.input_identity = Some(input_identity);
+        Ok(bound)
     }
 
     /// Read the legacy-compatible OCR payload.
@@ -171,6 +243,12 @@ impl BoundOcrResult {
     #[must_use]
     pub fn evidence_chain(&self) -> &[OcrEvidenceStep] {
         &self.evidence_chain
+    }
+
+    /// Exact normalized input identity, when supplied by the provider.
+    #[must_use]
+    pub const fn input_identity(&self) -> Option<OcrInputIdentity> {
+        self.input_identity
     }
 
     /// Consume the bound result after the caller has validated provider identity.

--- a/crates/core/src/ocr_binding.rs
+++ b/crates/core/src/ocr_binding.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct OcrOutputPlan {
     retained_budget: u64,
+    working_budget: u64,
     region_limit: u32,
     text_bytes_cap: u64,
 }
@@ -40,15 +41,39 @@ impl OcrOutputPlan {
         }
         Ok(Self {
             retained_budget: max_retained_bytes,
+            working_budget: 0,
             region_limit: max_regions,
             text_bytes_cap: max_text_bytes,
         })
+    }
+
+    /// Construct a plan that also declares the provider's peak transient working set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConversionError::ResourceLimit`] when the retained-output
+    /// bounds are zero, overflow, or cannot contain the declared payload.
+    pub fn try_new_with_working(
+        max_retained_bytes: u64,
+        max_working_bytes: u64,
+        max_regions: u32,
+        max_text_bytes: u64,
+    ) -> Result<Self, ConversionError> {
+        let mut plan = Self::try_new(max_retained_bytes, max_regions, max_text_bytes)?;
+        plan.working_budget = max_working_bytes;
+        Ok(plan)
     }
 
     /// Maximum bytes retained by the bound result and emitted OCR IR.
     #[must_use]
     pub const fn max_retained_bytes(self) -> u64 {
         self.retained_budget
+    }
+
+    /// Maximum transient bytes needed while the provider produces the result.
+    #[must_use]
+    pub const fn max_working_bytes(self) -> u64 {
+        self.working_budget
     }
 
     /// Maximum recognized regions returned by the provider.

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -1084,6 +1084,26 @@ pub trait Converter: Send + Sync {
     ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>>;
 }
 
+/// Transactional post-conversion enrichment before validation checkpoints and rendering.
+///
+/// Implementations consume the complete converter output and must return either a fully
+/// validated replacement or an error. This prevents partially enriched output from escaping.
+pub trait OutputEnricher: Send + Sync {
+    /// Stable implementation ID.
+    fn id(&self) -> &'static str;
+
+    /// Enrich one converter output under the original request authority.
+    fn enrich<'a>(
+        &'a self,
+        output: ConverterOutput,
+        converter_id: &'a str,
+        format: InputFormat,
+        options: &'a ConversionOptions,
+        services: &'a Services,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>>;
+}
+
 /// Render the unified IR through a single Markdown policy.
 pub trait MarkdownRenderer: Send + Sync {
     /// Stable renderer ID.
@@ -1426,6 +1446,7 @@ mod tests {
         let _: Option<&dyn SourceResolver> = None;
         let _: Option<&dyn FormatDetector> = None;
         let _: Option<&dyn Converter> = None;
+        let _: Option<&dyn OutputEnricher> = None;
         let _: Option<&dyn MarkdownRenderer> = None;
         let _: Option<&dyn OcrEngine> = None;
         let _: Option<&dyn Transcriber> = None;

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -410,6 +410,49 @@ impl ConverterOutput {
         Ok(self)
     }
 
+    /// Certify the incremental reservation acquired before invoking an output
+    /// enricher. Existing parent-context leases remain attached; any leases
+    /// produced through the temporary enrichment credit are replaced by the
+    /// authenticated parent reservation.
+    #[doc(hidden)]
+    pub fn certify_enrichment_reservation(
+        mut self,
+        context: &ExecutionContext,
+        mut reservation: ResourceReservation,
+    ) -> Result<Self, ConversionError> {
+        let required = estimate_retained_output(&self.document, &self.assets, &self.diagnostics)?;
+        if !reservation.belongs_to_memory_context(context) {
+            return Err(ConversionError::Internal {
+                detail: "enricher preflight reservation belongs to a different context".into(),
+            });
+        }
+        self.memory_lease.leases.retain(|lease| lease.belongs_to_memory_context(context));
+        let held = self
+            .memory_lease
+            .leases
+            .iter()
+            .map(ResourceReservation::bytes)
+            .try_fold(0_u64, u64::checked_add)
+            .ok_or_else(|| ConversionError::ResourceLimit {
+                limit: "max_memory_bytes",
+                detail: "enricher retained-memory accounting overflowed".into(),
+            })?;
+        let deficit = required.saturating_sub(held);
+        if reservation.bytes() < deficit {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_memory_bytes",
+                detail: format!(
+                    "enricher retained {deficit} incremental bytes beyond its {}-byte preflight plan",
+                    reservation.bytes()
+                ),
+            });
+        }
+        reservation.shrink(reservation.bytes().saturating_sub(deficit))?;
+        self.memory_lease.push(reservation)?;
+        self.memory_lease.accounted_bytes = required;
+        Ok(self)
+    }
+
     /// Consume the intermediate output and assemble a final result without
     /// exposing its detachable memory ownership.
     #[doc(hidden)]
@@ -1088,9 +1131,42 @@ pub trait Converter: Send + Sync {
 ///
 /// Implementations consume the complete converter output and must return either a fully
 /// validated replacement or an error. This prevents partially enriched output from escaping.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnrichmentPlan {
+    /// This enricher is an exact no-op for the request and is not invoked.
+    Skip,
+    /// Reserve this incremental peak before invoking the enricher.
+    Reserve(u64),
+}
+
+/// Transactional post-conversion enrichment with a mandatory preflight plan.
 pub trait OutputEnricher: Send + Sync {
     /// Stable implementation ID.
     fn id(&self) -> &'static str;
+
+    /// Conservative incremental allocation peak reserved before enrichment.
+    /// The plan must include all provider output, working-set, validation, and
+    /// retained-output growth that can coexist during [`Self::enrich`].
+    ///
+    /// # Errors
+    ///
+    /// Returns a stable component or resource error when no safe plan can be
+    /// declared for this output.
+    fn planned_enrichment_bytes(
+        &self,
+        output: &ConverterOutput,
+        converter_id: &str,
+        format: InputFormat,
+        options: &ConversionOptions,
+        services: &Services,
+        context: &ExecutionContext,
+    ) -> Result<EnrichmentPlan, ConversionError> {
+        let _ = (output, converter_id, format, options, services, context);
+        Err(ConversionError::ComponentUnavailable {
+            component: self.id().into(),
+            detail: "output enricher does not declare a preflight memory plan".into(),
+        })
+    }
 
     /// Enrich one converter output under the original request authority.
     fn enrich<'a>(
@@ -1178,6 +1254,29 @@ pub trait OcrEngine: Send + Sync {
         Err(ConversionError::ComponentUnavailable {
             component: self.id().into(),
             detail: "OCR engine does not declare a bound output plan".into(),
+        })
+    }
+
+    /// Bound the result for any canonical normalized PNG with these exact
+    /// dimensions. Container enrichers use this before allocating the
+    /// normalized bytes, then the provider revalidates the concrete request
+    /// through [`Self::planned_bound_output`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConversionError::ComponentUnavailable`] unless the provider
+    /// declares a bound for canonical normalized PNG input of this shape.
+    fn planned_normalized_png_output(
+        &self,
+        width: u32,
+        height: u32,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        let _ = (width, height, options, context);
+        Err(ConversionError::ComponentUnavailable {
+            component: self.id().into(),
+            detail: "OCR engine does not declare a normalized-PNG output bound".into(),
         })
     }
     /// Recognize text with additive, identity-bound structured evidence.

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -11,8 +11,8 @@ use into_markdown_core::{
     Asset, Block, BlockNode, ConversionError, ConversionOptions, ConversionRequest,
     ConversionResult, Converter, ConverterOutput, DetectionRequest, DetectionResult, Document,
     ExecutionContext, ExecutionStage, FormatCandidate, FormatDetector, FormatHint,
-    MarkdownRenderer, ProbeOutcome, Provenance, ResolvedInput, ResourceReservation, Services,
-    SourceLocator, SourceMetadata, SourceResolver, estimate_retained_result,
+    MarkdownRenderer, OutputEnricher, ProbeOutcome, Provenance, ResolvedInput, ResourceReservation,
+    Services, SourceLocator, SourceMetadata, SourceResolver, estimate_retained_result,
     estimate_validation_working_set,
 };
 use std::collections::BTreeSet;
@@ -95,6 +95,7 @@ pub struct EngineBuilder {
     registry: RegistryBuilder,
     renderer: Option<Arc<dyn MarkdownRenderer>>,
     services: Services,
+    enrichers: Vec<Arc<dyn OutputEnricher>>,
 }
 
 impl EngineBuilder {
@@ -123,6 +124,13 @@ impl EngineBuilder {
         self
     }
 
+    /// Register a transactional post-conversion enricher.
+    #[must_use]
+    pub fn enricher(mut self, enricher: Arc<dyn OutputEnricher>) -> Self {
+        self.enrichers.push(enricher);
+        self
+    }
+
     /// Validate IDs and build an immutable engine.
     ///
     /// # Errors
@@ -131,6 +139,7 @@ impl EngineBuilder {
     /// IDs.
     pub fn build(mut self) -> Result<Engine, ConversionError> {
         self.registry.validate()?;
+        validate_unique("output enricher", self.enrichers.iter().map(|value| value.id()))?;
         self.registry.format_detectors.sort_by(|left, right| {
             right.priority().cmp(&left.priority()).then_with(|| left.id().cmp(right.id()))
         });
@@ -146,6 +155,7 @@ impl EngineBuilder {
             converters: self.registry.converters,
             renderer: self.renderer,
             services: self.services,
+            enrichers: self.enrichers,
         })
     }
 }
@@ -157,6 +167,7 @@ pub struct Engine {
     converters: Vec<Arc<dyn Converter>>,
     renderer: Option<Arc<dyn MarkdownRenderer>>,
     services: Services,
+    enrichers: Vec<Arc<dyn OutputEnricher>>,
 }
 
 impl Engine {
@@ -313,6 +324,16 @@ impl Engine {
             |_| Ok(()),
         )
         .await?;
+        let output = invoke_enrichers(
+            &self.enrichers,
+            output,
+            attempt.converter.id(),
+            attempt.candidate.format,
+            &request.options,
+            &self.services,
+            &context,
+        )
+        .await?;
         let renderer = self.renderer.as_ref().ok_or_else(|| ConversionError::Internal {
             detail: "no Markdown renderer is registered".into(),
         })?;
@@ -410,6 +431,34 @@ impl Engine {
     ) -> Result<Vec<FormatCandidate>, ConversionError> {
         nested::detect_formats(&self.format_detectors, input, hint, context).await
     }
+}
+
+pub(crate) async fn invoke_enrichers(
+    enrichers: &[Arc<dyn OutputEnricher>],
+    mut output: ConverterOutput,
+    converter_id: &str,
+    format: into_markdown_core::InputFormat,
+    options: &ConversionOptions,
+    services: &Services,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    for enricher in enrichers {
+        context.checkpoint()?;
+        output = context
+            .run(enricher.enrich(output, converter_id, format, options, services, context))
+            .await??;
+        output.document.validate().map_err(|error| ConversionError::Internal {
+            detail: format!(
+                "output enricher {} returned invalid document IR ({} at {}): {}",
+                enricher.id(),
+                error.code.as_str(),
+                error.path,
+                error.detail
+            ),
+        })?;
+        output = output.account_retained(context)?;
+    }
+    Ok(output)
 }
 
 async fn invoke_converter_preflighted<F>(
@@ -1186,6 +1235,35 @@ mod tests {
         }
     }
 
+    struct TitleEnricher {
+        id: &'static str,
+        suffix: &'static str,
+    }
+
+    impl OutputEnricher for TitleEnricher {
+        fn id(&self) -> &'static str {
+            self.id
+        }
+
+        fn enrich<'a>(
+            &'a self,
+            mut output: ConverterOutput,
+            converter_id: &'a str,
+            format: InputFormat,
+            _: &'a ConversionOptions,
+            _: &'a Services,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+            let suffix = self.suffix;
+            Box::pin(async move {
+                assert_eq!(converter_id, "base.converter");
+                assert_eq!(format, InputFormat::Text);
+                output.document.metadata.title.get_or_insert_default().push_str(suffix);
+                Ok(output)
+            })
+        }
+    }
+
     struct CapacityRenderer(usize, Arc<std::sync::atomic::AtomicUsize>);
     impl MarkdownRenderer for CapacityRenderer {
         fn id(&self) -> &'static str {
@@ -1252,6 +1330,33 @@ mod tests {
             .register_source_resolver(Arc::new(BytesResolver))
             .register_source_resolver(Arc::new(BytesResolver));
         assert_eq!(builder.build().err().unwrap().code(), into_markdown_core::ErrorCode::Internal);
+    }
+
+    #[test]
+    fn duplicate_output_enricher_ids_are_rejected() {
+        let builder = EngineBuilder::new()
+            .enricher(Arc::new(TitleEnricher { id: "same.enricher", suffix: ":one" }))
+            .enricher(Arc::new(TitleEnricher { id: "same.enricher", suffix: ":two" }));
+        let error = builder.build().err().unwrap();
+        assert_eq!(error.code(), into_markdown_core::ErrorCode::Internal);
+        assert!(error.to_string().contains("duplicate output enricher ID"));
+    }
+
+    #[test]
+    fn output_enrichers_run_in_registration_order_before_rendering() {
+        let mut builder = EngineBuilder::new()
+            .renderer(Arc::new(EmptyRenderer))
+            .enricher(Arc::new(TitleEnricher { id: "first.enricher", suffix: ":one" }))
+            .enricher(Arc::new(TitleEnricher { id: "second.enricher", suffix: ":two" }));
+        builder
+            .registry_mut()
+            .register_source_resolver(Arc::new(BytesResolver))
+            .register_format_detector(Arc::new(TextDetector))
+            .register_converter(Arc::new(MatchingConverter("base.converter")));
+        let engine = builder.build().unwrap();
+        let request = ConversionRequest::new(InputRef::bytes(b"hello".as_slice(), Some("x.txt")));
+        let result = block_on(engine.convert(request)).unwrap();
+        assert_eq!(result.document.metadata.title.as_deref(), Some("base.converter:one:two"));
     }
 
     #[test]

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1275,6 +1275,8 @@ mod tests {
 
     struct PlanGuardEnricher(Arc<std::sync::atomic::AtomicUsize>);
 
+    struct LimitPlanGuardEnricher(Arc<std::sync::atomic::AtomicUsize>);
+
     struct SkipGuardEnricher(Arc<std::sync::atomic::AtomicUsize>);
 
     impl OutputEnricher for SkipGuardEnricher {
@@ -1332,6 +1334,38 @@ mod tests {
         ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
             self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Box::pin(async move { Ok(output) })
+        }
+    }
+
+    impl OutputEnricher for LimitPlanGuardEnricher {
+        fn id(&self) -> &'static str {
+            "test.limit-plan-guard-enricher"
+        }
+        fn planned_enrichment_bytes(
+            &self,
+            _: &ConverterOutput,
+            _: &str,
+            _: InputFormat,
+            _: &ConversionOptions,
+            _: &Services,
+            _: &ExecutionContext,
+        ) -> Result<EnrichmentPlan, ConversionError> {
+            Err(ConversionError::ResourceLimit {
+                limit: "max_archive_entries",
+                detail: "embedded visual references exceed the request limit".into(),
+            })
+        }
+        fn enrich<'a>(
+            &'a self,
+            _: ConverterOutput,
+            _: &'a str,
+            _: InputFormat,
+            _: &'a ConversionOptions,
+            _: &'a Services,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async { unreachable!("failed preflight must never execute the enricher") })
         }
     }
 
@@ -1488,6 +1522,33 @@ mod tests {
         ))
         .unwrap_err();
         assert!(matches!(error, ConversionError::ResourceLimit { limit: "max_memory_bytes", .. }));
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn output_enricher_limit_preflight_fails_before_entry_without_leases() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let enricher: Arc<dyn OutputEnricher> =
+            Arc::new(LimitPlanGuardEnricher(Arc::clone(&calls)));
+        let context = ExecutionContext::new(
+            into_markdown_core::ExecutionOptions::default(),
+            into_markdown_core::ResourceLimits::default(),
+        );
+        let error = block_on(invoke_enrichers(
+            &[enricher],
+            ConverterOutput::default(),
+            "test.converter",
+            InputFormat::Text,
+            &ConversionOptions::default(),
+            &Services::default(),
+            &context,
+        ))
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            ConversionError::ResourceLimit { limit: "max_archive_entries", .. }
+        ));
         assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
         assert_eq!(context.reserved_memory_bytes(), 0);
     }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -10,7 +10,7 @@ use fixed_alloc::{FixedSlots, try_clone_string};
 use into_markdown_core::{
     Asset, Block, BlockNode, ConversionError, ConversionOptions, ConversionRequest,
     ConversionResult, Converter, ConverterOutput, DetectionRequest, DetectionResult, Document,
-    ExecutionContext, ExecutionStage, FormatCandidate, FormatDetector, FormatHint,
+    EnrichmentPlan, ExecutionContext, ExecutionStage, FormatCandidate, FormatDetector, FormatHint,
     MarkdownRenderer, OutputEnricher, ProbeOutcome, Provenance, ResolvedInput, ResourceReservation,
     Services, SourceLocator, SourceMetadata, SourceResolver, estimate_retained_result,
     estimate_validation_working_set,
@@ -444,9 +444,39 @@ pub(crate) async fn invoke_enrichers(
 ) -> Result<ConverterOutput, ConversionError> {
     for enricher in enrichers {
         context.checkpoint()?;
+        let plan = enricher.planned_enrichment_bytes(
+            &output,
+            converter_id,
+            format,
+            options,
+            services,
+            context,
+        )?;
+        let EnrichmentPlan::Reserve(plan) = plan else {
+            continue;
+        };
+        let mut memory = context.reserve_memory(plan)?;
+        let credited_context = context.with_memory_credit(&mut memory)?;
         output = context
-            .run(enricher.enrich(output, converter_id, format, options, services, context))
+            .run(enricher.enrich(
+                output,
+                converter_id,
+                format,
+                options,
+                services,
+                &credited_context,
+            ))
             .await??;
+        let retained_bytes = into_markdown_core::estimate_retained_output(
+            &output.document,
+            &output.assets,
+            &output.diagnostics,
+        )?;
+        let validation_bytes =
+            estimate_validation_working_set(&output.document, &output.assets, &output.diagnostics)?;
+        let retained_memory = credited_context
+            .reserve_memory(retained_bytes.saturating_sub(output.leased_memory_for(context)))?;
+        let validation_memory = credited_context.reserve_memory(validation_bytes)?;
         output.document.validate().map_err(|error| ConversionError::Internal {
             detail: format!(
                 "output enricher {} returned invalid document IR ({} at {}): {}",
@@ -456,7 +486,10 @@ pub(crate) async fn invoke_enrichers(
                 error.detail
             ),
         })?;
-        output = output.account_retained(context)?;
+        drop(validation_memory);
+        drop(retained_memory);
+        drop(credited_context);
+        output = output.certify_enrichment_reservation(context, memory)?;
     }
     Ok(output)
 }
@@ -1240,9 +1273,83 @@ mod tests {
         suffix: &'static str,
     }
 
+    struct PlanGuardEnricher(Arc<std::sync::atomic::AtomicUsize>);
+
+    struct SkipGuardEnricher(Arc<std::sync::atomic::AtomicUsize>);
+
+    impl OutputEnricher for SkipGuardEnricher {
+        fn id(&self) -> &'static str {
+            "test.skip-guard-enricher"
+        }
+        fn planned_enrichment_bytes(
+            &self,
+            _: &ConverterOutput,
+            _: &str,
+            _: InputFormat,
+            _: &ConversionOptions,
+            _: &Services,
+            _: &ExecutionContext,
+        ) -> Result<EnrichmentPlan, ConversionError> {
+            Ok(EnrichmentPlan::Skip)
+        }
+        fn enrich<'a>(
+            &'a self,
+            _: ConverterOutput,
+            _: &'a str,
+            _: InputFormat,
+            _: &'a ConversionOptions,
+            _: &'a Services,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async { unreachable!("skipped enricher must never execute") })
+        }
+    }
+
+    impl OutputEnricher for PlanGuardEnricher {
+        fn id(&self) -> &'static str {
+            "test.plan-guard-enricher"
+        }
+        fn planned_enrichment_bytes(
+            &self,
+            _: &ConverterOutput,
+            _: &str,
+            _: InputFormat,
+            _: &ConversionOptions,
+            _: &Services,
+            _: &ExecutionContext,
+        ) -> Result<EnrichmentPlan, ConversionError> {
+            Ok(EnrichmentPlan::Reserve(8 * 1024))
+        }
+        fn enrich<'a>(
+            &'a self,
+            output: ConverterOutput,
+            _: &'a str,
+            _: InputFormat,
+            _: &'a ConversionOptions,
+            _: &'a Services,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Box::pin(async move { Ok(output) })
+        }
+    }
+
     impl OutputEnricher for TitleEnricher {
         fn id(&self) -> &'static str {
             self.id
+        }
+
+        fn planned_enrichment_bytes(
+            &self,
+            _: &ConverterOutput,
+            _: &str,
+            _: InputFormat,
+            _: &ConversionOptions,
+            _: &Services,
+            _: &ExecutionContext,
+        ) -> Result<EnrichmentPlan, ConversionError> {
+            Ok(EnrichmentPlan::Reserve(64 * 1024))
         }
 
         fn enrich<'a>(
@@ -1357,6 +1464,61 @@ mod tests {
         let request = ConversionRequest::new(InputRef::bytes(b"hello".as_slice(), Some("x.txt")));
         let result = block_on(engine.convert(request)).unwrap();
         assert_eq!(result.document.metadata.title.as_deref(), Some("base.converter:one:two"));
+    }
+
+    #[test]
+    fn output_enricher_plan_is_reserved_before_provider_entry() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let enricher: Arc<dyn OutputEnricher> = Arc::new(PlanGuardEnricher(Arc::clone(&calls)));
+        let context = ExecutionContext::new(
+            into_markdown_core::ExecutionOptions::default(),
+            into_markdown_core::ResourceLimits {
+                max_memory_bytes: 8 * 1024 - 1,
+                ..into_markdown_core::ResourceLimits::default()
+            },
+        );
+        let error = block_on(invoke_enrichers(
+            &[enricher],
+            ConverterOutput::default(),
+            "test.converter",
+            InputFormat::Text,
+            &ConversionOptions::default(),
+            &Services::default(),
+            &context,
+        ))
+        .unwrap_err();
+        assert!(matches!(error, ConversionError::ResourceLimit { limit: "max_memory_bytes", .. }));
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn skipped_output_enricher_is_an_exact_no_op_even_with_zero_memory_budget() {
+        let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let enricher: Arc<dyn OutputEnricher> = Arc::new(SkipGuardEnricher(Arc::clone(&calls)));
+        let context = ExecutionContext::new(
+            into_markdown_core::ExecutionOptions::default(),
+            into_markdown_core::ResourceLimits {
+                max_memory_bytes: 0,
+                ..into_markdown_core::ResourceLimits::default()
+            },
+        );
+        let output = ConverterOutput::default();
+        let result = block_on(invoke_enrichers(
+            &[enricher],
+            output,
+            "test.converter",
+            InputFormat::Text,
+            &ConversionOptions::default(),
+            &Services::default(),
+            &context,
+        ))
+        .unwrap();
+        assert_eq!(result.document, ConverterOutput::default().document);
+        assert!(result.assets.is_empty());
+        assert!(result.diagnostics.is_empty());
+        assert_eq!(calls.load(std::sync::atomic::Ordering::SeqCst), 0);
+        assert_eq!(context.reserved_memory_bytes(), 0);
     }
 
     #[test]

--- a/crates/engine/src/recovery.rs
+++ b/crates/engine/src/recovery.rs
@@ -6,7 +6,7 @@ pub use store::{RecoveryStore, RecoveryToken, TaskCheckpoint, TaskPhase};
 
 use super::{
     Attempt, Engine, collect_provenance_preflighted, invoke_converter_preflighted,
-    invoke_renderer_preflighted, measured_input_bytes, normalize_confidence,
+    invoke_enrichers, invoke_renderer_preflighted, measured_input_bytes, normalize_confidence,
     provenance_inventory_bytes,
 };
 use base64::{Engine as _, engine::general_purpose::STANDARD};
@@ -507,6 +507,16 @@ pub(super) async fn convert(
             },
         )
         .await?;
+        let output = invoke_enrichers(
+            &engine.enrichers,
+            output,
+            attempt.converter.id(),
+            attempt.candidate.format,
+            &request.options,
+            &engine.services,
+            &context,
+        )
+        .await?;
         store.commit(
             token,
             &context,
@@ -877,8 +887,8 @@ mod tests {
     use crate::EngineBuilder;
     use into_markdown_core::{
         BoxFuture, ConversionOptions, Converter, ExecutionOptions, FormatCandidate, FormatDetector,
-        FormatHint, Inline, InputFormat, InputRef, MarkdownRenderer, ResolvedInput, ResourceLimits,
-        Services, SourceResolver,
+        FormatHint, Inline, InputFormat, InputRef, MarkdownRenderer, OutputEnricher, ResolvedInput,
+        ResourceLimits, Services, SourceResolver,
     };
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::{fs, fs::File, io::Write as _, path::Path};
@@ -939,6 +949,32 @@ mod tests {
     }
 
     struct CountingConverter(Arc<AtomicUsize>);
+
+    struct CountingTitleEnricher(Arc<AtomicUsize>);
+
+    impl OutputEnricher for CountingTitleEnricher {
+        fn id(&self) -> &'static str {
+            "recovery.title-enricher"
+        }
+
+        fn enrich<'a>(
+            &'a self,
+            mut output: ConverterOutput,
+            converter_id: &'a str,
+            format: InputFormat,
+            _: &'a ConversionOptions,
+            _: &'a Services,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            Box::pin(async move {
+                assert_eq!(converter_id, "recovery.converter");
+                assert_eq!(format, InputFormat::Text);
+                output.document.metadata.title.get_or_insert_default().push_str(":enriched");
+                Ok(output)
+            })
+        }
+    }
 
     impl Converter for CountingConverter {
         fn id(&self) -> &'static str {
@@ -1210,6 +1246,23 @@ mod tests {
         fail_renderer: Arc<AtomicBool>,
     ) -> Engine {
         let mut builder = EngineBuilder::new()
+            .renderer(Arc::new(ControlledRenderer { fail: fail_renderer, calls: renderer_calls }));
+        builder
+            .registry_mut()
+            .register_source_resolver(Arc::new(BytesResolver))
+            .register_format_detector(Arc::new(TextDetector))
+            .register_converter(Arc::new(CountingConverter(conversions)));
+        builder.build().unwrap()
+    }
+
+    fn enriched_engine(
+        conversions: Arc<AtomicUsize>,
+        enrichments: Arc<AtomicUsize>,
+        renderer_calls: Arc<AtomicUsize>,
+        fail_renderer: Arc<AtomicBool>,
+    ) -> Engine {
+        let mut builder = EngineBuilder::new()
+            .enricher(Arc::new(CountingTitleEnricher(enrichments)))
             .renderer(Arc::new(ControlledRenderer { fail: fail_renderer, calls: renderer_calls }));
         builder
             .registry_mut()
@@ -1500,6 +1553,43 @@ mod tests {
         assert_eq!(replay.markdown, result.markdown);
         assert_eq!(conversions.load(Ordering::SeqCst), 1);
         assert_eq!(renders.load(Ordering::SeqCst), 3);
+    }
+
+    #[test]
+    fn enriched_output_is_checkpointed_transactionally_and_not_reenriched_after_restart() {
+        let directory = private_tempdir();
+        let store = RecoveryStore::open(directory.path()).unwrap();
+        let token = store.create_token().unwrap();
+        let conversions = Arc::new(AtomicUsize::new(0));
+        let enrichments = Arc::new(AtomicUsize::new(0));
+        let renders = Arc::new(AtomicUsize::new(0));
+        let fail = Arc::new(AtomicBool::new(true));
+        let request = || ConversionRequest::new(InputRef::bytes(b"hello".as_slice(), Some("x")));
+
+        let first = enriched_engine(
+            Arc::clone(&conversions),
+            Arc::clone(&enrichments),
+            Arc::clone(&renders),
+            Arc::clone(&fail),
+        );
+        assert_eq!(
+            block_on(first.convert_recoverable(request(), &store, &token)).unwrap_err().code(),
+            ErrorCode::Internal
+        );
+        assert_eq!(store.inspect(&token).unwrap().unwrap().phase, TaskPhase::Converted);
+
+        let restarted = enriched_engine(
+            Arc::clone(&conversions),
+            Arc::clone(&enrichments),
+            Arc::clone(&renders),
+            Arc::clone(&fail),
+        );
+        let result = block_on(restarted.convert_recoverable(request(), &store, &token)).unwrap();
+        assert_eq!(result.document.metadata.title.as_deref(), Some("hello:enriched"));
+        assert_eq!(result.markdown, "# hello:enriched\n");
+        assert_eq!(conversions.load(Ordering::SeqCst), 1);
+        assert_eq!(enrichments.load(Ordering::SeqCst), 1);
+        assert_eq!(renders.load(Ordering::SeqCst), 2);
     }
 
     #[test]

--- a/crates/engine/src/recovery.rs
+++ b/crates/engine/src/recovery.rs
@@ -517,6 +517,8 @@ pub(super) async fn convert(
             &context,
         )
         .await?;
+        validate_asset_inventory(&output.document, &output.assets, &request)?;
+        validate_diagnostics(&output.diagnostics)?;
         store.commit(
             token,
             &context,
@@ -952,6 +954,79 @@ mod tests {
 
     struct CountingTitleEnricher(Arc<AtomicUsize>);
 
+    struct ReferencedAssetDroppingEnricher(Arc<AtomicUsize>);
+
+    struct InvalidDiagnosticEnricher(Arc<AtomicUsize>);
+
+    impl OutputEnricher for ReferencedAssetDroppingEnricher {
+        fn id(&self) -> &'static str {
+            "recovery.referenced-asset-dropping-enricher"
+        }
+
+        fn planned_enrichment_bytes(
+            &self,
+            _: &ConverterOutput,
+            _: &str,
+            _: InputFormat,
+            _: &ConversionOptions,
+            _: &Services,
+            _: &ExecutionContext,
+        ) -> Result<into_markdown_core::EnrichmentPlan, ConversionError> {
+            Ok(into_markdown_core::EnrichmentPlan::Reserve(64 * 1024))
+        }
+
+        fn enrich<'a>(
+            &'a self,
+            mut output: ConverterOutput,
+            _: &'a str,
+            _: InputFormat,
+            _: &'a ConversionOptions,
+            _: &'a Services,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            output.assets.clear();
+            Box::pin(async move { Ok(output) })
+        }
+    }
+
+    impl OutputEnricher for InvalidDiagnosticEnricher {
+        fn id(&self) -> &'static str {
+            "recovery.invalid-diagnostic-enricher"
+        }
+
+        fn planned_enrichment_bytes(
+            &self,
+            _: &ConverterOutput,
+            _: &str,
+            _: InputFormat,
+            _: &ConversionOptions,
+            _: &Services,
+            _: &ExecutionContext,
+        ) -> Result<into_markdown_core::EnrichmentPlan, ConversionError> {
+            Ok(into_markdown_core::EnrichmentPlan::Reserve(64 * 1024))
+        }
+
+        fn enrich<'a>(
+            &'a self,
+            mut output: ConverterOutput,
+            _: &'a str,
+            _: InputFormat,
+            _: &'a ConversionOptions,
+            _: &'a Services,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            output.diagnostics.push(Diagnostic {
+                code: String::new(),
+                severity: into_markdown_core::DiagnosticSeverity::Warning,
+                message: "invalid diagnostic".into(),
+                locator: None,
+            });
+            Box::pin(async move { Ok(output) })
+        }
+    }
+
     impl OutputEnricher for CountingTitleEnricher {
         fn id(&self) -> &'static str {
             "recovery.title-enricher"
@@ -1318,6 +1393,30 @@ mod tests {
         builder.build().unwrap()
     }
 
+    fn fixture_engine_with_enricher(
+        output: &ConverterOutput,
+        conversions: Arc<AtomicUsize>,
+        renderer_calls: Arc<AtomicUsize>,
+        enricher: Arc<dyn OutputEnricher>,
+    ) -> Engine {
+        let mut builder =
+            EngineBuilder::new().enricher(enricher).renderer(Arc::new(ControlledRenderer {
+                fail: Arc::new(AtomicBool::new(false)),
+                calls: renderer_calls,
+            }));
+        builder
+            .registry_mut()
+            .register_source_resolver(Arc::new(BytesResolver))
+            .register_format_detector(Arc::new(TextDetector))
+            .register_converter(Arc::new(FixtureConverter {
+                conversions,
+                document: output.document.clone(),
+                assets: output.assets.clone(),
+                diagnostics: output.diagnostics.clone(),
+            }));
+        builder.build().unwrap()
+    }
+
     fn fixture_provenance() -> Provenance {
         Provenance {
             kind: into_markdown_core::ProvenanceKind::NativeParser,
@@ -1535,6 +1634,87 @@ mod tests {
     fn assert_unsafe_recovery<T>(result: Result<T, ConversionError>) {
         let Err(error) = result else { panic!("unsafe recovery root was accepted") };
         assert!(matches!(error, ConversionError::Recovery { reason: "unsafePath", .. }), "{error}");
+    }
+
+    #[test]
+    fn enricher_cannot_publish_checkpoint_with_missing_referenced_asset() {
+        let asset_id = AssetId("referenced-image".into());
+        let fixture = ConverterOutput::new(
+            Document {
+                blocks: vec![fixture_node(
+                    "image-node",
+                    Block::Image { asset: asset_id.clone(), alt: Some("diagram".into()) },
+                )],
+                ..Document::default()
+            },
+            vec![Asset {
+                id: asset_id,
+                filename: Some("diagram.png".into()),
+                media_type: "image/png".into(),
+                bytes: vec![1],
+                external_uri: None,
+            }],
+            Vec::new(),
+        );
+        let directory = private_tempdir();
+        let token = RecoveryToken::parse("11223344556677889900aabbccddeeff").unwrap();
+        let conversions = Arc::new(AtomicUsize::new(0));
+        let enrichments = Arc::new(AtomicUsize::new(0));
+        let renders = Arc::new(AtomicUsize::new(0));
+        let request = || ConversionRequest::new(InputRef::bytes(b"fixture".as_slice(), Some("x")));
+
+        for expected_attempts in 1..=2 {
+            let store = RecoveryStore::open(directory.path()).unwrap();
+            let engine = fixture_engine_with_enricher(
+                &fixture,
+                Arc::clone(&conversions),
+                Arc::clone(&renders),
+                Arc::new(ReferencedAssetDroppingEnricher(Arc::clone(&enrichments))),
+            );
+            let error =
+                block_on(engine.convert_recoverable(request(), &store, &token)).unwrap_err();
+            assert!(
+                matches!(error, ConversionError::Recovery { reason: "corrupt", .. }),
+                "{error}"
+            );
+            assert!(error.to_string().contains("missing asset referenced-image"), "{error}");
+            assert!(store.inspect(&token).unwrap().is_none());
+            assert_eq!(conversions.load(Ordering::SeqCst), expected_attempts);
+            assert_eq!(enrichments.load(Ordering::SeqCst), expected_attempts);
+            assert_eq!(renders.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[test]
+    fn enricher_cannot_publish_checkpoint_with_invalid_diagnostic() {
+        let fixture = fixture();
+        let directory = private_tempdir();
+        let token = RecoveryToken::parse("223344556677889900aabbccddeeff11").unwrap();
+        let conversions = Arc::new(AtomicUsize::new(0));
+        let enrichments = Arc::new(AtomicUsize::new(0));
+        let renders = Arc::new(AtomicUsize::new(0));
+        let request = || ConversionRequest::new(InputRef::bytes(b"fixture".as_slice(), Some("x")));
+
+        for expected_attempts in 1..=2 {
+            let store = RecoveryStore::open(directory.path()).unwrap();
+            let engine = fixture_engine_with_enricher(
+                &fixture,
+                Arc::clone(&conversions),
+                Arc::clone(&renders),
+                Arc::new(InvalidDiagnosticEnricher(Arc::clone(&enrichments))),
+            );
+            let error =
+                block_on(engine.convert_recoverable(request(), &store, &token)).unwrap_err();
+            assert!(
+                matches!(error, ConversionError::Recovery { reason: "corrupt", .. }),
+                "{error}"
+            );
+            assert!(error.to_string().contains("diagnostic code"), "{error}");
+            assert!(store.inspect(&token).unwrap().is_none());
+            assert_eq!(conversions.load(Ordering::SeqCst), expected_attempts);
+            assert_eq!(enrichments.load(Ordering::SeqCst), expected_attempts);
+            assert_eq!(renders.load(Ordering::SeqCst), 0);
+        }
     }
 
     #[test]

--- a/crates/engine/src/recovery.rs
+++ b/crates/engine/src/recovery.rs
@@ -957,6 +957,18 @@ mod tests {
             "recovery.title-enricher"
         }
 
+        fn planned_enrichment_bytes(
+            &self,
+            _: &ConverterOutput,
+            _: &str,
+            _: InputFormat,
+            _: &ConversionOptions,
+            _: &Services,
+            _: &ExecutionContext,
+        ) -> Result<into_markdown_core::EnrichmentPlan, ConversionError> {
+            Ok(into_markdown_core::EnrichmentPlan::Reserve(64 * 1024))
+        }
+
         fn enrich<'a>(
             &'a self,
             mut output: ConverterOutput,

--- a/crates/ocr/Cargo.toml
+++ b/crates/ocr/Cargo.toml
@@ -22,9 +22,17 @@ thiserror.workspace = true
 url.workspace = true
 unicode-normalization.workspace = true
 
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true
+
 [dev-dependencies]
 futures.workspace = true
 tempfile.workspace = true
 
-[lints]
-workspace = true
+[lints.rust]
+unsafe_code = "deny"
+missing_docs = "warn"
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"

--- a/crates/ocr/src/image_engine.rs
+++ b/crates/ocr/src/image_engine.rs
@@ -158,6 +158,32 @@ impl OcrEngine for PpOcrImageEngine {
         output_plan(&options.limits)
     }
 
+    fn planned_normalized_png_output(
+        &self,
+        width: u32,
+        height: u32,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        context.checkpoint()?;
+        if width == 0 || height == 0 || width > MAX_DIMENSION || height > MAX_DIMENSION {
+            return Err(resource(
+                "image_dimensions",
+                "OCR PNG dimensions are outside product bounds",
+            ));
+        }
+        let decoded = u64::from(width)
+            .checked_mul(u64::from(height))
+            .and_then(|pixels| pixels.checked_mul(4))
+            .ok_or_else(|| resource("max_decompressed_bytes", "OCR PNG size overflow"))?;
+        if decoded > self.limits.max_decompressed_bytes
+            || decoded > options.limits.max_decompressed_bytes
+        {
+            return Err(resource("max_decompressed_bytes", "OCR PNG dimensions exceed limits"));
+        }
+        output_plan(&options.limits)
+    }
+
     fn recognize_bound<'a>(
         &'a self,
         request: OcrRequest<'a>,

--- a/crates/ocr/src/image_engine.rs
+++ b/crates/ocr/src/image_engine.rs
@@ -80,9 +80,10 @@ impl PpOcrImageEngine {
         self.manager
             .verify_with_context(crate::detector_model::PIPELINE_ID, context)
             .map_err(map_manager_error)?;
-        let max_source_pixels = source_pixel_limit(&self.limits)?;
-        let max_regions = usize::try_from(self.limits.max_archive_entries.min(MAX_REGIONS))
-            .map_err(|_| {
+        let limits = effective_limits(&self.limits, context.resource_limits());
+        let max_source_pixels = source_pixel_limit(&limits)?;
+        let max_regions =
+            usize::try_from(limits.max_archive_entries.min(MAX_REGIONS)).map_err(|_| {
                 resource("max_archive_entries", "OCR region bound is not representable")
             })?;
         let detector = PpOcrTextDetector::new(
@@ -100,7 +101,7 @@ impl PpOcrImageEngine {
             &self.manager,
             RecognitionConfig {
                 max_regions,
-                max_decoded_bytes: usize::try_from(self.limits.max_field_bytes.min(MAX_TEXT_BYTES))
+                max_decoded_bytes: usize::try_from(limits.max_field_bytes.min(MAX_TEXT_BYTES))
                     .map_err(|_| {
                         resource("max_field_bytes", "OCR text bound is not representable")
                     })?,
@@ -108,7 +109,7 @@ impl PpOcrImageEngine {
             },
             context,
         )?;
-        let (pixels, _memory) = decode_normalized_png(request, &self.limits, context)?;
+        let (pixels, _memory) = decode_normalized_png(request, &limits, context)?;
         let image = PixelView {
             width: pixels.width() as usize,
             height: pixels.height() as usize,
@@ -154,8 +155,9 @@ impl OcrEngine for PpOcrImageEngine {
         context: &ExecutionContext,
     ) -> Result<OcrOutputPlan, ConversionError> {
         context.checkpoint()?;
-        let (width, height) = validate_png_header(request, &self.limits)?;
-        output_plan(&options.limits, width, height)
+        let limits = effective_limits(&self.limits, &options.limits);
+        let (width, height) = validate_png_header(request, &limits)?;
+        output_plan(&limits, width, height)
     }
 
     fn planned_normalized_png_output(
@@ -176,12 +178,11 @@ impl OcrEngine for PpOcrImageEngine {
             .checked_mul(u64::from(height))
             .and_then(|pixels| pixels.checked_mul(4))
             .ok_or_else(|| resource("max_decompressed_bytes", "OCR PNG size overflow"))?;
-        if decoded > self.limits.max_decompressed_bytes
-            || decoded > options.limits.max_decompressed_bytes
-        {
+        let limits = effective_limits(&self.limits, &options.limits);
+        if decoded > limits.max_decompressed_bytes {
             return Err(resource("max_decompressed_bytes", "OCR PNG dimensions exceed limits"));
         }
-        output_plan(&options.limits, width, height)
+        output_plan(&limits, width, height)
     }
 
     fn recognize_bound<'a>(
@@ -191,6 +192,17 @@ impl OcrEngine for PpOcrImageEngine {
     ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
         Box::pin(async move { self.execute(request, context).await.map(OcrRecognition::Bound) })
     }
+}
+
+fn effective_limits(service: &ResourceLimits, request: &ResourceLimits) -> ResourceLimits {
+    let mut limits = request.clone();
+    limits.max_input_bytes = limits.max_input_bytes.min(service.max_input_bytes);
+    limits.max_decompressed_bytes =
+        limits.max_decompressed_bytes.min(service.max_decompressed_bytes);
+    limits.max_archive_entries = limits.max_archive_entries.min(service.max_archive_entries);
+    limits.max_memory_bytes = limits.max_memory_bytes.min(service.max_memory_bytes);
+    limits.max_field_bytes = limits.max_field_bytes.min(service.max_field_bytes);
+    limits
 }
 
 fn decode_normalized_png(
@@ -449,4 +461,31 @@ fn resource(limit: &'static str, detail: impl Into<String>) -> ConversionError {
 
 fn ocr(detail: impl Into<String>) -> ConversionError {
     ConversionError::Ocr { provider: PROVIDER.into(), detail: detail.into() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_limits_never_exceed_request_or_service_envelope() {
+        let service = ResourceLimits::default();
+        let mut request = service.clone();
+        request.max_input_bytes = 12;
+        request.max_decompressed_bytes = 34;
+        request.max_archive_entries = 2;
+        request.max_memory_bytes = 56;
+        request.max_field_bytes = 7;
+
+        let effective = effective_limits(&service, &request);
+        assert_eq!(effective.max_input_bytes, 12);
+        assert_eq!(effective.max_decompressed_bytes, 34);
+        assert_eq!(effective.max_archive_entries, 2);
+        assert_eq!(effective.max_memory_bytes, 56);
+        assert_eq!(effective.max_field_bytes, 7);
+
+        let mut tighter_service = service;
+        tighter_service.max_archive_entries = 1;
+        assert_eq!(effective_limits(&tighter_service, &request).max_archive_entries, 1);
+    }
 }

--- a/crates/ocr/src/image_engine.rs
+++ b/crates/ocr/src/image_engine.rs
@@ -7,9 +7,10 @@ use crate::{
 use image::{DynamicImage, ImageFormat, ImageReader};
 use into_markdown_core::{
     BoundOcrResult, BoxFuture, ConversionError, ConversionOptions, ExecutionContext, OcrEngine,
-    OcrEvidenceStage, OcrEvidenceStep, OcrOutputPlan, OcrRecognition, OcrRegion, OcrRequest,
-    OcrResult, ResourceLimits, TensorRuntime,
+    OcrEvidenceStage, OcrEvidenceStep, OcrInputIdentity, OcrOutputPlan, OcrRecognition, OcrRegion,
+    OcrRequest, OcrResult, ResourceLimits, TensorRuntime,
 };
+use sha2::{Digest, Sha256};
 use std::io::Cursor;
 use std::sync::Arc;
 
@@ -121,7 +122,13 @@ impl PpOcrImageEngine {
         let recognition_result =
             recognizer.recognize_page(image, &detected, language, context).await?;
         context.checkpoint()?;
-        bind_result(&detected, recognition_result.result(), context)
+        let identity = OcrInputIdentity::try_new(
+            Sha256::digest(request.image).into(),
+            pixels.width(),
+            pixels.height(),
+            0,
+        )?;
+        bind_result(&detected, recognition_result.result(), identity, context)
     }
 }
 
@@ -224,6 +231,7 @@ fn validate_png_header(
 fn bind_result(
     detected: &crate::PageDetection,
     recognized: &crate::RecognitionResult,
+    identity: OcrInputIdentity,
     context: &ExecutionContext,
 ) -> Result<BoundOcrResult, ConversionError> {
     if recognized.provider.as_ref() != RECOGNIZER_PROVIDER
@@ -256,7 +264,7 @@ fn bind_result(
         });
         confidences.push(detection.confidence);
     }
-    BoundOcrResult::try_new(
+    BoundOcrResult::try_new_for_input(
         OcrResult { regions, provider: RECOGNIZER_PROVIDER.into() },
         confidences,
         vec![
@@ -271,6 +279,7 @@ fn bind_result(
                 model: Some(crate::recognizer_model::RECOGNIZER_MODEL_ID.into()),
             },
         ],
+        identity,
     )
 }
 

--- a/crates/ocr/src/image_engine.rs
+++ b/crates/ocr/src/image_engine.rs
@@ -1,14 +1,14 @@
 //! Product OCR engine joining the audited image, detector, and recognizer boundaries.
 
 use crate::{
-    DetectionConfig, ImageOrientation, ModelManager, PixelFormat, PixelView, PpOcrTextDetector,
-    PpOcrTextRecognizer, RecognitionConfig,
+    DetectionConfig, Dimension, ImageOrientation, ModelContract, ModelManager, PixelFormat,
+    PixelView, PpOcrTextDetector, PpOcrTextRecognizer, RecognitionConfig,
 };
 use image::{DynamicImage, ImageFormat, ImageReader};
 use into_markdown_core::{
     BoundOcrResult, BoxFuture, ConversionError, ConversionOptions, ExecutionContext, OcrEngine,
     OcrEvidenceStage, OcrEvidenceStep, OcrInputIdentity, OcrOutputPlan, OcrRecognition, OcrRegion,
-    OcrRequest, OcrResult, ResourceLimits, TensorRuntime,
+    OcrRequest, OcrResult, ResourceLimits, Tensor, TensorRuntime,
 };
 use sha2::{Digest, Sha256};
 use std::io::Cursor;
@@ -45,7 +45,7 @@ impl PpOcrImageEngine {
     ) -> Result<(), ConversionError> {
         context.checkpoint()?;
         validate_engine_limits(limits)?;
-        let plan = output_plan(limits)?;
+        let plan = output_plan(limits, 1, 1)?;
         if plan.max_retained_bytes() > limits.max_memory_bytes
             || plan.max_retained_bytes() > context.available_memory_bytes()
         {
@@ -154,8 +154,8 @@ impl OcrEngine for PpOcrImageEngine {
         context: &ExecutionContext,
     ) -> Result<OcrOutputPlan, ConversionError> {
         context.checkpoint()?;
-        validate_png_header(request, &self.limits)?;
-        output_plan(&options.limits)
+        let (width, height) = validate_png_header(request, &self.limits)?;
+        output_plan(&options.limits, width, height)
     }
 
     fn planned_normalized_png_output(
@@ -181,7 +181,7 @@ impl OcrEngine for PpOcrImageEngine {
         {
             return Err(resource("max_decompressed_bytes", "OCR PNG dimensions exceed limits"));
         }
-        output_plan(&options.limits)
+        output_plan(&options.limits, width, height)
     }
 
     fn recognize_bound<'a>(
@@ -338,7 +338,11 @@ fn validate_engine_limits(limits: &ResourceLimits) -> Result<(), ConversionError
     source_pixel_limit(limits).map(|_| ())
 }
 
-fn output_plan(limits: &ResourceLimits) -> Result<OcrOutputPlan, ConversionError> {
+fn output_plan(
+    limits: &ResourceLimits,
+    width: u32,
+    height: u32,
+) -> Result<OcrOutputPlan, ConversionError> {
     let max_regions = limits.max_archive_entries.min(MAX_REGIONS);
     let max_text = limits.max_field_bytes.min(MAX_TEXT_BYTES);
     let retained = u64::from(max_regions)
@@ -346,7 +350,73 @@ fn output_plan(limits: &ResourceLimits) -> Result<OcrOutputPlan, ConversionError
         .and_then(|bytes| bytes.checked_add(max_text.checked_mul(2)?))
         .and_then(|bytes| bytes.checked_add(OUTPUT_FIXED_BYTES))
         .ok_or_else(|| resource("max_memory_bytes", "OCR output plan overflow"))?;
-    OcrOutputPlan::try_new(retained, max_regions, max_text)
+    let working = provider_working_plan(width, height)?;
+    OcrOutputPlan::try_new_with_working(retained, working, max_regions, max_text)
+}
+
+fn provider_working_plan(width: u32, height: u32) -> Result<u64, ConversionError> {
+    let decoded = u64::from(width)
+        .checked_mul(u64::from(height))
+        .and_then(|pixels| pixels.checked_mul(16))
+        .ok_or_else(|| resource("max_memory_bytes", "OCR decoded working-set plan overflow"))?;
+    let detector = model_run_phase(&crate::ppocrv6_detector_contract())?;
+    let recognizer = model_run_phase(&crate::ppocrv6_recognizer_contract())?;
+    decoded
+        .checked_add(detector.max(recognizer))
+        .ok_or_else(|| resource("max_memory_bytes", "OCR provider working-set plan overflow"))
+}
+
+fn model_run_phase(contract: &ModelContract) -> Result<u64, ConversionError> {
+    let input_storage = max_tensor_storage(&contract.inputs)?;
+    let output_storage = max_tensor_storage(&contract.outputs)?;
+    let input_entries = u64::try_from(contract.inputs.len())
+        .ok()
+        .and_then(|count| count.checked_mul(std::mem::size_of::<(String, Tensor)>() as u64))
+        .ok_or_else(|| resource("max_memory_bytes", "OCR input plan overflow"))?;
+    let output_entries = u64::try_from(contract.outputs.len())
+        .ok()
+        .and_then(|count| count.checked_mul(std::mem::size_of::<Tensor>() as u64))
+        .ok_or_else(|| resource("max_memory_bytes", "OCR output plan overflow"))?;
+    // The prepared input remains live while the runtime clones it. Runtime
+    // output is charged twice (native backing plus the checked Rust copy),
+    // matching the executable runtime boundary's run_memory_peak contract.
+    input_storage
+        .checked_mul(2)
+        .and_then(|bytes| bytes.checked_add(input_entries))
+        .and_then(|bytes| bytes.checked_add(output_entries))
+        .and_then(|bytes| {
+            output_storage.checked_mul(2).and_then(|output| bytes.checked_add(output))
+        })
+        .and_then(|bytes| bytes.checked_add(contract.run_memory_bytes))
+        .ok_or_else(|| resource("max_memory_bytes", "OCR model working-set plan overflow"))
+}
+
+fn max_tensor_storage(specs: &[crate::TensorSpec]) -> Result<u64, ConversionError> {
+    specs.iter().try_fold(0_u64, |total, spec| {
+        let elements = spec.dimensions.iter().try_fold(1_u64, |count, dimension| {
+            let maximum = match dimension {
+                Dimension::Exact(value) => *value,
+                Dimension::Dynamic { max, .. } => *max,
+            };
+            count
+                .checked_mul(u64::try_from(maximum).map_err(|_| {
+                    resource("max_memory_bytes", "OCR tensor dimension is not representable")
+                })?)
+                .ok_or_else(|| resource("max_memory_bytes", "OCR tensor plan overflow"))
+        })?;
+        let shape = u64::try_from(spec.dimensions.len())
+            .ok()
+            .and_then(|rank| rank.checked_mul(std::mem::size_of::<usize>() as u64))
+            .ok_or_else(|| resource("max_memory_bytes", "OCR tensor shape plan overflow"))?;
+        total
+            .checked_add(
+                elements
+                    .checked_mul(std::mem::size_of::<f32>() as u64)
+                    .and_then(|bytes| bytes.checked_add(shape))
+                    .ok_or_else(|| resource("max_memory_bytes", "OCR tensor plan overflow"))?,
+            )
+            .ok_or_else(|| resource("max_memory_bytes", "OCR tensor plan overflow"))
+    })
 }
 
 fn map_manager_error(error: crate::ModelManagerError) -> ConversionError {

--- a/crates/ocr/src/lib.rs
+++ b/crates/ocr/src/lib.rs
@@ -17,7 +17,9 @@ use into_markdown_core::{
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
-use std::fs::{self, File, OpenOptions};
+#[cfg(not(windows))]
+use std::fs::OpenOptions;
+use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -33,6 +35,8 @@ mod onnx_proto;
 mod recognition;
 mod recognizer_model;
 mod runtime;
+#[cfg(windows)]
+mod windows_transaction_fs;
 
 pub use batch::BoundRecognition;
 
@@ -651,6 +655,17 @@ fn validate_bundle_roles(bundle: &ModelBundle) -> Result<(), ConversionError> {
         )));
     }
     if !bundle.runtime_artifacts.is_empty() {
+        let portable_names: BTreeSet<_> = bundle
+            .runtime_artifacts
+            .iter()
+            .map(|artifact| artifact.file_name.to_ascii_lowercase())
+            .collect();
+        if portable_names.len() != bundle.runtime_artifacts.len() {
+            return Err(invalid_manifest(format!(
+                "{} runtime artifact file names are not portable-unique",
+                bundle.id
+            )));
+        }
         let required_runtime_roles = match bundle.kind.as_str() {
             "ocr-pipeline" => BTreeSet::from(["detector", "recognizer-and-dictionary"]),
             "detector-component" => BTreeSet::from(["detector"]),
@@ -765,10 +780,39 @@ fn validate_id(value: &str) -> Result<(), ConversionError> {
 
 fn validate_file_name(value: &str) -> Result<(), ConversionError> {
     let path = Path::new(value);
+    let stem = value.split('.').next().unwrap_or_default();
+    let windows_reserved = matches!(
+        stem.to_ascii_uppercase().as_str(),
+        "CON"
+            | "PRN"
+            | "AUX"
+            | "NUL"
+            | "COM1"
+            | "COM2"
+            | "COM3"
+            | "COM4"
+            | "COM5"
+            | "COM6"
+            | "COM7"
+            | "COM8"
+            | "COM9"
+            | "LPT1"
+            | "LPT2"
+            | "LPT3"
+            | "LPT4"
+            | "LPT5"
+            | "LPT6"
+            | "LPT7"
+            | "LPT8"
+            | "LPT9"
+    );
     if value.is_empty()
         || path.is_absolute()
         || path.components().count() != 1
         || !matches!(path.components().next(), Some(Component::Normal(_)))
+        || value.contains(':')
+        || value.ends_with(['.', ' '])
+        || windows_reserved
     {
         return Err(invalid_manifest(format!("unsafe file name {value:?}")));
     }
@@ -1087,7 +1131,7 @@ impl ModelManager {
             return Ok(());
         }
         let lock = self.acquire_lock()?;
-        let result = self.recover_locked(bundle, context);
+        let result = self.recover_locked(bundle, context, &lock);
         drop(lock);
         result
     }
@@ -1169,7 +1213,9 @@ impl ModelManager {
             use std::os::unix::fs::MetadataExt as _;
             format!("unix-dev-ino:{}:{}", metadata.dev(), metadata.ino())
         };
-        #[cfg(not(unix))]
+        #[cfg(windows)]
+        let file_identity = windows_transaction_fs::file_identity(&file)?;
+        #[cfg(not(any(unix, windows)))]
         let file_identity = format!("verified:{}:{}", artifact.sha256, artifact.size);
         let actual_bytes = bytes.capacity();
         if actual_bytes > capacity {
@@ -1225,10 +1271,9 @@ impl ModelManager {
         {
             return Err(ModelManagerError::ReadOnly);
         }
-        fs::create_dir_all(&self.writable_root)?;
-        reject_symlink(&self.writable_root)?;
+        ensure_private_root(&self.writable_root)?;
         let lock = self.acquire_lock()?;
-        self.recover_locked(bundle, context)?;
+        self.recover_locked(bundle, context, &lock)?;
         let path = self.writable_root.join(id);
         if !safe_existing_directory(&path)? {
             return Err(ModelManagerError::NotInstalled);
@@ -1240,9 +1285,11 @@ impl ModelManager {
         if fs::symlink_metadata(&tombstone).is_ok() {
             return Err(ModelManagerError::Busy);
         }
+        lock.validate_root(&self.writable_root)?;
         rename_no_replace(&path, &tombstone)?;
         sync_directory(&self.writable_root)?;
-        let result = fs::remove_dir_all(&tombstone).map_err(ModelManagerError::Io);
+        lock.validate_root(&self.writable_root)?;
+        let result = retire_directory(&self.writable_root, &tombstone);
         drop(lock);
         result
     }
@@ -1296,10 +1343,9 @@ impl ModelManager {
         })?;
         let _temporary = context.reserve_temporary(total_size)?;
         let _memory = context.reserve_memory(64 * 1024)?;
-        fs::create_dir_all(&self.writable_root)?;
-        reject_symlink(&self.writable_root)?;
+        ensure_private_root(&self.writable_root)?;
         let lock = self.acquire_lock()?;
-        self.recover_locked(bundle, context)?;
+        self.recover_locked(bundle, context, &lock)?;
         let final_path = self.writable_root.join(id);
         let had_old = safe_existing_directory(&final_path)?;
         if had_old {
@@ -1315,13 +1361,13 @@ impl ModelManager {
         let backup_name = format!(".{id}.backup-{nonce}");
         let staging_path = self.writable_root.join(&staging_name);
         let backup_path = self.writable_root.join(&backup_name);
-        fs::create_dir(&staging_path)?;
+        create_private_directory(&staging_path)?;
         let staging = StagingDirectory::new(staging_path);
         for artifact in &bundle.runtime_artifacts {
             context.checkpoint()?;
             let acquired = fetcher.open(artifact, context)?;
             let path = staging.path().join(&artifact.file_name);
-            let mut destination = OpenOptions::new().write(true).create_new(true).open(&path)?;
+            let mut destination = create_private_file(&path)?;
             model_acquisition::write_verified_artifact(
                 artifact,
                 acquired,
@@ -1336,12 +1382,10 @@ impl ModelManager {
             "complete": true,
         }))
         .map_err(|error| ModelManagerError::Corrupt(error.to_string()))?;
-        let mut state_file = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(staging.path().join("install-state.json"))?;
+        let mut state_file = create_private_file(&staging.path().join("install-state.json"))?;
         state_file.write_all(&state)?;
         state_file.sync_all()?;
+        drop(state_file);
         sync_directory(staging.path())?;
         context.checkpoint()?;
 
@@ -1354,29 +1398,35 @@ impl ModelManager {
             root: self.ensure_root_identity()?,
             checksum: String::new(),
         };
+        lock.validate_root(&self.writable_root)?;
         self.write_journal(journal)?;
+        lock.validate_root(&self.writable_root)?;
         // From this point the durable journal, rather than Drop, owns cleanup.
         staging.disarm();
         if had_old {
+            lock.validate_root(&self.writable_root)?;
             rename_no_replace(&final_path, &backup_path)?;
             sync_directory(&self.writable_root)?;
+            lock.validate_root(&self.writable_root)?;
             if fault == InstallFault::AfterBackup {
                 return Err(ModelManagerError::Corrupt(
                     "simulated interruption after backup".into(),
                 ));
             }
         }
+        lock.validate_root(&self.writable_root)?;
         rename_no_replace(staging.path(), &final_path)?;
         sync_directory(&self.writable_root)?;
+        lock.validate_root(&self.writable_root)?;
         if fault == InstallFault::AfterPublish {
             return Err(ModelManagerError::Corrupt("simulated interruption after publish".into()));
         }
         verify_directory_with_context(bundle, &final_path, context)?;
         if had_old {
-            fs::remove_dir_all(&backup_path)?;
-            sync_directory(&self.writable_root)?;
+            retire_directory(&self.writable_root, &backup_path)?;
         }
         self.remove_journal(id)?;
+        lock.validate_root(&self.writable_root)?;
         drop(lock);
         self.status_with_context(id, context)
     }
@@ -1389,19 +1439,40 @@ impl ModelManager {
             .ok_or(ModelManagerError::UnknownBundle)
     }
 
-    fn acquire_lock(&self) -> Result<File, ModelManagerError> {
+    fn acquire_lock(&self) -> Result<TransactionLock, ModelManagerError> {
+        #[cfg(windows)]
+        let root = windows_transaction_fs::RootGuard::acquire(&self.writable_root)?;
         let path = self.writable_root.join(".models.lock");
         reject_symlink_if_present(&path)?;
-        let mut options = OpenOptions::new();
-        options.create(true).truncate(false).read(true).write(true);
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::OpenOptionsExt;
-            options.custom_flags(libc::O_NOFOLLOW);
-        }
-        let file = options.open(path)?;
+        #[cfg(windows)]
+        let file = match windows_transaction_fs::create_lock_file(&path) {
+            Ok(file) => file,
+            Err(ModelManagerError::Io(error))
+                if error.kind() == std::io::ErrorKind::AlreadyExists =>
+            {
+                windows_transaction_fs::open_lock_file(&path)?
+            }
+            Err(error) => return Err(error),
+        };
+        #[cfg(not(windows))]
+        let file = {
+            let mut options = OpenOptions::new();
+            options.create(true).truncate(false).read(true).write(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                options.custom_flags(libc::O_NOFOLLOW);
+            }
+            options.open(path)?
+        };
         file.try_lock().map_err(|_| ModelManagerError::Busy)?;
-        Ok(file)
+        #[cfg(windows)]
+        root.validate(&self.writable_root)?;
+        Ok(TransactionLock {
+            file,
+            #[cfg(windows)]
+            root,
+        })
     }
 
     fn reject_pending_transaction(&self, bundle: &ModelBundle) -> Result<(), ModelManagerError> {
@@ -1435,7 +1506,10 @@ impl ModelManager {
         &self,
         bundle: &ModelBundle,
         context: &ExecutionContext,
+        lock: &TransactionLock,
     ) -> Result<(), ModelManagerError> {
+        lock.validate_root(&self.writable_root)?;
+        cleanup_retired_garbage(&self.writable_root)?;
         context.checkpoint()?;
         ensure_durable_transactions_supported()?;
         let root_identity = self.ensure_root_identity()?;
@@ -1480,8 +1554,7 @@ impl ModelManager {
             // Journal was durable but the old bundle was not moved: roll back the staged update.
             (true, true, false) => {
                 verify_directory_with_context(bundle, &final_path, context)?;
-                fs::remove_dir_all(&staging_path)?;
-                sync_directory(&self.writable_root)?;
+                retire_directory(&self.writable_root, &staging_path)?;
             }
             // The old bundle was backed up: finish publishing the complete staged bundle.
             (false, true, true) => {
@@ -1492,16 +1565,14 @@ impl ModelManager {
                     }
                     rename_no_replace(&backup_path, &final_path)?;
                     sync_directory(&self.writable_root)?;
-                    fs::remove_dir_all(&staging_path)?;
-                    sync_directory(&self.writable_root)?;
+                    retire_directory(&self.writable_root, &staging_path)?;
                     self.remove_journal(&bundle.id)?;
                     return Ok(());
                 }
                 rename_no_replace(&staging_path, &final_path)?;
                 sync_directory(&self.writable_root)?;
                 verify_directory_with_context(bundle, &final_path, context)?;
-                fs::remove_dir_all(&backup_path)?;
-                sync_directory(&self.writable_root)?;
+                retire_directory(&self.writable_root, &backup_path)?;
             }
             // A new install was staged and its journal was durable: finish publication.
             (false, true, false) => {
@@ -1513,8 +1584,7 @@ impl ModelManager {
             // Publication completed; only durable cleanup remains.
             (true, false, true) => {
                 verify_directory_with_context(bundle, &final_path, context)?;
-                fs::remove_dir_all(&backup_path)?;
-                sync_directory(&self.writable_root)?;
+                retire_directory(&self.writable_root, &backup_path)?;
             }
             (true, false, false) => {
                 verify_directory_with_context(bundle, &final_path, context)?;
@@ -1531,7 +1601,8 @@ impl ModelManager {
                 ));
             }
         }
-        self.remove_journal(&bundle.id)
+        self.remove_journal(&bundle.id)?;
+        lock.validate_root(&self.writable_root)
     }
 
     fn write_journal(&self, mut journal: InstallJournal) -> Result<(), ModelManagerError> {
@@ -1550,8 +1621,7 @@ impl ModelManager {
     fn remove_journal(&self, id: &str) -> Result<(), ModelManagerError> {
         let path = journal_path(&self.writable_root, id);
         reject_symlink(&path)?;
-        fs::remove_file(path)?;
-        sync_directory(&self.writable_root)
+        retire_file(&self.writable_root, &path)
     }
 
     fn ensure_root_identity(&self) -> Result<RootIdentity, ModelManagerError> {
@@ -1598,8 +1668,7 @@ impl ModelManager {
         let general_prefix = format!(".{}.install-journal.tmp-", bundle.id);
         let prefix = format!("{general_prefix}{}-", root.token);
         let mut temps = Vec::new();
-        for entry in fs::read_dir(&self.writable_root)? {
-            let entry = entry?;
+        for entry in bounded_directory_entries(&self.writable_root, MAX_MODEL_ROOT_ENTRIES)? {
             let name =
                 entry.file_name().into_string().map_err(|_| ModelManagerError::UnsafePath)?;
             if name.starts_with(&general_prefix) {
@@ -1647,11 +1716,11 @@ impl ModelManager {
         }
         let staging = self.writable_root.join(format!(".{}.staging-{nonce}", bundle.id));
         let staging_exists = safe_existing_directory(&staging)?;
-        fs::remove_file(&temp_path)?;
+        retire_file(&self.writable_root, &temp_path)?;
         if staging_exists {
-            fs::remove_dir_all(staging)?;
+            retire_directory(&self.writable_root, &staging)?;
         }
-        sync_directory(&self.writable_root)
+        Ok(())
     }
 }
 
@@ -1671,8 +1740,7 @@ fn verify_directory_with_context(
     }
     let expected: BTreeSet<_> =
         bundle.runtime_artifacts.iter().map(|artifact| artifact.file_name.as_str()).collect();
-    for entry in fs::read_dir(path)? {
-        let entry = entry?;
+    for entry in bounded_directory_entries(path, MAX_MODEL_BUNDLE_ENTRIES)? {
         let file_type = entry.file_type()?;
         let name = entry.file_name();
         let name = name.to_str().ok_or(ModelManagerError::UnsafePath)?;
@@ -1824,7 +1892,13 @@ fn current_root_identity(
             token: token.unwrap_or_default(),
         })
     }
-    #[cfg(not(unix))]
+    #[cfg(windows)]
+    {
+        let _ = canonical;
+        let (canonical_path, filesystem_id) = windows_transaction_fs::root_identity(root)?;
+        Ok(RootIdentity { canonical_path, filesystem_id, token: token.unwrap_or_default() })
+    }
+    #[cfg(not(any(unix, windows)))]
     {
         let _ = (canonical, token);
         Err(ModelManagerError::ComponentUnavailable)
@@ -1863,8 +1937,7 @@ fn cleanup_root_temps(root: &Path, identity: &RootIdentity) -> Result<(), ModelM
     let general_prefix = ".models-root.tmp-";
     let expected_prefix = format!("{general_prefix}{}-", root_binding(identity));
     let mut temps = Vec::new();
-    for entry in fs::read_dir(root)? {
-        let entry = entry?;
+    for entry in bounded_directory_entries(root, MAX_MODEL_ROOT_ENTRIES)? {
         let name = entry.file_name().into_string().map_err(|_| ModelManagerError::UnsafePath)?;
         if name.starts_with(general_prefix) {
             if !name.strip_prefix(&expected_prefix).is_some_and(valid_nonce) {
@@ -1880,20 +1953,78 @@ fn cleanup_root_temps(root: &Path, identity: &RootIdentity) -> Result<(), ModelM
     }
     if let Some(path) = temps.pop() {
         required_file_if_present(&path)?.ok_or(ModelManagerError::UnsafePath)?;
-        fs::remove_file(path)?;
-        sync_directory(root)?;
+        retire_file(root, &path)?;
     }
     Ok(())
 }
 
+fn ensure_private_root(path: &Path) -> Result<(), ModelManagerError> {
+    #[cfg(unix)]
+    {
+        fs::create_dir_all(path)?;
+        reject_symlink(path)
+    }
+    #[cfg(windows)]
+    {
+        windows_transaction_fs::ensure_private_root(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        Err(ModelManagerError::ComponentUnavailable)
+    }
+}
+
+fn create_private_directory(path: &Path) -> Result<(), ModelManagerError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt;
+        fs::DirBuilder::new().mode(0o700).create(path)?;
+        Ok(())
+    }
+    #[cfg(windows)]
+    {
+        windows_transaction_fs::create_private_directory(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        Err(ModelManagerError::ComponentUnavailable)
+    }
+}
+
+fn create_private_file(path: &Path) -> Result<File, ModelManagerError> {
+    #[cfg(unix)]
+    {
+        let mut options = OpenOptions::new();
+        options.write(true).read(true).create_new(true);
+        use std::os::unix::fs::OpenOptionsExt;
+        Ok(options.mode(0o600).custom_flags(libc::O_NOFOLLOW).open(path)?)
+    }
+    #[cfg(windows)]
+    {
+        windows_transaction_fs::create_private_file(path)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = path;
+        Err(ModelManagerError::ComponentUnavailable)
+    }
+}
+
 fn write_private_file(path: &Path, bytes: &[u8]) -> Result<(), ModelManagerError> {
+    #[cfg(windows)]
+    let mut file = create_private_file(path)?;
+    #[cfg(not(windows))]
     let mut options = OpenOptions::new();
+    #[cfg(not(windows))]
     options.write(true).create_new(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
     }
+    #[cfg(not(windows))]
     let mut file = options.open(path)?;
     file.write_all(bytes)?;
     file.sync_all()?;
@@ -1911,8 +2042,13 @@ fn validate_private_permissions(path: &Path) -> Result<(), ModelManagerError> {
     }
     #[cfg(not(unix))]
     {
-        let _ = path;
-        Err(ModelManagerError::ComponentUnavailable)
+        #[cfg(windows)]
+        return windows_transaction_fs::validate_private_file(path);
+        #[cfg(not(windows))]
+        {
+            let _ = path;
+            Err(ModelManagerError::ComponentUnavailable)
+        }
     }
 }
 
@@ -1932,25 +2068,51 @@ fn rename_no_replace(from: &Path, to: &Path) -> Result<(), ModelManagerError> {
     }
     #[cfg(not(any(target_os = "linux", target_os = "macos")))]
     {
-        let _ = (from, to);
-        Err(ModelManagerError::ComponentUnavailable)
+        #[cfg(windows)]
+        return windows_transaction_fs::rename_no_replace(from, to);
+        #[cfg(not(windows))]
+        {
+            let _ = (from, to);
+            Err(ModelManagerError::ComponentUnavailable)
+        }
     }
 }
 
 fn ensure_durable_transactions_supported() -> Result<(), ModelManagerError> {
-    if cfg!(any(target_os = "linux", target_os = "macos")) {
+    if cfg!(any(target_os = "linux", target_os = "macos", windows)) {
         Ok(())
     } else {
         Err(ModelManagerError::ComponentUnavailable)
     }
 }
 
+// Model roots contain manifests, installed bundles, and transaction residue;
+// bundles contain two runtime roles plus install state today. These generous
+// bounds keep all recovery/verification scans finite in same-user-writable
+// directories while retaining room for future manifest evolution.
+const MAX_MODEL_ROOT_ENTRIES: usize = 1_024;
+const MAX_MODEL_BUNDLE_ENTRIES: usize = 64;
+
+fn bounded_directory_entries(
+    path: &Path,
+    maximum: usize,
+) -> Result<Vec<fs::DirEntry>, ModelManagerError> {
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        if entries.len() == maximum {
+            return Err(ModelManagerError::DataDirectoryUnsafe);
+        }
+        entries.push(entry);
+    }
+    Ok(entries)
+}
+
 fn transaction_residues(root: &Path, id: &str) -> Result<Vec<String>, ModelManagerError> {
     let staging_prefix = format!(".{id}.staging-");
     let backup_prefix = format!(".{id}.backup-");
     let mut result = Vec::new();
-    for entry in fs::read_dir(root)? {
-        let entry = entry?;
+    for entry in bounded_directory_entries(root, MAX_MODEL_ROOT_ENTRIES)? {
         let name = entry.file_name().into_string().map_err(|_| ModelManagerError::UnsafePath)?;
         if name.starts_with(&staging_prefix) || name.starts_with(&backup_prefix) {
             result.push(name);
@@ -1962,8 +2124,7 @@ fn transaction_residues(root: &Path, id: &str) -> Result<Vec<String>, ModelManag
 
 fn journal_temporary_present(root: &Path, id: &str) -> Result<bool, ModelManagerError> {
     let prefix = format!(".{id}.install-journal.tmp-");
-    for entry in fs::read_dir(root)? {
-        let entry = entry?;
+    for entry in bounded_directory_entries(root, MAX_MODEL_ROOT_ENTRIES)? {
         let name = entry.file_name().into_string().map_err(|_| ModelManagerError::UnsafePath)?;
         if name.starts_with(&prefix) {
             return Ok(true);
@@ -1998,39 +2159,147 @@ fn required_regular_file(path: &Path, missing: &str) -> Result<File, ModelManage
 }
 
 fn open_regular_no_follow(path: &Path) -> Result<File, ModelManagerError> {
-    let mut options = OpenOptions::new();
-    options.read(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.custom_flags(libc::O_NOFOLLOW);
-    }
     #[cfg(windows)]
+    return windows_transaction_fs::open_private_file_read(path);
+    #[cfg(not(windows))]
     {
-        use std::os::windows::fs::OpenOptionsExt;
-        const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
-        options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
-    }
-    let file = options.open(path).map_err(|error| {
+        let mut options = OpenOptions::new();
+        options.read(true);
         #[cfg(unix)]
-        if error.raw_os_error() == Some(libc::ELOOP) {
-            return ModelManagerError::UnsafePath;
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.custom_flags(libc::O_NOFOLLOW);
         }
-        ModelManagerError::Io(error)
-    })?;
-    let metadata = file.metadata()?;
-    #[cfg(windows)]
-    {
-        use std::os::windows::fs::MetadataExt;
-        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
-        if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::OpenOptionsExt;
+            const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+            options.custom_flags(FILE_FLAG_OPEN_REPARSE_POINT);
+        }
+        let file = options.open(path).map_err(|error| {
+            #[cfg(unix)]
+            if error.raw_os_error() == Some(libc::ELOOP) {
+                return ModelManagerError::UnsafePath;
+            }
+            ModelManagerError::Io(error)
+        })?;
+        let metadata = file.metadata()?;
+        #[cfg(windows)]
+        {
+            use std::os::windows::fs::MetadataExt;
+            const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0000_0400;
+            if metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+                return Err(ModelManagerError::UnsafePath);
+            }
+        }
+        if !metadata.is_file() {
             return Err(ModelManagerError::UnsafePath);
         }
+        Ok(file)
     }
-    if !metadata.is_file() {
-        return Err(ModelManagerError::UnsafePath);
+}
+
+struct TransactionLock {
+    file: File,
+    #[cfg(windows)]
+    root: windows_transaction_fs::RootGuard,
+}
+
+impl TransactionLock {
+    fn validate_root(&self, path: &Path) -> Result<(), ModelManagerError> {
+        #[cfg(windows)]
+        self.root.validate(path)?;
+        #[cfg(not(windows))]
+        let _ = path;
+        // Reading metadata keeps the lock handle live and also avoids a dead-code
+        // field on platforms where the OS lock is released by Drop.
+        let _ = self.file.metadata()?;
+        Ok(())
     }
-    Ok(file)
+}
+
+fn validate_flat_private_directory(path: &Path) -> Result<(), ModelManagerError> {
+    #[cfg(windows)]
+    windows_transaction_fs::validate_private_directory(path)?;
+    reject_symlink(path)?;
+    for entry in bounded_directory_entries(path, MAX_MODEL_BUNDLE_ENTRIES)? {
+        if !entry.file_type()?.is_file() {
+            return Err(ModelManagerError::UnsafePath);
+        }
+        #[cfg(windows)]
+        windows_transaction_fs::validate_private_file(&entry.path())?;
+    }
+    Ok(())
+}
+
+fn retire_directory(root: &Path, path: &Path) -> Result<(), ModelManagerError> {
+    #[cfg(windows)]
+    {
+        validate_flat_private_directory(path)?;
+        let garbage = root.join(format!(".models-garbage-dir-{}", transaction_nonce()?));
+        rename_no_replace(path, &garbage)?;
+        sync_directory(root)?;
+        // Namespace retirement is the commit. Deletion may be delayed by an AV
+        // scanner and is retried under the model lock on the next transaction.
+        if windows_transaction_fs::delete_flat_private_directory(&garbage).is_ok() {
+            sync_directory(root)?;
+        }
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        fs::remove_dir_all(path)?;
+        sync_directory(root)
+    }
+}
+
+fn retire_file(root: &Path, path: &Path) -> Result<(), ModelManagerError> {
+    #[cfg(windows)]
+    {
+        windows_transaction_fs::validate_private_file(path)?;
+        let garbage = root.join(format!(".models-garbage-file-{}", transaction_nonce()?));
+        rename_no_replace(path, &garbage)?;
+        sync_directory(root)?;
+        if windows_transaction_fs::delete_private_file(&garbage).is_ok() {
+            sync_directory(root)?;
+        }
+        Ok(())
+    }
+    #[cfg(not(windows))]
+    {
+        fs::remove_file(path)?;
+        sync_directory(root)
+    }
+}
+
+fn cleanup_retired_garbage(root: &Path) -> Result<(), ModelManagerError> {
+    #[cfg(windows)]
+    {
+        for entry in bounded_directory_entries(root, MAX_MODEL_ROOT_ENTRIES)? {
+            let name =
+                entry.file_name().into_string().map_err(|_| ModelManagerError::UnsafePath)?;
+            if let Some(nonce) = name.strip_prefix(".models-garbage-file-") {
+                if !valid_nonce(nonce) {
+                    return Err(ModelManagerError::UnsafePath);
+                }
+                windows_transaction_fs::validate_private_file(&entry.path())?;
+                if windows_transaction_fs::delete_private_file(&entry.path()).is_ok() {
+                    sync_directory(root)?;
+                }
+            } else if let Some(nonce) = name.strip_prefix(".models-garbage-dir-") {
+                if !valid_nonce(nonce) {
+                    return Err(ModelManagerError::UnsafePath);
+                }
+                validate_flat_private_directory(&entry.path())?;
+                if windows_transaction_fs::delete_flat_private_directory(&entry.path()).is_ok() {
+                    sync_directory(root)?;
+                }
+            }
+        }
+    }
+    #[cfg(not(windows))]
+    let _ = root;
+    Ok(())
 }
 
 struct StagingDirectory {
@@ -2054,8 +2323,10 @@ impl StagingDirectory {
 
 impl Drop for StagingDirectory {
     fn drop(&mut self) {
-        if self.armed.get() {
-            let _ = fs::remove_dir_all(&self.path);
+        if self.armed.get()
+            && let Some(root) = self.path.parent()
+        {
+            let _ = retire_directory(root, &self.path);
         }
     }
 }
@@ -2063,7 +2334,11 @@ impl Drop for StagingDirectory {
 fn safe_existing_directory(path: &Path) -> Result<bool, ModelManagerError> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() => Err(ModelManagerError::UnsafePath),
-        Ok(metadata) if metadata.is_dir() => Ok(true),
+        Ok(metadata) if metadata.is_dir() => {
+            #[cfg(windows)]
+            windows_transaction_fs::validate_private_directory(path)?;
+            Ok(true)
+        }
         Ok(_) => Err(ModelManagerError::UnsafePath),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(error) => Err(ModelManagerError::Io(error)),
@@ -2092,8 +2367,13 @@ fn sync_directory(path: &Path) -> Result<(), ModelManagerError> {
     }
     #[cfg(not(unix))]
     {
-        let _ = path;
-        Err(ModelManagerError::ComponentUnavailable)
+        #[cfg(windows)]
+        return windows_transaction_fs::flush_directory(path);
+        #[cfg(not(windows))]
+        {
+            let _ = path;
+            Err(ModelManagerError::ComponentUnavailable)
+        }
     }
 }
 
@@ -2291,26 +2571,57 @@ mod tests {
 
     #[test]
     fn four_product_targets_have_deterministic_data_directories() {
+        #[cfg(not(windows))]
         let env = DataDirectoryEnvironment {
             xdg_data_home: Some(PathBuf::from("/xdg")),
             home: Some(PathBuf::from("/home/alice")),
             local_app_data: Some(PathBuf::from("/windows/local")),
         };
+        #[cfg(windows)]
+        let env = DataDirectoryEnvironment {
+            xdg_data_home: Some(PathBuf::from(r"C:\xdg")),
+            home: Some(PathBuf::from(r"C:\Users\alice")),
+            local_app_data: Some(PathBuf::from(r"C:\Users\alice\AppData\Local")),
+        };
+        #[cfg(not(windows))]
         assert_eq!(
             model_data_directory(ProductTarget::MacOsArm64, &env).unwrap(),
             PathBuf::from("/home/alice/Library/Application Support/into-markdown/models")
         );
+        #[cfg(windows)]
+        assert_eq!(
+            model_data_directory(ProductTarget::MacOsArm64, &env).unwrap(),
+            PathBuf::from(r"C:\Users\alice\Library\Application Support\into-markdown\models")
+        );
+        #[cfg(not(windows))]
         assert_eq!(
             model_data_directory(ProductTarget::LinuxX86_64, &env).unwrap(),
             PathBuf::from("/xdg/into-markdown/models")
         );
+        #[cfg(windows)]
+        assert_eq!(
+            model_data_directory(ProductTarget::LinuxX86_64, &env).unwrap(),
+            PathBuf::from(r"C:\xdg\into-markdown\models")
+        );
+        #[cfg(not(windows))]
         assert_eq!(
             model_data_directory(ProductTarget::LinuxArm64, &env).unwrap(),
             PathBuf::from("/xdg/into-markdown/models")
         );
+        #[cfg(windows)]
+        assert_eq!(
+            model_data_directory(ProductTarget::LinuxArm64, &env).unwrap(),
+            PathBuf::from(r"C:\xdg\into-markdown\models")
+        );
+        #[cfg(not(windows))]
         assert_eq!(
             model_data_directory(ProductTarget::WindowsX86_64, &env).unwrap(),
             PathBuf::from("/windows/local/into-markdown/models")
+        );
+        #[cfg(windows)]
+        assert_eq!(
+            model_data_directory(ProductTarget::WindowsX86_64, &env).unwrap(),
+            PathBuf::from(r"C:\Users\alice\AppData\Local\into-markdown\models")
         );
     }
 
@@ -2333,12 +2644,25 @@ mod tests {
         let writable = temp.path().join("writable");
         let id = "pp-ocrv6-tiny-zh-en";
         for root in [&bundled, &writable] {
-            fs::create_dir_all(root.join(id)).unwrap();
-            fs::write(
-                root.join(id).join("install-state.json"),
-                br#"{"schemaVersion":1,"bundleId":"pp-ocrv6-tiny-zh-en","complete":true}"#,
-            )
-            .unwrap();
+            #[cfg(windows)]
+            {
+                windows_transaction_fs::create_private_directory(root).unwrap();
+                windows_transaction_fs::create_private_directory(&root.join(id)).unwrap();
+                write_private_file(
+                    &root.join(id).join("install-state.json"),
+                    br#"{"schemaVersion":1,"bundleId":"pp-ocrv6-tiny-zh-en","complete":true}"#,
+                )
+                .unwrap();
+            }
+            #[cfg(not(windows))]
+            {
+                fs::create_dir_all(root.join(id)).unwrap();
+                fs::write(
+                    root.join(id).join("install-state.json"),
+                    br#"{"schemaVersion":1,"bundleId":"pp-ocrv6-tiny-zh-en","complete":true}"#,
+                )
+                .unwrap();
+            }
         }
         let manager = ModelManager::new(
             ModelManifest::embedded().unwrap(),
@@ -2398,6 +2722,8 @@ mod tests {
     }
 
     fn installable_manager(root: &Path) -> ModelManager {
+        #[cfg(windows)]
+        windows_transaction_fs::harden_test_directory(root).unwrap();
         let mut manifest = ModelManifest::embedded().unwrap();
         let bundle =
             manifest.bundles.iter_mut().find(|bundle| bundle.id == TEST_INSTALL_ID).unwrap();
@@ -2437,13 +2763,21 @@ mod tests {
     }
 
     fn write_complete_test_bundle(path: &Path, id: &str) {
+        #[cfg(windows)]
+        windows_transaction_fs::create_private_directory(path).unwrap();
+        #[cfg(not(windows))]
         fs::create_dir(path).unwrap();
-        fs::write(path.join("model.onnx"), b"hello").unwrap();
-        fs::write(
-            path.join("install-state.json"),
-            format!(r#"{{"schemaVersion":1,"bundleId":"{id}","complete":true}}"#),
-        )
-        .unwrap();
+        let state = format!(r#"{{"schemaVersion":1,"bundleId":"{id}","complete":true}}"#);
+        #[cfg(windows)]
+        {
+            write_private_file(&path.join("model.onnx"), b"hello").unwrap();
+            write_private_file(&path.join("install-state.json"), state.as_bytes()).unwrap();
+        }
+        #[cfg(not(windows))]
+        {
+            fs::write(path.join("model.onnx"), b"hello").unwrap();
+            fs::write(path.join("install-state.json"), state).unwrap();
+        }
     }
 
     fn test_journal(manager: &ModelManager, id: &str, nonce: &str) -> (InstallJournal, Vec<u8>) {
@@ -2595,7 +2929,8 @@ mod tests {
                 .is_err()
         );
         destination_manager.install(id, &fetcher, &execution(5)).unwrap();
-        fs::copy(journal_path(source.path(), id), journal_path(destination.path(), id)).unwrap();
+        let source_journal = fs::read(journal_path(source.path(), id)).unwrap();
+        write_private_file(&journal_path(destination.path(), id), &source_journal).unwrap();
         let before = fs::read(destination.path().join(id).join("model.onnx")).unwrap();
         assert!(matches!(
             destination_manager.recover_with_context(id, &execution(5)),
@@ -2607,9 +2942,9 @@ mod tests {
 
     #[test]
     fn durable_transaction_policy_matches_compiled_platform() {
-        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        #[cfg(any(target_os = "linux", target_os = "macos", windows))]
         assert!(ensure_durable_transactions_supported().is_ok());
-        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        #[cfg(not(any(target_os = "linux", target_os = "macos", windows)))]
         assert!(matches!(
             ensure_durable_transactions_supported(),
             Err(ModelManagerError::ComponentUnavailable)
@@ -2757,7 +3092,21 @@ mod tests {
             manager.install(TEST_INSTALL_ID, &fetcher, &execution(5)),
             Err(ModelManagerError::Busy)
         ));
+        #[cfg(windows)]
+        {
+            let lock = temp.path().join(".models.lock");
+            let moved = temp.path().join(".models.lock.moved");
+            assert!(fs::rename(&lock, &moved).is_err());
+            assert!(fs::remove_file(&lock).is_err());
+        }
         drop(held);
+        #[cfg(windows)]
+        {
+            let lock = temp.path().join(".models.lock");
+            let moved = temp.path().join(".models.lock.moved");
+            fs::rename(&lock, &moved).unwrap();
+            fs::rename(&moved, &lock).unwrap();
+        }
         let token = into_markdown_core::CancellationToken::new();
         token.cancel();
         let cancelled = ExecutionContext::new(

--- a/crates/ocr/src/merge/provenance.rs
+++ b/crates/ocr/src/merge/provenance.rs
@@ -40,13 +40,14 @@ pub(crate) fn materialize_paragraphs(
                     recognition_confidence: candidate.recognition_confidence,
                 });
             }
+            let bounds = evidence_bounds(&regions).ok_or_else(|| super::ocr("emptyOcrLine"))?;
             paragraph_confidence = paragraph_confidence.min(line_confidence);
             let provenance = Provenance {
                 kind: ProvenanceKind::LocalOcr,
                 provider: clone_string(&page.recognition.result().provider)?,
                 locator: SourceLocator {
                     page: Some(page.page()),
-                    bounds: Some(line.bounds),
+                    bounds: Some(bounds),
                     rotation_degrees: Some(line.angle_degrees.rem_euclid(360.0)),
                     page_width: Some(page.page_width()),
                     page_height: Some(page.page_height()),
@@ -83,6 +84,37 @@ pub(crate) fn materialize_paragraphs(
         });
     }
     Ok(nodes)
+}
+
+fn evidence_bounds(regions: &[OcrSourceRegion]) -> Option<into_markdown_core::Rect> {
+    (!regions.is_empty()).then(|| {
+        let minimum_x = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.x)
+            .fold(f32::INFINITY, f32::min);
+        let minimum_y = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.y)
+            .fold(f32::INFINITY, f32::min);
+        let maximum_x = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.x)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let maximum_y = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.y)
+            .fold(f32::NEG_INFINITY, f32::max);
+        into_markdown_core::Rect {
+            x: minimum_x,
+            y: minimum_y,
+            width: maximum_x - minimum_x,
+            height: maximum_y - minimum_y,
+        }
+    })
 }
 
 pub(crate) fn page_provenance(page: &OcrPageInput) -> Result<Provenance, ConversionError> {

--- a/crates/ocr/src/windows_transaction_fs.rs
+++ b/crates/ocr/src/windows_transaction_fs.rs
@@ -1,0 +1,867 @@
+//! Audited Windows filesystem boundary for model installation transactions.
+#![allow(unsafe_code, reason = "narrow Win32 filesystem and ACL boundary")]
+#![allow(
+    clippy::borrow_as_ptr,
+    clippy::cast_possible_wrap,
+    clippy::cast_ptr_alignment,
+    reason = "Win32 bindings require raw out-pointers and traversal of API-defined aligned buffers"
+)]
+
+use crate::ModelManagerError;
+use std::ffi::OsStr;
+use std::fs::File;
+use std::mem::{size_of, zeroed};
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
+use std::path::Path;
+use std::ptr::{null, null_mut};
+use windows_sys::Win32::Foundation::{
+    CloseHandle, ERROR_HANDLE_EOF, ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_HANDLE,
+    ERROR_MORE_DATA, GENERIC_READ, GENERIC_WRITE, HANDLE, INVALID_HANDLE_VALUE, LocalFree,
+};
+#[cfg(test)]
+use windows_sys::Win32::Security::Authorization::SetSecurityInfo;
+use windows_sys::Win32::Security::Authorization::{
+    ConvertSidToStringSidW, ConvertStringSecurityDescriptorToSecurityDescriptorW, GetSecurityInfo,
+    SDDL_REVISION_1, SE_FILE_OBJECT,
+};
+#[cfg(test)]
+use windows_sys::Win32::Security::PROTECTED_DACL_SECURITY_INFORMATION;
+use windows_sys::Win32::Security::{
+    ACL, ACL_SIZE_INFORMATION, AclSizeInformation, DACL_SECURITY_INFORMATION, EqualSid,
+    GetAclInformation, GetSecurityDescriptorControl, GetSecurityDescriptorDacl,
+    GetTokenInformation, OWNER_SECURITY_INFORMATION, PSECURITY_DESCRIPTOR, PSID, SE_DACL_PROTECTED,
+    SECURITY_ATTRIBUTES, TOKEN_QUERY, TOKEN_USER, TokenUser,
+};
+#[cfg(test)]
+use windows_sys::Win32::Storage::FileSystem::WRITE_DAC;
+use windows_sys::Win32::Storage::FileSystem::{
+    CREATE_NEW, CreateDirectoryW, CreateFileW, DELETE, FILE_ATTRIBUTE_NORMAL,
+    FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO, FILE_DISPOSITION_INFO,
+    FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_ID_INFO, FILE_READ_ATTRIBUTES,
+    FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FILE_STREAM_INFO, FileAttributeTagInfo,
+    FileDispositionInfo, FileIdInfo, FileStreamInfo, FlushFileBuffers, GetDriveTypeW,
+    GetFileInformationByHandle, GetFileInformationByHandleEx, GetFinalPathNameByHandleW,
+    GetVolumeInformationW, GetVolumePathNameW, MOVEFILE_WRITE_THROUGH, MoveFileExW, OPEN_EXISTING,
+    READ_CONTROL, SetFileInformationByHandle, VOLUME_NAME_GUID,
+};
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+use windows_sys::Win32::System::WindowsProgramming::DRIVE_FIXED;
+
+fn wide(value: &OsStr) -> Vec<u16> {
+    value.encode_wide().chain(Some(0)).collect()
+}
+
+fn last_error() -> ModelManagerError {
+    ModelManagerError::Io(std::io::Error::last_os_error())
+}
+
+struct SecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+impl SecurityDescriptor {
+    fn private() -> Result<Self, ModelManagerError> {
+        let user = current_user_sid_string()?;
+        let text = format!("D:P(A;OICI;FA;;;SY)(A;OICI;FA;;;BA)(A;OICI;FA;;;{user})");
+        let sddl = wide(OsStr::new(&text));
+        let mut descriptor = null_mut();
+        // SAFETY: NUL-terminated input and valid out pointer; LocalFree owns the returned buffer.
+        if unsafe {
+            ConvertStringSecurityDescriptorToSecurityDescriptorW(
+                sddl.as_ptr(),
+                SDDL_REVISION_1,
+                &mut descriptor,
+                null_mut(),
+            )
+        } == 0
+        {
+            return Err(last_error());
+        }
+        Ok(Self(descriptor))
+    }
+
+    fn attributes(&mut self) -> SECURITY_ATTRIBUTES {
+        SECURITY_ATTRIBUTES {
+            nLength: u32::try_from(size_of::<SECURITY_ATTRIBUTES>()).expect("structure size fits"),
+            lpSecurityDescriptor: self.0,
+            bInheritHandle: 0,
+        }
+    }
+}
+
+struct OwnedHandle(HANDLE);
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        // SAFETY: this guard exclusively owns the token handle.
+        unsafe { CloseHandle(self.0) };
+    }
+}
+
+fn current_user_sid() -> Result<(OwnedHandle, Vec<usize>), ModelManagerError> {
+    let mut token = null_mut();
+    // SAFETY: pseudo-process handle is valid and output pointer is writable.
+    if unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token) } == 0 {
+        return Err(last_error());
+    }
+    let token = OwnedHandle(token);
+    let mut needed = 0;
+    // SAFETY: null query obtains the required buffer length.
+    unsafe { GetTokenInformation(token.0, TokenUser, null_mut(), 0, &mut needed) };
+    if needed < u32::try_from(size_of::<TOKEN_USER>()).unwrap() {
+        return Err(last_error());
+    }
+    let words = (needed as usize).div_ceil(size_of::<usize>());
+    let mut buffer = vec![0_usize; words];
+    // SAFETY: buffer has the exact size returned by the initial query.
+    if unsafe {
+        GetTokenInformation(token.0, TokenUser, buffer.as_mut_ptr().cast(), needed, &mut needed)
+    } == 0
+    {
+        return Err(last_error());
+    }
+    Ok((token, buffer))
+}
+
+fn current_user_sid_string() -> Result<String, ModelManagerError> {
+    let (_token, buffer) = current_user_sid()?;
+    // SAFETY: buffer contains TOKEN_USER returned by GetTokenInformation.
+    let sid = unsafe { (*(buffer.as_ptr().cast::<TOKEN_USER>())).User.Sid };
+    let mut value = null_mut();
+    // SAFETY: SID is live and output pointer is writable.
+    if unsafe { ConvertSidToStringSidW(sid, &mut value) } == 0 {
+        return Err(last_error());
+    }
+    let mut length = 0;
+    // SAFETY: returned value is a NUL-terminated UTF-16 string.
+    while unsafe { *value.add(length) } != 0 {
+        length += 1;
+    }
+    // SAFETY: the measured slice lies within the returned allocation.
+    let result = String::from_utf16(unsafe { std::slice::from_raw_parts(value, length) })
+        .map_err(|_| ModelManagerError::UnsafePath);
+    // SAFETY: the conversion API allocates with LocalAlloc.
+    unsafe { LocalFree(value.cast()) };
+    result
+}
+
+impl Drop for SecurityDescriptor {
+    fn drop(&mut self) {
+        // SAFETY: descriptor was allocated by the matching Win32 conversion API.
+        unsafe { LocalFree(self.0.cast()) };
+    }
+}
+
+fn open(path: &Path, directory: bool, access: u32) -> Result<File, ModelManagerError> {
+    open_with_share(path, directory, access, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+}
+
+fn open_with_share(
+    path: &Path,
+    directory: bool,
+    access: u32,
+    share_mode: u32,
+) -> Result<File, ModelManagerError> {
+    let path_wide = wide(path.as_os_str());
+    let flags = FILE_FLAG_OPEN_REPARSE_POINT
+        | if directory { FILE_FLAG_BACKUP_SEMANTICS } else { FILE_ATTRIBUTE_NORMAL };
+    // SAFETY: all pointers are valid for the duration of the call.
+    let handle = unsafe {
+        CreateFileW(
+            path_wide.as_ptr(),
+            access | READ_CONTROL | if directory { GENERIC_READ } else { 0 },
+            share_mode,
+            null(),
+            OPEN_EXISTING,
+            flags,
+            null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(last_error());
+    }
+    // SAFETY: handle is newly owned and valid.
+    let file = unsafe { File::from_raw_handle(handle as RawHandle) };
+    validate_handle(&file, directory)?;
+    Ok(file)
+}
+
+fn validate_handle(file: &File, directory: bool) -> Result<(), ModelManagerError> {
+    // SAFETY: fixed-size output and live handle.
+    let mut tag: FILE_ATTRIBUTE_TAG_INFO = unsafe { zeroed() };
+    if unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle() as HANDLE,
+            FileAttributeTagInfo,
+            (&raw mut tag).cast(),
+            u32::try_from(size_of::<FILE_ATTRIBUTE_TAG_INFO>()).unwrap(),
+        )
+    } == 0
+    {
+        return Err(last_error());
+    }
+    if tag.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+        return Err(ModelManagerError::UnsafePath);
+    }
+    // SAFETY: fixed-size output and live handle.
+    let mut info = unsafe { zeroed() };
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle() as HANDLE, &mut info) } == 0 {
+        return Err(last_error());
+    }
+    if !directory && info.nNumberOfLinks != 1 {
+        return Err(ModelManagerError::UnsafePath);
+    }
+    validate_acl(file)?;
+    // Named data streams on artifact/control files are rejected. Directory ADS
+    // are not transaction namespace children and FileStreamInfo is not supported
+    // for non-empty directory handles on all supported Windows filesystems; all
+    // transaction-created component names separately reject `:`.
+    if directory { Ok(()) } else { validate_no_alternate_streams(file) }
+}
+
+fn validate_acl(file: &File) -> Result<(), ModelManagerError> {
+    let mut descriptor_raw = null_mut();
+    let mut owner: PSID = null_mut();
+    // SAFETY: live file handle and valid optional output pointers.
+    let status = unsafe {
+        GetSecurityInfo(
+            file.as_raw_handle() as HANDLE,
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+            &mut owner,
+            null_mut(),
+            null_mut(),
+            null_mut(),
+            &mut descriptor_raw,
+        )
+    };
+    if status != 0 {
+        return Err(ModelManagerError::Io(std::io::Error::from_raw_os_error(status as i32)));
+    }
+    let descriptor = SecurityDescriptor(descriptor_raw);
+    let (_token, user_buffer) = current_user_sid()?;
+    // SAFETY: the token buffer contains TOKEN_USER and both SIDs are live.
+    let user = unsafe { (*(user_buffer.as_ptr().cast::<TOKEN_USER>())).User.Sid };
+    let owner_matches = unsafe { EqualSid(owner, user) } != 0;
+    let expected = SecurityDescriptor::private()?;
+    let dacl_matches = dacl_bytes(descriptor.0)? == dacl_bytes(expected.0)?;
+    let mut control = 0;
+    let mut revision = 0;
+    // SAFETY: descriptor was returned by GetSecurityInfo and remains live.
+    let ok = unsafe { GetSecurityDescriptorControl(descriptor.0, &mut control, &mut revision) };
+    if ok == 0 {
+        return Err(last_error());
+    }
+    if !owner_matches || !dacl_matches || control & SE_DACL_PROTECTED == 0 {
+        return Err(ModelManagerError::DataDirectoryUnsafe);
+    }
+    Ok(())
+}
+
+fn validate_no_alternate_streams(file: &File) -> Result<(), ModelManagerError> {
+    // FILE_STREAM_INFO is a variable-length linked list. Use an aligned backing
+    // allocation and retry boundedly because the API does not return the required size.
+    let mut bytes = 1024_usize;
+    let storage = loop {
+        if bytes > 1024 * 1024 {
+            return Err(ModelManagerError::UnsafePath);
+        }
+        let words = bytes.div_ceil(size_of::<u64>());
+        let mut storage = vec![0_u64; words];
+        // SAFETY: aligned storage is writable for the declared byte length and the handle is live.
+        let ok = unsafe {
+            GetFileInformationByHandleEx(
+                file.as_raw_handle() as HANDLE,
+                FileStreamInfo,
+                storage.as_mut_ptr().cast(),
+                u32::try_from(storage.len() * size_of::<u64>()).unwrap(),
+            )
+        };
+        if ok != 0 {
+            break storage;
+        }
+        let error = std::io::Error::last_os_error();
+        match error.raw_os_error() {
+            Some(code) if code == ERROR_HANDLE_EOF as i32 => return Ok(()),
+            Some(code)
+                if code == ERROR_MORE_DATA as i32 || code == ERROR_INSUFFICIENT_BUFFER as i32 =>
+            {
+                bytes = bytes.checked_mul(2).ok_or(ModelManagerError::UnsafePath)?;
+            }
+            _ => return Err(ModelManagerError::Io(error)),
+        }
+    };
+    let buffer = unsafe {
+        std::slice::from_raw_parts(storage.as_ptr().cast::<u8>(), storage.len() * size_of::<u64>())
+    };
+    let mut offset = 0_usize;
+    loop {
+        let header_end = offset
+            .checked_add(size_of::<FILE_STREAM_INFO>())
+            .ok_or(ModelManagerError::UnsafePath)?;
+        if header_end > buffer.len() {
+            return Err(ModelManagerError::UnsafePath);
+        }
+        // SAFETY: storage is aligned and offset values are validated before traversal.
+        let info = unsafe { &*buffer.as_ptr().add(offset).cast::<FILE_STREAM_INFO>() };
+        let name_bytes =
+            usize::try_from(info.StreamNameLength).map_err(|_| ModelManagerError::UnsafePath)?;
+        if name_bytes % size_of::<u16>() != 0 {
+            return Err(ModelManagerError::UnsafePath);
+        }
+        let name_start = offset
+            .checked_add(std::mem::offset_of!(FILE_STREAM_INFO, StreamName))
+            .ok_or(ModelManagerError::UnsafePath)?;
+        let name_end = name_start.checked_add(name_bytes).ok_or(ModelManagerError::UnsafePath)?;
+        if name_end > buffer.len() {
+            return Err(ModelManagerError::UnsafePath);
+        }
+        // SAFETY: UTF-16 stream name extent was checked and storage is suitably aligned.
+        let name = unsafe {
+            std::slice::from_raw_parts(
+                buffer.as_ptr().add(name_start).cast::<u16>(),
+                name_bytes / size_of::<u16>(),
+            )
+        };
+        if name != "::$DATA".encode_utf16().collect::<Vec<_>>() {
+            return Err(ModelManagerError::UnsafePath);
+        }
+        if info.NextEntryOffset == 0 {
+            return Ok(());
+        }
+        let next =
+            usize::try_from(info.NextEntryOffset).map_err(|_| ModelManagerError::UnsafePath)?;
+        if next < size_of::<FILE_STREAM_INFO>() || next % size_of::<u64>() != 0 {
+            return Err(ModelManagerError::UnsafePath);
+        }
+        offset = offset.checked_add(next).ok_or(ModelManagerError::UnsafePath)?;
+    }
+}
+
+fn dacl_bytes(descriptor: PSECURITY_DESCRIPTOR) -> Result<Vec<u8>, ModelManagerError> {
+    let mut present = 0;
+    let mut defaulted = 0;
+    let mut acl: *mut ACL = null_mut();
+    // SAFETY: descriptor is live and all out pointers are writable.
+    if unsafe { GetSecurityDescriptorDacl(descriptor, &mut present, &mut acl, &mut defaulted) } == 0
+    {
+        return Err(last_error());
+    }
+    if present == 0 || acl.is_null() {
+        return Err(ModelManagerError::DataDirectoryUnsafe);
+    }
+    // SAFETY: fixed-size output and ACL returned from the descriptor.
+    let mut size: ACL_SIZE_INFORMATION = unsafe { zeroed() };
+    if unsafe {
+        GetAclInformation(
+            acl,
+            (&raw mut size).cast(),
+            u32::try_from(size_of::<ACL_SIZE_INFORMATION>()).unwrap(),
+            AclSizeInformation,
+        )
+    } == 0
+    {
+        return Err(last_error());
+    }
+    // SAFETY: AclBytesInUse is the validated byte length reported by GetAclInformation.
+    Ok(unsafe { std::slice::from_raw_parts(acl.cast::<u8>(), size.AclBytesInUse as usize) }
+        .to_vec())
+}
+
+pub(crate) fn create_private_directory(path: &Path) -> Result<(), ModelManagerError> {
+    let mut descriptor = SecurityDescriptor::private()?;
+    let attributes = descriptor.attributes();
+    let path_wide = wide(path.as_os_str());
+    // SAFETY: pointers remain valid through the call.
+    if unsafe { CreateDirectoryW(path_wide.as_ptr(), &attributes) } == 0 {
+        return Err(last_error());
+    }
+    validate_private_directory(path)
+}
+
+pub(crate) fn ensure_private_root(path: &Path) -> Result<(), ModelManagerError> {
+    match create_private_directory(path) {
+        Ok(()) => {}
+        Err(ModelManagerError::Io(error)) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            validate_private_directory(path)?;
+        }
+        Err(error) => return Err(error),
+    }
+    validate_volume(path)
+}
+
+pub(crate) fn create_private_file(path: &Path) -> Result<File, ModelManagerError> {
+    create_private_file_with_share(path, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+}
+
+fn create_private_file_with_share(path: &Path, share_mode: u32) -> Result<File, ModelManagerError> {
+    let mut descriptor = SecurityDescriptor::private()?;
+    let attributes = descriptor.attributes();
+    let path_wide = wide(path.as_os_str());
+    // SAFETY: pointers remain valid through the call.
+    let handle = unsafe {
+        CreateFileW(
+            path_wide.as_ptr(),
+            GENERIC_READ | GENERIC_WRITE,
+            share_mode,
+            &attributes,
+            CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OPEN_REPARSE_POINT,
+            null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(last_error());
+    }
+    // SAFETY: handle is newly owned and valid.
+    let file = unsafe { File::from_raw_handle(handle as RawHandle) };
+    validate_handle(&file, false)?;
+    Ok(file)
+}
+
+pub(crate) fn validate_private_directory(path: &Path) -> Result<(), ModelManagerError> {
+    open(path, true, FILE_READ_ATTRIBUTES).map(drop)
+}
+
+pub(crate) fn validate_private_file(path: &Path) -> Result<(), ModelManagerError> {
+    open(path, false, FILE_READ_ATTRIBUTES).map(drop)
+}
+
+pub(crate) fn create_lock_file(path: &Path) -> Result<File, ModelManagerError> {
+    create_private_file_with_share(path, FILE_SHARE_READ | FILE_SHARE_WRITE)
+}
+
+pub(crate) fn open_lock_file(path: &Path) -> Result<File, ModelManagerError> {
+    open_with_share(path, false, GENERIC_READ | GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE)
+}
+
+pub(crate) fn open_private_file_read(path: &Path) -> Result<File, ModelManagerError> {
+    open(path, false, GENERIC_READ)
+}
+
+fn open_for_delete(path: &Path, directory: bool) -> Result<File, ModelManagerError> {
+    let path_wide = wide(path.as_os_str());
+    let flags = FILE_FLAG_OPEN_REPARSE_POINT
+        | if directory { FILE_FLAG_BACKUP_SEMANTICS } else { FILE_ATTRIBUTE_NORMAL };
+    // Omit FILE_SHARE_DELETE so the validated object cannot be renamed or
+    // replaced between validation and handle-bound disposition.
+    let handle = unsafe {
+        CreateFileW(
+            path_wide.as_ptr(),
+            DELETE | FILE_READ_ATTRIBUTES | READ_CONTROL,
+            FILE_SHARE_READ | FILE_SHARE_WRITE,
+            null(),
+            OPEN_EXISTING,
+            flags,
+            null_mut(),
+        )
+    };
+    if handle == INVALID_HANDLE_VALUE {
+        return Err(last_error());
+    }
+    let file = unsafe { File::from_raw_handle(handle as RawHandle) };
+    validate_handle(&file, directory)?;
+    Ok(file)
+}
+
+fn mark_delete(file: &File) -> Result<(), ModelManagerError> {
+    let disposition = FILE_DISPOSITION_INFO { DeleteFile: true };
+    if unsafe {
+        SetFileInformationByHandle(
+            file.as_raw_handle() as HANDLE,
+            FileDispositionInfo,
+            (&raw const disposition).cast(),
+            u32::try_from(size_of::<FILE_DISPOSITION_INFO>()).unwrap(),
+        )
+    } == 0
+    {
+        return Err(last_error());
+    }
+    Ok(())
+}
+
+pub(crate) fn delete_private_file(path: &Path) -> Result<(), ModelManagerError> {
+    let file = open_for_delete(path, false)?;
+    mark_delete(&file)
+}
+
+// A model bundle currently contains two runtime artifacts plus its state file.
+// Keep ample headroom for format evolution while ensuring cleanup cannot be
+// turned into an unbounded scan of an attacker-controlled directory.
+pub(crate) const MAX_PRIVATE_DIRECTORY_FILES: usize = 64;
+
+pub(crate) fn delete_flat_private_directory(path: &Path) -> Result<(), ModelManagerError> {
+    // Retaining this no-share-delete handle binds enumeration and final removal
+    // to the same validated directory object.
+    let directory = open_for_delete(path, true)?;
+    let mut files = Vec::new();
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            return Err(ModelManagerError::UnsafePath);
+        }
+        if files.len() == MAX_PRIVATE_DIRECTORY_FILES {
+            return Err(ModelManagerError::DataDirectoryUnsafe);
+        }
+        validate_private_file(&entry.path())?;
+        files.push(entry.path());
+    }
+    // Deletion starts only after the bounded preflight has validated every
+    // observed child, so an over-limit or non-file directory fails closed.
+    for file in files {
+        delete_private_file(&file)?;
+    }
+    mark_delete(&directory)
+}
+
+pub(crate) fn root_identity(path: &Path) -> Result<(String, String), ModelManagerError> {
+    let file = open(path, true, FILE_READ_ATTRIBUTES)?;
+    identity_from_handle(&file)
+}
+
+fn identity_from_handle(file: &File) -> Result<(String, String), ModelManagerError> {
+    // SAFETY: fixed-size output and live handle.
+    let mut id: FILE_ID_INFO = unsafe { zeroed() };
+    if unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle() as HANDLE,
+            FileIdInfo,
+            (&raw mut id).cast(),
+            u32::try_from(size_of::<FILE_ID_INFO>()).unwrap(),
+        )
+    } == 0
+    {
+        return Err(last_error());
+    }
+    let mut buffer = vec![0_u16; 512];
+    let length = loop {
+        // SAFETY: writable UTF-16 buffer and live handle.
+        let length = unsafe {
+            GetFinalPathNameByHandleW(
+                file.as_raw_handle() as HANDLE,
+                buffer.as_mut_ptr(),
+                u32::try_from(buffer.len()).unwrap(),
+                VOLUME_NAME_GUID,
+            )
+        };
+        if length == 0 {
+            return Err(last_error());
+        }
+        if (length as usize) < buffer.len() {
+            break length as usize;
+        }
+        let required = (length as usize).checked_add(1).ok_or(ModelManagerError::UnsafePath)?;
+        if required > 32_768 {
+            return Err(ModelManagerError::UnsafePath);
+        }
+        buffer.resize(required, 0);
+    };
+    buffer.truncate(length);
+    let canonical = String::from_utf16(&buffer).map_err(|_| ModelManagerError::UnsafePath)?;
+    let fsid = format!("windows-volume-file:{:016x}:{}", id.VolumeSerialNumber, hex_id(&id));
+    Ok((canonical, fsid))
+}
+
+pub(crate) struct RootGuard {
+    file: File,
+    identity: (String, String),
+}
+
+impl RootGuard {
+    pub(crate) fn acquire(path: &Path) -> Result<Self, ModelManagerError> {
+        let path_wide = wide(path.as_os_str());
+        // Deliberately omit FILE_SHARE_DELETE: while this guard is live Windows
+        // prevents rename/delete/recreation of the transaction root.
+        // SAFETY: NUL-terminated path and valid arguments.
+        let handle = unsafe {
+            CreateFileW(
+                path_wide.as_ptr(),
+                FILE_READ_ATTRIBUTES | READ_CONTROL | GENERIC_READ,
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                null(),
+                OPEN_EXISTING,
+                FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+                null_mut(),
+            )
+        };
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(last_error());
+        }
+        // SAFETY: handle is newly owned and valid.
+        let file = unsafe { File::from_raw_handle(handle as RawHandle) };
+        validate_handle(&file, true)?;
+        let identity = identity_from_handle(&file)?;
+        Ok(Self { file, identity })
+    }
+
+    pub(crate) fn validate(&self, path: &Path) -> Result<(), ModelManagerError> {
+        let current = root_identity(path)?;
+        if current != self.identity {
+            return Err(ModelManagerError::DataDirectoryUnsafe);
+        }
+        // Keep the handle observably live across the comparison.
+        let retained = identity_from_handle(&self.file)?;
+        if retained != self.identity {
+            return Err(ModelManagerError::DataDirectoryUnsafe);
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn file_identity(file: &File) -> Result<String, ModelManagerError> {
+    // SAFETY: fixed-size output and live retained artifact handle.
+    let mut id: FILE_ID_INFO = unsafe { zeroed() };
+    if unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle() as HANDLE,
+            FileIdInfo,
+            (&raw mut id).cast(),
+            u32::try_from(size_of::<FILE_ID_INFO>()).unwrap(),
+        )
+    } == 0
+    {
+        return Err(last_error());
+    }
+    Ok(format!("windows-volume-file:{:016x}:{}", id.VolumeSerialNumber, hex_id(&id)))
+}
+
+fn hex_id(id: &FILE_ID_INFO) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut value = String::with_capacity(id.FileId.Identifier.len() * 2);
+    for byte in id.FileId.Identifier {
+        value.push(char::from(HEX[usize::from(byte >> 4)]));
+        value.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    value
+}
+
+fn validate_volume(path: &Path) -> Result<(), ModelManagerError> {
+    let path_wide = wide(path.as_os_str());
+    let mut root = vec![0_u16; 1024];
+    // SAFETY: valid input and writable output buffer.
+    if unsafe {
+        GetVolumePathNameW(
+            path_wide.as_ptr(),
+            root.as_mut_ptr(),
+            u32::try_from(root.len()).unwrap(),
+        )
+    } == 0
+    {
+        return Err(last_error());
+    }
+    // SAFETY: root is NUL-terminated by GetVolumePathNameW.
+    if unsafe { GetDriveTypeW(root.as_ptr()) } != DRIVE_FIXED {
+        return Err(ModelManagerError::ComponentUnavailable);
+    }
+    let mut fs_name = [0_u16; 32];
+    // SAFETY: all output buffers are valid and root is NUL-terminated.
+    if unsafe {
+        GetVolumeInformationW(
+            root.as_ptr(),
+            null_mut(),
+            0,
+            null_mut(),
+            null_mut(),
+            null_mut(),
+            fs_name.as_mut_ptr(),
+            u32::try_from(fs_name.len()).unwrap(),
+        )
+    } == 0
+    {
+        return Err(last_error());
+    }
+    let length = fs_name.iter().position(|unit| *unit == 0).unwrap_or(fs_name.len());
+    let name = String::from_utf16_lossy(&fs_name[..length]);
+    if name != "NTFS" && name != "ReFS" {
+        return Err(ModelManagerError::ComponentUnavailable);
+    }
+    Ok(())
+}
+
+pub(crate) fn rename_no_replace(from: &Path, to: &Path) -> Result<(), ModelManagerError> {
+    let from = wide(from.as_os_str());
+    let to = wide(to.as_os_str());
+    // SAFETY: NUL-terminated path inputs remain valid through the call. Absence of
+    // MOVEFILE_REPLACE_EXISTING and MOVEFILE_COPY_ALLOWED enforces same-volume no-replace.
+    if unsafe { MoveFileExW(from.as_ptr(), to.as_ptr(), MOVEFILE_WRITE_THROUGH) } == 0 {
+        return Err(last_error());
+    }
+    Ok(())
+}
+
+pub(crate) fn flush_file(file: &File) -> Result<(), ModelManagerError> {
+    // SAFETY: live file handle.
+    if unsafe { FlushFileBuffers(file.as_raw_handle() as HANDLE) } == 0 {
+        return Err(last_error());
+    }
+    Ok(())
+}
+
+pub(crate) fn flush_directory(path: &Path) -> Result<(), ModelManagerError> {
+    // Some supported Windows versions/filesystems reject GENERIC_WRITE or
+    // FlushFileBuffers for directory handles. Namespace durability is supplied
+    // by every MoveFileExW(..., MOVEFILE_WRITE_THROUGH) commit point; attempt the
+    // directory flush where the local filesystem exposes it.
+    match open(path, true, GENERIC_READ | GENERIC_WRITE)
+        .and_then(|directory| flush_file(&directory))
+    {
+        Ok(()) => Ok(()),
+        Err(ModelManagerError::Io(ref error))
+            if error.kind() == std::io::ErrorKind::PermissionDenied
+                || error.raw_os_error() == Some(ERROR_INVALID_HANDLE as i32) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(error),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn harden_test_directory(path: &Path) -> Result<(), ModelManagerError> {
+    let directory = match open(path, true, FILE_READ_ATTRIBUTES) {
+        Ok(_) => return Ok(()),
+        Err(ModelManagerError::DataDirectoryUnsafe) => {
+            let path_wide = wide(path.as_os_str());
+            // SAFETY: NUL-terminated path and valid flags; this handle is immediately owned.
+            let handle = unsafe {
+                CreateFileW(
+                    path_wide.as_ptr(),
+                    READ_CONTROL | WRITE_DAC,
+                    FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                    null(),
+                    OPEN_EXISTING,
+                    FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS,
+                    null_mut(),
+                )
+            };
+            if handle == INVALID_HANDLE_VALUE {
+                return Err(last_error());
+            }
+            // SAFETY: handle is newly owned and valid.
+            unsafe { File::from_raw_handle(handle as RawHandle) }
+        }
+        Err(error) => return Err(error),
+    };
+    let descriptor = SecurityDescriptor::private()?;
+    let mut present = 0;
+    let mut defaulted = 0;
+    let mut dacl: *mut ACL = null_mut();
+    // SAFETY: descriptor is live and output pointers are writable.
+    if unsafe { GetSecurityDescriptorDacl(descriptor.0, &mut present, &mut dacl, &mut defaulted) }
+        == 0
+        || present == 0
+        || dacl.is_null()
+    {
+        return Err(last_error());
+    }
+    // SAFETY: live directory handle and DACL owned by the live descriptor.
+    let status = unsafe {
+        SetSecurityInfo(
+            directory.as_raw_handle() as HANDLE,
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            null_mut(),
+            null_mut(),
+            dacl,
+            null_mut(),
+        )
+    };
+    if status != 0 {
+        return Err(ModelManagerError::Io(std::io::Error::from_raw_os_error(status as i32)));
+    }
+    validate_private_directory(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    #[test]
+    fn private_root_file_directory_and_no_replace_are_usable() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("models");
+        create_private_directory(&root).unwrap();
+        validate_volume(&root).unwrap();
+        validate_private_directory(&root).unwrap();
+        root_identity(&root).unwrap();
+        let source = root.join("source");
+        let mut file = create_private_file(&source).unwrap();
+        file.write_all(b"model").unwrap();
+        file.sync_all().unwrap();
+        drop(file);
+        validate_private_file(&source).unwrap();
+        let destination = root.join("destination");
+        rename_no_replace(&source, &destination).unwrap();
+        let another = root.join("another");
+        drop(create_private_file(&another).unwrap());
+        assert!(rename_no_replace(&another, &destination).is_err());
+        let directory = root.join("staging");
+        create_private_directory(&directory).unwrap();
+        drop(create_private_file(&directory.join("artifact")).unwrap());
+        validate_private_directory(&directory).unwrap();
+        flush_directory(&root).unwrap();
+        delete_flat_private_directory(&directory).unwrap();
+        assert!(!directory.exists());
+        delete_private_file(&another).unwrap();
+        assert!(!another.exists());
+    }
+
+    #[test]
+    fn flat_cleanup_fails_closed_before_deleting_an_over_limit_directory() {
+        let parent = tempfile::tempdir().unwrap();
+        let directory = parent.path().join("models");
+        create_private_directory(&directory).unwrap();
+        for index in 0..=MAX_PRIVATE_DIRECTORY_FILES {
+            drop(create_private_file(&directory.join(format!("artifact-{index}"))).unwrap());
+        }
+
+        assert!(matches!(
+            delete_flat_private_directory(&directory),
+            Err(ModelManagerError::DataDirectoryUnsafe)
+        ));
+        assert_eq!(std::fs::read_dir(&directory).unwrap().count(), MAX_PRIVATE_DIRECTORY_FILES + 1);
+    }
+
+    #[test]
+    fn existing_inherited_acl_root_is_rejected_then_test_hardening_is_stable() {
+        let parent = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            ensure_private_root(parent.path()),
+            Err(ModelManagerError::DataDirectoryUnsafe)
+        ));
+        harden_test_directory(parent.path()).unwrap();
+        ensure_private_root(parent.path()).unwrap();
+        harden_test_directory(parent.path()).unwrap();
+    }
+
+    #[test]
+    fn file_stream_hardlink_identity_and_root_lifetime_are_enforced() {
+        let parent = tempfile::tempdir().unwrap();
+        let root = parent.path().join("models");
+        create_private_directory(&root).unwrap();
+
+        let first = root.join("first");
+        let first_file = create_private_file(&first).unwrap();
+        let first_identity = file_identity(&first_file).unwrap();
+        drop(first_file);
+        let second = root.join("second");
+        let second_file = create_private_file(&second).unwrap();
+        assert_ne!(first_identity, file_identity(&second_file).unwrap());
+        drop(second_file);
+
+        std::fs::write(format!("{}:untrusted", first.display()), b"stream").unwrap();
+        assert!(matches!(validate_private_file(&first), Err(ModelManagerError::UnsafePath)));
+        std::fs::remove_file(format!("{}:untrusted", first.display())).unwrap();
+        let link = root.join("linked");
+        std::fs::hard_link(&first, &link).unwrap();
+        assert!(matches!(validate_private_file(&first), Err(ModelManagerError::UnsafePath)));
+        std::fs::remove_file(link).unwrap();
+
+        let guard = RootGuard::acquire(&root).unwrap();
+        let moved = parent.path().join("moved-models");
+        assert!(std::fs::rename(&root, &moved).is_err());
+        guard.validate(&root).unwrap();
+        drop(guard);
+        std::fs::rename(&root, &moved).unwrap();
+    }
+}

--- a/crates/onnxruntime/src/worker.rs
+++ b/crates/onnxruntime/src/worker.rs
@@ -347,12 +347,20 @@ fn spawn_worker_windows(
         JOB_OBJECT_LIMIT_PROCESS_MEMORY, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
         JobObjectExtendedLimitInformation, SetInformationJobObject,
     };
+    use windows_sys::Win32::System::SystemInformation::{GetSystemInfo, SYSTEM_INFO};
     use windows_sys::Win32::System::Threading::{CREATE_NO_WINDOW, CREATE_SUSPENDED};
 
     #[link(name = "ntdll")]
     unsafe extern "system" {
         fn NtResumeProcess(process: *mut core::ffi::c_void) -> i32;
     }
+
+    let mut system_information = SYSTEM_INFO::default();
+    // SAFETY: the pointer addresses a live, correctly sized SYSTEM_INFO value.
+    unsafe { GetSystemInfo(&raw mut system_information) };
+    let page_size = u64::from(system_information.dwPageSize);
+    let physical_memory = align_physical_memory_limit(limits.physical_memory, page_size)
+        .ok_or_else(|| resource_error("nativeWorkerMemory"))?;
 
     let mut command = Command::new(executable);
     command
@@ -361,7 +369,7 @@ fn spawn_worker_windows(
         .arg("--address-limit")
         .arg(limits.address_space.to_string())
         .arg("--physical-limit")
-        .arg(limits.physical_memory.to_string())
+        .arg(physical_memory.to_string())
         .current_dir(working_directory)
         .env_clear()
         .stdin(Stdio::piped())
@@ -379,8 +387,8 @@ fn spawn_worker_windows(
     let mut information = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
     information.BasicLimitInformation.LimitFlags =
         JOB_OBJECT_LIMIT_PROCESS_MEMORY | JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-    information.ProcessMemoryLimit = usize::try_from(limits.physical_memory)
-        .map_err(|_| resource_error("nativeWorkerMemory"))?;
+    information.ProcessMemoryLimit =
+        usize::try_from(physical_memory).map_err(|_| resource_error("nativeWorkerMemory"))?;
     // SAFETY: job/process handles are live and information has the exact API
     // layout and size. The process is still suspended during both calls.
     let configured = unsafe {
@@ -411,6 +419,14 @@ fn spawn_worker_windows(
     // SAFETY: ownership of the unique live job handle transfers here.
     let job = unsafe { OwnedHandle::from_raw_handle(job) };
     Ok(WorkerProcess { child, _job: job })
+}
+
+const fn align_physical_memory_limit(limit: u64, page_size: u64) -> Option<u64> {
+    if page_size == 0 {
+        return None;
+    }
+    let aligned = limit / page_size * page_size;
+    if aligned == 0 { None } else { Some(aligned) }
 }
 
 pub(crate) fn validate_worker_path(path: &Path) -> Result<(), ConversionError> {
@@ -785,6 +801,14 @@ mod tests {
                 .and_then(|value| value.checked_add(contract.run_memory_bytes))
                 .is_none()
         );
+    }
+
+    #[test]
+    fn physical_memory_limit_uses_the_same_page_aligned_value_for_parent_and_child() {
+        assert_eq!(align_physical_memory_limit(65_537, 4_096), Some(65_536));
+        assert_eq!(align_physical_memory_limit(4_096, 4_096), Some(4_096));
+        assert_eq!(align_physical_memory_limit(4_095, 4_096), None);
+        assert_eq!(align_physical_memory_limit(4_096, 0), None);
     }
 
     #[cfg(windows)]

--- a/crates/onnxruntime/tests/ppocrv6_merge_quality.rs
+++ b/crates/onnxruntime/tests/ppocrv6_merge_quality.rs
@@ -93,9 +93,9 @@ mod quality {
         );
         let dictionary = fs::read(runfiles.join("_main/models/ppocrv6_tiny_dict.txt")).unwrap();
         let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
-        let model_root = tempfile::tempdir().unwrap();
-        let manager =
-            Arc::new(ModelManager::embedded(model_root.path().to_path_buf(), None).unwrap());
+        let model_parent = tempfile::tempdir().unwrap();
+        let model_root = model_parent.path().join("models");
+        let manager = Arc::new(ModelManager::embedded(model_root, None).unwrap());
         manager
             .install(
                 "pp-ocrv6-tiny-recognizer-onnx",

--- a/crates/onnxruntime/tests/ppocrv6_quality.rs
+++ b/crates/onnxruntime/tests/ppocrv6_quality.rs
@@ -64,9 +64,9 @@ mod quality {
             into_markdown_core::ExecutionOptions::default(),
             into_markdown_core::ResourceLimits::default(),
         );
-        let model_root = tempfile::tempdir().unwrap();
-        let manager =
-            Arc::new(ModelManager::embedded(model_root.path().to_path_buf(), None).unwrap());
+        let model_parent = tempfile::tempdir().unwrap();
+        let model_root = model_parent.path().join("models");
+        let manager = Arc::new(ModelManager::embedded(model_root, None).unwrap());
         manager
             .install(
                 "pp-ocrv6-tiny-recognizer-onnx",

--- a/crates/pdf-layout/src/dedup.rs
+++ b/crates/pdf-layout/src/dedup.rs
@@ -2,10 +2,58 @@ use crate::budget::LayoutBudget;
 use crate::geometry::overlap_ratio;
 use crate::lines;
 use crate::memory;
-use crate::model::{Line, SourceKind};
+use crate::model::{Atom, Line, SourceKind};
 use crate::ordering;
 use into_markdown_core::ConversionError;
 use unicode_normalization::UnicodeNormalization;
+
+pub(crate) fn suppress_overlapping_ocr_atoms(
+    atoms: Vec<Atom>,
+    budget: &mut LayoutBudget<'_>,
+) -> Result<Vec<Atom>, ConversionError> {
+    let mut kept = Vec::<AtomCandidate>::new();
+    kept.try_reserve_exact(atoms.len()).map_err(|_| memory("layout atom dedup output"))?;
+    for atom in atoms {
+        budget.checkpoint_item()?;
+        let normalized = canonical(lines::inline_text(&atom.inline), budget)?;
+        let mut duplicate = false;
+        if atom.source_kind == SourceKind::Ocr && !normalized.is_empty() {
+            for existing in kept.iter().rev() {
+                budget.compare()?;
+                if existing.atom.source_kind != SourceKind::Ocr
+                    || existing.atom.orientation != atom.orientation
+                    || overlap_ratio(existing.atom.bounds, atom.bounds) < 0.55
+                {
+                    continue;
+                }
+                if equivalent_ocr_text(&existing.normalized, &normalized) {
+                    duplicate = true;
+                    break;
+                }
+            }
+        }
+        if !duplicate {
+            kept.push(AtomCandidate { atom, normalized });
+        }
+    }
+    let mut output = Vec::new();
+    output.try_reserve_exact(kept.len()).map_err(|_| memory("layout atom dedup atoms"))?;
+    output.extend(kept.into_iter().map(|candidate| candidate.atom));
+    Ok(output)
+}
+
+struct AtomCandidate {
+    atom: Atom,
+    normalized: String,
+}
+
+fn equivalent_ocr_text(left: &str, right: &str) -> bool {
+    if left == right {
+        return true;
+    }
+    let (shorter, longer) = if left.len() <= right.len() { (left, right) } else { (right, left) };
+    shorter.chars().take(3).count() == 3 && longer.contains(shorter)
+}
 
 pub(crate) fn suppress(
     lines: Vec<Line>,

--- a/crates/pdf-layout/src/materialize.rs
+++ b/crates/pdf-layout/src/materialize.rs
@@ -33,7 +33,12 @@ pub(crate) fn reconstruct_page(
     if content.atoms.is_empty() {
         return Ok(content.passthrough);
     }
-    let clustered = lines::cluster(content.atoms, budget)?;
+    // Page-render OCR and embedded-image OCR can describe the same pixels with
+    // different line segmentation. Remove overlapping OCR atoms before line
+    // clustering; once combined into one line, exact line-level deduplication
+    // can no longer distinguish those duplicate observations.
+    let atoms = dedup::suppress_overlapping_ocr_atoms(content.atoms, budget)?;
+    let clustered = lines::cluster(atoms, budget)?;
     let deduplicated = dedup::suppress(clustered, budget)?;
     let median_font = semantics::font_baseline(&deduplicated, budget)?;
     // Lock locally corroborated two-dimensional grids before interpreting

--- a/crates/pdf-layout/src/tests.rs
+++ b/crates/pdf-layout/src/tests.rs
@@ -954,6 +954,25 @@ fn native_and_ocr_overlap_is_deduplicated_without_losing_evidence_source() {
 }
 
 #[test]
+fn overlapping_page_and_embedded_ocr_with_different_segmentation_is_deduplicated() {
+    let combined = Rect { x: 40.0, y: 80.0, width: 160.0, height: 18.0 };
+    let mut inlines = vec![ocr("OCR START 101", combined)];
+    inlines.push(ocr("OCR START", Rect { x: 40.0, y: 80.0, width: 115.0, height: 18.0 }));
+    inlines.push(ocr("101", Rect { x: 160.0, y: 80.0, width: 40.0, height: 18.0 }));
+    inlines.push(ocr("OCR START 101", Rect { x: 40.0, y: 180.0, width: 160.0, height: 18.0 }));
+
+    let actual = rebuild(document(inlines));
+    let text = page_blocks(&actual)
+        .iter()
+        .map(|node| block_text(&node.block))
+        .collect::<Vec<_>>()
+        .join("|");
+    assert_eq!(text.matches("OCR START 101").count(), 2);
+    assert!(!text.contains("OCR STARTOCR START"));
+    assert!(!text.contains("101101"));
+}
+
+#[test]
 fn page_wide_spatial_dedup_finds_old_overlap_and_preserves_distant_equal_text() {
     let top = Rect { x: 40.0, y: 20.0, width: 40.0, height: 6.0 };
     let mut inlines = source_text("same", top, 12.0);

--- a/crates/pdfium/src/native.rs
+++ b/crates/pdfium/src/native.rs
@@ -2050,13 +2050,8 @@ fn open_locked(path: &Path) -> Result<File, Error> {
 fn validate_binary(bytes: &[u8], platform: Platform, artifact: &Artifact) -> Result<(), Error> {
     let file =
         object::File::parse(bytes).map_err(|error| Error::BinaryValidation(error.to_string()))?;
-    let (format, architecture) = match platform {
-        Platform::MacArm64 => (BinaryFormat::MachO, Architecture::Aarch64),
-        Platform::LinuxX64 => (BinaryFormat::Elf, Architecture::X86_64),
-        Platform::LinuxArm64 => (BinaryFormat::Elf, Architecture::Aarch64),
-        Platform::WindowsX64 => (BinaryFormat::Coff, Architecture::X86_64),
-    };
-    if file.format() != format || file.architecture() != architecture || !file.is_64() {
+    let (format, architecture) = expected_binary_identity(platform);
+    if !binary_identity_matches(platform, file.format(), file.architecture(), file.is_64()) {
         return Err(Error::BinaryValidation(format!(
             "expected {format:?}/{architecture:?}/64-bit, got {:?}/{:?}/{}-bit",
             file.format(),
@@ -2098,6 +2093,25 @@ fn validate_binary(bytes: &[u8], platform: Platform, artifact: &Artifact) -> Res
     Ok(())
 }
 
+fn expected_binary_identity(platform: Platform) -> (BinaryFormat, Architecture) {
+    match platform {
+        Platform::MacArm64 => (BinaryFormat::MachO, Architecture::Aarch64),
+        Platform::LinuxX64 => (BinaryFormat::Elf, Architecture::X86_64),
+        Platform::LinuxArm64 => (BinaryFormat::Elf, Architecture::Aarch64),
+        Platform::WindowsX64 => (BinaryFormat::Pe, Architecture::X86_64),
+    }
+}
+
+fn binary_identity_matches(
+    platform: Platform,
+    actual_format: BinaryFormat,
+    actual_architecture: Architecture,
+    is_64: bool,
+) -> bool {
+    let (format, architecture) = expected_binary_identity(platform);
+    actual_format == format && actual_architecture == architecture && is_64
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2117,7 +2131,7 @@ mod tests {
         assert_eq!(std::mem::size_of::<Config>(), 32);
         assert_eq!(std::mem::align_of::<Config>(), 8);
         assert_eq!(std::mem::size_of::<c_uint>(), 4);
-        assert_eq!(std::mem::size_of::<c_ulong>(), 8);
+        assert_eq!(std::mem::size_of::<c_ulong>(), if cfg!(windows) { 4 } else { 8 });
         let _: GetUnicode = unicode_signature;
         let _: GetActionType = action_type_signature;
         assert_eq!(std::mem::offset_of!(Config, version), 0);
@@ -2159,6 +2173,28 @@ mod tests {
         assert!(matches!(
             artifact_from_manifest(&value.to_string(), Platform::MacArm64),
             Err(Error::BinaryValidation(message)) if message.contains("unknown field")
+        ));
+    }
+
+    #[test]
+    fn windows_runtime_requires_a_64_bit_x86_64_pe_image() {
+        assert!(binary_identity_matches(
+            Platform::WindowsX64,
+            BinaryFormat::Pe,
+            Architecture::X86_64,
+            true
+        ));
+        assert!(!binary_identity_matches(
+            Platform::WindowsX64,
+            BinaryFormat::Coff,
+            Architecture::X86_64,
+            true
+        ));
+        assert!(!binary_identity_matches(
+            Platform::WindowsX64,
+            BinaryFormat::Pe,
+            Architecture::I386,
+            false
         ));
     }
     #[test]

--- a/docs/models.md
+++ b/docs/models.md
@@ -32,9 +32,14 @@ commit `2661c7c0ef5c613e8f93c6e93b2e052399f0f854`、官方 ONNX TAR、最终 ONN
   `~/.local/share/into-markdown/models`
 - Windows x86_64：`%LOCALAPPDATA%\into-markdown\models`
 
-Windows x86_64 的目录解析与 source-only 查询可用；在实现并审计“不跟随 reparse point
-打开目录并 flush 目录 handle”前，即使未来清单加入完整 runtime files，Windows 安装
-事务也稳定返回 `componentUnavailable`，不会把空操作当作持久化成功。
+程序化调用方必须把 `ModelManager` 指向专用的 `models` 叶目录，而不是通用临时目录或其父目录。该叶目录首次使用时可以尚不存在，由管理器创建；如果已经存在，它必须已经具有管理器要求的受保护精确 ACL。继承普通 ACL 的 `tempdir` 或共享目录会 fail closed。测试代码也应传入例如 `tempdir/models` 这样的未创建子目录。
+
+Windows x86_64 在固定本地 NTFS/ReFS 上支持安装、删除和崩溃恢复。事务持有经 ACL、
+reparse point 与物理 FileId 校验的根目录 handle；私有文件拒绝 hardlink 与 ADS，发布使用
+同卷 `MoveFileExW(MOVEFILE_WRITE_THROUGH)` no-replace rename。目录 handle 可用时额外执行
+`FlushFileBuffers`；Windows 返回 `ERROR_INVALID_HANDLE` 的文件系统由 write-through rename
+提供 namespace durability。网络盘、可移动盘及其他文件系统稳定返回
+`componentUnavailable`。
 
 ## 安装事务与安全边界
 

--- a/docs/ocr-and-ai.md
+++ b/docs/ocr-and-ai.md
@@ -5,7 +5,10 @@
 The default API engine runs embedded raster OCR after a format converter has
 produced validated IR and before the renderer or a recovery `converted`
 checkpoint is published. It applies to PDF, Office and OpenDocument containers,
-EPUB, MSG, RTF, local/data/CID HTML images, notebooks, and ZIP/nested documents.
+EPUB, MSG, RTF, converter-resolved local/data/CID HTML images, notebooks, and
+ZIP/nested documents. The OCR stage never opens an ordinary HTML path itself;
+only bytes that the converter has already resolved under its resource policy
+are eligible.
 It does not reinterpret arbitrary strings in text, Markdown, CSV, JSON, XML, or
 feeds as images, and it never fetches an external image URI.
 

--- a/docs/ocr-and-ai.md
+++ b/docs/ocr-and-ai.md
@@ -1,5 +1,28 @@
 # OCR 与 AI
 
+## Embedded visual OCR
+
+The default API engine runs embedded raster OCR after a format converter has
+produced validated IR and before the renderer or a recovery `converted`
+checkpoint is published. It applies to PDF, Office and OpenDocument containers,
+EPUB, MSG, RTF, local/data/CID HTML images, notebooks, and ZIP/nested documents.
+It does not reinterpret arbitrary strings in text, Markdown, CSV, JSON, XML, or
+feeds as images, and it never fetches an external image URI.
+
+PNG, JPEG, GIF, WebP, BMP, and TIFF assets are decoded through the audited image
+boundary and normalized to one PNG frame. Animated/multi-page, fully transparent,
+SVG, EMF, and WMF visuals are excluded. Identical source bytes are recognized
+once per request, while every image reference receives its own adjacent OCR node
+and source locator. The bound OCR result must identify the SHA-256, dimensions,
+and frame of the exact normalized input together with exact detector and
+recognizer model identities; mismatches fail before publication.
+
+`asset_mode=extract` and `asset_mode=embed` keep both the image and OCR text.
+`asset_mode=omit` hides the image but retains OCR text. `ocr=off` bypasses this
+stage exactly. Embedded processing shares request cancellation, deadline,
+memory, asset, entry, and OCR-count limits. In PDF IR, image-local OCR geometry
+is transformed into the image's page rectangle before rendering.
+
 ## 本地 OCR
 
 完整 `pp-ocrv6-tiny-zh-en` 是可安装的 detector + recognizer pipeline。两个组件精确绑定

--- a/docs/security.md
+++ b/docs/security.md
@@ -248,7 +248,9 @@ sandbox：部署方仍应使用平台 sandbox/container 加固，FFmpeg 的最�
   与锁内原子切换；install/remove 或显式恢复会在锁内恢复中断事务，查询与校验只读并在
   发现未完成事务时 fail closed，损坏或歧义 journal 一律 fail closed；
   journal 先完整写入并同步根身份绑定的临时文件，再以 no-replace rename 发布；Windows
-  目录 handle 持久同步尚未审计，因此 Windows 安装稳定拒绝而不伪报成功；
+  x86_64 在固定本地 NTFS/ReFS 上持有受保护 DACL 与物理 FileId 绑定的根 handle，使用
+  `MoveFileExW(MOVEFILE_WRITE_THROUGH)` no-replace 发布，并将待删对象先原子退休到唯一
+  garbage 名称后再 best-effort 清理；
   校验和删除拒绝符号链接及非普通对象，随包只读模型不能删除。取消、超时、临时空间
   预算和内存预算由统一 ExecutionContext 执行。
 - OCR 识别只消费检测器给出的 raw-source `CropDescriptor`，不会再次应用 EXIF orientation。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,27 +11,33 @@ The executable format matrix is split by responsibility so a passing row has
 real parser evidence as well as common-enricher evidence:
 
 - `into-markdown` API tests dynamically create DOCX, PPTX, XLSX, ODT, ODS, ODP,
-  EPUB, RTF, IPYNB, HTML data-image, and nested-ZIP inputs. The PPTX fixture
-  interleaves one repeated image at the start, middle, and end; XLSX is the
-  image-only/no-native-text case; the 256-paragraph DOCX covers normal document
-  volume, all three asset modes, and `Off`.
+  EPUB, RTF, IPYNB, HTML data-image, and nested-ZIP inputs. The six-slide PPTX
+  fixture interleaves one repeated image at the start, middle, end, and inside a
+  group while preserving a table and cached chart. The three-sheet XLSX fixture
+  verifies repeated-image locators in workbook order. A blank image provides
+  the no-text case. The 256-paragraph DOCX covers normal document volume, all
+  three asset modes, and `Off`.
 - Common-enricher tests run every eligible `InputFormat`, reject arbitrary
   CSV/JSON/XML/Text/Feed/Markdown assets, preserve a locator for every repeated
   reference, reject a mismatched normalized-input identity, and fail before OCR
   publication on cancellation or reference/byte/OCR-work budget exhaustion.
 - PDF layout tests merge page-coordinate OCR with native text, remove spatial
   duplicates without deleting OCR evidence, and keep a coordinate-mapped OCR
-  node when there is no native text. The existing generated mixed, scanned,
-  rotated, and text-only PDF smoke fixtures cover page/start/middle/end cases.
-- MSG positive/negative coverage is in
+  node when there is no native text. A dynamically generated API fixture also
+  contains two byte-identical image XObjects and checks one recognition with
+  per-reference publication; that test is runtime-gated by `PDFIUM_LIBRARY` and
+  is not evidence unless the pinned runtime target is actually executed.
+- MSG parser positive/negative coverage is in
   `html_cid_and_by_value_attachment_are_offline_assets` and
   `cid_resources_require_an_exact_reference_and_an_audited_image`; remote HTML
   is never fetched, while audited data/CID or converter-resolved local assets
-  enter the same stage.
+  enter the common stage. These parser tests and the format-wide enricher tests
+  are separate evidence; they do not claim a real MSG API end-to-end run.
 - Legacy DOC/PPT/XLS nested dispatch is exercised by
   `all_legacy_families_use_same_context_nested_dispatch_and_conservative_provenance`.
   The real installed-runtime target remains
-  `manual_native_three_families_enter_real_nested_converters`.
+  `manual_native_three_families_enter_real_nested_converters`; an unexecuted
+  manual target is not counted as runtime evidence.
 - RecoveryStore tests (Unix filesystem semantics) prove enriched converter
   output is atomically checkpointed before rendering and is not enriched again
   after a process restart. Windows gates compile that path; Unix CI executes it.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,46 @@
 # 测试策略
 
+Embedded-visual OCR regression tests create real container files dynamically
+instead of committing synthetic office archives. They use a source-bound mock
+OCR provider to verify normalized-input identity, byte deduplication with
+per-reference locators, PDF coordinate mapping, `off` no-op behavior, and
+extract/embed/omit asset behavior. Official detector/recognizer and platform
+runtime validation remains in the existing explicit manual quality targets.
+
+The executable format matrix is split by responsibility so a passing row has
+real parser evidence as well as common-enricher evidence:
+
+- `into-markdown` API tests dynamically create DOCX, PPTX, XLSX, ODT, ODS, ODP,
+  EPUB, RTF, IPYNB, HTML data-image, and nested-ZIP inputs. The PPTX fixture
+  interleaves one repeated image at the start, middle, and end; XLSX is the
+  image-only/no-native-text case; the 256-paragraph DOCX covers normal document
+  volume, all three asset modes, and `Off`.
+- Common-enricher tests run every eligible `InputFormat`, reject arbitrary
+  CSV/JSON/XML/Text/Feed/Markdown assets, preserve a locator for every repeated
+  reference, reject a mismatched normalized-input identity, and fail before OCR
+  publication on cancellation or reference/byte/OCR-work budget exhaustion.
+- PDF layout tests merge page-coordinate OCR with native text, remove spatial
+  duplicates without deleting OCR evidence, and keep a coordinate-mapped OCR
+  node when there is no native text. The existing generated mixed, scanned,
+  rotated, and text-only PDF smoke fixtures cover page/start/middle/end cases.
+- MSG positive/negative coverage is in
+  `html_cid_and_by_value_attachment_are_offline_assets` and
+  `cid_resources_require_an_exact_reference_and_an_audited_image`; remote HTML
+  is never fetched, while audited data/CID or converter-resolved local assets
+  enter the same stage.
+- Legacy DOC/PPT/XLS nested dispatch is exercised by
+  `all_legacy_families_use_same_context_nested_dispatch_and_conservative_provenance`.
+  The real installed-runtime target remains
+  `manual_native_three_families_enter_real_nested_converters`.
+- RecoveryStore tests (Unix filesystem semantics) prove enriched converter
+  output is atomically checkpointed before rendering and is not enriched again
+  after a process restart. Windows gates compile that path; Unix CI executes it.
+
+The focused local commands are `cargo test -p into-markdown-converters
+embedded_visual_ocr`, `cargo test -p into-markdown embedded_visual_ocr_tests`,
+and `cargo test -p into-markdown-pdf-layout
+native_and_ocr_overlap_is_deduplicated_without_losing_evidence_source`.
+
 ## 公共契约套件
 
 `tests/contracts` 是下游调用方视角的黑盒公共契约套件。它只通过公开 crate
@@ -10,8 +51,9 @@
 适配器以及请求构造器。Cargo 测试与 Bazel 构建都会编译该 target，因此只在实现
 crate 内保持源码兼容不能通过检查。
 
-契约套件逐项覆盖八个公共 SPI：`SourceResolver`、`FormatDetector`、`Converter`、
-`MarkdownRenderer`、`OcrEngine`、`Transcriber`、`TensorRuntime` 和 `AiProvider`。
+契约套件逐项覆盖九个公共 SPI：`SourceResolver`、`FormatDetector`、`Converter`、
+`OutputEnricher`、`MarkdownRenderer`、`OcrEngine`、`Transcriber`、`TensorRuntime` 和
+`AiProvider`。
 每个接口必须可形成 `Send + Sync` trait object；异步返回值会被实际轮询至完成、取消
 或超时，不使用无法终止的 pending future。Engine 契约覆盖重复 ID、显式 hint、
 confidence/priority/稳定 ID 排序、仅 `NotApplicable` 回退、其它错误立即短路、IR

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -16,7 +16,9 @@ real parser evidence as well as common-enricher evidence:
   group while preserving a table and cached chart. The three-sheet XLSX fixture
   verifies repeated-image locators in workbook order. A blank image provides
   the no-text case. The 256-paragraph DOCX covers normal document volume, all
-  three asset modes, and `Off`.
+  three asset modes, and `Off`. A real EPUB container negative proves that an
+  external image is not fetched or retained and that a manifest/chapter path
+  traversal is rejected before OCR.
 - Common-enricher tests run every eligible `InputFormat`, reject arbitrary
   CSV/JSON/XML/Text/Feed/Markdown assets, preserve a locator for every repeated
   reference, reject a mismatched normalized-input identity, and fail before OCR
@@ -24,8 +26,9 @@ real parser evidence as well as common-enricher evidence:
 - PDF layout tests merge page-coordinate OCR with native text, remove spatial
   duplicates without deleting OCR evidence, and keep a coordinate-mapped OCR
   node when there is no native text. A dynamically generated API fixture also
-  contains two byte-identical image XObjects and checks one recognition with
-  per-reference publication; that test is runtime-gated by `PDFIUM_LIBRARY` and
+  contains two distinct image XObjects and draws one of them twice, checking
+  one recognition per unique embedded input with per-reference publication;
+  that test is runtime-gated by `PDFIUM_LIBRARY` and
   is not evidence unless the pinned runtime target is actually executed.
 - MSG parser positive/negative coverage is in
   `html_cid_and_by_value_attachment_are_offline_assets` and

--- a/tests/contracts/src/lib.rs
+++ b/tests/contracts/src/lib.rs
@@ -354,6 +354,7 @@ mod tests {
         require_send_sync::<dyn SourceResolver>();
         require_send_sync::<dyn FormatDetector>();
         require_send_sync::<dyn Converter>();
+        require_send_sync::<dyn OutputEnricher>();
         require_send_sync::<dyn MarkdownRenderer>();
         require_send_sync::<dyn OcrEngine>();
         require_send_sync::<dyn Transcriber>();
@@ -362,6 +363,7 @@ mod tests {
         let _: Option<&dyn SourceResolver> = None;
         let _: Option<&dyn FormatDetector> = None;
         let _: Option<&dyn Converter> = None;
+        let _: Option<&dyn OutputEnricher> = None;
         let _: Option<&dyn MarkdownRenderer> = None;
         let _: Option<&dyn OcrEngine> = None;
         let _: Option<&dyn Transcriber> = None;


### PR DESCRIPTION
## Summary

- add a transactional OutputEnricher stage after conversion and before rendering/recovery publication
- OCR embedded raster assets across PDF, Office/ODF/EPUB/MSG/RTF/HTML/IPYNB/ZIP containers with exact normalized-input identity binding, byte deduplication, per-reference provenance, bounded resources, cancellation, and offline semantics
- address all actionable review findings, including: Auto animated/multipage exclusion, GIF decoded-vs-working memory, BigTIFF dimensions, node-count preflight, canonical base64 padding, enriched recovery validation, and PDF table-limit preservation
- support durable PP-OCR model installation on Windows x64 local NTFS/ReFS through a narrow audited Win32 boundary
- enforce a dedicated protected-DACL model root, physical FileId/volume identity, no reparse/hardlink/ADS, no-replace write-through publication, retained root and lock handles, bounded recovery cleanup, and fail-closed crash recovery
- update Windows PP-OCR quality tests to use a dedicated initially absent models child directory

Closes #150

## Main-agent acceptance evidence

Final head: a1de2f0d1180caea559a2c41cb911681b6cd632c.

Passed on Windows with Rust stable 1.97.1:

- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- affected workspace cargo check for OCR, engine, converters, API, ONNX Runtime, and PDFium targets
- OCR strict clippy: all targets with -D warnings
- Win32 filesystem boundary: 4/4
- model installation atomic/idempotent, concurrent-lock, fault-recovery, truncated-journal, cross-root replay, corrupt/ambiguous journal, and traversal regressions
- embedded visual OCR review regressions: 24/24
- PDF OCR relayout regressions: 2/2
- engine library: 23/23, including post-enrichment asset and diagnostic revalidation
- dynamic container/API and fixed-runtime PDF/EPUB evidence recorded in earlier commits remains green

Cargo dependency hydration now succeeds on this host with CARGO_HTTP_CHECK_REVOKE=false, including aho-corasick 1.1.5 and serde_spanned 1.1.1.

## Known unrelated baseline failures

These were not changed, per scope:

- full OCR library: 111 passed, 13 failed, 1 ignored; failures are existing character-table hash/model-identity/authority drift
- full Windows workspace check reaches apps/cli and fails in unchanged Windows SafeDir code (missing unsupported_safe_dir and private sync calls)
- license-check/release-audit run but report existing NOTICE, authority, asset, and fixture inventory drift across the repository
- full workspace strict clippy reports existing legacy-office/converter lints

## Remaining local environment gate

Bazelisk 1.28.1 / Bazel 9.2.0 and TLS trust are working. The Windows Bazel targets are blocked before analysis because rules_rust crate-universe must create a workspace symlink and this non-elevated host has Developer Mode disabled (Windows error 1314). No repository or dependency was patched to bypass that security requirement.

After enabling Windows Developer Mode or running the shell elevated, run:

- npx --yes @bazel/bazelisk --host_jvm_args=-Djavax.net.ssl.trustStoreType=Windows-ROOT --host_jvm_args=-Djavax.net.ssl.trustStore=NONE test //crates/ocr:ocr_test
- the same command for //crates/api:ppocrv6_image_quality and the related ONNX PP-OCR quality targets

The Windows Bazel symlink privilege limitation is recorded as a non-blocking local environment constraint; Cargo release-binary PP-OCRv6 end-to-end acceptance passed, all review threads are resolved, and GitHub reports the PR mergeable.