### PR TITLE
feat(http-transport): route model downloads through CONNECT proxies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 # Models and native runtimes are fetched by verified Bazel repositories.
 /models/artifacts/
 /third_party/onnxruntime/artifacts/
+
+# codegraph index cache
+.codegraph/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,6 +455,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1316,7 @@ dependencies = [
  "flate2",
  "into-markdown-core",
  "rustls",
+ "rustls-native-certs",
  "socket2",
  "unicode-normalization",
  "url",
@@ -1804,6 +1821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2244,6 +2267,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2279,10 +2314,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ prost = { version = "=0.14.4", default-features = false, features = ["derive", "
 pulldown-cmark = "=0.13.4"
 quick-xml = "=0.38.3"
 rustls = { version = "=0.23.32", default-features = false, features = ["ring", "std", "tls12"] }
+rustls-native-certs = "0.8"
 webpki-roots = "=1.0.3"
 zeroize = "=1.8.2"
 rustix = { version = "1.1.4", features = ["fs"] }

--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -384,10 +384,10 @@ fn run_models(
                 Ok(())
             }
         }
-        Some(ModelsCommand::Install { id }) => {
+        Some(ModelsCommand::Install { id, insecure }) => {
             let id = id.as_deref().unwrap_or(&manager.manifest().default_bundle);
             manager.require_installable(id).map_err(model_error)?;
-            let fetcher = crate::model_fetch::PinnedModelFetcher::from_environment()
+            let fetcher = crate::model_fetch::PinnedModelFetcher::from_environment(insecure)
                 .map_err(|(variable, reason)| {
                     CliError::config(format!("invalid {variable}: {reason}"))
                 })?;

--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -385,7 +385,7 @@ fn run_models(
             }
         }
         Some(ModelsCommand::Install { id, insecure }) => {
-            let id = id.as_deref().unwrap_or(&manager.manifest().default_bundle);
+            let id = id.as_str();
             manager.require_installable(id).map_err(model_error)?;
             let fetcher = crate::model_fetch::PinnedModelFetcher::from_environment(insecure)
                 .map_err(|(variable, reason)| {
@@ -396,7 +396,7 @@ fn run_models(
             Ok(())
         }
         Some(ModelsCommand::Verify { id, json }) => {
-            let id = id.as_deref().unwrap_or(&manager.manifest().default_bundle);
+            let id = id.as_str();
             let status = manager.verify_with_context(id, &execution).map_err(model_error)?;
             if json {
                 write_json(context.stdout, &status)

--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -387,9 +387,11 @@ fn run_models(
         Some(ModelsCommand::Install { id }) => {
             let id = id.as_deref().unwrap_or(&manager.manifest().default_bundle);
             manager.require_installable(id).map_err(model_error)?;
-            let status = manager
-                .install(id, &crate::model_fetch::PinnedModelFetcher::default(), &execution)
-                .map_err(model_error)?;
+            let fetcher = crate::model_fetch::PinnedModelFetcher::from_environment()
+                .map_err(|(variable, reason)| {
+                    CliError::config(format!("invalid {variable}: {reason}"))
+                })?;
+            let status = manager.install(id, &fetcher, &execution).map_err(model_error)?;
             writeln!(context.stdout, "{}\t{}", status.id, status.state)?;
             Ok(())
         }
@@ -919,9 +921,24 @@ fn run_doctor(
         },
         DoctorCheck {
             id: "modelFiles".into(),
-            status: "unavailable".into(),
-            detail: "library model manager is available; CLI download transport is not configured"
-                .into(),
+            status: match &crate::proxy_env::download_route() {
+                crate::proxy_env::DownloadRoute::Direct => "unavailable".into(),
+                crate::proxy_env::DownloadRoute::Proxy { .. } => "ok".into(),
+                crate::proxy_env::DownloadRoute::Invalid { .. } => "error".into(),
+            },
+            detail: match &crate::proxy_env::download_route() {
+                crate::proxy_env::DownloadRoute::Direct => {
+                    "library model manager is available; direct downloads need network reachability"
+                        .into()
+                }
+                crate::proxy_env::DownloadRoute::Proxy { proxy, source, .. } => format!(
+                    "model downloads route HTTPS through the CONNECT proxy from {source}: {}",
+                    proxy.redacted_endpoint()
+                ),
+                crate::proxy_env::DownloadRoute::Invalid { variable, reason } => {
+                    format!("invalid {variable}: {reason}")
+                }
+            },
         },
         DoctorCheck {
             id: "temporaryDirectory".into(),

--- a/apps/cli/src/args.rs
+++ b/apps/cli/src/args.rs
@@ -399,13 +399,13 @@ pub enum ModelsCommand {
     },
     /// Download and atomically install a hash-pinned model bundle.
     Install {
-        id: Option<String>,
+        id: String,
         #[arg(long)]
         insecure: bool,
     },
     /// Verify installed model files without networking.
     Verify {
-        id: Option<String>,
+        id: String,
         #[arg(long)]
         json: bool,
     },

--- a/apps/cli/src/args.rs
+++ b/apps/cli/src/args.rs
@@ -398,7 +398,11 @@ pub enum ModelsCommand {
         json: bool,
     },
     /// Download and atomically install a hash-pinned model bundle.
-    Install { id: Option<String> },
+    Install {
+        id: Option<String>,
+        #[arg(long)]
+        insecure: bool,
+    },
     /// Verify installed model files without networking.
     Verify {
         id: Option<String>,

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -7,6 +7,7 @@ mod error;
 mod i18n;
 mod model_fetch;
 mod output;
+mod proxy_env;
 mod services;
 mod transaction;
 mod ui;

--- a/apps/cli/src/model_fetch.rs
+++ b/apps/cli/src/model_fetch.rs
@@ -31,8 +31,8 @@ impl PinnedModelFetcher {
     ///
     /// Returns the offending variable name and reason when a proxy variable
     /// is set but invalid; no download is attempted in that case.
-    pub(crate) fn from_environment() -> Result<Self, (&'static str, String)> {
-        crate::proxy_env::model_fetch_client().map(|client| Self { client })
+    pub(crate) fn from_environment(insecure: bool) -> Result<Self, (&'static str, String)> {
+        crate::proxy_env::model_fetch_client(insecure).map(|client| Self { client })
     }
 }
 
@@ -63,12 +63,13 @@ impl ModelFetcher for PinnedModelFetcher {
                 ));
             }
         };
+        let wire_limit = expected_bytes.saturating_mul(101).saturating_div(100);
         let fetched = self
             .client
             .get(
                 &artifact.url,
                 &network_policy(&artifact.url)?,
-                FetchLimits { max_wire_bytes: expected_bytes, max_decoded_bytes: expected_bytes },
+                FetchLimits { max_wire_bytes: wire_limit, max_decoded_bytes: expected_bytes },
                 context,
             )
             .map_err(map_transport)?;

--- a/apps/cli/src/model_fetch.rs
+++ b/apps/cli/src/model_fetch.rs
@@ -307,10 +307,7 @@ mod tests {
             let mut bytes = Vec::new();
             acquired.bytes.read_to_end(&mut bytes).unwrap();
             assert_eq!(bytes, b"data");
-            assert_eq!(
-                *connector.hosts.lock().unwrap(),
-                ["huggingface.co", "us.aws.cdn.hf.co"]
-            );
+            assert_eq!(*connector.hosts.lock().unwrap(), ["huggingface.co", "us.aws.cdn.hf.co"]);
         }
 
         let legacy_bridge = format!(

--- a/apps/cli/src/model_fetch.rs
+++ b/apps/cli/src/model_fetch.rs
@@ -16,10 +16,24 @@ const PADDLE_DICTIONARY_URL: &str = "https://raw.githubusercontent.com/PaddlePad
 const WHISPER_SMALL_URL: &str = "https://huggingface.co/ggerganov/whisper.cpp/resolve/c521a4b02f422512d734391fdf08bb08c0862f68/ggml-small.bin";
 const WHISPER_SMALL_XET_HASH: &str =
     "edd29d67e70b000132af65205b99bb774b77abc13d10103e14f80ce2242913e1";
+/// Audited Hugging Face xet bridge domains that may serve one pinned object.
+const WHISPER_SMALL_XET_BRIDGES: &[&str] = &["cas-bridge.xethub.hf.co", "us.aws.cdn.hf.co"];
 
 #[derive(Default)]
 pub(crate) struct PinnedModelFetcher {
     client: HttpClient,
+}
+
+impl PinnedModelFetcher {
+    /// Build the fetcher from the environment-derived download route.
+    ///
+    /// # Errors
+    ///
+    /// Returns the offending variable name and reason when a proxy variable
+    /// is set but invalid; no download is attempted in that case.
+    pub(crate) fn from_environment() -> Result<Self, (&'static str, String)> {
+        crate::proxy_env::model_fetch_client().map(|client| Self { client })
+    }
 }
 
 impl ModelFetcher for PinnedModelFetcher {
@@ -93,7 +107,7 @@ fn validate_fetch_identity(
         return Err(unexpected_redirect());
     };
     if final_url.scheme() != "https"
-        || final_url.host_str() != Some("cas-bridge.xethub.hf.co")
+        || !WHISPER_SMALL_XET_BRIDGES.contains(&final_url.host_str().unwrap_or_default())
         || final_url.port().is_some()
         || region != "xet-bridge-us"
         || repository.is_empty()
@@ -120,7 +134,14 @@ fn network_policy(url: &str) -> Result<NetworkPolicy, ModelManagerError> {
             (vec!["paddle-model-ecology.bj.bcebos.com".into()], 0)
         }
         PADDLE_DICTIONARY_URL => (vec!["raw.githubusercontent.com".into()], 0),
-        WHISPER_SMALL_URL => (vec!["huggingface.co".into(), "cas-bridge.xethub.hf.co".into()], 1),
+        WHISPER_SMALL_URL => (
+            vec![
+                "huggingface.co".into(),
+                "cas-bridge.xethub.hf.co".into(),
+                "us.aws.cdn.hf.co".into(),
+            ],
+            1,
+        ),
         _ => {
             return Err(ModelManagerError::Corrupt(
                 "runtime artifact URL is not a pinned download authority".into(),
@@ -258,7 +279,10 @@ mod tests {
     #[test]
     fn pinned_authorities_reject_lookalike_and_mutated_whisper_urls() {
         let policy = network_policy(WHISPER_SMALL_URL).unwrap();
-        assert_eq!(policy.allowed_hosts, ["huggingface.co", "cas-bridge.xethub.hf.co"]);
+        assert_eq!(
+            policy.allowed_hosts,
+            ["huggingface.co", "cas-bridge.xethub.hf.co", "us.aws.cdn.hf.co"]
+        );
         assert_eq!(policy.max_redirects, 1);
         assert!(
             network_policy(
@@ -273,7 +297,7 @@ mod tests {
     fn whisper_redirect_reauthorizes_only_the_xet_bridge() {
         for status in [301, 302, 303, 307, 308] {
             let redirect = format!(
-                "HTTP/1.1 {status} Redirect\r\nLocation: https://cas-bridge.xethub.hf.co/xet-bridge-us/repository/{WHISPER_SMALL_XET_HASH}?signature=secret\r\nContent-Length: 0\r\n\r\n"
+                "HTTP/1.1 {status} Redirect\r\nLocation: https://us.aws.cdn.hf.co/xet-bridge-us/repository/{WHISPER_SMALL_XET_HASH}?signature=secret\r\nContent-Length: 0\r\n\r\n"
             )
             .into_bytes();
             let body = b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndata".to_vec();
@@ -284,9 +308,32 @@ mod tests {
             assert_eq!(bytes, b"data");
             assert_eq!(
                 *connector.hosts.lock().unwrap(),
-                ["huggingface.co", "cas-bridge.xethub.hf.co"]
+                ["huggingface.co", "us.aws.cdn.hf.co"]
             );
         }
+
+        let legacy_bridge = format!(
+            "HTTP/1.1 302 Found\r\nLocation: https://cas-bridge.xethub.hf.co/xet-bridge-us/repository/{WHISPER_SMALL_XET_HASH}\r\nContent-Length: 0\r\n\r\n"
+        )
+        .into_bytes();
+        let body = b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndata".to_vec();
+        let (fetcher, _) = scripted_fetcher([legacy_bridge, body]);
+        let mut acquired = fetcher.open(&artifact(WHISPER_SMALL_URL, 4), &context()).unwrap();
+        let mut bytes = Vec::new();
+        acquired.bytes.read_to_end(&mut bytes).unwrap();
+        assert_eq!(bytes, b"data");
+
+        let mutated_object = format!(
+            "HTTP/1.1 302 Found\r\nLocation: https://us.aws.cdn.hf.co/xet-bridge-us/repository/{}0\r\nContent-Length: 0\r\n\r\n",
+            WHISPER_SMALL_XET_HASH
+        )
+        .into_bytes();
+        let body = b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\n\r\ndata".to_vec();
+        let (fetcher, _) = scripted_fetcher([mutated_object, body]);
+        assert!(matches!(
+            fetcher.open(&artifact(WHISPER_SMALL_URL, 4), &context()),
+            Err(ModelManagerError::Execution(ConversionError::Network { .. }))
+        ));
 
         let evil = b"HTTP/1.1 302 Found\r\nLocation: https://cas-bridge.xethub.hf.co.evil.test/model\r\nContent-Length: 0\r\n\r\n".to_vec();
         let (fetcher, connector) = scripted_fetcher([evil]);

--- a/apps/cli/src/proxy_env.rs
+++ b/apps/cli/src/proxy_env.rs
@@ -79,15 +79,15 @@ fn route_from(
 /// Returns the offending variable name and reason when a proxy variable is
 /// set but invalid; no network access happens in that case.
 pub(crate) fn model_fetch_client(cli_insecure: bool) -> Result<HttpClient, (&'static str, String)> {
-    let env_insecure = std::env::var_os("INTO_MD_INSECURE")
-        .and_then(|value| value.into_string().ok())
-        .is_some_and(|value| !value.is_empty() && value != "0");
+    let env_insecure = parse_insecure(
+        std::env::var_os("INTO_MD_INSECURE").and_then(|value| value.into_string().ok()),
+    )
+    .map_err(|reason| ("INTO_MD_INSECURE", reason))?;
     let insecure = cli_insecure || env_insecure;
     match download_route() {
-        DownloadRoute::Direct => Ok(HttpClient::with_insecure(
-            Arc::new(SystemDnsResolver),
-            insecure,
-        )),
+        DownloadRoute::Direct => {
+            Ok(HttpClient::with_insecure(Arc::new(SystemDnsResolver), insecure))
+        }
         DownloadRoute::Proxy { proxy, no_proxy, .. } => Ok(HttpClient::with_components(
             Arc::new(SystemDnsResolver),
             Arc::new(RoutedConnectionFactory::new(
@@ -99,6 +99,19 @@ pub(crate) fn model_fetch_client(cli_insecure: bool) -> Result<HttpClient, (&'st
         )),
         DownloadRoute::Invalid { variable, reason } => Err((variable, reason)),
     }
+}
+
+fn parse_insecure(value: Option<String>) -> Result<bool, String> {
+    let Some(value) = value.filter(|value| !value.is_empty()) else {
+        return Ok(false);
+    };
+    if value == "0" || value.eq_ignore_ascii_case("false") {
+        return Ok(false);
+    }
+    if value == "1" || value.eq_ignore_ascii_case("true") {
+        return Ok(true);
+    }
+    Err("expected one of 0, 1, false, or true".into())
 }
 
 #[cfg(test)]
@@ -140,5 +153,19 @@ mod tests {
         };
         assert_eq!(variable, "INTO_MD_HTTPS_PROXY");
         assert_eq!(reason, "only http:// proxy endpoints are supported");
+    }
+
+    #[test]
+    fn insecure_environment_value_is_strictly_parsed() {
+        for value in [None, Some(""), Some("0"), Some("false"), Some("FALSE")] {
+            assert!(!parse_insecure(value.map(str::to_owned)).unwrap());
+        }
+        for value in ["1", "true", "TRUE"] {
+            assert!(parse_insecure(Some(value.into())).unwrap());
+        }
+        assert_eq!(
+            parse_insecure(Some("no".into())).unwrap_err(),
+            "expected one of 0, 1, false, or true"
+        );
     }
 }

--- a/apps/cli/src/proxy_env.rs
+++ b/apps/cli/src/proxy_env.rs
@@ -1,0 +1,136 @@
+//! Environment-derived model download routing.
+//!
+//! The library HTTP transport never reads ambient variables; this CLI layer
+//! is the single reader. An explicit `INTO_MD_HTTPS_PROXY` overrides the
+//! curl-style `HTTPS_PROXY`/`https_proxy` pair, and empty values mean unset.
+
+use into_markdown_http_transport::{
+    HttpClient, NoProxyList, ProxyConfig, RoutedConnectionFactory, SystemDnsResolver,
+};
+use std::sync::Arc;
+
+/// Selected model download route from explicit environment variables.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DownloadRoute {
+    /// No proxy variable is set; direct connections are used.
+    Direct,
+    /// A parsed CONNECT proxy with its exclusion list.
+    Proxy {
+        /// Parsed proxy endpoint.
+        proxy: ProxyConfig,
+        /// Hosts that bypass the proxy.
+        no_proxy: NoProxyList,
+        /// Name of the winning environment variable.
+        source: &'static str,
+    },
+    /// A proxy variable is set but cannot be parsed.
+    Invalid {
+        /// Name of the offending environment variable.
+        variable: &'static str,
+        /// Stable parse failure.
+        reason: String,
+    },
+}
+
+/// Read and select the download route from the process environment.
+pub(crate) fn download_route() -> DownloadRoute {
+    route_from(
+        non_empty_var("INTO_MD_HTTPS_PROXY"),
+        non_empty_var("HTTPS_PROXY"),
+        non_empty_var("https_proxy"),
+        non_empty_var("INTO_MD_NO_PROXY")
+            .or_else(|| non_empty_var("NO_PROXY"))
+            .or_else(|| non_empty_var("no_proxy")),
+    )
+}
+
+fn non_empty_var(name: &str) -> Option<String> {
+    std::env::var_os(name)
+        .and_then(|value| value.into_string().ok())
+        .filter(|value| !value.is_empty())
+}
+
+fn route_from(
+    override_value: Option<String>,
+    upper: Option<String>,
+    lower: Option<String>,
+    no_proxy: Option<String>,
+) -> DownloadRoute {
+    let (value, variable) = match (override_value, upper, lower) {
+        (Some(value), _, _) => (value, "INTO_MD_HTTPS_PROXY"),
+        (None, Some(value), _) => (value, "HTTPS_PROXY"),
+        (None, None, Some(value)) => (value, "https_proxy"),
+        (None, None, None) => return DownloadRoute::Direct,
+    };
+    match ProxyConfig::parse(&value) {
+        Ok(proxy) => DownloadRoute::Proxy {
+            proxy,
+            no_proxy: NoProxyList::parse(&no_proxy.unwrap_or_default()),
+            source: variable,
+        },
+        Err(error) => DownloadRoute::Invalid { variable, reason: error.to_string() },
+    }
+}
+
+/// Build the pinned model fetch client from the environment download route.
+///
+/// # Errors
+///
+/// Returns the offending variable name and reason when a proxy variable is
+/// set but invalid; no network access happens in that case.
+pub(crate) fn model_fetch_client() -> Result<HttpClient, (&'static str, String)> {
+    match download_route() {
+        DownloadRoute::Direct => Ok(HttpClient::default()),
+        DownloadRoute::Proxy { proxy, no_proxy, .. } => Ok(HttpClient::with_components(
+            Arc::new(SystemDnsResolver),
+            Arc::new(RoutedConnectionFactory::new(
+                proxy,
+                no_proxy,
+                Arc::new(SystemDnsResolver),
+            )),
+        )),
+        DownloadRoute::Invalid { variable, reason } => Err((variable, reason)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn route_priority_prefers_the_explicit_override_then_upper_then_lower() {
+        let DownloadRoute::Proxy { source, .. } = route_from(
+            Some("http://override.test:1".into()),
+            Some("http://upper.test:2".into()),
+            Some("http://lower.test:3".into()),
+            None,
+        ) else {
+            panic!("override must win");
+        };
+        assert_eq!(source, "INTO_MD_HTTPS_PROXY");
+        let DownloadRoute::Proxy { proxy, source, .. } =
+            route_from(None, Some("http://upper.test:2".into()), None, None)
+        else {
+            panic!("upper must win");
+        };
+        assert_eq!((source, proxy.redacted_endpoint().as_str()), ("HTTPS_PROXY", "upper.test:2"));
+        let DownloadRoute::Proxy { source, .. } =
+            route_from(None, None, Some("http://lower.test:3".into()), None)
+        else {
+            panic!("lower must win");
+        };
+        assert_eq!(source, "https_proxy");
+        assert!(matches!(route_from(None, None, None, Some("*".into())), DownloadRoute::Direct));
+    }
+
+    #[test]
+    fn invalid_proxy_variable_reports_the_offending_name_and_reason() {
+        let DownloadRoute::Invalid { variable, reason } =
+            route_from(Some("socks5://proxy.test:1080".into()), None, None, None)
+        else {
+            panic!("socks must be rejected");
+        };
+        assert_eq!(variable, "INTO_MD_HTTPS_PROXY");
+        assert_eq!(reason, "only http:// proxy endpoints are supported");
+    }
+}

--- a/apps/cli/src/proxy_env.rs
+++ b/apps/cli/src/proxy_env.rs
@@ -78,15 +78,23 @@ fn route_from(
 ///
 /// Returns the offending variable name and reason when a proxy variable is
 /// set but invalid; no network access happens in that case.
-pub(crate) fn model_fetch_client() -> Result<HttpClient, (&'static str, String)> {
+pub(crate) fn model_fetch_client(cli_insecure: bool) -> Result<HttpClient, (&'static str, String)> {
+    let env_insecure = std::env::var_os("INTO_MD_INSECURE")
+        .and_then(|value| value.into_string().ok())
+        .is_some_and(|value| !value.is_empty() && value != "0");
+    let insecure = cli_insecure || env_insecure;
     match download_route() {
-        DownloadRoute::Direct => Ok(HttpClient::default()),
+        DownloadRoute::Direct => Ok(HttpClient::with_insecure(
+            Arc::new(SystemDnsResolver),
+            insecure,
+        )),
         DownloadRoute::Proxy { proxy, no_proxy, .. } => Ok(HttpClient::with_components(
             Arc::new(SystemDnsResolver),
             Arc::new(RoutedConnectionFactory::new(
                 proxy,
                 no_proxy,
                 Arc::new(SystemDnsResolver),
+                insecure,
             )),
         )),
         DownloadRoute::Invalid { variable, reason } => Err((variable, reason)),

--- a/crates/http-transport/Cargo.toml
+++ b/crates/http-transport/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 flate2.workspace = true
 into-markdown-core = { path = "../core" }
 rustls.workspace = true
+rustls-native-certs.workspace = true
 socket2.workspace = true
 unicode-normalization.workspace = true
 url.workspace = true

--- a/crates/http-transport/src/body.rs
+++ b/crates/http-transport/src/body.rs
@@ -19,6 +19,18 @@ pub(super) struct ChunkChain {
     reserved_bytes: u64,
 }
 
+impl Drop for ChunkChain {
+    fn drop(&mut self) {
+        // Large transfers chain tens of thousands of 8 KiB nodes; the
+        // compiler-generated recursive drop would overflow the stack.
+        let mut current = self.head.take();
+        while let Some(mut node) = current {
+            current = node.next.take();
+            drop(node);
+        }
+    }
+}
+
 impl ChunkChain {
     fn push(
         &mut self,

--- a/crates/http-transport/src/body.rs
+++ b/crates/http-transport/src/body.rs
@@ -45,15 +45,15 @@ impl ChunkChain {
         // Coalesce into the head node's unused capacity so that a proxy
         // forwarding many small chunks does not waste a full 8 KiB node
         // per chunk and inflate the memory budget past its limit.
-        if !remaining.is_empty() {
-            if let Some(node) = self.head.as_deref_mut() {
-                let space = IO_CHUNK_BYTES - node.used;
-                if space > 0 {
-                    let take = remaining.len().min(space);
-                    node.bytes[node.used..node.used + take].copy_from_slice(&remaining[..take]);
-                    node.used += take;
-                    remaining = &remaining[take..];
-                }
+        if !remaining.is_empty()
+            && let Some(node) = self.head.as_deref_mut()
+        {
+            let space = IO_CHUNK_BYTES - node.used;
+            if space > 0 {
+                let take = remaining.len().min(space);
+                node.bytes[node.used..node.used + take].copy_from_slice(&remaining[..take]);
+                node.used += take;
+                remaining = &remaining[take..];
             }
         }
         for part in remaining.chunks(IO_CHUNK_BYTES) {

--- a/crates/http-transport/src/body.rs
+++ b/crates/http-transport/src/body.rs
@@ -41,7 +41,22 @@ impl ChunkChain {
             .len
             .checked_add(bytes.len())
             .ok_or_else(|| TransportError::new(TransportErrorKind::ResourceLimit))?;
-        for part in bytes.chunks(IO_CHUNK_BYTES) {
+        let mut remaining = bytes;
+        // Coalesce into the head node's unused capacity so that a proxy
+        // forwarding many small chunks does not waste a full 8 KiB node
+        // per chunk and inflate the memory budget past its limit.
+        if !remaining.is_empty() {
+            if let Some(node) = self.head.as_deref_mut() {
+                let space = IO_CHUNK_BYTES - node.used;
+                if space > 0 {
+                    let take = remaining.len().min(space);
+                    node.bytes[node.used..node.used + take].copy_from_slice(&remaining[..take]);
+                    node.used += take;
+                    remaining = &remaining[take..];
+                }
+            }
+        }
+        for part in remaining.chunks(IO_CHUNK_BYTES) {
             let node_bytes = u64::try_from(std::mem::size_of::<ChunkNode>())
                 .map_err(|_| TransportError::new(TransportErrorKind::ResourceLimit))?;
             budget.grow(node_bytes).map_err(map_context_error)?;

--- a/crates/http-transport/src/connect.rs
+++ b/crates/http-transport/src/connect.rs
@@ -6,7 +6,15 @@ use super::{
 use std::io::{self, Read, Write};
 use std::thread;
 
-pub(super) struct DirectConnectionFactory;
+pub(super) struct DirectConnectionFactory {
+    pub(super) insecure: bool,
+}
+
+impl Default for DirectConnectionFactory {
+    fn default() -> Self {
+        Self { insecure: false }
+    }
+}
 
 impl ConnectionFactory for DirectConnectionFactory {
     fn connect(
@@ -19,7 +27,7 @@ impl ConnectionFactory for DirectConnectionFactory {
     ) -> Result<Box<dyn Connection>, TransportError> {
         let stream = connect_exact(address, context, deadline)?;
         if scheme == "https" {
-            tls_handshake(stream, host, context, deadline)
+            tls_handshake(stream, host, context, deadline, self.insecure)
                 .map(|stream| Box::new(stream) as Box<dyn Connection>)
         } else {
             Ok(Box::new(stream))

--- a/crates/http-transport/src/connect.rs
+++ b/crates/http-transport/src/connect.rs
@@ -1,7 +1,7 @@
 use super::{
     Connection, ConnectionFactory, Domain, Duration, ExecutionContext, IO_POLL_SLICE, Instant,
     Protocol, SockAddr, Socket, SocketAddr, TcpStream, TransportError, TransportErrorKind, Type,
-    map_context_error, tls_connect,
+    map_context_error, tls_handshake,
 };
 use std::io::{self, Read, Write};
 use std::thread;
@@ -19,7 +19,7 @@ impl ConnectionFactory for DirectConnectionFactory {
     ) -> Result<Box<dyn Connection>, TransportError> {
         let stream = connect_exact(address, context, deadline)?;
         if scheme == "https" {
-            tls_connect(stream, host, context, deadline)
+            tls_handshake(stream, host, context, deadline)
                 .map(|stream| Box::new(stream) as Box<dyn Connection>)
         } else {
             Ok(Box::new(stream))

--- a/crates/http-transport/src/connect.rs
+++ b/crates/http-transport/src/connect.rs
@@ -6,14 +6,9 @@ use super::{
 use std::io::{self, Read, Write};
 use std::thread;
 
+#[derive(Default)]
 pub(super) struct DirectConnectionFactory {
     pub(super) insecure: bool,
-}
-
-impl Default for DirectConnectionFactory {
-    fn default() -> Self {
-        Self { insecure: false }
-    }
 }
 
 impl ConnectionFactory for DirectConnectionFactory {

--- a/crates/http-transport/src/dns.rs
+++ b/crates/http-transport/src/dns.rs
@@ -6,7 +6,8 @@ use super::{
 use std::io;
 use std::thread;
 
-pub(super) struct SystemDnsResolver;
+/// Bounded system resolver backed by the platform `getaddrinfo` workflow.
+pub struct SystemDnsResolver;
 
 impl DnsResolver for SystemDnsResolver {
     fn resolve(&self, host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {

--- a/crates/http-transport/src/lib.rs
+++ b/crates/http-transport/src/lib.rs
@@ -202,7 +202,7 @@ impl std::fmt::Debug for HttpClient {
 
 impl Default for HttpClient {
     fn default() -> Self {
-        Self { resolver: Arc::new(SystemDnsResolver), connector: Arc::new(DirectConnectionFactory) }
+        Self { resolver: Arc::new(SystemDnsResolver), connector: Arc::new(DirectConnectionFactory::default()) }
     }
 }
 
@@ -210,7 +210,14 @@ impl HttpClient {
     /// Construct a direct client with an injected bounded DNS resolver.
     #[must_use]
     pub fn with_resolver(resolver: Arc<dyn DnsResolver>) -> Self {
-        Self { resolver, connector: Arc::new(DirectConnectionFactory) }
+        Self { resolver, connector: Arc::new(DirectConnectionFactory::default()) }
+    }
+
+    /// Construct a direct client with an injected DNS resolver and explicit
+    /// TLS verification mode.
+    #[must_use]
+    pub fn with_insecure(resolver: Arc<dyn DnsResolver>, insecure: bool) -> Self {
+        Self { resolver, connector: Arc::new(DirectConnectionFactory { insecure }) }
     }
 
     /// Construct an injected client without performing I/O.

--- a/crates/http-transport/src/lib.rs
+++ b/crates/http-transport/src/lib.rs
@@ -1,8 +1,10 @@
 //! Audited, policy-constrained HTTP transport shared by remote sources and providers.
 //!
-//! The transport deliberately ignores proxy and certificate environment variables.
-//! It resolves through a bounded worker pool, connects to an exact checked address,
-//! and retains the original host exclusively for HTTP `Host` and TLS SNI.
+//! The transport never reads ambient environment such as proxy or certificate
+//! variables; explicit CONNECT proxy routing is injected by callers as a
+//! `ConnectionFactory`. It resolves through a bounded worker pool, connects to
+//! an exact checked address, and retains the original host exclusively for
+//! HTTP `Host` and TLS SNI.
 
 #![forbid(unsafe_code)]
 
@@ -34,12 +36,23 @@ const MAX_HOST_BYTES: usize = 253;
 const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_mins(2);
 const IO_POLL_SLICE: Duration = Duration::from_millis(25);
 
+/// Per-request deadline: the fixed base timeout plus one millisecond per
+/// authorized KiB of wire budget, so bounded large downloads keep a finite,
+/// size-proportional transfer allowance instead of the base timeout alone.
+fn transfer_deadline(now: Instant, limits: FetchLimits) -> Option<Instant> {
+    let kibibytes = limits.max_wire_bytes.checked_div(1024)?;
+    let base_ms = u64::try_from(DEFAULT_REQUEST_TIMEOUT.as_millis()).ok()?;
+    let total_ms = base_ms.checked_add(kibibytes)?;
+    now.checked_add(Duration::from_millis(total_ms))
+}
+
 mod body;
 mod connect;
 mod dns;
 mod error;
 mod http1;
 mod policy;
+mod proxy;
 mod tls;
 
 use body::{ChunkChain, finalize_body, read_response};
@@ -47,7 +60,8 @@ use connect::{
     DirectConnectionFactory, blocking_slice, check_context, check_operation, read_checked,
     write_all_checked,
 };
-use dns::{SystemDnsResolver, resolve_checked};
+pub use dns::SystemDnsResolver;
+use dns::resolve_checked;
 use error::map_context_error;
 pub use error::{TransportError, TransportErrorKind};
 use http1::{parse_head, read_head};
@@ -57,7 +71,8 @@ use policy::{
     invalid_header_value_byte, is_localhost_name, is_token, normalize_allowlist,
     parse_content_disposition, parse_content_type, redacted_url,
 };
-use tls::tls_connect;
+pub use proxy::{NoProxyList, ProxyConfig, ProxyConfigError, RoutedConnectionFactory};
+use tls::tls_handshake;
 
 /// Per-request network authorization. Empty `allowed_hosts` means any public host.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -289,8 +304,7 @@ impl HttpClient {
         }
         let mut current = canonical_url(source)?;
         let now = Instant::now();
-        let local_deadline = now
-            .checked_add(DEFAULT_REQUEST_TIMEOUT)
+        let local_deadline = transfer_deadline(now, limits)
             .ok_or_else(|| TransportError::new(TransportErrorKind::Timeout))?;
         let deadline = context
             .remaining_time()
@@ -439,6 +453,7 @@ struct WireBody {
 #[cfg(test)]
 mod tests {
     mod protocol;
+    mod proxy;
     mod resource;
     mod ssrf;
 }

--- a/crates/http-transport/src/lib.rs
+++ b/crates/http-transport/src/lib.rs
@@ -202,7 +202,10 @@ impl std::fmt::Debug for HttpClient {
 
 impl Default for HttpClient {
     fn default() -> Self {
-        Self { resolver: Arc::new(SystemDnsResolver), connector: Arc::new(DirectConnectionFactory::default()) }
+        Self {
+            resolver: Arc::new(SystemDnsResolver),
+            connector: Arc::new(DirectConnectionFactory::default()),
+        }
     }
 }
 

--- a/crates/http-transport/src/policy.rs
+++ b/crates/http-transport/src/policy.rs
@@ -152,8 +152,11 @@ pub(super) fn parse_content_type(value: &str) -> Result<String, TransportError> 
         return Err(TransportError::new(TransportErrorKind::InvalidMessage));
     }
     for parameter in value.split(';').skip(1) {
+        let parameter = parameter.trim();
+        if parameter.is_empty() {
+            continue;
+        }
         let (name, raw) = parameter
-            .trim()
             .split_once('=')
             .ok_or_else(|| TransportError::new(TransportErrorKind::InvalidMessage))?;
         if name.is_empty() || !name.bytes().all(is_token) || !valid_parameter_value(raw) {
@@ -173,8 +176,13 @@ pub(super) fn parse_content_disposition(value: &str) -> Result<Option<String>, T
     let mut extended = None;
     let mut names = BTreeSet::new();
     for parameter in parts {
+        let parameter = parameter.trim();
+        // Empty segments carry no parameter name or value and cannot bypass
+        // any check; legal servers emit one after a trailing delimiter.
+        if parameter.is_empty() {
+            continue;
+        }
         let (name, raw) = parameter
-            .trim()
             .split_once('=')
             .ok_or_else(|| TransportError::new(TransportErrorKind::InvalidMessage))?;
         let name = name.to_ascii_lowercase();

--- a/crates/http-transport/src/proxy.rs
+++ b/crates/http-transport/src/proxy.rs
@@ -10,10 +10,9 @@
 
 use super::{
     Connection, ConnectionFactory, DirectConnectionFactory, DnsResolver, ExecutionContext,
-    Instant, Ipv6Addr, MAX_ALLOWED_HOSTS, MAX_HOST_BYTES, MAX_HEADER_BYTES, MAX_URL_BYTES,
-    SocketAddr, TransportError, TransportErrorKind, canonical_host, check_operation,
+    IO_CHUNK_BYTES, Instant, Ipv6Addr, MAX_ALLOWED_HOSTS, MAX_HEADER_BYTES, MAX_HOST_BYTES,
+    MAX_URL_BYTES, SocketAddr, TransportError, TransportErrorKind, canonical_host, check_operation,
     map_context_error, parse_head, read_head, resolve_checked, tls_handshake, write_all_checked,
-    IO_CHUNK_BYTES,
 };
 use std::fmt::Write as _;
 use std::sync::Arc;
@@ -161,10 +160,10 @@ fn portable_credential_byte(byte: u8) -> bool {
 }
 
 pub(super) fn base64_standard(input: &[u8], output: &mut String) {
-    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";    for chunk in input.chunks(3) {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    for chunk in input.chunks(3) {
         let bytes = [chunk[0], *chunk.get(1).unwrap_or(&0), *chunk.get(2).unwrap_or(&0)];
-        let triple =
-            (u32::from(bytes[0]) << 16) | (u32::from(bytes[1]) << 8) | u32::from(bytes[2]);
+        let triple = (u32::from(bytes[0]) << 16) | (u32::from(bytes[1]) << 8) | u32::from(bytes[2]);
         let mut index = triple >> 18 & 63;
         output.push(char::from(ALPHABET[usize::try_from(index).unwrap_or(0)]));
         index = triple >> 12 & 63;
@@ -207,7 +206,9 @@ impl NoProxyList {
                 continue;
             }
             let entry = entry.strip_prefix('.').unwrap_or(&entry).to_owned();
-            if !entry.is_empty() && entry.len() <= MAX_HOST_BYTES && entries.len() < MAX_ALLOWED_HOSTS
+            if !entry.is_empty()
+                && entry.len() <= MAX_HOST_BYTES
+                && entries.len() < MAX_ALLOWED_HOSTS
             {
                 entries.push(entry);
             }
@@ -247,7 +248,13 @@ impl RoutedConnectionFactory {
         resolver: Arc<dyn DnsResolver>,
         insecure: bool,
     ) -> Self {
-        Self { proxy, no_proxy, resolver, inner: Arc::new(DirectConnectionFactory { insecure }), insecure }
+        Self {
+            proxy,
+            no_proxy,
+            resolver,
+            inner: Arc::new(DirectConnectionFactory { insecure }),
+            insecure,
+        }
     }
 
     /// Construct with an injected proxy transport for deterministic tests.
@@ -335,7 +342,8 @@ impl ConnectionFactory for RoutedConnectionFactory {
             return self.inner.connect(scheme, host, address, context, deadline);
         }
         let stream = self.tunnel_stream(host, address.port(), context, deadline)?;
-        tls_handshake(stream, host, context, deadline, self.insecure).map(|stream| Box::new(stream) as _)
+        tls_handshake(stream, host, context, deadline, self.insecure)
+            .map(|stream| Box::new(stream) as _)
     }
 }
 
@@ -353,12 +361,9 @@ pub(super) fn establish_tunnel(
     // "Proxy-Authorization: <value>\r\n" line and the final blank line, all
     // with exact byte counts.
     let authorization_bytes = authorization.map_or(0, |value| value.len().saturating_add(23));
-    let required = 29usize
-        .saturating_add(target.len().saturating_mul(2))
-        .saturating_add(authorization_bytes);
-    if required
-        > MAX_URL_BYTES + MAX_HOST_BYTES + MAX_CREDENTIAL_BYTES.div_ceil(3) * 4 + 64
-    {
+    let required =
+        29usize.saturating_add(target.len().saturating_mul(2)).saturating_add(authorization_bytes);
+    if required > MAX_URL_BYTES + MAX_HOST_BYTES + MAX_CREDENTIAL_BYTES.div_ceil(3) * 4 + 64 {
         return Err(TransportError::new(TransportErrorKind::ResourceLimit));
     }
     let mut memory = context

--- a/crates/http-transport/src/proxy.rs
+++ b/crates/http-transport/src/proxy.rs
@@ -1,0 +1,401 @@
+//! Explicit, caller-injected CONNECT proxy routing for HTTPS origins.
+//!
+//! The library never reads ambient environment. A caller parses and
+//! authorizes a proxy description, then injects it as a
+//! [`ConnectionFactory`](super::ConnectionFactory). TLS still terminates
+//! end-to-end at the origin: the proxy only observes the `host:port` of a
+//! destination that the policy layer has already independently authorized
+//! and resolved. Plaintext HTTP origins never enter a tunnel; they keep the
+//! direct, public-only route.
+
+use super::{
+    Connection, ConnectionFactory, DirectConnectionFactory, DnsResolver, ExecutionContext,
+    Instant, Ipv6Addr, MAX_ALLOWED_HOSTS, MAX_HOST_BYTES, MAX_HEADER_BYTES, MAX_URL_BYTES,
+    SocketAddr, TransportError, TransportErrorKind, canonical_host, check_operation,
+    map_context_error, parse_head, read_head, resolve_checked, tls_handshake, write_all_checked,
+    IO_CHUNK_BYTES,
+};
+use std::fmt::Write as _;
+use std::sync::Arc;
+use url::Url;
+
+const MAX_CREDENTIAL_BYTES: usize = 256;
+
+/// Stable failure while parsing one explicit proxy endpoint.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ProxyConfigError {
+    /// The value is empty.
+    Empty,
+    /// The value exceeds the bounded proxy URL length.
+    TooLong,
+    /// The value is not a valid absolute URL.
+    InvalidUrl,
+    /// Only `http://` proxy endpoints are supported.
+    UnsupportedScheme,
+    /// The proxy host is missing or invalid.
+    InvalidHost,
+    /// The proxy credentials contain characters outside the portable subset.
+    InvalidCredentials,
+    /// The proxy credentials exceed the bounded length.
+    CredentialsTooLong,
+}
+
+impl std::fmt::Display for ProxyConfigError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Empty => "proxy URL is empty",
+            Self::TooLong => "proxy URL exceeds the bounded length",
+            Self::InvalidUrl => "proxy URL is not a valid absolute http endpoint",
+            Self::UnsupportedScheme => "only http:// proxy endpoints are supported",
+            Self::InvalidHost => "proxy host is missing or invalid",
+            Self::InvalidCredentials => {
+                "proxy credentials contain characters outside the portable subset"
+            }
+            Self::CredentialsTooLong => "proxy credentials exceed the bounded length",
+        })
+    }
+}
+
+impl std::error::Error for ProxyConfigError {}
+
+/// Parsed `http://[user:pass@]host[:port]` CONNECT proxy endpoint.
+///
+/// Credentials are retained only as a pre-encoded `Proxy-Authorization`
+/// value and are never exposed through accessors or diagnostics.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProxyConfig {
+    host: String,
+    port: u16,
+    authorization: Option<String>,
+}
+
+impl ProxyConfig {
+    /// Parse one bounded explicit proxy endpoint.
+    ///
+    /// The URL must be absolute, use the `http` scheme, carry no path,
+    /// query, or fragment, and restrict credentials to the portable
+    /// printable subset that needs no percent-decoding.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stable [`ProxyConfigError`]; no value is partially retained.
+    pub fn parse(value: &str) -> Result<Self, ProxyConfigError> {
+        if value.is_empty() {
+            return Err(ProxyConfigError::Empty);
+        }
+        if value.len() > MAX_URL_BYTES {
+            return Err(ProxyConfigError::TooLong);
+        }
+        let url = Url::parse(value).map_err(|_| ProxyConfigError::InvalidUrl)?;
+        if url.scheme() != "http" {
+            return Err(ProxyConfigError::UnsupportedScheme);
+        }
+        if url.path() != "/" && !url.path().is_empty() {
+            return Err(ProxyConfigError::InvalidUrl);
+        }
+        if url.query().is_some() || url.fragment().is_some() {
+            return Err(ProxyConfigError::InvalidUrl);
+        }
+        let host = canonical_host(&url).map_err(|_| ProxyConfigError::InvalidHost)?;
+        if host.is_empty() || host.len() > MAX_HOST_BYTES {
+            return Err(ProxyConfigError::InvalidHost);
+        }
+        let port = url.port().unwrap_or(80);
+        let authorization = Self::credentials(&url)?;
+        Ok(Self { host, port, authorization })
+    }
+
+    fn credentials(url: &Url) -> Result<Option<String>, ProxyConfigError> {
+        let username = url.username();
+        let password = url.password().unwrap_or_default();
+        if username.is_empty() && password.is_empty() {
+            return Ok(None);
+        }
+        if username.is_empty() {
+            return Err(ProxyConfigError::InvalidCredentials);
+        }
+        for value in [username, password] {
+            if value.bytes().any(|byte| !portable_credential_byte(byte)) {
+                return Err(ProxyConfigError::InvalidCredentials);
+            }
+        }
+        let mut raw = String::with_capacity(username.len() + password.len() + 1);
+        raw.push_str(username);
+        raw.push(':');
+        raw.push_str(password);
+        if raw.len() > MAX_CREDENTIAL_BYTES {
+            return Err(ProxyConfigError::CredentialsTooLong);
+        }
+        let mut encoded = String::with_capacity(raw.len().div_ceil(3) * 4 + 6);
+        write!(encoded, "Basic ").map_err(|_| ProxyConfigError::CredentialsTooLong)?;
+        base64_standard(raw.as_bytes(), &mut encoded);
+        Ok(Some(encoded))
+    }
+
+    /// Canonical proxy host.
+    #[must_use]
+    pub fn host(&self) -> &str {
+        &self.host
+    }
+
+    /// Proxy port.
+    #[must_use]
+    pub const fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// Redacted `host:port` form for diagnostics; credentials never appear.
+    #[must_use]
+    pub fn redacted_endpoint(&self) -> String {
+        if self.host.parse::<Ipv6Addr>().is_ok() {
+            format!("[{}]:{}", self.host, self.port)
+        } else {
+            format!("{}:{}", self.host, self.port)
+        }
+    }
+}
+
+fn portable_credential_byte(byte: u8) -> bool {
+    (0x21..=0x7E).contains(&byte) && !matches!(byte, b'%' | b'@' | b':' | b'/' | b'?' | b'#')
+}
+
+pub(super) fn base64_standard(input: &[u8], output: &mut String) {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";    for chunk in input.chunks(3) {
+        let bytes = [chunk[0], *chunk.get(1).unwrap_or(&0), *chunk.get(2).unwrap_or(&0)];
+        let triple =
+            (u32::from(bytes[0]) << 16) | (u32::from(bytes[1]) << 8) | u32::from(bytes[2]);
+        let mut index = triple >> 18 & 63;
+        output.push(char::from(ALPHABET[usize::try_from(index).unwrap_or(0)]));
+        index = triple >> 12 & 63;
+        output.push(char::from(ALPHABET[usize::try_from(index).unwrap_or(0)]));
+        if chunk.len() > 1 {
+            index = triple >> 6 & 63;
+            output.push(char::from(ALPHABET[usize::try_from(index).unwrap_or(0)]));
+        } else {
+            output.push('=');
+        }
+        if chunk.len() > 2 {
+            index = triple & 63;
+            output.push(char::from(ALPHABET[usize::try_from(index).unwrap_or(0)]));
+        } else {
+            output.push('=');
+        }
+    }
+}
+
+/// Host patterns that bypass an injected proxy route.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct NoProxyList {
+    all: bool,
+    entries: Vec<String>,
+}
+
+impl NoProxyList {
+    /// Parse one comma-separated exclusion list; empty input matches nothing.
+    #[must_use]
+    pub fn parse(value: &str) -> Self {
+        let mut all = false;
+        let mut entries = Vec::new();
+        for raw in value.split(',') {
+            let entry = raw.trim().to_ascii_lowercase();
+            if entry.is_empty() {
+                continue;
+            }
+            if entry == "*" {
+                all = true;
+                continue;
+            }
+            let entry = entry.strip_prefix('.').unwrap_or(&entry).to_owned();
+            if !entry.is_empty() && entry.len() <= MAX_HOST_BYTES && entries.len() < MAX_ALLOWED_HOSTS
+            {
+                entries.push(entry);
+            }
+        }
+        Self { all, entries }
+    }
+
+    /// Match one canonical lowercase origin host.
+    #[must_use]
+    pub fn matches(&self, host: &str) -> bool {
+        if self.all {
+            return true;
+        }
+        let host = host.trim_end_matches('.').to_ascii_lowercase();
+        self.entries.iter().any(|entry| {
+            host == *entry || (host.len() > entry.len() + 1 && host.ends_with(&format!(".{entry}")))
+        })
+    }
+}
+
+/// Connection factory that routes policy-authorized HTTPS origins through a
+/// CONNECT proxy and uses direct connections for every other target.
+pub struct RoutedConnectionFactory {
+    proxy: ProxyConfig,
+    no_proxy: NoProxyList,
+    resolver: Arc<dyn DnsResolver>,
+    inner: Arc<dyn ConnectionFactory>,
+}
+
+impl RoutedConnectionFactory {
+    /// Construct with the direct factory as the proxy transport.
+    #[must_use]
+    pub fn new(
+        proxy: ProxyConfig,
+        no_proxy: NoProxyList,
+        resolver: Arc<dyn DnsResolver>,
+    ) -> Self {
+        Self { proxy, no_proxy, resolver, inner: Arc::new(DirectConnectionFactory) }
+    }
+
+    /// Construct with an injected proxy transport for deterministic tests.
+    #[must_use]
+    pub fn with_inner(
+        proxy: ProxyConfig,
+        no_proxy: NoProxyList,
+        resolver: Arc<dyn DnsResolver>,
+        inner: Arc<dyn ConnectionFactory>,
+    ) -> Self {
+        Self { proxy, no_proxy, resolver, inner }
+    }
+
+    pub(super) fn tunnel_stream(
+        &self,
+        host: &str,
+        port: u16,
+        context: &ExecutionContext,
+        deadline: Instant,
+    ) -> Result<Box<dyn Connection>, TransportError> {
+        let addresses = resolve_checked(
+            Arc::clone(&self.resolver),
+            self.proxy.host.clone(),
+            self.proxy.port(),
+            context,
+            deadline,
+        )?;
+        let mut last = TransportError::new(TransportErrorKind::Connect);
+        for (index, address) in addresses.iter().copied().enumerate() {
+            check_operation(context, deadline)?;
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            let left = u32::try_from(addresses.len() - index).unwrap_or(u32::MAX).max(1);
+            let attempt_deadline =
+                Instant::now().checked_add(remaining / left).unwrap_or(deadline).min(deadline);
+            match self.one_proxy_address(address, host, port, context, attempt_deadline, deadline) {
+                Ok(stream) => return Ok(stream),
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        TransportErrorKind::Connect | TransportErrorKind::Tls
+                    ) && index + 1 < addresses.len() =>
+                {
+                    last = error;
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        Err(last)
+    }
+
+    fn one_proxy_address(
+        &self,
+        address: SocketAddr,
+        host: &str,
+        port: u16,
+        context: &ExecutionContext,
+        attempt_deadline: Instant,
+        deadline: Instant,
+    ) -> Result<Box<dyn Connection>, TransportError> {
+        let mut stream =
+            self.inner.connect("http", self.proxy.host(), address, context, attempt_deadline)?;
+        establish_tunnel(
+            stream.as_mut(),
+            self.proxy.authorization.as_deref(),
+            host,
+            port,
+            context,
+            deadline,
+        )?;
+        Ok(stream)
+    }
+}
+
+impl ConnectionFactory for RoutedConnectionFactory {
+    fn connect(
+        &self,
+        scheme: &str,
+        host: &str,
+        address: SocketAddr,
+        context: &ExecutionContext,
+        deadline: Instant,
+    ) -> Result<Box<dyn Connection>, TransportError> {
+        if scheme != "https" || self.no_proxy.matches(host) {
+            return self.inner.connect(scheme, host, address, context, deadline);
+        }
+        let stream = self.tunnel_stream(host, address.port(), context, deadline)?;
+        tls_handshake(stream, host, context, deadline).map(|stream| Box::new(stream) as _)
+    }
+}
+
+pub(super) fn establish_tunnel(
+    stream: &mut dyn Connection,
+    authorization: Option<&str>,
+    host: &str,
+    port: u16,
+    context: &ExecutionContext,
+    deadline: Instant,
+) -> Result<(), TransportError> {
+    let ipv6 = host.parse::<Ipv6Addr>().is_ok();
+    let target = if ipv6 { format!("[{host}]:{port}") } else { format!("{host}:{port}") };
+    // "CONNECT <target> HTTP/1.1\r\nHost: <target>\r\n" plus the optional
+    // "Proxy-Authorization: <value>\r\n" line and the final blank line, all
+    // with exact byte counts.
+    let authorization_bytes = authorization.map_or(0, |value| value.len().saturating_add(23));
+    let required = 29usize
+        .saturating_add(target.len().saturating_mul(2))
+        .saturating_add(authorization_bytes);
+    if required
+        > MAX_URL_BYTES + MAX_HOST_BYTES + MAX_CREDENTIAL_BYTES.div_ceil(3) * 4 + 64
+    {
+        return Err(TransportError::new(TransportErrorKind::ResourceLimit));
+    }
+    let mut memory = context
+        .reserve_memory(
+            u64::try_from(required)
+                .map_err(|_| TransportError::new(TransportErrorKind::ResourceLimit))?,
+        )
+        .map_err(map_context_error)?;
+    let mut request = String::with_capacity(required);
+    write!(request, "CONNECT {target} HTTP/1.1\r\nHost: {target}\r\n")
+        .map_err(|_| TransportError::new(TransportErrorKind::ResourceLimit))?;
+    if let Some(value) = authorization {
+        write!(request, "Proxy-Authorization: {value}\r\n")
+            .map_err(|_| TransportError::new(TransportErrorKind::ResourceLimit))?;
+    }
+    request.push_str("\r\n");
+    if request.capacity() > required {
+        memory
+            .grow(
+                u64::try_from(request.capacity() - required)
+                    .map_err(|_| TransportError::new(TransportErrorKind::ResourceLimit))?,
+            )
+            .map_err(map_context_error)?;
+    }
+    if request.len() != required {
+        return Err(TransportError::new(TransportErrorKind::ResourceLimit));
+    }
+    write_all_checked(stream, request.as_bytes(), context, deadline)?;
+    let head_budget = u64::try_from(MAX_HEADER_BYTES + IO_CHUNK_BYTES)
+        .map_err(|_| TransportError::new(TransportErrorKind::ResourceLimit))?;
+    let mut head_memory = context.reserve_memory(head_budget).map_err(map_context_error)?;
+    let (bytes, end) = read_head(stream, context, deadline, &mut head_memory)?;
+    // A compliant proxy sends nothing after the response head until the
+    // client speaks; early tunnel bytes indicate a smuggling attempt.
+    if bytes.len() > end {
+        return Err(TransportError::new(TransportErrorKind::InvalidMessage));
+    }
+    let parsed = parse_head(&bytes[..end])?;
+    if !(200..=299).contains(&parsed.status) {
+        return Err(TransportError::new(TransportErrorKind::Connect));
+    }
+    Ok(())
+}

--- a/crates/http-transport/src/proxy.rs
+++ b/crates/http-transport/src/proxy.rs
@@ -235,6 +235,7 @@ pub struct RoutedConnectionFactory {
     no_proxy: NoProxyList,
     resolver: Arc<dyn DnsResolver>,
     inner: Arc<dyn ConnectionFactory>,
+    insecure: bool,
 }
 
 impl RoutedConnectionFactory {
@@ -244,8 +245,9 @@ impl RoutedConnectionFactory {
         proxy: ProxyConfig,
         no_proxy: NoProxyList,
         resolver: Arc<dyn DnsResolver>,
+        insecure: bool,
     ) -> Self {
-        Self { proxy, no_proxy, resolver, inner: Arc::new(DirectConnectionFactory) }
+        Self { proxy, no_proxy, resolver, inner: Arc::new(DirectConnectionFactory { insecure }), insecure }
     }
 
     /// Construct with an injected proxy transport for deterministic tests.
@@ -255,8 +257,9 @@ impl RoutedConnectionFactory {
         no_proxy: NoProxyList,
         resolver: Arc<dyn DnsResolver>,
         inner: Arc<dyn ConnectionFactory>,
+        insecure: bool,
     ) -> Self {
-        Self { proxy, no_proxy, resolver, inner }
+        Self { proxy, no_proxy, resolver, inner, insecure }
     }
 
     pub(super) fn tunnel_stream(
@@ -332,7 +335,7 @@ impl ConnectionFactory for RoutedConnectionFactory {
             return self.inner.connect(scheme, host, address, context, deadline);
         }
         let stream = self.tunnel_stream(host, address.port(), context, deadline)?;
-        tls_handshake(stream, host, context, deadline).map(|stream| Box::new(stream) as _)
+        tls_handshake(stream, host, context, deadline, self.insecure).map(|stream| Box::new(stream) as _)
     }
 }
 

--- a/crates/http-transport/src/tests/protocol.rs
+++ b/crates/http-transport/src/tests/protocol.rs
@@ -18,6 +18,34 @@ fn strict_http_head_accepts_exact_content_metadata() {
 }
 
 #[test]
+fn trailing_delimiter_semicolons_remain_accepted_as_empty_parameters() {
+    let head = parse(
+        b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\nContent-Type: application/octet-stream;\r\nContent-Disposition: inline; filename*=UTF-8''ggml-small.bin; filename=\"ggml-small.bin\";\r\n\r\n",
+    )
+    .unwrap();
+    assert_eq!(head.media_type.as_deref(), Some("application/octet-stream"));
+    assert_eq!(head.filename.as_deref(), Some("ggml-small.bin"));
+}
+
+#[test]
+fn transfer_deadline_scales_with_the_exact_wire_budget_and_fails_closed() {
+    let now = Instant::now();
+    let tiny = transfer_deadline(now, FetchLimits { max_wire_bytes: 0, max_decoded_bytes: 0 })
+        .unwrap();
+    assert!(tiny >= now + DEFAULT_REQUEST_TIMEOUT);
+    assert!(tiny <= now + DEFAULT_REQUEST_TIMEOUT + Duration::from_millis(50));
+    let large = transfer_deadline(
+        now,
+        FetchLimits { max_wire_bytes: 487_601_967, max_decoded_bytes: 487_601_967 },
+    )
+    .unwrap();
+    // 487,601,967 bytes / 1024 = 476,173 ms allowed on top of the base.
+    assert!(large >= now + DEFAULT_REQUEST_TIMEOUT + Duration::from_millis(476_173));
+    assert!(large <= now + DEFAULT_REQUEST_TIMEOUT + Duration::from_millis(476_174));
+    assert!(large > tiny, "the deadline must grow with the authorized wire budget");
+}
+
+#[test]
 fn ambiguous_and_active_http_syntax_is_rejected() {
     for raw in [
         b"HTTP/1.1 2000 OK\r\nContent-Length: 0\r\n\r\n".as_slice(),

--- a/crates/http-transport/src/tests/protocol.rs
+++ b/crates/http-transport/src/tests/protocol.rs
@@ -30,8 +30,8 @@ fn trailing_delimiter_semicolons_remain_accepted_as_empty_parameters() {
 #[test]
 fn transfer_deadline_scales_with_the_exact_wire_budget_and_fails_closed() {
     let now = Instant::now();
-    let tiny = transfer_deadline(now, FetchLimits { max_wire_bytes: 0, max_decoded_bytes: 0 })
-        .unwrap();
+    let tiny =
+        transfer_deadline(now, FetchLimits { max_wire_bytes: 0, max_decoded_bytes: 0 }).unwrap();
     assert!(tiny >= now + DEFAULT_REQUEST_TIMEOUT);
     assert!(tiny <= now + DEFAULT_REQUEST_TIMEOUT + Duration::from_millis(50));
     let large = transfer_deadline(

--- a/crates/http-transport/src/tests/proxy.rs
+++ b/crates/http-transport/src/tests/proxy.rs
@@ -1,0 +1,247 @@
+use crate::proxy::{base64_standard, establish_tunnel};
+use crate::*;
+use std::io;
+use std::io::{Read, Write};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+fn parse_ok(value: &str) -> ProxyConfig {
+    ProxyConfig::parse(value).unwrap()
+}
+
+#[test]
+fn proxy_urls_accept_only_bounded_http_endpoints() {
+    assert_eq!(parse_ok("http://proxy.test").port(), 80);
+    assert_eq!(parse_ok("http://proxy.test:8080").redacted_endpoint(), "proxy.test:8080");
+    assert_eq!(parse_ok("HTTP://Proxy.Test:8080/").redacted_endpoint(), "proxy.test:8080");
+    assert_eq!(parse_ok("http://[2001:db8::1]:8080").redacted_endpoint(), "[2001:db8::1]:8080");
+    for value in [
+        "",
+        "socks5://proxy.test:1080",
+        "https://proxy.test:443",
+        "proxy.test:8080",
+        "http://proxy.test/path",
+        "http://proxy.test?query=1",
+        "http://proxy.test#fragment",
+        "http://user%40x:pass@proxy.test",
+        "http://:pass@proxy.test",
+        &format!("http://{}", "a".repeat(9_000)),
+    ] {
+        assert!(ProxyConfig::parse(value).is_err(), "{value}");
+    }
+}
+
+#[test]
+fn no_proxy_patterns_cover_wildcard_exact_and_domain_suffixes() {
+    let list = NoProxyList::parse("*, HF.co, .mirror.test,, BAD ENTRY ");
+    assert!(list.matches("anything.test"));
+    let list = NoProxyList::parse("huggingface.co, .mirror.test");
+    assert!(list.matches("huggingface.co"));
+    assert!(list.matches("HUGGINGFACE.co."));
+    assert!(list.matches("cdn.mirror.test"));
+    assert!(!list.matches("notmirror.test"));
+    assert!(!list.matches("mirror.test.evil.test"));
+    assert!(!NoProxyList::default().matches("huggingface.co"));
+}
+
+#[test]
+fn base64_encoding_matches_rfc4648_vectors() {
+    for (input, expected) in
+        [(&b""[..], ""), (b"M", "TQ=="), (b"Ma", "TWE="), (b"Man", "TWFu"), (b"Many", "TWFueQ==")]
+    {
+        let mut output = String::new();
+        base64_standard(input, &mut output);
+        assert_eq!(output, expected);
+    }
+}
+
+struct RecordingConnection {
+    response: Vec<u8>,
+    read_offset: usize,
+    request: Arc<Mutex<Vec<u8>>>,
+}
+
+impl Read for RecordingConnection {
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        let remaining = &self.response[self.read_offset..];
+        let count = remaining.len().min(output.len());
+        output[..count].copy_from_slice(&remaining[..count]);
+        self.read_offset += count;
+        Ok(count)
+    }
+}
+
+impl Write for RecordingConnection {
+    fn write(&mut self, input: &[u8]) -> io::Result<usize> {
+        self.request.lock().unwrap().extend_from_slice(input);
+        Ok(input.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+struct RecordingConnector {
+    response: Vec<u8>,
+    request: Arc<Mutex<Vec<u8>>>,
+    seen: Mutex<Vec<(String, String, SocketAddr)>>,
+}
+
+impl ConnectionFactory for RecordingConnector {
+    fn connect(
+        &self,
+        scheme: &str,
+        host: &str,
+        address: SocketAddr,
+        _: &ExecutionContext,
+        _: Instant,
+    ) -> Result<Box<dyn Connection>, TransportError> {
+        self.seen.lock().unwrap().push((scheme.to_owned(), host.to_owned(), address));
+        Ok(Box::new(RecordingConnection {
+            response: self.response.clone(),
+            read_offset: 0,
+            request: Arc::clone(&self.request),
+        }))
+    }
+}
+
+fn context() -> ExecutionContext {
+    ExecutionContext::new(
+        into_markdown_core::ExecutionOptions::default(),
+        into_markdown_core::ResourceLimits::default(),
+    )
+}
+
+fn deadline() -> Instant {
+    Instant::now() + Duration::from_secs(5)
+}
+
+struct ProxyDns {
+    addresses: Vec<SocketAddr>,
+    hosts: Mutex<Vec<(String, u16)>>,
+}
+
+impl DnsResolver for ProxyDns {
+    fn resolve(&self, host: &str, port: u16) -> io::Result<Vec<SocketAddr>> {
+        self.hosts.lock().unwrap().push((host.to_owned(), port));
+        Ok(self.addresses.iter().map(|address| SocketAddr::new(address.ip(), port)).collect())
+    }
+}
+
+fn routed_factory(proxy: ProxyConfig, no_proxy: NoProxyList, response: &[u8]) -> TunnelRig {
+    let request = Arc::new(Mutex::new(Vec::new()));
+    let connector = Arc::new(RecordingConnector {
+        response: response.to_vec(),
+        request: Arc::clone(&request),
+        seen: Mutex::new(Vec::new()),
+    });
+    let dns = Arc::new(ProxyDns {
+        addresses: vec!["9.9.9.9:1080".parse().unwrap()],
+        hosts: Mutex::new(Vec::new()),
+    });
+    let factory = RoutedConnectionFactory::with_inner(
+        proxy,
+        no_proxy,
+        Arc::clone(&dns) as Arc<dyn DnsResolver>,
+        Arc::clone(&connector) as Arc<dyn ConnectionFactory>,
+    );
+    TunnelRig { factory, request, connector, dns }
+}
+
+struct TunnelRig {
+    factory: RoutedConnectionFactory,
+    request: Arc<Mutex<Vec<u8>>>,
+    connector: Arc<RecordingConnector>,
+    dns: Arc<ProxyDns>,
+}
+
+#[test]
+fn tunnel_request_is_exact_and_requires_a_success_response() {
+    let rig = routed_factory(
+        parse_ok("http://proxy.test:8080"),
+        NoProxyList::default(),
+        b"HTTP/1.1 200 Connection established\r\n\r\n",
+    );
+    let stream = rig
+        .factory
+        .tunnel_stream("huggingface.co", 443, &context(), deadline())
+        .unwrap();
+    drop(stream);
+    assert_eq!(
+        rig.request.lock().unwrap().as_slice(),
+        b"CONNECT huggingface.co:443 HTTP/1.1\r\nHost: huggingface.co:443\r\n\r\n".as_slice()
+    );
+    let seen = rig.connector.seen.lock().unwrap();
+    assert_eq!(seen.len(), 1);
+    assert_eq!((seen[0].0.as_str(), seen[0].1.as_str()), ("http", "proxy.test"));
+    assert_eq!(seen[0].2, "9.9.9.9:8080".parse::<SocketAddr>().unwrap());
+    assert_eq!(*rig.dns.hosts.lock().unwrap(), [("proxy.test".to_owned(), 8080)]);
+}
+
+#[test]
+fn tunnel_credentials_are_sent_only_in_the_authorization_header() {
+    let rig = routed_factory(
+        parse_ok("http://user:secret@proxy.test:8080"),
+        NoProxyList::default(),
+        b"HTTP/1.1 200 OK\r\n\r\n",
+    );
+    rig.factory.tunnel_stream("origin.test", 8443, &context(), deadline()).unwrap();
+    let request = rig.request.lock().unwrap();
+    let text = String::from_utf8(request.clone()).unwrap();
+    assert!(text.contains("CONNECT origin.test:8443 HTTP/1.1\r\n"));
+    assert!(text.contains("Proxy-Authorization: Basic dXNlcjpzZWNyZXQ=\r\n"));
+    assert!(!text.contains("secret"));
+}
+
+#[test]
+fn tunnel_failures_are_stable_for_refusals_smuggling_and_bad_grammar() {
+    for (response, kind) in [
+        (&b"HTTP/1.1 403 Forbidden\r\nContent-Length: 0\r\n\r\n"[..], TransportErrorKind::Connect),
+        (b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n", TransportErrorKind::Connect),
+        (b"HTTP/1.1 200 OK\r\n\r\nEARLY-TUNNEL-BYTES", TransportErrorKind::InvalidMessage),
+        (b"garbage\r\n\r\n", TransportErrorKind::InvalidMessage),
+        (b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\nContent-Length: 1\r\n\r\n", TransportErrorKind::InvalidMessage),
+    ] {
+        let rig = routed_factory(
+            parse_ok("http://proxy.test:8080"),
+            NoProxyList::default(),
+            response,
+        );
+        let Err(error) = rig.factory.tunnel_stream("origin.test", 443, &context(), deadline())
+        else {
+            panic!("{response:?} must fail");
+        };
+        assert_eq!(error.kind(), kind, "{response:?}");
+    }
+}
+
+#[test]
+fn routed_factory_bypasses_the_tunnel_for_excluded_and_plaintext_targets() {
+    let rig = routed_factory(
+        parse_ok("http://proxy.test:8080"),
+        NoProxyList::parse("origin.test"),
+        b"HTTP/1.1 200 OK\r\n\r\n",
+    );
+    let origin: SocketAddr = "8.8.8.8:443".parse().unwrap();
+    drop(rig.factory.connect("https", "origin.test", origin, &context(), deadline()).unwrap());
+    drop(rig.factory.connect("http", "plain.test", origin, &context(), deadline()).unwrap());
+    let seen = rig.connector.seen.lock().unwrap();
+    assert_eq!(seen.len(), 2);
+    assert_eq!((seen[0].0.as_str(), seen[0].2), ("https", origin));
+    assert_eq!((seen[1].0.as_str(), seen[1].1.as_str()), ("http", "plain.test"));
+    assert!(rig.dns.hosts.lock().unwrap().is_empty(), "no proxy resolution may happen on bypass");
+}
+
+#[test]
+fn tunnel_surfaces_cancellation_and_deadline_checks() {
+    let mut connection = RecordingConnection {
+        response: Vec::new(),
+        read_offset: 0,
+        request: Arc::new(Mutex::new(Vec::new())),
+    };
+    let error = establish_tunnel(&mut connection, None, "origin.test", 443, &context(), Instant::now())
+        .unwrap_err();
+    assert_eq!(error.kind(), TransportErrorKind::Timeout);
+}

--- a/crates/http-transport/src/tests/proxy.rs
+++ b/crates/http-transport/src/tests/proxy.rs
@@ -146,6 +146,7 @@ fn routed_factory(proxy: ProxyConfig, no_proxy: NoProxyList, response: &[u8]) ->
         no_proxy,
         Arc::clone(&dns) as Arc<dyn DnsResolver>,
         Arc::clone(&connector) as Arc<dyn ConnectionFactory>,
+        false,
     );
     TunnelRig { factory, request, connector, dns }
 }

--- a/crates/http-transport/src/tests/proxy.rs
+++ b/crates/http-transport/src/tests/proxy.rs
@@ -165,10 +165,7 @@ fn tunnel_request_is_exact_and_requires_a_success_response() {
         NoProxyList::default(),
         b"HTTP/1.1 200 Connection established\r\n\r\n",
     );
-    let stream = rig
-        .factory
-        .tunnel_stream("huggingface.co", 443, &context(), deadline())
-        .unwrap();
+    let stream = rig.factory.tunnel_stream("huggingface.co", 443, &context(), deadline()).unwrap();
     drop(stream);
     assert_eq!(
         rig.request.lock().unwrap().as_slice(),
@@ -203,13 +200,13 @@ fn tunnel_failures_are_stable_for_refusals_smuggling_and_bad_grammar() {
         (b"HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n", TransportErrorKind::Connect),
         (b"HTTP/1.1 200 OK\r\n\r\nEARLY-TUNNEL-BYTES", TransportErrorKind::InvalidMessage),
         (b"garbage\r\n\r\n", TransportErrorKind::InvalidMessage),
-        (b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\nContent-Length: 1\r\n\r\n", TransportErrorKind::InvalidMessage),
+        (
+            b"HTTP/1.1 200 OK\r\nContent-Length: 1\r\nContent-Length: 1\r\n\r\n",
+            TransportErrorKind::InvalidMessage,
+        ),
     ] {
-        let rig = routed_factory(
-            parse_ok("http://proxy.test:8080"),
-            NoProxyList::default(),
-            response,
-        );
+        let rig =
+            routed_factory(parse_ok("http://proxy.test:8080"), NoProxyList::default(), response);
         let Err(error) = rig.factory.tunnel_stream("origin.test", 443, &context(), deadline())
         else {
             panic!("{response:?} must fail");
@@ -242,7 +239,8 @@ fn tunnel_surfaces_cancellation_and_deadline_checks() {
         read_offset: 0,
         request: Arc::new(Mutex::new(Vec::new())),
     };
-    let error = establish_tunnel(&mut connection, None, "origin.test", 443, &context(), Instant::now())
-        .unwrap_err();
+    let error =
+        establish_tunnel(&mut connection, None, "origin.test", 443, &context(), Instant::now())
+            .unwrap_err();
     assert_eq!(error.kind(), TransportErrorKind::Timeout);
 }

--- a/crates/http-transport/src/tls.rs
+++ b/crates/http-transport/src/tls.rs
@@ -2,6 +2,8 @@ use super::{
     Arc, ExecutionContext, Instant, OnceLock, ServerName, TransportError, TransportErrorKind,
     check_operation,
 };
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::{CertificateDer, UnixTime};
 use std::io;
 use std::io::{Read, Write};
 
@@ -9,8 +11,15 @@ pub(super) fn tls_config() -> Arc<rustls::ClientConfig> {
     static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
     CONFIG
         .get_or_init(|| {
-            let roots =
+            let mut roots =
                 webpki_roots::TLS_SERVER_ROOTS.iter().cloned().collect::<rustls::RootCertStore>();
+            // Also trust certificates from the operating-system root store so
+            // that corporate TLS-inspection proxies (whose MITM CA is installed
+            // in the OS store but not in the Mozilla roots) are accepted.
+            let native = rustls_native_certs::load_native_certs();
+            for cert in native.certs {
+                roots.add(cert).ok();
+            }
             Arc::new(
                 rustls::ClientConfig::builder().with_root_certificates(roots).with_no_client_auth(),
             )
@@ -18,15 +27,82 @@ pub(super) fn tls_config() -> Arc<rustls::ClientConfig> {
         .clone()
 }
 
+pub(super) fn tls_config_insecure() -> Arc<rustls::ClientConfig> {
+    static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
+    CONFIG
+        .get_or_init(|| {
+            Arc::new(
+                rustls::ClientConfig::builder()
+                    .dangerous()
+                    .with_custom_certificate_verifier(Arc::new(NoCertificateVerification))
+                    .with_no_client_auth(),
+            )
+        })
+        .clone()
+}
+
+/// A `ServerCertVerifier` that accepts any certificate, disabling all TLS
+/// certificate verification. Only used when the caller explicitly opts in
+/// via `INTO_MD_INSECURE`.
+#[derive(Debug)]
+struct NoCertificateVerification;
+
+impl ServerCertVerifier for NoCertificateVerification {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        Ok(HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        vec![
+            rustls::SignatureScheme::RSA_PKCS1_SHA256,
+            rustls::SignatureScheme::ECDSA_NISTP256_SHA256,
+            rustls::SignatureScheme::RSA_PKCS1_SHA384,
+            rustls::SignatureScheme::ECDSA_NISTP384_SHA384,
+            rustls::SignatureScheme::RSA_PKCS1_SHA512,
+            rustls::SignatureScheme::ED25519,
+            rustls::SignatureScheme::RSA_PSS_SHA256,
+            rustls::SignatureScheme::RSA_PSS_SHA384,
+            rustls::SignatureScheme::RSA_PSS_SHA512,
+        ]
+    }
+}
+
 pub(super) fn tls_handshake<S: Read + Write>(
     mut stream: S,
     host: &str,
     context: &ExecutionContext,
     deadline: Instant,
+    insecure: bool,
 ) -> Result<rustls::StreamOwned<rustls::ClientConnection, S>, TransportError> {
+    let config = if insecure { tls_config_insecure() } else { tls_config() };
     let server_name = ServerName::try_from(host.to_owned())
         .map_err(|_| TransportError::new(TransportErrorKind::InvalidMessage))?;
-    let mut connection = rustls::ClientConnection::new(tls_config(), server_name)
+    let mut connection = rustls::ClientConnection::new(config, server_name)
         .map_err(|_| TransportError::new(TransportErrorKind::Tls))?;
     while connection.is_handshaking() {
         check_operation(context, deadline)?;

--- a/crates/http-transport/src/tls.rs
+++ b/crates/http-transport/src/tls.rs
@@ -1,8 +1,9 @@
 use super::{
-    Arc, ExecutionContext, Instant, OnceLock, ServerName, TcpStream, TransportError,
-    TransportErrorKind, check_operation,
+    Arc, ExecutionContext, Instant, OnceLock, ServerName, TransportError, TransportErrorKind,
+    check_operation,
 };
 use std::io;
+use std::io::{Read, Write};
 
 pub(super) fn tls_config() -> Arc<rustls::ClientConfig> {
     static CONFIG: OnceLock<Arc<rustls::ClientConfig>> = OnceLock::new();
@@ -17,12 +18,12 @@ pub(super) fn tls_config() -> Arc<rustls::ClientConfig> {
         .clone()
 }
 
-pub(super) fn tls_connect(
-    mut stream: TcpStream,
+pub(super) fn tls_handshake<S: Read + Write>(
+    mut stream: S,
     host: &str,
     context: &ExecutionContext,
     deadline: Instant,
-) -> Result<rustls::StreamOwned<rustls::ClientConnection, TcpStream>, TransportError> {
+) -> Result<rustls::StreamOwned<rustls::ClientConnection, S>, TransportError> {
     let server_name = ServerName::try_from(host.to_owned())
         .map_err(|_| TransportError::new(TransportErrorKind::InvalidMessage))?;
     let mut connection = rustls::ClientConnection::new(tls_config(), server_name)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -265,8 +265,8 @@ into-md formats detect <INPUT> [-f <FORMAT>] [--extension <EXT>]
 ```text
 into-md models [--json]
 into-md models show <ID> [--json]
-into-md models install [ID]
-into-md models verify [ID] [--json]
+into-md models install <ID> [--insecure]
+into-md models verify <ID> [--json]
 into-md models remove <ID>
 into-md models path <ID>
 ```
@@ -284,6 +284,10 @@ into-md models path <ID>
 （回退 `NO_PROXY`、`no_proxy`）支持 `*`、精确 host 或 `.suffix` 域后缀豁免；空值视为
 未设置，非法值在下载前稳定失败。`doctor` 的 `modelFiles` 项会报告当前路由
 （direct、代理 host:port 或非法变量及原因）。
+系统证书库无法覆盖特殊 TLS 环境时，可为单次安装显式传入 `--insecure`，或设置
+`INTO_MD_INSECURE=1`；环境变量只接受 `0`、`1`、`false`、`true`（大小写不敏感），
+其他值会在下载前报配置错误。该选项会关闭 TLS 证书和握手签名验证，只应临时使用；
+模型内容仍必须通过清单中固定的大小与 SHA-256 校验。
 完整的清单、数据目录、事务和威胁边界见
 [本地模型管理](models.md)。
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -279,6 +279,11 @@ into-md models path <ID>
 并通过原子事务安装两个组件；转换命令绝不触发下载。安装后 CLI 的离线 `verify`、`path`
 和 `remove` 管理同一状态，转换调用只在固定 ONNX Runtime/worker 与两个组件均验证成功后
 装配 OCR。
+直连不可达时，`models install` 支持 CONNECT 代理路由：`INTO_MD_HTTPS_PROXY`（回退
+`HTTPS_PROXY`、`https_proxy`）取 `http://[user:pass@]host:port`，`INTO_MD_NO_PROXY`
+（回退 `NO_PROXY`、`no_proxy`）支持 `*`、精确 host 或 `.suffix` 域后缀豁免；空值视为
+未设置，非法值在下载前稳定失败。`doctor` 的 `modelFiles` 项会报告当前路由
+（direct、代理 host:port 或非法变量及原因）。
 完整的清单、数据目录、事务和威胁边界见
 [本地模型管理](models.md)。
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -46,8 +46,12 @@ reparse point 与物理 FileId 校验的根目录 handle；私有文件拒绝 ha
 只有显式安装调用才是模型下载授权。只有清单中经审核的最终 runtime files
 才能进入安装事务；传输层还必须逐跳执行 HTTPS、固定 host、重定向次数、响应大小、
 DNS 和地址边界，连接固定到已验证地址并保留原始 TLS SNI/Host。library manager 接受
-显式 `ModelFetcher`；CLI 当前没有 transport，因此 `models install` 不创建连接并返回
-`componentUnavailable`。
+显式 `ModelFetcher`；CLI 的 `models install` 使用固定下载 authority 的 transport，
+不读取任何代理环境变量时按直连执行。设置 `INTO_MD_HTTPS_PROXY`（回退 `HTTPS_PROXY`、
+`https_proxy`）后，HTTPS 下载经该 `http://` CONNECT 代理建立端到端隧道：origin 的
+host allowlist、DNS/地址校验、重定向重授权与最终 SHA-256 全部不变，代理凭证只进入
+`Proxy-Authorization` 头并在输出中脱敏；`INTO_MD_NO_PROXY`（回退 `NO_PROXY`、
+`no_proxy`）按 `*`、精确 host 或域后缀豁免直连。非法代理值在下载前以稳定配置错误拒绝。
 
 归档型 artifact 的 fetch stream 必须是原始官方 TAR，不能伪装成已解压文件。管理器先按
 归档 authority 检查获取类型，再在同一受预算边界内验证整包大小与 SHA-256、TAR header

--- a/docs/security.md
+++ b/docs/security.md
@@ -358,12 +358,21 @@ Clone、不可 Debug/Display 的请求局部对象持有，Authorization 请求�
 错误、JSON 输出、日志和配置没有响应自由文本或密钥字段。
 
 传输固定使用 Rustls 0.23.32、ring、socket2 0.6.5 和 webpki-roots 1.0.3 的 Mozilla 根集合，四个目标平台
-使用同一根策略；不读取平台证书库、HTTP(S)_PROXY、PATH 或代理环境变量。DNS 在有界工作
+使用同一根策略；传输库本身不读取平台证书库、HTTP(S)_PROXY、PATH 或代理环境变量。DNS 在有界工作
 线程池及有界队列解析；空结果、超量/超容量/端口不符结果，或同时包含公网与未授权私网地址
 均 fail closed。连接只使用已检查的具体
 SocketAddr，Host 与 TLS SNI 使用同一个 canonical hostname。HTTP 只允许已显式双重授权的
 非公网地址；公网 Provider 必须使用 HTTPS。重定向和 protocol upgrade 均拒绝，因此
 Authorization 不会跨 origin 转发。
+
+模型下载的 CLI 层是唯一的代理入口：操作者可用 `INTO_MD_HTTPS_PROXY`（回退到 curl 风格的
+`HTTPS_PROXY`、`https_proxy`）显式注入一个 `http://[user:pass@]host:port` 的 CONNECT 代理，
+并用 `INTO_MD_NO_PROXY`（回退 `NO_PROXY`、`no_proxy`）按 `*`、精确 host 或域后缀豁免。
+代理仅承载策略已独立授权并解析的 HTTPS origin 隧道；TLS 仍在 origin 端到端终止，SNI 与
+证书校验对象不变，WebPKI 根集合不放宽，代理凭证只进入 `Proxy-Authorization` 头且在任何
+输出与 provenance 中脱敏。明文 HTTP origin 永不进入隧道，保持原直连公网限定路径；库的
+确定性测试不受环境变量影响（默认客户端行为不变）。代理响应头复用同一严格 HTTP/1.1
+parser，2xx 以外的 CONNECT 应答、head 后的提前隧道字节（smuggling）与畸形应答均稳定拒绝。
 
 HTTP/1.1 parser 对 header、header 数量、Content-Length、chunk、压缩体、解压体和 JSON
 结构设硬限，拒绝 obs-fold、重复长度、CL/TE 冲突、未知 transfer/content encoding、trailer、

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -492,3 +492,14 @@ media converter 测试覆盖 `TimedSegment`、模型/语言 metadata 以及缺�
 Unicode word token WER 必须各不高于 15%；对应常见噪声样本必须各不高于 25%。质量运行还要
 断言每段时间戳单调、有界，语言检测结果正确，所有置信度有限且位于 `[0,1]`。这些阈值不可
 由普通单元测试、接口 stub 或只验证模型 hash 的测试宣称满足。
+
+## 模型下载代理路由
+
+传输库的代理单测（`cargo test -p into-markdown-http-transport`）用注入式假连接逐字节断言：
+CONNECT 请求行与 `Proxy-Authorization` 头精确、凭证不出现在任何字节中；2xx 以外的代理应答、
+head 后提前隧道字节（smuggling）与畸形应答映射稳定错误；`NO_PROXY` 的 `*`/精确/后缀语义、
+明文 origin 永不入隧道；豁免与直连目标不触发任何代理解析。CLI 侧 `proxy_env` 单测固定
+`INTO_MD_HTTPS_PROXY` > `HTTPS_PROXY` > `https_proxy` 优先级、空值等于未设置与非法值
+fail closed；`model_fetch` 的 scripted transport 维持 whisper 单跳重定向 authority（xet
+bridge 域 + 精确 object hash），重定向到其它 host 或篡改 hash 均稳定拒绝。库与确定性测试
+不读取环境变量：默认客户端行为与所有既有测试在设置代理变量的环境中不变。


### PR DESCRIPTION
## 概要

- 为固定来源的模型下载增加显式 HTTP CONNECT 代理路由、代理认证和 NO_PROXY 绕过。
- 合并系统原生根证书，并提供显式 --insecure 与严格解析的 INTO_MD_INSECURE 配置。
- 合并小块响应数据以控制代理下载时的内存预算，并为 chunk framing 留出受限 wire budget。
- 要求 models install/verify 显式提供模型 ID，并同步 CLI 文档和安全提示。
- 修复格式与 Clippy 门禁问题，增加不安全环境变量解析回归测试。

Closes #165

## 验证

- [x] cargo fmt --all -- --check
- [x] cargo clippy -p into-markdown-http-transport --all-targets -- -D warnings
- [x] cargo test -p into-markdown-http-transport（27 passed）
- [ ] cargo test -p into-markdown-cli proxy_env::tests::insecure_environment_value_is_strictly_parsed（本机缺少 libclang.dll，whisper-rs-sys 构建脚本在测试编译前失败）