### PR TITLE
fix: Windows non-blocking connect completion and degenerate OCR crops

### DIFF
--- a/crates/http-transport/src/connect.rs
+++ b/crates/http-transport/src/connect.rs
@@ -35,6 +35,9 @@ pub(super) fn connect_exact(
     let socket = Socket::new(Domain::for_address(address), Type::STREAM, Some(Protocol::TCP))
         .map_err(|_| TransportError::new(TransportErrorKind::Connect))?;
     socket.set_nonblocking(true).map_err(|_| TransportError::new(TransportErrorKind::Connect))?;
+    // TCP_NODELAY must be applied before connect: Windows rejects it with
+    // WSAEINVAL on a socket that just completed a non-blocking connect.
+    socket.set_tcp_nodelay(true).map_err(|_| TransportError::new(TransportErrorKind::Connect))?;
     match socket.connect(&SockAddr::from(address)) {
         Ok(()) => {}
         Err(error) if connect_pending(&error) => loop {
@@ -46,8 +49,14 @@ pub(super) fn connect_exact(
             {
                 return Err(TransportError::new(TransportErrorKind::Connect));
             }
-            if socket.peer_addr().is_ok() {
-                break;
+            // Retry the connect instead of consulting `peer_addr`: on Windows a
+            // non-blocking connect can report a peer address before the socket
+            // accepts writes, which surfaces as WSAENOTCONN on the first send.
+            match socket.connect(&SockAddr::from(address)) {
+                Ok(()) => break,
+                Err(error) if reconnect_complete(&error) => break,
+                Err(error) if reconnect_pending(&error) => {}
+                Err(_) => return Err(TransportError::new(TransportErrorKind::Connect)),
             }
             thread::sleep(blocking_slice(deadline));
         },
@@ -56,7 +65,6 @@ pub(super) fn connect_exact(
     check_operation(context, deadline)?;
     socket.set_nonblocking(false).map_err(|_| TransportError::new(TransportErrorKind::Connect))?;
     let stream = TcpStream::from(socket);
-    stream.set_nodelay(true).map_err(|_| TransportError::new(TransportErrorKind::Connect))?;
     stream
         .set_read_timeout(Some(IO_POLL_SLICE))
         .map_err(|_| TransportError::new(TransportErrorKind::Connect))?;
@@ -69,6 +77,16 @@ pub(super) fn connect_exact(
 pub(super) fn connect_pending(error: &io::Error) -> bool {
     matches!(error.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted)
         || matches!(error.raw_os_error(), Some(36 | 115 | 10035))
+}
+
+pub(super) fn reconnect_complete(error: &io::Error) -> bool {
+    // WSAEISCONN (Windows), EISCONN (Linux 106, macOS/BSD 56).
+    matches!(error.raw_os_error(), Some(10056 | 106 | 56))
+}
+
+pub(super) fn reconnect_pending(error: &io::Error) -> bool {
+    matches!(error.kind(), io::ErrorKind::WouldBlock | io::ErrorKind::Interrupted)
+        || matches!(error.raw_os_error(), Some(36 | 115 | 114 | 37 | 10035 | 10037))
 }
 
 pub(super) fn write_all_checked(

--- a/crates/http-transport/src/tests/protocol.rs
+++ b/crates/http-transport/src/tests/protocol.rs
@@ -39,3 +39,41 @@ fn portable_filename_rejects_paths_devices_and_non_nfc() {
     }
     assert_eq!(portable_filename("报告.md").unwrap(), "报告.md");
 }
+
+#[test]
+fn non_blocking_connect_probe_classifies_pending_and_complete_states() {
+    use crate::connect::{connect_pending, reconnect_complete, reconnect_pending};
+    use std::io;
+
+    let pending = [io::Error::from_raw_os_error(10035), io::Error::from_raw_os_error(36)];
+    for error in &pending {
+        assert!(connect_pending(error));
+        assert!(reconnect_pending(error));
+        assert!(!reconnect_complete(error));
+    }
+    let still_pending = [
+        io::Error::from_raw_os_error(10037),
+        io::Error::from_raw_os_error(115),
+        io::Error::from_raw_os_error(114),
+        io::Error::from_raw_os_error(37),
+    ];
+    for error in &still_pending {
+        assert!(reconnect_pending(error));
+        assert!(!reconnect_complete(error));
+    }
+    let complete = [
+        io::Error::from_raw_os_error(10056),
+        io::Error::from_raw_os_error(106),
+        io::Error::from_raw_os_error(56),
+    ];
+    for error in &complete {
+        assert!(reconnect_complete(error));
+        assert!(!reconnect_pending(error));
+    }
+    let failed = [io::Error::from_raw_os_error(10061), io::Error::from_raw_os_error(111)];
+    for error in &failed {
+        assert!(!connect_pending(error));
+        assert!(!reconnect_pending(error));
+        assert!(!reconnect_complete(error));
+    }
+}

--- a/crates/ocr/src/detection.rs
+++ b/crates/ocr/src/detection.rs
@@ -857,6 +857,12 @@ fn postprocess(
         if source.iter().any(|point| !point.0.is_finite() || !point.1.is_finite()) {
             return Err(ocr("invalidDetectionGeometry"));
         }
+        // Border-clamped or subpixel model quads can collapse into sliver
+        // polygons that recognition would reject as a hard crop error; they are
+        // detector noise and are skipped like the geometric filters above.
+        if !usable_source_quad(source) {
+            continue;
+        }
         let (crop_width, crop_height) = crop_dimensions(source)?;
         let dx = source[1].0 - source[0].0;
         let dy = source[1].1 - source[0].1;
@@ -1361,6 +1367,21 @@ fn crop_dimensions(polygon: [(f32, f32); 4]) -> Result<(u32, u32), ConversionErr
     let left = distance(polygon[0], polygon[3])?;
     let right = distance(polygon[1], polygon[2])?;
     Ok((rounded_axis(top, bottom)?, rounded_axis(left, right)?))
+}
+
+/// Signed shoelace area of a source-space polygon, computed with the same
+/// widening and vertex walk as recognition's crop validation so the detector
+/// only emits regions the recognizer accepts.
+fn source_polygon_area(polygon: [(f32, f32); 4]) -> f64 {
+    polygon.iter().enumerate().fold(0.0_f64, |sum, (index, &(x, y))| {
+        let (next_x, next_y) = polygon[(index + 1) % 4];
+        sum + f64::from(x) * f64::from(next_y) - f64::from(next_x) * f64::from(y)
+    })
+}
+
+fn usable_source_quad(polygon: [(f32, f32); 4]) -> bool {
+    let area = source_polygon_area(polygon);
+    area.is_finite() && area.abs() > 1.0
 }
 
 fn is_convex_quad(quad: [[f64; 2]; 4]) -> bool {
@@ -1949,6 +1970,34 @@ mod tests {
             crop_dimensions(too_wide),
             Err(ConversionError::Ocr { ref detail, .. }) if detail == "invalidDetectionGeometry"
         ));
+    }
+
+    #[test]
+    fn source_polygon_area_matches_recognition_vertex_walk() {
+        let unit = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)];
+        let collapsed_height = [(437.0, 21.0), (439.0, 21.0), (439.0, 21.0), (437.0, 21.0)];
+        let tall_sliver = [(241.0, 28.0), (242.0, 28.0), (242.0, 31.0), (241.0, 31.0)];
+        let band = [(29.0, 0.0), (639.0, 0.0), (639.0, 119.0), (29.0, 119.0)];
+        assert_eq!(source_polygon_area(unit).to_bits(), 2.0_f64.to_bits());
+        assert_eq!(source_polygon_area(collapsed_height).to_bits(), 0.0_f64.to_bits());
+        assert_eq!(source_polygon_area(tall_sliver).to_bits(), 6.0_f64.to_bits());
+        assert_eq!(source_polygon_area(band).to_bits(), 145_180.0_f64.to_bits());
+    }
+
+    #[test]
+    fn usable_source_quad_rejects_degenerate_slivers_only() {
+        let collapsed_height = [(437.0, 21.0), (439.0, 21.0), (439.0, 21.0), (437.0, 21.0)];
+        let collapsed_line = [(0.0, 5.0), (10.0, 5.0), (10.0, 5.0), (0.0, 5.0)];
+        let zero_area_bowtie = [(0.0, 0.0), (10.0, 10.0), (10.0, 0.0), (0.0, 10.0)];
+        let unit = [(157.0, 20.0), (158.0, 20.0), (158.0, 21.0), (157.0, 21.0)];
+        let tall_sliver = [(241.0, 28.0), (242.0, 28.0), (242.0, 31.0), (241.0, 31.0)];
+        let band = [(29.0, 0.0), (639.0, 0.0), (639.0, 119.0), (29.0, 119.0)];
+        assert!(!usable_source_quad(collapsed_height));
+        assert!(!usable_source_quad(collapsed_line));
+        assert!(!usable_source_quad(zero_area_bowtie));
+        assert!(usable_source_quad(unit));
+        assert!(usable_source_quad(tall_sliver));
+        assert!(usable_source_quad(band));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- fix Windows non-blocking connect completion in the audited HTTP transport: apply `TCP_NODELAY` before connect and replace the `peer_addr` completion probe with a retried connect classified by `WSAEISCONN/EISCONN` versus `WOULDBLOCK/ALREADY` (#152)
- skip degenerate detector quads whose shoelace area is at most 1.0 (the exact vertex walk and threshold recognition uses) so one noisy region no longer fails the whole `--ocr always` conversion with `invalidRecognitionCrop`; the recognizer stays strict (#153)

## Root-cause evidence (real binaries, no mocks)

#152, reproduced 100% with a socket2 minimal harness and by calling `HttpClient` directly:
- `setsockopt(TCP_NODELAY)` after a completed non-blocking connect returns `WSAEINVAL (10022)` on Windows and was mapped to `Connect`.
- With that fixed, the handshake still failed: `peer_addr().is_ok()` reports success on Windows before the socket accepts writes; the first `send` returns `WSAENOTCONN (10057)` and only succeeds ~300 ms later. A retried connect observing `WSAEISCONN (10056)` is the reliable completion signal.

#153, reproduced with the installed official PP-OCRv6 tiny detector on a striped text-free 640x120 PNG:
- the detector emitted 9 regions, including clamped sliver quads such as `[(437,21),(439,21),(439,21),(437,21)]` (zero area) and 1x1 crops; `validated_crop` correctly fails closed on `area.abs() <= 1.0`, which aborted the entire conversion.

## Verification (Windows x86_64, release binary of this branch)

- `into-md models remove` + `into-md models install pp-ocrv6-tiny-zh-en` over the real network: download, SHA-256 verification, transactional install, and `models verify` all pass; `doctor` reports `runtime.ocr ok`.
- Library-level `HttpClient::get` against the pinned BOS URL downloads the full 1,792,000-byte detector TAR.
- Striped PNG with `--ocr always`: exit 0, no inserted block, no junk text; the probe confirms degenerate regions are filtered (9 -> 7) and the remaining ones decode as empty text and are dropped at merge.
- No regressions: all 17 probe images and the four container documents (DOCX/PPTX/XLSX/PDF with embedded text images) produce bit-for-bit identical OCR output versus `56f791b`; `--ocr off` output is byte-identical to the pre-#151 baseline for DOCX/PPTX/XLSX (PDF baseline cannot run on Windows before #151 due to the fixed PE/Coff check).

## Tests

- new `non_blocking_connect_probe_classifies_pending_and_complete_states` (http-transport): 16/16 crate tests pass.
- new `source_polygon_area_matches_recognition_vertex_walk` and `usable_source_quad_rejects_degenerate_slivers_only` (ocr detection): 33/33 detection tests pass.
- `cargo fmt --all -- --check` clean; `cargo clippy -p into-markdown-http-transport -p into-markdown-ocr --all-targets -- -D warnings` clean.

## Known unrelated baseline failures

- `recognition::tests::all_exif_orientations_flow_from_detection_to_raw_source_recognition` fails with `characterTableHashMismatch` on the unmodified `56f791b` baseline as well (previously recorded fixture drift; unchanged by this PR).
- The Windows file-output transaction (`transaction.rs`) and CLI baseline build gaps remain out of scope here; stdout and `--emit bundle` paths were used for end-to-end validation.

Fixes #152
Fixes #153
