### PR TITLE
feat(plugins): add isolated process-v1 runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1414,6 +1414,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "into-markdown-process-plugin"
+version = "0.0.0"
+dependencies = [
+ "base64",
+ "into-markdown-core",
+ "libc",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "into-markdown-render-markdown"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/onnxruntime",
     "crates/pdf-layout",
     "crates/pdfium",
+    "crates/process-plugin",
     "crates/render-markdown",
     "crates/task-store",
     "tests/contracts",

--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -534,6 +534,13 @@ impl ExecutionContext {
         self.reserve(ResourceKind::Temporary, bytes)
     }
 
+    /// Current live temporary-storage reservations for boundary and lifecycle audits.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn reserved_temporary_bytes(&self) -> u64 {
+        self.shared.temporary_bytes.load(Ordering::Acquire)
+    }
+
     /// Create an automatically cleaned temporary file charged as bytes are written.
     ///
     /// # Errors

--- a/crates/process-plugin/BUILD.bazel
+++ b/crates/process-plugin/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@crates//:defs.bzl", "all_crate_deps", "aliases")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library", "rust_test")
+
+package(default_visibility = ["//crates:__subpackages__"])
+
+exports_files(["BUILD.bazel", "Cargo.toml"], visibility = ["//visibility:public"])
+
+rust_library(
+    name = "process_plugin",
+    srcs = glob(["src/**/*.rs"], exclude = ["src/bin/**/*.rs"]),
+    crate_name = "into_markdown_process_plugin",
+    edition = "2024",
+    deps = ["//crates/core"] + all_crate_deps(normal = True),
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+)
+
+rust_binary(
+    name = "process-plugin-fixture",
+    srcs = ["src/bin/process_plugin_fixture.rs"],
+    crate_name = "process_plugin_fixture",
+    edition = "2024",
+    deps = [
+        ":process_plugin",
+        "//crates/core",
+    ] + all_crate_deps(normal = True),
+    proc_macro_deps = all_crate_deps(proc_macro = True),
+)
+
+rust_test(
+    name = "process_plugin_test",
+    crate = ":process_plugin",
+    aliases = aliases(normal_dev = True, proc_macro_dev = True),
+    data = [":process-plugin-fixture"],
+    edition = "2024",
+    deps = all_crate_deps(normal_dev = True),
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+)
+
+rust_test(
+    name = "process_plugin_integration_test",
+    srcs = ["tests/runtime.rs"],
+    crate_name = "process_plugin_integration_test",
+    aliases = aliases(normal_dev = True, proc_macro_dev = True),
+    data = [":process-plugin-fixture"],
+    edition = "2024",
+    deps = [
+        ":process_plugin",
+        "//crates/core",
+    ] + all_crate_deps(normal = True, normal_dev = True),
+    proc_macro_deps = all_crate_deps(proc_macro_dev = True),
+)

--- a/crates/process-plugin/Cargo.toml
+++ b/crates/process-plugin/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "into-markdown-process-plugin"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+license.workspace = true
+
+[dependencies]
+base64.workspace = true
+into-markdown-core = { path = "../core" }
+libc.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true
+
+[lints.rust]
+unsafe_code = "allow"
+missing_docs = "warn"
+unsafe_op_in_unsafe_fn = "deny"
+
+[lints.clippy]
+all = "warn"
+pedantic = "warn"
+
+[[bin]]
+name = "process-plugin-fixture"
+path = "src/bin/process_plugin_fixture.rs"

--- a/crates/process-plugin/src/bin/process_plugin_fixture.rs
+++ b/crates/process-plugin/src/bin/process_plugin_fixture.rs
@@ -1,0 +1,195 @@
+//! Cross-platform adversarial executable for the real process sandbox tests.
+
+use into_markdown_core::{
+    Asset, AssetId, ConversionResult, Diagnostic, DiagnosticSeverity, Document, DtoJsonStyle,
+    Provenance, ProvenanceKind, ResultDto, SourceLocator,
+};
+use into_markdown_process_plugin::worker::{self, WorkerError};
+use std::io::Write as _;
+use std::time::Duration;
+
+fn main() -> std::io::Result<()> {
+    if std::env::var("PROCESS_PLUGIN_FIXTURE_MODE").as_deref() == Ok("stall-request") {
+        return stall_after_hello();
+    }
+    worker::serve("fixture.process-v1", 16 * 1024 * 1024, |request, events, cancellation| {
+        let command = String::from_utf8_lossy(&request.source);
+        if exit_for_raw_fixture(&command, &request.request_id) {
+            unreachable!("raw fixtures always exit the process")
+        }
+        match command.as_ref() {
+            "crash" => std::process::abort(),
+            "hang" => loop {
+                std::thread::sleep(Duration::from_millis(10));
+            },
+            "cancel" => {
+                events
+                    .progress("converting", Some(0), Some(1), Some("cancel-ready".into()))
+                    .map_err(|_| WorkerError::new("event", "progress failed"))?;
+                while !cancellation.is_cancelled() {
+                    std::thread::sleep(Duration::from_millis(2));
+                }
+                Err(WorkerError::new("cancelled", "cancelled"))
+            }
+            "stage-isolated" => {
+                events
+                    .progress("converting", Some(0), Some(1), Some("stage-ready".into()))
+                    .map_err(|_| WorkerError::new("event", "progress failed"))?;
+                std::thread::sleep(Duration::from_millis(500));
+                Ok(result("stage-isolated"))
+            }
+            "frame-flood" => {
+                for sequence in 1..=64 {
+                    raw_json(&serde_json::json!({
+                        "type":"progress", "protocol_version":1,
+                        "request_id":request.request_id, "sequence":sequence,
+                        "stage":"converting", "completed_units":sequence,
+                        "total_units":64, "message":"flood"
+                    }));
+                }
+                loop {
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+            }
+            value if value.starts_with("file:") => {
+                let denied = std::fs::read(&value[5..]).is_err();
+                Ok(result(if denied { "file-denied" } else { "file-leaked" }))
+            }
+            value if value.starts_with("network:") => {
+                let denied = std::net::TcpStream::connect(&value[8..]).is_err();
+                Ok(result(if denied { "network-denied" } else { "network-leaked" }))
+            }
+            "secret" => Ok(result(
+                if std::env::var_os("PATH").is_none()
+                    && std::env::var_os("AWS_SECRET_ACCESS_KEY").is_none()
+                {
+                    "secret-denied"
+                } else {
+                    "secret-leaked"
+                },
+            )),
+            "ok" => {
+                events
+                    .progress("converting", Some(1), Some(2), Some("fixture".into()))
+                    .map_err(|_| WorkerError::new("event", "progress failed"))?;
+                events
+                    .diagnostic(Diagnostic {
+                        code: "fixtureNotice".into(),
+                        severity: DiagnosticSeverity::Info,
+                        message: "fixture diagnostic".into(),
+                        locator: None,
+                    })
+                    .map_err(|_| WorkerError::new("event", "diagnostic failed"))?;
+                Ok(result("ok"))
+            }
+            _ => Err(WorkerError::new("unknownFixture", "unknown fixture command")),
+        }
+    })
+}
+
+fn exit_for_raw_fixture(command: &str, request_id: &str) -> bool {
+    match command {
+        "malformed" => raw_and_exit(b"\x01\x00\x00\x00{"),
+        "oversize" => raw_and_exit(&(16_u32 * 1024 * 1024 + 1).to_le_bytes()),
+        "bad-order" => {
+            for (sequence, completed) in [(2, 1), (1, 2)] {
+                raw_json(&serde_json::json!({
+                    "type":"progress", "protocol_version":1,
+                    "request_id":request_id, "sequence":sequence,
+                    "stage":"converting", "completed_units":completed,
+                    "total_units":2, "message":null
+                }));
+            }
+            std::process::exit(0);
+        }
+        "invalid-result" => {
+            raw_json(&serde_json::json!({
+                "type":"response", "protocol_version":1,
+                "request_id":request_id, "result_json":"{}"
+            }));
+            std::process::exit(0);
+        }
+        "missing-error-id" => {
+            raw_json(&serde_json::json!({
+                "type":"error", "protocol_version":1,
+                "request_id":null, "code":"fixtureError", "message":"missing identity"
+            }));
+            std::process::exit(0);
+        }
+        "extra-after-response" => {
+            let result_json =
+                ResultDto::json_from_result(&result("first"), DtoJsonStyle::Compact).unwrap();
+            raw_json(&serde_json::json!({
+                "type":"response", "protocol_version":1,
+                "request_id":request_id, "result_json":result_json
+            }));
+            raw_json(&serde_json::json!({
+                "type":"progress", "protocol_version":1,
+                "request_id":request_id, "sequence":1,
+                "stage":"completed", "completed_units":1,
+                "total_units":1, "message":null
+            }));
+            std::process::exit(0);
+        }
+        _ => false,
+    }
+}
+
+fn stall_after_hello() -> std::io::Result<()> {
+    use std::io::Read as _;
+    let mut stdin = std::io::stdin().lock();
+    let mut prefix = [0_u8; 4];
+    stdin.read_exact(&mut prefix)?;
+    let length = u32::from_le_bytes(prefix);
+    if length == 0 || length > 64 * 1024 {
+        return Err(std::io::ErrorKind::InvalidData.into());
+    }
+    let mut bytes = vec![0_u8; length as usize];
+    stdin.read_exact(&mut bytes)?;
+    let hello: serde_json::Value = serde_json::from_slice(&bytes)?;
+    raw_json(&serde_json::json!({
+        "type":"hello",
+        "selected_version":1,
+        "plugin_id":hello.get("plugin_id").and_then(serde_json::Value::as_str),
+        "nonce":hello.get("nonce").and_then(serde_json::Value::as_str)
+    }));
+    loop {
+        std::thread::sleep(Duration::from_secs(1));
+    }
+}
+
+fn result(markdown: &str) -> ConversionResult {
+    ConversionResult::new(
+        Document::default(),
+        markdown.into(),
+        vec![Asset {
+            id: AssetId("fixture-resource".into()),
+            filename: Some("fixture.bin".into()),
+            media_type: "application/octet-stream".into(),
+            bytes: vec![1, 2, 3],
+            external_uri: None,
+        }],
+        Vec::new(),
+        vec![Provenance {
+            kind: ProvenanceKind::NativeParser,
+            provider: "fixture.process-v1".into(),
+            locator: SourceLocator::default(),
+            confidence: Some(1.0),
+        }],
+    )
+}
+
+fn raw_json(value: &serde_json::Value) {
+    let bytes = serde_json::to_vec(value).unwrap();
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(&u32::try_from(bytes.len()).unwrap().to_le_bytes()).unwrap();
+    stdout.write_all(&bytes).unwrap();
+    stdout.flush().unwrap();
+}
+
+fn raw_and_exit(bytes: &[u8]) -> ! {
+    let mut stdout = std::io::stdout().lock();
+    stdout.write_all(bytes).unwrap();
+    stdout.flush().unwrap();
+    std::process::exit(0)
+}

--- a/crates/process-plugin/src/lib.rs
+++ b/crates/process-plugin/src/lib.rs
@@ -1,0 +1,1290 @@
+//! Fail-closed host runtime for `process-v1` conversion plugins.
+//!
+//! Plugins are untrusted executables. The host authenticates the executable, starts it with an
+//! empty environment in an operating-system sandbox, and accepts only bounded, versioned,
+//! length-prefixed JSON frames. Source bytes and returned resources cross the pipe rather than a
+//! shared filesystem.
+#![deny(unsafe_op_in_unsafe_fn)]
+
+mod protocol;
+mod sandbox;
+pub mod worker;
+
+use base64::Engine as _;
+use into_markdown_core::{
+    ConversionResult, Diagnostic, DiagnosticsDto, ExecutionContext, ExecutionStage,
+    ResourceReservation, ResultDto,
+};
+use protocol::{HostMessage, PROTOCOL_V1, PluginMessage};
+use sha2::{Digest as _, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::ffi::OsString;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+    mpsc,
+};
+use std::time::{Duration, Instant};
+use thiserror::Error;
+
+const HASH_BUFFER_SIZE: usize = 64 * 1024;
+const HASH_BUFFER_BYTES: u64 = 64 * 1024;
+const ABSOLUTE_EXECUTABLE_BYTES: u64 = 512 * 1024 * 1024;
+const ABSOLUTE_RUNTIME_BYTES: u64 = 1024 * 1024 * 1024;
+const ABSOLUTE_RUNTIME_ENTRIES: usize = 10_000;
+
+/// Stable process-plugin failure categories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PluginErrorCode {
+    /// The local plugin authority is malformed or no longer matches disk.
+    Authority,
+    /// The operating-system sandbox could not be installed fail-closed.
+    SandboxUnavailable,
+    /// The authenticated executable could not be launched.
+    Launch,
+    /// The peer violated framing, ordering, identity, or version rules.
+    Protocol,
+    /// The peer emitted a frame larger than policy permits.
+    FrameTooLarge,
+    /// The plugin exited or its protocol stream ended before a terminal response.
+    Crashed,
+    /// The request exceeded its host deadline.
+    Timeout,
+    /// The caller cancelled the request.
+    Cancelled,
+    /// The returned IR, resources, diagnostics, or provenance were invalid.
+    InvalidResult,
+    /// The plugin returned a controlled terminal error.
+    Plugin,
+    /// A host resource budget was exceeded.
+    ResourceLimit,
+}
+
+impl PluginErrorCode {
+    /// Stable lower-camel-case representation.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Authority => "pluginAuthority",
+            Self::SandboxUnavailable => "pluginSandboxUnavailable",
+            Self::Launch => "pluginLaunch",
+            Self::Protocol => "pluginProtocol",
+            Self::FrameTooLarge => "pluginFrameTooLarge",
+            Self::Crashed => "pluginCrashed",
+            Self::Timeout => "pluginTimeout",
+            Self::Cancelled => "pluginCancelled",
+            Self::InvalidResult => "pluginInvalidResult",
+            Self::Plugin => "pluginError",
+            Self::ResourceLimit => "pluginResourceLimit",
+        }
+    }
+}
+
+/// Sanitized process-plugin failure. Child stderr is never included verbatim.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{code}: {detail}", code = code.as_str())]
+pub struct PluginError {
+    /// Stable machine category.
+    pub code: PluginErrorCode,
+    /// Bounded host-generated detail.
+    pub detail: String,
+}
+
+impl PluginError {
+    fn new(code: PluginErrorCode, detail: impl Into<String>) -> Self {
+        let mut detail = detail.into();
+        detail.truncate(512);
+        Self { code, detail }
+    }
+}
+
+/// Immutable authority for one installed executable.
+#[derive(Debug, Clone)]
+pub struct PluginManifest {
+    /// Stable lowercase plugin identifier.
+    pub plugin_id: String,
+    /// Absolute executable path.
+    pub executable: PathBuf,
+    /// Canonical runtime directory containing the executable and its private libraries.
+    pub runtime_root: PathBuf,
+    /// Lowercase SHA-256 of the executable.
+    pub executable_sha256: String,
+    /// Ordered supported protocol versions.
+    pub protocol_versions: Vec<u32>,
+}
+
+/// Windows `AppContainer` identity provisioned and ACL-authorized by the plugin installer.
+#[cfg(windows)]
+#[derive(Debug, Clone)]
+pub struct WindowsSandboxAuthority {
+    /// `AppContainer` profile name.
+    pub profile_name: String,
+    /// Expected derived SID.
+    pub sid: String,
+    /// Canonical `AppContainer` storage directory used as the private working root.
+    pub storage_root: PathBuf,
+}
+
+/// Host-enforced limits and the complete declared environment capability.
+#[derive(Debug, Clone)]
+pub struct RuntimePolicy {
+    /// Maximum encoded JSON bytes in one frame.
+    pub max_frame_bytes: u32,
+    /// Maximum nested result JSON bytes.
+    pub max_output_bytes: u64,
+    /// Child virtual-address/job memory ceiling.
+    pub max_memory_bytes: u64,
+    /// Maximum size of a child-created file.
+    pub max_file_bytes: u64,
+    /// Maximum child file descriptors.
+    pub max_open_files: u32,
+    /// Maximum handshake duration independent of request timeout.
+    pub handshake_timeout: Duration,
+    /// Hard request duration even when the caller supplied no shorter context deadline.
+    pub request_timeout: Duration,
+    /// Grace after sending cancellation before forced tree termination.
+    pub cancellation_grace: Duration,
+    /// Complete explicit environment. No parent variable is inherited.
+    pub environment: BTreeMap<OsString, OsString>,
+    /// Pre-provisioned no-capability `AppContainer` authority.
+    #[cfg(windows)]
+    pub windows: WindowsSandboxAuthority,
+}
+
+impl Default for RuntimePolicy {
+    fn default() -> Self {
+        Self {
+            max_frame_bytes: 16 * 1024 * 1024,
+            max_output_bytes: 12 * 1024 * 1024,
+            max_memory_bytes: 512 * 1024 * 1024,
+            max_file_bytes: 64 * 1024 * 1024,
+            max_open_files: 64,
+            handshake_timeout: Duration::from_secs(5),
+            request_timeout: Duration::from_mins(1),
+            cancellation_grace: Duration::from_millis(100),
+            environment: BTreeMap::new(),
+            #[cfg(windows)]
+            windows: WindowsSandboxAuthority {
+                profile_name: String::new(),
+                sid: String::new(),
+                storage_root: PathBuf::new(),
+            },
+        }
+    }
+}
+
+/// One bounded conversion invocation.
+#[derive(Debug, Clone, Copy)]
+pub struct PluginRequest<'a> {
+    /// Stable request ID unique within the host process.
+    pub request_id: &'a str,
+    /// Stable input-format wire name.
+    pub input_format: &'a str,
+    /// Display-only source name.
+    pub source_name: Option<&'a str>,
+    /// Authenticated input bytes sent inline.
+    pub source: &'a [u8],
+}
+
+/// Validated terminal result plus authenticated runtime identity.
+#[derive(Debug)]
+pub struct PluginExecution {
+    /// Fully decoded and validated result DTO.
+    pub result: ConversionResult,
+    /// Manifest plugin ID matched during handshake.
+    pub plugin_id: String,
+    /// Executable SHA-256 revalidated immediately before launch.
+    pub executable_sha256: String,
+}
+
+/// Reusable authenticated process-plugin runtime.
+#[derive(Debug, Clone)]
+pub struct ProcessPlugin {
+    plugin: ValidatedPlugin,
+    policy: RuntimePolicy,
+}
+
+#[derive(Debug, Clone)]
+struct ValidatedPlugin {
+    plugin_id: String,
+    executable: PathBuf,
+    runtime_root: PathBuf,
+    executable_sha256: String,
+    protocol_versions: Vec<u32>,
+}
+
+impl ProcessPlugin {
+    /// Validate static authority. Disk identity is checked again for every launch.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`PluginErrorCode::Authority`] when manifest or policy authority is invalid.
+    pub fn new(manifest: PluginManifest, policy: RuntimePolicy) -> Result<Self, PluginError> {
+        validate_policy(&policy)?;
+        let plugin = validate_manifest(manifest, policy.max_file_bytes)?;
+        Ok(Self { plugin, policy })
+    }
+
+    /// Execute one plugin request, forwarding progress and respecting cancellation/deadlines.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stable [`PluginError`] for authority, sandbox, protocol, lifecycle, resource,
+    /// cancellation, timeout, plugin, or result-validation failures.
+    #[allow(clippy::too_many_lines)]
+    pub fn execute(
+        &self,
+        request: PluginRequest<'_>,
+        context: &ExecutionContext,
+    ) -> Result<PluginExecution, PluginError> {
+        validate_request(&request, &self.policy)?;
+        let encoded_bound = u64::from(self.policy.max_frame_bytes)
+            .checked_mul(2)
+            .and_then(|value| value.checked_add(self.policy.max_output_bytes))
+            .and_then(|value| value.checked_add(HASH_BUFFER_BYTES))
+            .ok_or_else(|| {
+                PluginError::new(PluginErrorCode::ResourceLimit, "frame reservation overflow")
+            })?;
+        let _wire_memory =
+            context.reserve_memory(encoded_bound).map_err(|error| map_execution_error(&error))?;
+        verify_executable(&self.plugin, self.policy.max_file_bytes)?;
+        let directory_guard = sandbox::working_directory(&self.policy)?;
+        let staged = stage_plugin(&self.plugin, &self.policy, directory_guard, context)?;
+        verify_executable(&staged.plugin, self.policy.max_file_bytes)?;
+        let mut child = sandbox::spawn(&staged.plugin, &self.policy, &staged.working_directory)?;
+        let mut stdin = child
+            .take_stdin()
+            .ok_or_else(|| PluginError::new(PluginErrorCode::Launch, "plugin stdin missing"))?;
+        let mut stdout = child
+            .take_stdout()
+            .ok_or_else(|| PluginError::new(PluginErrorCode::Launch, "plugin stdout missing"))?;
+        let stderr = child
+            .take_stderr()
+            .ok_or_else(|| PluginError::new(PluginErrorCode::Launch, "plugin stderr missing"))?;
+        let maximum = self.policy.max_frame_bytes;
+        // One queued frame plus the reader's current frame is covered by the two-frame execution
+        // context reservation above. Backpressure remains cancellable during tree teardown.
+        let (frames_tx, frames_rx) = mpsc::sync_channel(1);
+        let reader_stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&reader_stop);
+        let reader_handle = std::thread::Builder::new()
+            .name("process-plugin-protocol".into())
+            .spawn(move || {
+                loop {
+                    let mut frame = protocol::read_frame::<PluginMessage>(&mut stdout, maximum);
+                    let terminal = frame.is_err();
+                    loop {
+                        if thread_stop.load(Ordering::Acquire) {
+                            return;
+                        }
+                        match frames_tx.try_send(frame) {
+                            Ok(()) => break,
+                            Err(mpsc::TrySendError::Full(returned)) => {
+                                frame = returned;
+                                std::thread::sleep(Duration::from_millis(1));
+                            }
+                            Err(mpsc::TrySendError::Disconnected(_)) => return,
+                        }
+                    }
+                    if terminal {
+                        break;
+                    }
+                }
+            })
+            .map_err(|_| {
+                PluginError::new(PluginErrorCode::Launch, "protocol reader unavailable")
+            })?;
+        let reader = ProtocolReader { stop: reader_stop, handle: reader_handle };
+        let stderr_reader = std::thread::Builder::new()
+            .name("process-plugin-stderr".into())
+            .spawn(move || drain_stderr(stderr))
+            .map_err(|_| PluginError::new(PluginErrorCode::Launch, "stderr reader unavailable"))?;
+        let nonce = request_nonce(request.request_id);
+        if let Err(error) = protocol::write_frame(
+            &mut stdin,
+            &HostMessage::Hello {
+                supported_versions: self.plugin.protocol_versions.clone(),
+                plugin_id: self.plugin.plugin_id.clone(),
+                nonce: nonce.clone(),
+            },
+            maximum,
+        ) {
+            return finish_error(child, reader, stderr_reader, map_write_error(&error));
+        }
+        let handshake_deadline = Instant::now().checked_add(self.policy.handshake_timeout);
+        let hello = match receive_until(&frames_rx, &mut child, context, handshake_deadline, false)
+        {
+            Ok(hello) => hello,
+            Err(error) => return finish_error(child, reader, stderr_reader, error),
+        };
+        match hello {
+            PluginMessage::Hello { selected_version, plugin_id, nonce: echoed }
+                if selected_version == PROTOCOL_V1
+                    && self.plugin.protocol_versions.contains(&selected_version)
+                    && plugin_id == self.plugin.plugin_id
+                    && echoed == nonce => {}
+            _ => {
+                return finish_error(
+                    child,
+                    reader,
+                    stderr_reader,
+                    PluginError::new(PluginErrorCode::Protocol, "invalid handshake response"),
+                );
+            }
+        }
+        let source_base64 = base64::engine::general_purpose::STANDARD.encode(request.source);
+        let request_deadline = Instant::now().checked_add(self.policy.request_timeout);
+        stdin = match write_request_bounded(
+            stdin,
+            HostMessage::Request {
+                protocol_version: PROTOCOL_V1,
+                request_id: request.request_id.to_owned(),
+                input_format: request.input_format.to_owned(),
+                source_name: request.source_name.map(str::to_owned),
+                source_base64,
+                maximum_output_bytes: self.policy.max_output_bytes,
+            },
+            maximum,
+            &mut child,
+            context,
+            request_deadline,
+        ) {
+            Ok(stdin) => stdin,
+            Err(error) => return finish_error(child, reader, stderr_reader, error),
+        };
+        let mut last_sequence = 0_u64;
+        let mut event_count = 0_u32;
+        let mut streamed_diagnostics = Vec::new();
+        let mut streamed_diagnostic_bytes = 0_u64;
+        macro_rules! finish_on_error {
+            ($expression:expr) => {
+                match $expression {
+                    Ok(value) => value,
+                    Err(error) => return finish_error(child, reader, stderr_reader, error),
+                }
+            };
+        }
+        loop {
+            let frame = match receive_until(&frames_rx, &mut child, context, request_deadline, true)
+            {
+                Ok(frame) => frame,
+                Err(error)
+                    if matches!(
+                        error.code,
+                        PluginErrorCode::Cancelled | PluginErrorCode::Timeout
+                    ) =>
+                {
+                    let _ = protocol::write_frame(
+                        &mut stdin,
+                        &HostMessage::Cancel {
+                            protocol_version: PROTOCOL_V1,
+                            request_id: request.request_id.to_owned(),
+                        },
+                        maximum,
+                    );
+                    let grace = Instant::now().checked_add(self.policy.cancellation_grace);
+                    while grace.is_some_and(|deadline| Instant::now() < deadline) {
+                        if child.try_wait().ok().flatten().is_some() {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(2));
+                    }
+                    terminate_tree(&mut child);
+                    let _ = reader.join();
+                    let _ = stderr_reader.join();
+                    return Err(error);
+                }
+                Err(error) => return finish_error(child, reader, stderr_reader, error),
+            };
+            // Cancellation can race the final millisecond of recv_timeout. Re-check after a frame
+            // becomes readable so a cooperative terminal/error cannot overwrite an already-set
+            // caller cancellation state.
+            if let Err(error) = context.checkpoint().map_err(|error| map_execution_error(&error)) {
+                let _ = protocol::write_frame(
+                    &mut stdin,
+                    &HostMessage::Cancel {
+                        protocol_version: PROTOCOL_V1,
+                        request_id: request.request_id.to_owned(),
+                    },
+                    maximum,
+                );
+                let grace = Instant::now().checked_add(self.policy.cancellation_grace);
+                while grace.is_some_and(|deadline| Instant::now() < deadline) {
+                    if child.try_wait().ok().flatten().is_some() {
+                        break;
+                    }
+                    std::thread::sleep(Duration::from_millis(2));
+                }
+                terminate_tree(&mut child);
+                let _ = reader.join();
+                let _ = stderr_reader.join();
+                return Err(error);
+            }
+            match frame {
+                PluginMessage::Progress {
+                    protocol_version,
+                    request_id,
+                    sequence,
+                    stage,
+                    completed_units,
+                    total_units,
+                    message,
+                } => {
+                    event_count = event_count.saturating_add(1);
+                    if event_count > 10_000
+                        || message.as_ref().is_some_and(|value| value.len() > 4096)
+                    {
+                        return finish_error(
+                            child,
+                            reader,
+                            stderr_reader,
+                            PluginError::new(
+                                PluginErrorCode::ResourceLimit,
+                                "plugin event limit exceeded",
+                            ),
+                        );
+                    }
+                    finish_on_error!(validate_event(
+                        protocol_version,
+                        &request_id,
+                        request.request_id,
+                        sequence,
+                        &mut last_sequence,
+                    ));
+                    let stage = finish_on_error!(parse_stage(&stage));
+                    finish_on_error!(
+                        context
+                            .report(stage, completed_units, total_units, message)
+                            .map_err(|error| map_execution_error(&error))
+                    );
+                }
+                PluginMessage::Diagnostic {
+                    protocol_version,
+                    request_id,
+                    sequence,
+                    diagnostic_json,
+                } => {
+                    event_count = event_count.saturating_add(1);
+                    streamed_diagnostic_bytes =
+                        streamed_diagnostic_bytes.saturating_add(diagnostic_json.len() as u64);
+                    if event_count > 10_000
+                        || streamed_diagnostic_bytes > self.policy.max_output_bytes
+                    {
+                        return finish_error(
+                            child,
+                            reader,
+                            stderr_reader,
+                            PluginError::new(
+                                PluginErrorCode::ResourceLimit,
+                                "plugin event limit exceeded",
+                            ),
+                        );
+                    }
+                    finish_on_error!(validate_event(
+                        protocol_version,
+                        &request_id,
+                        request.request_id,
+                        sequence,
+                        &mut last_sequence,
+                    ));
+                    let envelope = finish_on_error!(
+                        DiagnosticsDto::from_json(&diagnostic_json).map_err(|_| {
+                            PluginError::new(PluginErrorCode::Protocol, "invalid diagnostic event")
+                        })
+                    );
+                    if envelope.diagnostics.len() != 1 {
+                        return finish_error(
+                            child,
+                            reader,
+                            stderr_reader,
+                            PluginError::new(
+                                PluginErrorCode::Protocol,
+                                "diagnostic event must contain exactly one record",
+                            ),
+                        );
+                    }
+                    let diagnostic = finish_on_error!(
+                        envelope.diagnostics.into_iter().next().ok_or_else(|| PluginError::new(
+                            PluginErrorCode::Protocol,
+                            "diagnostic event is empty",
+                        ))
+                    );
+                    streamed_diagnostics.push(finish_on_error!(
+                        Diagnostic::try_from(diagnostic).map_err(|_| {
+                            PluginError::new(PluginErrorCode::Protocol, "invalid diagnostic event")
+                        })
+                    ));
+                }
+                PluginMessage::Response { protocol_version, request_id, result_json } => {
+                    if protocol_version != PROTOCOL_V1 || request_id != request.request_id {
+                        return finish_error(
+                            child,
+                            reader,
+                            stderr_reader,
+                            PluginError::new(
+                                PluginErrorCode::Protocol,
+                                "terminal response identity mismatch",
+                            ),
+                        );
+                    }
+                    if result_json.len() as u64 > self.policy.max_output_bytes {
+                        return finish_error(
+                            child,
+                            reader,
+                            stderr_reader,
+                            PluginError::new(
+                                PluginErrorCode::FrameTooLarge,
+                                "nested result exceeds output limit",
+                            ),
+                        );
+                    }
+                    if (result_json.len() as u64)
+                        .checked_add(streamed_diagnostic_bytes)
+                        .is_none_or(|bytes| bytes > self.policy.max_output_bytes)
+                    {
+                        return finish_error(
+                            child,
+                            reader,
+                            stderr_reader,
+                            PluginError::new(
+                                PluginErrorCode::FrameTooLarge,
+                                "combined result and diagnostics exceed output limit",
+                            ),
+                        );
+                    }
+                    let dto = finish_on_error!(ResultDto::from_json(&result_json).map_err(|_| {
+                        PluginError::new(
+                            PluginErrorCode::InvalidResult,
+                            "returned result DTO is invalid",
+                        )
+                    }));
+                    let mut result =
+                        finish_on_error!(ConversionResult::try_from(dto).map_err(|_| {
+                            PluginError::new(
+                                PluginErrorCode::InvalidResult,
+                                "returned result conversion failed",
+                            )
+                        }));
+                    result.diagnostics.splice(0..0, streamed_diagnostics);
+                    drop(stdin);
+                    let status = wait_bounded(&mut child, Duration::from_millis(250));
+                    if status != Some(true) {
+                        terminate_tree(&mut child);
+                        let _ = reader.join();
+                        let _ = stderr_reader.join();
+                        return Err(PluginError::new(
+                            PluginErrorCode::Crashed,
+                            "plugin did not exit successfully after response",
+                        ));
+                    }
+                    if reader.join_after_drain(&frames_rx) {
+                        let _ = stderr_reader.join();
+                        return Err(PluginError::new(
+                            PluginErrorCode::Protocol,
+                            "frame followed terminal response",
+                        ));
+                    }
+                    let _ = stderr_reader.join();
+                    return Ok(PluginExecution {
+                        result,
+                        plugin_id: self.plugin.plugin_id.clone(),
+                        executable_sha256: self.plugin.executable_sha256.clone(),
+                    });
+                }
+                PluginMessage::Error { protocol_version, request_id, code, message } => {
+                    if protocol_version != PROTOCOL_V1
+                        || request_id.as_deref() != Some(request.request_id)
+                        || !valid_token(&code, 64)
+                        || message.len() > 4096
+                    {
+                        return finish_error(
+                            child,
+                            reader,
+                            stderr_reader,
+                            PluginError::new(
+                                PluginErrorCode::Protocol,
+                                "invalid plugin error frame",
+                            ),
+                        );
+                    }
+                    return finish_error(
+                        child,
+                        reader,
+                        stderr_reader,
+                        PluginError::new(
+                            PluginErrorCode::Plugin,
+                            format!("plugin returned {code}"),
+                        ),
+                    );
+                }
+                PluginMessage::Hello { .. } => {
+                    return finish_error(
+                        child,
+                        reader,
+                        stderr_reader,
+                        PluginError::new(PluginErrorCode::Protocol, "duplicate handshake"),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn write_request_bounded(
+    mut stdin: Box<dyn std::io::Write + Send>,
+    request: HostMessage,
+    maximum: u32,
+    child: &mut sandbox::SandboxChild,
+    context: &ExecutionContext,
+    deadline: Option<Instant>,
+) -> Result<Box<dyn std::io::Write + Send>, PluginError> {
+    let (finished_tx, finished_rx) = mpsc::sync_channel(1);
+    let writer = std::thread::Builder::new()
+        .name("process-plugin-request".into())
+        .spawn(move || {
+            let result = protocol::write_frame(&mut stdin, &request, maximum);
+            let _ = finished_tx.send((stdin, result));
+        })
+        .map_err(|_| PluginError::new(PluginErrorCode::Launch, "request writer unavailable"))?;
+    loop {
+        match finished_rx.recv_timeout(Duration::from_millis(5)) {
+            Ok((stdin, result)) => {
+                let _ = writer.join();
+                return result.map(|()| stdin).map_err(|error| map_write_error(&error));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                let _ = writer.join();
+                return Err(PluginError::new(
+                    PluginErrorCode::Protocol,
+                    "request writer ended unexpectedly",
+                ));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+        }
+        let context_error = context.checkpoint().err().map(|error| map_execution_error(&error));
+        let policy_timeout = deadline.is_some_and(|value| Instant::now() >= value);
+        let child_ended = child.try_wait().ok().flatten().is_some();
+        if context_error.is_some() || policy_timeout || child_ended {
+            child.terminate();
+            let _ = writer.join();
+            return Err(context_error.unwrap_or_else(|| {
+                if policy_timeout {
+                    PluginError::new(PluginErrorCode::Timeout, "plugin request write timed out")
+                } else {
+                    PluginError::new(
+                        PluginErrorCode::Crashed,
+                        "plugin exited while receiving request",
+                    )
+                }
+            }));
+        }
+    }
+}
+
+fn receive_until(
+    frames: &mpsc::Receiver<std::io::Result<PluginMessage>>,
+    child: &mut sandbox::SandboxChild,
+    context: &ExecutionContext,
+    deadline: Option<Instant>,
+    request_active: bool,
+) -> Result<PluginMessage, PluginError> {
+    loop {
+        if request_active {
+            context.checkpoint().map_err(|error| map_execution_error(&error))?;
+        }
+        if deadline.is_some_and(|value| Instant::now() >= value) {
+            return Err(PluginError::new(
+                PluginErrorCode::Timeout,
+                if request_active {
+                    "plugin request timed out"
+                } else {
+                    "plugin handshake timed out"
+                },
+            ));
+        }
+        match frames.recv_timeout(Duration::from_millis(5)) {
+            Ok(Ok(frame)) => return Ok(frame),
+            Ok(Err(error)) => {
+                let detail = error.to_string();
+                let code = if detail.contains("stream ended before frame") {
+                    PluginErrorCode::Crashed
+                } else if detail.contains("exceeds limit") {
+                    PluginErrorCode::FrameTooLarge
+                } else {
+                    PluginErrorCode::Protocol
+                };
+                return Err(PluginError::new(code, "plugin protocol stream is malformed"));
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(PluginError::new(
+                    PluginErrorCode::Crashed,
+                    "plugin protocol stream ended",
+                ));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if child
+                    .try_wait()
+                    .map_err(|()| PluginError::new(PluginErrorCode::Crashed, "plugin wait failed"))?
+                    .is_some()
+                {
+                    return Err(PluginError::new(
+                        PluginErrorCode::Crashed,
+                        "plugin exited before terminal response",
+                    ));
+                }
+            }
+        }
+    }
+}
+
+fn finish_error(
+    mut child: sandbox::SandboxChild,
+    reader: ProtocolReader,
+    stderr: std::thread::JoinHandle<()>,
+    error: PluginError,
+) -> Result<PluginExecution, PluginError> {
+    terminate_tree(&mut child);
+    let _ = reader.join();
+    let _ = stderr.join();
+    Err(error)
+}
+
+struct ProtocolReader {
+    stop: Arc<AtomicBool>,
+    handle: std::thread::JoinHandle<()>,
+}
+
+impl ProtocolReader {
+    fn join(self) -> std::thread::Result<()> {
+        self.stop.store(true, Ordering::Release);
+        self.handle.join()
+    }
+
+    fn join_after_drain(self, frames: &mpsc::Receiver<std::io::Result<PluginMessage>>) -> bool {
+        let mut extra = false;
+        for frame in frames {
+            extra |= frame.is_ok();
+        }
+        let _ = self.handle.join();
+        extra
+    }
+}
+
+fn wait_bounded(child: &mut sandbox::SandboxChild, duration: Duration) -> Option<bool> {
+    let deadline = Instant::now().checked_add(duration)?;
+    loop {
+        if let Ok(Some(success)) = child.try_wait() {
+            return Some(success);
+        }
+        if Instant::now() >= deadline {
+            return None;
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+}
+
+fn terminate_tree(child: &mut sandbox::SandboxChild) {
+    child.terminate();
+}
+
+fn drain_stderr(mut stderr: impl std::io::Read) {
+    let mut buffer = [0_u8; 4096];
+    let mut total = 0_usize;
+    loop {
+        match stderr.read(&mut buffer) {
+            Ok(0) | Err(_) => break,
+            Ok(read) => total = total.saturating_add(read).min(16 * 1024),
+        }
+    }
+    let _ = total;
+}
+
+fn validate_policy(policy: &RuntimePolicy) -> Result<(), PluginError> {
+    if !(1024..=protocol::ABSOLUTE_MAX_FRAME_BYTES).contains(&policy.max_frame_bytes)
+        || policy.max_output_bytes == 0
+        || policy.max_output_bytes > u64::from(policy.max_frame_bytes)
+        || policy.max_memory_bytes < 32 * 1024 * 1024
+        || policy.max_file_bytes == 0
+        || !(16..=4096).contains(&policy.max_open_files)
+        || policy.handshake_timeout.is_zero()
+        || policy.request_timeout.is_zero()
+        || policy.request_timeout > Duration::from_hours(1)
+        || policy.cancellation_grace > Duration::from_secs(5)
+        || policy.environment.len() > 64
+    {
+        return Err(PluginError::new(PluginErrorCode::Authority, "invalid runtime policy"));
+    }
+    for (name, value) in &policy.environment {
+        let name = name.to_str().ok_or_else(|| {
+            PluginError::new(PluginErrorCode::Authority, "environment name is not UTF-8")
+        })?;
+        let value = value.to_str().ok_or_else(|| {
+            PluginError::new(PluginErrorCode::Authority, "environment value is not UTF-8")
+        })?;
+        if !valid_environment_name(name)
+            || reserved_environment_name(name)
+            || value.len() > 4096
+            || value.contains('\0')
+        {
+            return Err(PluginError::new(
+                PluginErrorCode::Authority,
+                "invalid declared environment",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_manifest(
+    manifest: PluginManifest,
+    maximum_file_bytes: u64,
+) -> Result<ValidatedPlugin, PluginError> {
+    if !valid_token(&manifest.plugin_id, 128)
+        || manifest.protocol_versions.is_empty()
+        || manifest.protocol_versions.len() > 8
+        || !manifest.protocol_versions.contains(&PROTOCOL_V1)
+        || manifest.protocol_versions.iter().copied().collect::<BTreeSet<_>>().len()
+            != manifest.protocol_versions.len()
+        || !valid_sha256(&manifest.executable_sha256)
+    {
+        return Err(PluginError::new(PluginErrorCode::Authority, "invalid plugin manifest"));
+    }
+    let executable = canonical_regular_file(&manifest.executable)?;
+    let runtime_root = canonical_directory(&manifest.runtime_root)?;
+    if !executable.starts_with(&runtime_root) {
+        return Err(PluginError::new(
+            PluginErrorCode::Authority,
+            "executable escapes runtime root",
+        ));
+    }
+    let plugin = ValidatedPlugin {
+        plugin_id: manifest.plugin_id,
+        executable,
+        runtime_root,
+        executable_sha256: manifest.executable_sha256,
+        protocol_versions: manifest.protocol_versions,
+    };
+    verify_executable(&plugin, maximum_file_bytes)?;
+    Ok(plugin)
+}
+
+fn verify_executable(plugin: &ValidatedPlugin, maximum_file_bytes: u64) -> Result<(), PluginError> {
+    if canonical_regular_file(&plugin.executable)? != plugin.executable {
+        return Err(PluginError::new(PluginErrorCode::Authority, "executable identity changed"));
+    }
+    let metadata = std::fs::metadata(&plugin.executable).map_err(|_| {
+        PluginError::new(PluginErrorCode::Authority, "executable metadata unavailable")
+    })?;
+    let maximum = maximum_file_bytes.min(ABSOLUTE_EXECUTABLE_BYTES);
+    if metadata.len() == 0 || metadata.len() > maximum {
+        return Err(PluginError::new(
+            PluginErrorCode::Authority,
+            "executable exceeds authenticated file limit",
+        ));
+    }
+    let mut file = std::fs::File::open(&plugin.executable)
+        .map_err(|_| PluginError::new(PluginErrorCode::Authority, "executable cannot be read"))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = vec![0_u8; HASH_BUFFER_SIZE].into_boxed_slice();
+    let mut total = 0_u64;
+    loop {
+        let read = file
+            .read(&mut buffer)
+            .map_err(|_| PluginError::new(PluginErrorCode::Authority, "executable read failed"))?;
+        if read == 0 {
+            break;
+        }
+        total = total.saturating_add(read as u64);
+        if total > maximum {
+            return Err(PluginError::new(
+                PluginErrorCode::Authority,
+                "executable exceeds authenticated file limit",
+            ));
+        }
+        hasher.update(&buffer[..read]);
+    }
+    if total != metadata.len() {
+        return Err(PluginError::new(PluginErrorCode::Authority, "executable size changed"));
+    }
+    let digest = format!("{:x}", hasher.finalize());
+    if digest != plugin.executable_sha256 {
+        return Err(PluginError::new(PluginErrorCode::Authority, "executable digest mismatch"));
+    }
+    Ok(())
+}
+
+fn stage_plugin(
+    plugin: &ValidatedPlugin,
+    policy: &RuntimePolicy,
+    directory_guard: tempfile::TempDir,
+    context: &ExecutionContext,
+) -> Result<StagedPlugin, PluginError> {
+    let private_root = directory_guard.path().canonicalize().map_err(|_| {
+        PluginError::new(PluginErrorCode::Launch, "private working directory identity failed")
+    })?;
+    let runtime = private_root.join("runtime");
+    let working = private_root.join("work");
+    std::fs::create_dir(&runtime)
+        .and_then(|()| std::fs::create_dir(&working))
+        .map_err(|_| PluginError::new(PluginErrorCode::Launch, "private runtime unavailable"))?;
+    let executable_relative =
+        plugin.executable.strip_prefix(&plugin.runtime_root).map_err(|_| {
+            PluginError::new(PluginErrorCode::Authority, "executable runtime identity changed")
+        })?;
+    let temporary =
+        copy_runtime_tree(&plugin.runtime_root, &runtime, policy.max_file_bytes, context)?;
+    let executable = runtime.join(executable_relative).canonicalize().map_err(|_| {
+        PluginError::new(PluginErrorCode::Authority, "staged executable unavailable")
+    })?;
+    make_staged_file_private(&executable, true)?;
+    let runtime_root = runtime
+        .canonicalize()
+        .map_err(|_| PluginError::new(PluginErrorCode::Authority, "staged runtime unavailable"))?;
+    let working = working.canonicalize().map_err(|_| {
+        PluginError::new(PluginErrorCode::Launch, "private work directory unavailable")
+    })?;
+    Ok(StagedPlugin {
+        plugin: ValidatedPlugin {
+            plugin_id: plugin.plugin_id.clone(),
+            executable,
+            runtime_root,
+            executable_sha256: plugin.executable_sha256.clone(),
+            protocol_versions: plugin.protocol_versions.clone(),
+        },
+        working_directory: working,
+        _directory: directory_guard,
+        _temporary: temporary,
+    })
+}
+
+struct StagedPlugin {
+    plugin: ValidatedPlugin,
+    working_directory: PathBuf,
+    // Fields drop in declaration order: remove files before releasing their accounting guard.
+    _directory: tempfile::TempDir,
+    _temporary: ResourceReservation,
+}
+
+#[allow(clippy::too_many_lines)]
+fn copy_runtime_tree(
+    source: &Path,
+    destination: &Path,
+    maximum_file: u64,
+    context: &ExecutionContext,
+) -> Result<ResourceReservation, PluginError> {
+    let mut pending = vec![(source.to_path_buf(), destination.to_path_buf())];
+    let mut entries = 0_usize;
+    let mut total = 0_u64;
+    let mut temporary =
+        context.reserve_temporary(0).map_err(|error| map_execution_error(&error))?;
+    let mut buffer = vec![0_u8; HASH_BUFFER_SIZE].into_boxed_slice();
+    while let Some((source_directory, destination_directory)) = pending.pop() {
+        let children = std::fs::read_dir(&source_directory)
+            .map_err(|_| PluginError::new(PluginErrorCode::Authority, "runtime tree unreadable"))?;
+        for child in children {
+            let child = child.map_err(|_| {
+                PluginError::new(PluginErrorCode::Authority, "runtime entry unreadable")
+            })?;
+            entries = entries.saturating_add(1);
+            if entries > ABSOLUTE_RUNTIME_ENTRIES {
+                return Err(PluginError::new(
+                    PluginErrorCode::Authority,
+                    "runtime tree entry limit exceeded",
+                ));
+            }
+            let source_path = child.path();
+            let destination_path = destination_directory.join(child.file_name());
+            let metadata = std::fs::symlink_metadata(&source_path).map_err(|_| {
+                PluginError::new(PluginErrorCode::Authority, "runtime entry metadata unavailable")
+            })?;
+            if metadata.file_type().is_symlink() {
+                return Err(PluginError::new(
+                    PluginErrorCode::Authority,
+                    "runtime tree contains a symbolic link",
+                ));
+            }
+            if metadata.is_dir() {
+                std::fs::create_dir(&destination_path).map_err(|_| {
+                    PluginError::new(PluginErrorCode::Launch, "staged runtime directory failed")
+                })?;
+                pending.push((source_path, destination_path));
+            } else if metadata.is_file() {
+                let maximum = maximum_file.min(ABSOLUTE_EXECUTABLE_BYTES);
+                if metadata.len() > maximum {
+                    return Err(PluginError::new(
+                        PluginErrorCode::Authority,
+                        "runtime file limit exceeded",
+                    ));
+                }
+                let mut source_file = std::fs::File::open(&source_path).map_err(|_| {
+                    PluginError::new(PluginErrorCode::Authority, "runtime file unreadable")
+                })?;
+                let mut destination_file = std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&destination_path)
+                    .map_err(|_| {
+                        PluginError::new(PluginErrorCode::Launch, "staged runtime create failed")
+                    })?;
+                let mut copied = 0_u64;
+                loop {
+                    context.checkpoint().map_err(|error| map_execution_error(&error))?;
+                    let read = source_file.read(&mut buffer).map_err(|_| {
+                        PluginError::new(PluginErrorCode::Authority, "runtime file read failed")
+                    })?;
+                    if read == 0 {
+                        break;
+                    }
+                    copied = copied.saturating_add(read as u64);
+                    if copied > metadata.len() || copied > maximum {
+                        return Err(PluginError::new(
+                            PluginErrorCode::Authority,
+                            "runtime file changed while staging",
+                        ));
+                    }
+                    temporary.grow(read as u64).map_err(|error| map_execution_error(&error))?;
+                    std::io::Write::write_all(&mut destination_file, &buffer[..read]).map_err(
+                        |_| {
+                            PluginError::new(PluginErrorCode::Launch, "staged runtime write failed")
+                        },
+                    )?;
+                }
+                drop(destination_file);
+                let copied = std::fs::metadata(&destination_path)
+                    .map_err(|_| {
+                        PluginError::new(PluginErrorCode::Launch, "staged runtime metadata failed")
+                    })?
+                    .len();
+                if copied != metadata.len() || copied > maximum {
+                    return Err(PluginError::new(
+                        PluginErrorCode::Authority,
+                        "runtime file changed while staging",
+                    ));
+                }
+                total = total.saturating_add(copied);
+                if total > ABSOLUTE_RUNTIME_BYTES {
+                    return Err(PluginError::new(
+                        PluginErrorCode::Authority,
+                        "runtime tree byte limit exceeded",
+                    ));
+                }
+                make_staged_file_private(&destination_path, false)?;
+            } else {
+                return Err(PluginError::new(
+                    PluginErrorCode::Authority,
+                    "runtime tree contains a special file",
+                ));
+            }
+        }
+    }
+    Ok(temporary)
+}
+
+#[allow(clippy::unnecessary_wraps)] // Windows needs no chmod; Unix reports permission failures.
+fn make_staged_file_private(path: &Path, executable: bool) -> Result<(), PluginError> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        let mode = if executable { 0o500 } else { 0o400 };
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode)).map_err(|_| {
+            PluginError::new(PluginErrorCode::Launch, "staged runtime permissions failed")
+        })?;
+    }
+    #[cfg(windows)]
+    {
+        let _ = (path, executable);
+    }
+    Ok(())
+}
+
+fn canonical_regular_file(path: &Path) -> Result<PathBuf, PluginError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|_| {
+        PluginError::new(PluginErrorCode::Authority, "executable metadata unavailable")
+    })?;
+    if !path.is_absolute() || metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(PluginError::new(
+            PluginErrorCode::Authority,
+            "executable is not a private regular file",
+        ));
+    }
+    path.canonicalize().map_err(|_| {
+        PluginError::new(PluginErrorCode::Authority, "executable canonicalization failed")
+    })
+}
+
+fn canonical_directory(path: &Path) -> Result<PathBuf, PluginError> {
+    let metadata = std::fs::symlink_metadata(path).map_err(|_| {
+        PluginError::new(PluginErrorCode::Authority, "runtime root metadata unavailable")
+    })?;
+    if !path.is_absolute() || metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err(PluginError::new(
+            PluginErrorCode::Authority,
+            "runtime root is not a canonical directory",
+        ));
+    }
+    path.canonicalize().map_err(|_| {
+        PluginError::new(PluginErrorCode::Authority, "runtime root canonicalization failed")
+    })
+}
+
+fn validate_request(
+    request: &PluginRequest<'_>,
+    policy: &RuntimePolicy,
+) -> Result<(), PluginError> {
+    let encoded = request
+        .source
+        .len()
+        .checked_mul(4)
+        .and_then(|value| value.checked_add(2))
+        .map(|value| value / 3)
+        .ok_or_else(|| {
+            PluginError::new(PluginErrorCode::ResourceLimit, "source encoding overflow")
+        })?;
+    if !valid_token(request.request_id, 128)
+        || !valid_token(request.input_format, 64)
+        || request.source.is_empty()
+        || encoded.saturating_add(4096) > policy.max_frame_bytes as usize
+        || request.source_name.is_some_and(|name| name.len() > 1024 || name.contains('\0'))
+    {
+        return Err(PluginError::new(
+            PluginErrorCode::ResourceLimit,
+            "request exceeds process protocol limits",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_event(
+    version: u32,
+    id: &str,
+    expected: &str,
+    sequence: u64,
+    last: &mut u64,
+) -> Result<(), PluginError> {
+    if version != PROTOCOL_V1 || id != expected || sequence == 0 || sequence <= *last {
+        return Err(PluginError::new(
+            PluginErrorCode::Protocol,
+            "invalid event identity or ordering",
+        ));
+    }
+    *last = sequence;
+    Ok(())
+}
+
+fn parse_stage(stage: &str) -> Result<ExecutionStage, PluginError> {
+    match stage {
+        "resolving" => Ok(ExecutionStage::Resolving),
+        "detecting" => Ok(ExecutionStage::Detecting),
+        "probing" => Ok(ExecutionStage::Probing),
+        "converting" => Ok(ExecutionStage::Converting),
+        "ai" => Ok(ExecutionStage::Ai),
+        "ocr" => Ok(ExecutionStage::Ocr),
+        "rendering" => Ok(ExecutionStage::Rendering),
+        "completed" => Ok(ExecutionStage::Completed),
+        _ => Err(PluginError::new(PluginErrorCode::Protocol, "unknown progress stage")),
+    }
+}
+
+fn map_execution_error(error: &into_markdown_core::ConversionError) -> PluginError {
+    match error {
+        into_markdown_core::ConversionError::Cancelled => {
+            PluginError::new(PluginErrorCode::Cancelled, "plugin request cancelled")
+        }
+        into_markdown_core::ConversionError::Timeout => {
+            PluginError::new(PluginErrorCode::Timeout, "plugin request timed out")
+        }
+        _ => PluginError::new(
+            PluginErrorCode::ResourceLimit,
+            "execution context rejected plugin event",
+        ),
+    }
+}
+
+fn map_write_error(error: &std::io::Error) -> PluginError {
+    let code = if error.to_string().contains("exceeds limit") {
+        PluginErrorCode::FrameTooLarge
+    } else {
+        PluginErrorCode::Protocol
+    };
+    PluginError::new(code, "host could not write protocol frame")
+}
+
+fn valid_token(value: &str, maximum: usize) -> bool {
+    !value.is_empty()
+        && value.len() <= maximum
+        && value.bytes().all(|byte| {
+            byte.is_ascii_lowercase() || byte.is_ascii_digit() || matches!(byte, b'.' | b'_' | b'-')
+        })
+}
+
+fn valid_environment_name(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && !value.starts_with('=')
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
+fn reserved_environment_name(value: &str) -> bool {
+    matches!(
+        value,
+        "INTO_MARKDOWN_PLUGIN_PROTOCOL"
+            | "SYSTEMROOT"
+            | "WINDIR"
+            | "SYSTEMDRIVE"
+            | "USERPROFILE"
+            | "LOCALAPPDATA"
+            | "APPDATA"
+            | "TEMP"
+            | "TMP"
+    )
+}
+
+fn valid_sha256(value: &str) -> bool {
+    value.len() == 64
+        && value.bytes().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn request_nonce(request_id: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"into-markdown/process-v1/nonce\0");
+    hasher.update(request_id.as_bytes());
+    hasher.update(std::process::id().to_le_bytes());
+    let time = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    hasher.update(time.to_le_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn policy_rejects_host_owned_environment_names() {
+        for name in [
+            "INTO_MARKDOWN_PLUGIN_PROTOCOL",
+            "SYSTEMROOT",
+            "WINDIR",
+            "SYSTEMDRIVE",
+            "USERPROFILE",
+            "LOCALAPPDATA",
+            "APPDATA",
+            "TEMP",
+            "TMP",
+        ] {
+            let mut policy = RuntimePolicy::default();
+            policy.environment.insert(name.into(), "attacker-controlled".into());
+            assert_eq!(validate_policy(&policy).unwrap_err().code, PluginErrorCode::Authority);
+        }
+        let mut policy = RuntimePolicy::default();
+        policy.environment.insert("PLUGIN_LOCALE".into(), "en-US".into());
+        validate_policy(&policy).unwrap();
+    }
+}

--- a/crates/process-plugin/src/protocol.rs
+++ b/crates/process-plugin/src/protocol.rs
@@ -1,0 +1,158 @@
+use serde::{Deserialize, Serialize};
+use std::io::{self, Read, Write};
+
+/// The only process-plugin protocol revision implemented by this crate.
+pub const PROTOCOL_V1: u32 = 1;
+/// Hard ceiling independent of caller policy. A peer cannot make the host allocate beyond it.
+pub const ABSOLUTE_MAX_FRAME_BYTES: u32 = 64 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum HostMessage {
+    Hello {
+        supported_versions: Vec<u32>,
+        plugin_id: String,
+        nonce: String,
+    },
+    Request {
+        protocol_version: u32,
+        request_id: String,
+        input_format: String,
+        source_name: Option<String>,
+        source_base64: String,
+        maximum_output_bytes: u64,
+    },
+    Cancel {
+        protocol_version: u32,
+        request_id: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) enum PluginMessage {
+    Hello {
+        selected_version: u32,
+        plugin_id: String,
+        nonce: String,
+    },
+    Progress {
+        protocol_version: u32,
+        request_id: String,
+        sequence: u64,
+        stage: String,
+        completed_units: Option<u64>,
+        total_units: Option<u64>,
+        message: Option<String>,
+    },
+    Diagnostic {
+        protocol_version: u32,
+        request_id: String,
+        sequence: u64,
+        diagnostic_json: String,
+    },
+    Response {
+        protocol_version: u32,
+        request_id: String,
+        result_json: String,
+    },
+    Error {
+        protocol_version: u32,
+        request_id: Option<String>,
+        code: String,
+        message: String,
+    },
+}
+
+pub(crate) fn write_frame<T: Serialize>(
+    output: &mut impl Write,
+    value: &T,
+    maximum: u32,
+) -> io::Result<()> {
+    let bytes = serde_json::to_vec(value)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let length = u32::try_from(bytes.len())
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "frame length overflow"))?;
+    if length == 0 || length > maximum || length > ABSOLUTE_MAX_FRAME_BYTES {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "frame exceeds limit"));
+    }
+    output.write_all(&length.to_le_bytes())?;
+    output.write_all(&bytes)?;
+    output.flush()
+}
+
+pub(crate) fn read_frame<T: for<'de> Deserialize<'de>>(
+    input: &mut impl Read,
+    maximum: u32,
+) -> io::Result<T> {
+    let mut prefix = [0_u8; 4];
+    let mut prefix_bytes = 0_usize;
+    while prefix_bytes < prefix.len() {
+        match input.read(&mut prefix[prefix_bytes..])? {
+            0 if prefix_bytes == 0 => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "stream ended before frame",
+                ));
+            }
+            0 => {
+                return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "truncated frame prefix"));
+            }
+            read => prefix_bytes += read,
+        }
+    }
+    let length = u32::from_le_bytes(prefix);
+    if length == 0 || length > maximum || length > ABSOLUTE_MAX_FRAME_BYTES {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "frame exceeds limit"));
+    }
+    let mut bytes = Vec::new();
+    bytes
+        .try_reserve_exact(length as usize)
+        .map_err(|_| io::Error::new(io::ErrorKind::OutOfMemory, "frame allocation failed"))?;
+    bytes.resize(length as usize, 0);
+    input.read_exact(&mut bytes).map_err(|error| {
+        if error.kind() == io::ErrorKind::UnexpectedEof {
+            io::Error::new(io::ErrorKind::UnexpectedEof, "truncated frame body")
+        } else {
+            error
+        }
+    })?;
+    let mut decoder = serde_json::Deserializer::from_slice(&bytes);
+    let value = T::deserialize(&mut decoder)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    decoder.end().map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    Ok(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_round_trip_and_little_endian_prefix() {
+        let value = HostMessage::Cancel { protocol_version: 1, request_id: "request-1".into() };
+        let mut bytes = Vec::new();
+        write_frame(&mut bytes, &value, 4096).unwrap();
+        assert_eq!(u32::from_le_bytes(bytes[..4].try_into().unwrap()) as usize, bytes.len() - 4);
+        assert_eq!(read_frame::<HostMessage>(&mut bytes.as_slice(), 4096).unwrap(), value);
+    }
+
+    #[test]
+    fn empty_oversize_truncated_unknown_and_trailing_frames_fail_closed() {
+        for bytes in [
+            0_u32.to_le_bytes().to_vec(),
+            4097_u32.to_le_bytes().to_vec(),
+            [5_u32.to_le_bytes().as_slice(), b"{}"].concat(),
+        ] {
+            assert!(read_frame::<HostMessage>(&mut bytes.as_slice(), 4096).is_err());
+        }
+        let unknown = br#"{"type":"cancel","protocol_version":1,"request_id":"x","extra":1}"#;
+        let mut framed = u32::try_from(unknown.len()).unwrap().to_le_bytes().to_vec();
+        framed.extend_from_slice(unknown);
+        assert!(read_frame::<HostMessage>(&mut framed.as_slice(), 4096).is_err());
+        let trailing = br#"{"type":"cancel","protocol_version":1,"request_id":"x"} false"#;
+        let mut framed = u32::try_from(trailing.len()).unwrap().to_le_bytes().to_vec();
+        framed.extend_from_slice(trailing);
+        assert!(read_frame::<HostMessage>(&mut framed.as_slice(), 4096).is_err());
+    }
+}

--- a/crates/process-plugin/src/sandbox/mod.rs
+++ b/crates/process-plugin/src/sandbox/mod.rs
@@ -1,0 +1,128 @@
+use crate::{PluginError, PluginErrorCode, RuntimePolicy, ValidatedPlugin};
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+
+#[cfg(unix)]
+mod unix;
+#[cfg(windows)]
+mod windows;
+
+pub(crate) fn working_directory(policy: &RuntimePolicy) -> Result<tempfile::TempDir, PluginError> {
+    #[cfg(unix)]
+    {
+        let _ = policy;
+        return tempfile::Builder::new().prefix("into-md-plugin-").tempdir().map_err(|_| {
+            PluginError::new(PluginErrorCode::Launch, "private working directory unavailable")
+        });
+    }
+    #[cfg(windows)]
+    {
+        return windows::working_directory(policy);
+    }
+    #[allow(unreachable_code)]
+    Err(PluginError::new(PluginErrorCode::SandboxUnavailable, "unsupported target"))
+}
+
+pub(crate) fn spawn(
+    plugin: &ValidatedPlugin,
+    policy: &RuntimePolicy,
+    directory: &std::path::Path,
+) -> Result<SandboxChild, PluginError> {
+    let mut command = Command::new(&plugin.executable);
+    command
+        .current_dir(directory)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env_clear();
+    for (name, value) in &policy.environment {
+        command.env(name, value);
+    }
+    command.env("INTO_MARKDOWN_PLUGIN_PROTOCOL", "process-v1");
+    #[cfg(unix)]
+    unix::prepare(&mut command, plugin, policy, directory)?;
+    #[cfg(windows)]
+    return windows::spawn(command, plugin, policy, directory);
+    #[cfg(unix)]
+    return command.spawn().map(SandboxChild::Unix).map_err(|error| {
+        PluginError::new(
+            PluginErrorCode::Launch,
+            format!("plugin launch failed (os={:?})", error.raw_os_error()),
+        )
+    });
+    #[allow(unreachable_code)]
+    Err(PluginError::new(PluginErrorCode::SandboxUnavailable, "unsupported target"))
+}
+
+pub(crate) enum SandboxChild {
+    #[cfg(unix)]
+    Unix(std::process::Child),
+    #[cfg(windows)]
+    Windows(windows::Child),
+}
+
+impl SandboxChild {
+    pub(crate) fn take_stdin(&mut self) -> Option<Box<dyn Write + Send>> {
+        match self {
+            #[cfg(unix)]
+            Self::Unix(child) => child.stdin.take().map(|value| Box::new(value) as _),
+            #[cfg(windows)]
+            Self::Windows(child) => child.take_stdin().map(|value| Box::new(value) as _),
+        }
+    }
+
+    pub(crate) fn take_stdout(&mut self) -> Option<Box<dyn Read + Send>> {
+        match self {
+            #[cfg(unix)]
+            Self::Unix(child) => child.stdout.take().map(|value| Box::new(value) as _),
+            #[cfg(windows)]
+            Self::Windows(child) => child.take_stdout().map(|value| Box::new(value) as _),
+        }
+    }
+
+    pub(crate) fn take_stderr(&mut self) -> Option<Box<dyn Read + Send>> {
+        match self {
+            #[cfg(unix)]
+            Self::Unix(child) => child.stderr.take().map(|value| Box::new(value) as _),
+            #[cfg(windows)]
+            Self::Windows(child) => child.take_stderr().map(|value| Box::new(value) as _),
+        }
+    }
+
+    pub(crate) fn try_wait(&mut self) -> Result<Option<bool>, ()> {
+        match self {
+            #[cfg(unix)]
+            Self::Unix(child) => {
+                child.try_wait().map(|value| value.map(|status| status.success())).map_err(|_| ())
+            }
+            #[cfg(windows)]
+            Self::Windows(child) => child.try_wait(),
+        }
+    }
+
+    pub(crate) fn terminate(&mut self) {
+        match self {
+            #[cfg(unix)]
+            Self::Unix(child) => {
+                // SAFETY: `process_group(0)` created a group whose ID is the child PID; a negative
+                // PID addresses precisely that group. SIGKILL requires no pointer validity.
+                unsafe {
+                    let _ = libc::kill(-(child.id() as i32), libc::SIGKILL);
+                }
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            #[cfg(windows)]
+            Self::Windows(child) => child.terminate(),
+        }
+    }
+}
+
+impl Drop for SandboxChild {
+    fn drop(&mut self) {
+        // A failed status query is not proof of exit. Fail closed by attempting tree termination.
+        if !matches!(self.try_wait(), Ok(Some(_))) {
+            self.terminate();
+        }
+    }
+}

--- a/crates/process-plugin/src/sandbox/unix.rs
+++ b/crates/process-plugin/src/sandbox/unix.rs
@@ -1,0 +1,388 @@
+use crate::{PluginError, RuntimePolicy, ValidatedPlugin};
+use std::os::unix::process::CommandExt as _;
+use std::path::Path;
+use std::process::Command;
+
+pub(super) fn prepare(
+    command: &mut Command,
+    plugin: &ValidatedPlugin,
+    policy: &RuntimePolicy,
+    directory: &Path,
+) -> Result<(), PluginError> {
+    let memory = policy.max_memory_bytes;
+    let file = policy.max_file_bytes;
+    let open_files = policy.max_open_files;
+    command.process_group(0);
+    #[cfg(target_os = "linux")]
+    let landlock = linux::Landlock::prepare(&plugin.runtime_root, directory).map_err(|_| {
+        PluginError::new(crate::PluginErrorCode::SandboxUnavailable, "Landlock setup failed")
+    })?;
+    #[cfg(target_os = "linux")]
+    let mut seccomp = linux::Seccomp::prepare().map_err(|_| {
+        PluginError::new(crate::PluginErrorCode::SandboxUnavailable, "seccomp setup failed")
+    })?;
+    #[cfg(target_os = "macos")]
+    let seatbelt = macos::Seatbelt::prepare(&plugin.runtime_root, directory).map_err(|_| {
+        PluginError::new(crate::PluginErrorCode::SandboxUnavailable, "Seatbelt setup failed")
+    })?;
+    // SAFETY: on Linux, every allocation, path lookup, FD open, and BPF construction happened
+    // above the fork; the closure performs only raw async-signal-safe syscalls on owned storage.
+    // macOS sandbox_init is the platform's process activation API and receives a prebuilt profile.
+    unsafe {
+        command.pre_exec(move || {
+            install_limits(memory, file, open_files)?;
+            install_no_new_privileges()?;
+            #[cfg(target_os = "linux")]
+            {
+                landlock.restrict()?;
+                seccomp.install()?;
+            }
+            #[cfg(target_os = "macos")]
+            seatbelt.install()?;
+            Ok(())
+        });
+    }
+    Ok(())
+}
+
+fn install_limits(memory: u64, file: u64, open_files: u32) -> std::io::Result<()> {
+    set_limit(libc::RLIMIT_AS, memory)?;
+    set_limit(libc::RLIMIT_FSIZE, file)?;
+    set_limit(libc::RLIMIT_NOFILE, u64::from(open_files))?;
+    set_limit(libc::RLIMIT_CORE, 0)
+}
+
+fn install_no_new_privileges() -> std::io::Result<()> {
+    // Prevent privilege gain across the imminent plugin exec and every later exec.
+    // SAFETY: prctl takes scalar arguments only for PR_SET_NO_NEW_PRIVS.
+    if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+type RlimitResource = libc::c_int;
+#[cfg(target_os = "linux")]
+type RlimitResource = libc::__rlimit_resource_t;
+
+fn set_limit(resource: RlimitResource, value: u64) -> std::io::Result<()> {
+    let value = libc::rlim_t::try_from(value)
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let limit = libc::rlimit { rlim_cur: value, rlim_max: value };
+    // SAFETY: `limit` is initialized and the resource selector is one of the constants above.
+    if unsafe { libc::setrlimit(resource, &raw const limit) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+    use super::*;
+    use std::os::fd::{AsRawFd as _, FromRawFd as _, OwnedFd};
+    use std::os::unix::ffi::OsStrExt as _;
+
+    const CREATE_RULESET_VERSION: u32 = 1;
+    const RULE_PATH_BENEATH: u32 = 1;
+    const EXECUTE: u64 = 1 << 0;
+    const WRITE_FILE: u64 = 1 << 1;
+    const READ_FILE: u64 = 1 << 2;
+    const READ_DIR: u64 = 1 << 3;
+    const REMOVE_DIR: u64 = 1 << 4;
+    const REMOVE_FILE: u64 = 1 << 5;
+    const MAKE_CHAR: u64 = 1 << 6;
+    const MAKE_DIR: u64 = 1 << 7;
+    const MAKE_REG: u64 = 1 << 8;
+    const MAKE_SOCK: u64 = 1 << 9;
+    const MAKE_FIFO: u64 = 1 << 10;
+    const MAKE_BLOCK: u64 = 1 << 11;
+    const MAKE_SYM: u64 = 1 << 12;
+    const REFER: u64 = 1 << 13;
+    const TRUNCATE: u64 = 1 << 14;
+    const READ: u64 = EXECUTE | READ_FILE | READ_DIR;
+    const WRITE: u64 = WRITE_FILE
+        | REMOVE_DIR
+        | REMOVE_FILE
+        | MAKE_CHAR
+        | MAKE_DIR
+        | MAKE_REG
+        | MAKE_SOCK
+        | MAKE_FIFO
+        | MAKE_BLOCK
+        | MAKE_SYM
+        | REFER
+        | TRUNCATE;
+
+    #[repr(C)]
+    struct RulesetAttr {
+        handled_access_fs: u64,
+    }
+    #[repr(C)]
+    struct PathBeneathAttr {
+        allowed_access: u64,
+        parent_fd: i32,
+        reserved: u32,
+    }
+
+    pub(super) struct Landlock {
+        ruleset: OwnedFd,
+    }
+
+    impl Landlock {
+        pub(super) fn prepare(runtime: &Path, temporary: &Path) -> std::io::Result<Self> {
+            let attr = RulesetAttr { handled_access_fs: READ | WRITE };
+            // SAFETY: the kernel receives a correctly sized initialized ruleset structure.
+            let fd = unsafe {
+                libc::syscall(
+                    libc::SYS_landlock_create_ruleset,
+                    &raw const attr,
+                    std::mem::size_of::<RulesetAttr>(),
+                    0,
+                )
+            };
+            if fd < 0 {
+                // SAFETY: null/zero is the documented ABI-version query and has no side effects.
+                let _ = unsafe {
+                    libc::syscall(
+                        libc::SYS_landlock_create_ruleset,
+                        std::ptr::null::<RulesetAttr>(),
+                        0,
+                        CREATE_RULESET_VERSION,
+                    )
+                };
+                return Err(std::io::Error::last_os_error());
+            }
+            // SAFETY: a nonnegative return from create_ruleset is a newly owned FD.
+            let ruleset =
+                unsafe { OwnedFd::from_raw_fd(i32::try_from(fd).map_err(std::io::Error::other)?) };
+            add_path(&ruleset, runtime, READ)?;
+            add_path(&ruleset, temporary, READ | WRITE)?;
+            for path in ["/lib", "/lib64", "/usr/lib", "/usr/lib64", "/etc/ld.so.cache"] {
+                let path = Path::new(path);
+                if path.exists() {
+                    let access = if path.is_dir() { READ } else { READ_FILE };
+                    add_path(&ruleset, path, access)?;
+                }
+            }
+            Ok(Self { ruleset })
+        }
+
+        pub(super) fn restrict(&self) -> std::io::Result<()> {
+            // SAFETY: `ruleset` remains an owned valid Landlock FD through this call.
+            if unsafe {
+                libc::syscall(libc::SYS_landlock_restrict_self, self.ruleset.as_raw_fd(), 0)
+            } != 0
+            {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        }
+    }
+
+    fn add_path(ruleset: &OwnedFd, path: &Path, access: u64) -> std::io::Result<()> {
+        let value = std::ffi::CString::new(path.as_os_str().as_bytes())
+            .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+        // SAFETY: `value` is NUL-terminated; open returns an independent descriptor.
+        let fd = unsafe { libc::open(value.as_ptr(), libc::O_PATH | libc::O_CLOEXEC) };
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: a nonnegative open result is newly owned.
+        let parent = unsafe { OwnedFd::from_raw_fd(fd) };
+        let attr =
+            PathBeneathAttr { allowed_access: access, parent_fd: parent.as_raw_fd(), reserved: 0 };
+        // SAFETY: both FDs and the initialized path-beneath structure remain valid for the call.
+        if unsafe {
+            libc::syscall(
+                libc::SYS_landlock_add_rule,
+                ruleset.as_raw_fd(),
+                RULE_PATH_BENEATH,
+                &raw const attr,
+                0,
+            )
+        } != 0
+        {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    pub(super) struct Seccomp {
+        filters: Vec<libc::sock_filter>,
+        process_instruction: usize,
+        filter_count: u16,
+    }
+
+    impl Seccomp {
+        pub(super) fn prepare() -> std::io::Result<Self> {
+            const LD_W_ABS: u16 = 0x20;
+            const JMP_JEQ_K: u16 = 0x15;
+            const JMP_JSET_K: u16 = 0x45;
+            const RET_K: u16 = 0x06;
+            const KILL: u32 = 0x8000_0000;
+            const ALLOW: u32 = 0x7fff_0000;
+            const ERRNO: u32 = 0x0005_0000;
+            let arch = if cfg!(target_arch = "x86_64") { 0xc000_003e } else { 0xc000_00b7 };
+            let stmt = |code, k| libc::sock_filter { code, jt: 0, jf: 0, k };
+            let jump = |code, k, jt, jf| libc::sock_filter { code, jt, jf, k };
+            let denied = [
+                libc::SYS_socket,
+                libc::SYS_socketpair,
+                libc::SYS_connect,
+                libc::SYS_bind,
+                libc::SYS_listen,
+                libc::SYS_accept,
+                libc::SYS_accept4,
+                libc::SYS_ptrace,
+                libc::SYS_mount,
+                libc::SYS_umount2,
+                libc::SYS_unshare,
+                libc::SYS_setns,
+                libc::SYS_bpf,
+                libc::SYS_perf_event_open,
+                libc::SYS_keyctl,
+                libc::SYS_open_by_handle_at,
+                libc::SYS_kill,
+                libc::SYS_tkill,
+                libc::SYS_pidfd_send_signal,
+                libc::SYS_process_vm_readv,
+                libc::SYS_process_vm_writev,
+                libc::SYS_io_uring_setup,
+                libc::SYS_io_uring_enter,
+                libc::SYS_io_uring_register,
+            ];
+            let legacy: &[libc::c_long] =
+                if cfg!(target_arch = "x86_64") { &[libc::SYS_fork, libc::SYS_vfork] } else { &[] };
+            let mut filters = Vec::with_capacity(64 + denied.len() * 2);
+            filters.push(stmt(LD_W_ABS, 4));
+            filters.push(jump(JMP_JEQ_K, arch, 1, 0));
+            filters.push(stmt(RET_K, KILL));
+            filters.push(stmt(LD_W_ABS, 0));
+            filters.push(jump(
+                JMP_JEQ_K,
+                u32::try_from(libc::SYS_clone).map_err(std::io::Error::other)?,
+                0,
+                4,
+            ));
+            filters.push(stmt(LD_W_ABS, 16));
+            filters.push(jump(JMP_JSET_K, libc::CLONE_THREAD as u32, 1, 0));
+            filters.push(stmt(RET_K, ERRNO | libc::EPERM as u32));
+            filters.push(stmt(RET_K, ALLOW));
+            filters.push(jump(
+                JMP_JEQ_K,
+                u32::try_from(libc::SYS_clone3).map_err(std::io::Error::other)?,
+                0,
+                1,
+            ));
+            filters.push(stmt(RET_K, ERRNO | libc::ENOSYS as u32));
+            let process_instruction;
+            filters.push(jump(
+                JMP_JEQ_K,
+                u32::try_from(libc::SYS_tgkill).map_err(std::io::Error::other)?,
+                0,
+                4,
+            ));
+            filters.push(stmt(LD_W_ABS, 16));
+            process_instruction = filters.len();
+            filters.push(jump(JMP_JEQ_K, 0, 1, 0));
+            filters.push(stmt(RET_K, ERRNO | libc::EPERM as u32));
+            filters.push(stmt(RET_K, ALLOW));
+            for syscall in denied.into_iter().chain(legacy.iter().copied()) {
+                filters.push(jump(
+                    JMP_JEQ_K,
+                    u32::try_from(syscall).map_err(std::io::Error::other)?,
+                    0,
+                    1,
+                ));
+                filters.push(stmt(RET_K, ERRNO | libc::EPERM as u32));
+            }
+            filters.push(stmt(RET_K, ALLOW));
+            let filter_count = u16::try_from(filters.len()).map_err(std::io::Error::other)?;
+            Ok(Self { filters, process_instruction, filter_count })
+        }
+
+        pub(super) fn install(&mut self) -> std::io::Result<()> {
+            // SAFETY: getpid takes no pointers and is async-signal-safe.
+            self.filters[self.process_instruction].k = unsafe { libc::getpid() as u32 };
+            let program =
+                libc::sock_fprog { len: self.filter_count, filter: self.filters.as_mut_ptr() };
+            // SAFETY: `program` points to initialized BPF storage that lives through prctl.
+            if unsafe {
+                libc::prctl(libc::PR_SET_SECCOMP, libc::SECCOMP_MODE_FILTER, &raw const program)
+            } != 0
+            {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use std::fmt::Write as _;
+
+    #[link(name = "sandbox")]
+    unsafe extern "C" {
+        fn sandbox_init(
+            profile: *const libc::c_char,
+            flags: u64,
+            error: *mut *mut libc::c_char,
+        ) -> i32;
+        fn sandbox_free_error(error: *mut libc::c_char);
+    }
+
+    pub(super) struct Seatbelt {
+        profile: std::ffi::CString,
+    }
+
+    impl Seatbelt {
+        pub(super) fn prepare(runtime: &Path, temporary: &Path) -> std::io::Result<Self> {
+            let runtime = escape(runtime)?;
+            let temporary = escape(temporary)?;
+            let mut profile = String::from(
+                "(version 1)\n(deny default)\n(deny network*)\n(deny process-fork)\n(allow process-info*)\n(allow sysctl-read)\n(allow signal (target self))\n",
+            );
+            writeln!(profile, "(allow process-exec (subpath \"{runtime}\"))")
+                .map_err(std::io::Error::other)?;
+            writeln!(
+                profile,
+                "(allow file-read* (subpath \"{runtime}\") (subpath \"{temporary}\"))"
+            )
+            .map_err(std::io::Error::other)?;
+            writeln!(profile, "(allow file-write* (subpath \"{temporary}\"))")
+                .map_err(std::io::Error::other)?;
+            for root in ["/usr/lib", "/System/Library"] {
+                writeln!(profile, "(allow file-read* (subpath \"{root}\"))")
+                    .map_err(std::io::Error::other)?;
+            }
+            let profile =
+                std::ffi::CString::new(profile).map_err(|_| std::io::ErrorKind::InvalidInput)?;
+            Ok(Self { profile })
+        }
+
+        pub(super) fn install(&self) -> std::io::Result<()> {
+            let mut error = std::ptr::null_mut();
+            // SAFETY: the prebuilt NUL-terminated profile remains alive; `error` is writable.
+            let result = unsafe { sandbox_init(self.profile.as_ptr(), 0, &raw mut error) };
+            if !error.is_null() {
+                // SAFETY: sandbox_init returned this allocation for the matching free API.
+                unsafe { sandbox_free_error(error) };
+            }
+            if result != 0 {
+                return Err(std::io::Error::other("sandbox_init failed"));
+            }
+            Ok(())
+        }
+    }
+
+    fn escape(path: &Path) -> std::io::Result<String> {
+        let value = path.to_str().ok_or(std::io::ErrorKind::InvalidInput)?;
+        if value.bytes().any(|byte| byte == 0 || byte.is_ascii_control()) {
+            return Err(std::io::ErrorKind::InvalidInput.into());
+        }
+        Ok(value.replace('\\', "\\\\").replace('"', "\\\""))
+    }
+}

--- a/crates/process-plugin/src/sandbox/windows.rs
+++ b/crates/process-plugin/src/sandbox/windows.rs
@@ -1,0 +1,582 @@
+use crate::{PluginError, PluginErrorCode, RuntimePolicy, ValidatedPlugin};
+use std::fs::File;
+use std::mem::size_of;
+use std::os::windows::ffi::OsStrExt as _;
+use std::os::windows::io::{AsRawHandle as _, FromRawHandle as _, OwnedHandle};
+use std::path::Path;
+use windows_sys::Win32::Foundation::{
+    CloseHandle, HANDLE, HANDLE_FLAG_INHERIT, INVALID_HANDLE_VALUE, LocalFree,
+    SetHandleInformation, WAIT_OBJECT_0, WAIT_TIMEOUT,
+};
+use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+use windows_sys::Win32::Security::Isolation::{
+    DeriveAppContainerSidFromAppContainerName, GetAppContainerFolderPath,
+};
+use windows_sys::Win32::Security::{
+    FreeSid, GetTokenInformation, PSID, SECURITY_ATTRIBUTES, SECURITY_CAPABILITIES,
+    TOKEN_APPCONTAINER_INFORMATION, TokenAppContainerSid, TokenIsAppContainer,
+};
+use windows_sys::Win32::System::JobObjects::{
+    AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_ACTIVE_PROCESS,
+    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, JOB_OBJECT_LIMIT_PROCESS_MEMORY,
+    JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+    SetInformationJobObject, TerminateJobObject,
+};
+use windows_sys::Win32::System::Pipes::CreatePipe;
+use windows_sys::Win32::System::SystemInformation::GetWindowsDirectoryW;
+use windows_sys::Win32::System::Threading::{
+    CREATE_NO_WINDOW, CREATE_SUSPENDED, CREATE_UNICODE_ENVIRONMENT, CreateProcessW,
+    DeleteProcThreadAttributeList, EXTENDED_STARTUPINFO_PRESENT, GetExitCodeProcess,
+    InitializeProcThreadAttributeList, OpenProcessToken, PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
+    PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES, PROCESS_INFORMATION, ResumeThread,
+    STARTF_USESTDHANDLES, STARTUPINFOEXW, TerminateProcess, UpdateProcThreadAttribute,
+    WaitForSingleObject,
+};
+
+const INFINITE: u32 = u32::MAX;
+
+pub(crate) struct Child {
+    process: OwnedHandle,
+    job: OwnedHandle,
+    stdin: Option<File>,
+    stdout: Option<File>,
+    stderr: Option<File>,
+}
+
+impl Child {
+    pub(crate) fn take_stdin(&mut self) -> Option<File> {
+        self.stdin.take()
+    }
+    pub(crate) fn take_stdout(&mut self) -> Option<File> {
+        self.stdout.take()
+    }
+    pub(crate) fn take_stderr(&mut self) -> Option<File> {
+        self.stderr.take()
+    }
+
+    pub(crate) fn try_wait(&mut self) -> Result<Option<bool>, ()> {
+        // SAFETY: `process` owns a live or signalled kernel process handle for this entire call.
+        match unsafe { WaitForSingleObject(self.process.as_raw_handle(), 0) } {
+            WAIT_TIMEOUT => Ok(None),
+            WAIT_OBJECT_0 => {
+                let mut code = 0_u32;
+                // SAFETY: the signalled process handle is valid and `code` is writable.
+                if unsafe { GetExitCodeProcess(self.process.as_raw_handle(), &raw mut code) } == 0 {
+                    Err(())
+                } else {
+                    Ok(Some(code == 0))
+                }
+            }
+            _ => Err(()),
+        }
+    }
+
+    pub(crate) fn terminate(&mut self) {
+        // SAFETY: both owned handles remain valid; Job close-kill and explicit termination cover
+        // the full process tree, and waiting keeps teardown synchronous.
+        unsafe {
+            let _ = TerminateJobObject(self.job.as_raw_handle(), 1);
+            let _ = TerminateProcess(self.process.as_raw_handle(), 1);
+            let _ = WaitForSingleObject(self.process.as_raw_handle(), INFINITE);
+        }
+    }
+}
+
+pub(super) fn working_directory(policy: &RuntimePolicy) -> Result<tempfile::TempDir, PluginError> {
+    validate_storage(policy)?;
+    tempfile::Builder::new()
+        .prefix("into-md-plugin-")
+        .tempdir_in(&policy.windows.storage_root)
+        .map_err(|_| unavailable("AppContainer working directory unavailable"))
+}
+
+pub(super) fn spawn(
+    _command: std::process::Command,
+    plugin: &ValidatedPlugin,
+    policy: &RuntimePolicy,
+    directory: &Path,
+) -> Result<super::SandboxChild, PluginError> {
+    let _ = &plugin.runtime_root;
+    validate_storage(policy)?;
+    let sid = AppContainerSid::derive(&policy.windows.profile_name, &policy.windows.sid)?;
+    let stdin = Pipe::new(false)?;
+    let stdout = Pipe::new(true)?;
+    let stderr = Pipe::new(true)?;
+    let inherited = [stdin.child_raw(), stdout.child_raw(), stderr.child_raw()];
+    let capabilities = SECURITY_CAPABILITIES {
+        AppContainerSid: sid.as_ptr(),
+        Capabilities: std::ptr::null_mut(),
+        CapabilityCount: 0,
+        Reserved: 0,
+    };
+    let mut attributes = AttributeList::new(2)?;
+    attributes.update(
+        usize::try_from(PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES)
+            .map_err(|_| unavailable("attribute conversion failed"))?,
+        (&raw const capabilities).cast(),
+        size_of::<SECURITY_CAPABILITIES>(),
+    )?;
+    attributes.update(
+        usize::try_from(PROC_THREAD_ATTRIBUTE_HANDLE_LIST)
+            .map_err(|_| unavailable("attribute conversion failed"))?,
+        inherited.as_ptr().cast(),
+        size_of::<[HANDLE; 3]>(),
+    )?;
+    let mut startup = STARTUPINFOEXW::default();
+    startup.StartupInfo.cb = u32::try_from(size_of::<STARTUPINFOEXW>())
+        .map_err(|_| unavailable("startup conversion failed"))?;
+    startup.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    startup.StartupInfo.hStdInput = inherited[0];
+    startup.StartupInfo.hStdOutput = inherited[1];
+    startup.StartupInfo.hStdError = inherited[2];
+    startup.lpAttributeList = attributes.as_mut_ptr();
+    let application = wide_path(&plugin.executable)?;
+    let current_directory = wide_path(directory)?;
+    let environment = environment_block(policy, directory)?;
+    // Establish every fallible Job limit before creating a suspended process.
+    let job = create_job(policy.max_memory_bytes)?;
+    let mut information = PROCESS_INFORMATION::default();
+    // SAFETY: all UTF-16 buffers, startup attributes, capability/SID storage, inherited handles,
+    // and output pointers remain alive for the duration of CreateProcessW.
+    if unsafe {
+        CreateProcessW(
+            application.as_ptr(),
+            std::ptr::null_mut(),
+            std::ptr::null(),
+            std::ptr::null(),
+            1,
+            CREATE_SUSPENDED
+                | CREATE_NO_WINDOW
+                | CREATE_UNICODE_ENVIRONMENT
+                | EXTENDED_STARTUPINFO_PRESENT,
+            environment.as_ptr().cast(),
+            current_directory.as_ptr(),
+            &raw const startup.StartupInfo,
+            &raw mut information,
+        )
+    } == 0
+    {
+        let error = std::io::Error::last_os_error();
+        return Err(PluginError::new(
+            PluginErrorCode::Launch,
+            format!("AppContainer process launch failed (os={:?})", error.raw_os_error()),
+        ));
+    }
+    // SAFETY: successful CreateProcessW returns two new, non-null handles whose ownership passes
+    // to the caller exactly once.
+    let process = unsafe { OwnedHandle::from_raw_handle(information.hProcess) };
+    // SAFETY: as above, this is the separately owned primary-thread handle.
+    let thread = unsafe { OwnedHandle::from_raw_handle(information.hThread) };
+    // SAFETY: the owned Job and suspended process handles are valid and not shared mutably.
+    if unsafe { AssignProcessToJobObject(job.as_raw_handle(), process.as_raw_handle()) } == 0 {
+        terminate_suspended(&job, &process);
+        return Err(unavailable("AppContainer job assignment failed"));
+    }
+    match process_token_matches(process.as_raw_handle(), &policy.windows.sid) {
+        Ok(true) => {}
+        Ok(false) => {
+            terminate_suspended(&job, &process);
+            return Err(unavailable("AppContainer process identity mismatch"));
+        }
+        Err(error) => {
+            terminate_suspended(&job, &process);
+            return Err(error);
+        }
+    }
+    // SAFETY: `thread` is the still-suspended primary thread returned by CreateProcessW.
+    if unsafe { ResumeThread(thread.as_raw_handle()) } != 1 {
+        terminate_suspended(&job, &process);
+        return Err(unavailable("AppContainer identity/job installation failed"));
+    }
+    drop(thread);
+    drop(attributes);
+    Ok(super::SandboxChild::Windows(Child {
+        process,
+        job,
+        stdin: Some(stdin.into_parent()),
+        stdout: Some(stdout.into_parent()),
+        stderr: Some(stderr.into_parent()),
+    }))
+}
+
+fn terminate_suspended(job: &OwnedHandle, process: &OwnedHandle) {
+    // SAFETY: both handles are owned by the caller and valid. TerminateProcess also covers the
+    // rare AssignProcessToJobObject failure where the process never became a Job member.
+    unsafe {
+        let _ = TerminateJobObject(job.as_raw_handle(), 1);
+        let _ = TerminateProcess(process.as_raw_handle(), 1);
+        let _ = WaitForSingleObject(process.as_raw_handle(), INFINITE);
+    }
+}
+
+fn validate_storage(policy: &RuntimePolicy) -> Result<(), PluginError> {
+    if policy.windows.profile_name.is_empty() || !policy.windows.sid.starts_with("S-1-15-2-") {
+        return Err(unavailable("AppContainer authority missing"));
+    }
+    let sid = AppContainerSid::derive(&policy.windows.profile_name, &policy.windows.sid)?;
+    let actual = storage_path(sid.as_ptr())?;
+    let expected = policy
+        .windows
+        .storage_root
+        .canonicalize()
+        .map_err(|_| unavailable("AppContainer storage unavailable"))?;
+    if actual != expected || !expected.is_dir() {
+        return Err(unavailable("AppContainer storage identity mismatch"));
+    }
+    Ok(())
+}
+
+fn environment_block(policy: &RuntimePolicy, directory: &Path) -> Result<Vec<u16>, PluginError> {
+    let mut pairs = policy
+        .environment
+        .iter()
+        .map(|(key, value)| format!("{}={}", key.to_string_lossy(), value.to_string_lossy()))
+        .collect::<Vec<_>>();
+    pairs.push("INTO_MARKDOWN_PLUGIN_PROTOCOL=process-v1".into());
+    let windows = windows_directory()?;
+    let drive = Path::new(&windows)
+        .components()
+        .next()
+        .and_then(|component| match component {
+            std::path::Component::Prefix(prefix) => Some(prefix.as_os_str().to_string_lossy()),
+            _ => None,
+        })
+        .ok_or_else(|| unavailable("Windows system drive unavailable"))?;
+    let private = directory.to_string_lossy();
+    pairs.extend([
+        format!("SystemRoot={windows}"),
+        format!("windir={windows}"),
+        format!("SystemDrive={drive}"),
+        format!("USERPROFILE={private}"),
+        format!("LOCALAPPDATA={private}"),
+        format!("APPDATA={private}"),
+        format!("TEMP={private}"),
+        format!("TMP={private}"),
+    ]);
+    pairs.sort_by_key(|value| value.to_uppercase());
+    let mut block = Vec::new();
+    for pair in pairs {
+        block.extend(pair.encode_utf16());
+        block.push(0);
+    }
+    block.push(0);
+    Ok(block)
+}
+
+fn windows_directory() -> Result<String, PluginError> {
+    let mut buffer = vec![0_u16; 32_768];
+    // SAFETY: the vector exposes its full writable capacity and the supplied length matches it.
+    let length = unsafe {
+        GetWindowsDirectoryW(
+            buffer.as_mut_ptr(),
+            u32::try_from(buffer.len())
+                .map_err(|_| unavailable("Windows directory buffer overflow"))?,
+        )
+    };
+    let length =
+        usize::try_from(length).map_err(|_| unavailable("Windows directory length overflow"))?;
+    if length == 0 || length >= buffer.len() {
+        return Err(unavailable("Windows directory unavailable"));
+    }
+    String::from_utf16(&buffer[..length]).map_err(|_| unavailable("Windows directory is invalid"))
+}
+
+fn create_job(memory: u64) -> Result<OwnedHandle, PluginError> {
+    // SAFETY: null security/name pointers request a private unnamed Job.
+    let raw = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+    if raw.is_null() || raw == INVALID_HANDLE_VALUE {
+        return Err(unavailable("job creation failed"));
+    }
+    // SAFETY: the successful call returned a newly owned non-null Job handle.
+    let job = unsafe { OwnedHandle::from_raw_handle(raw) };
+    let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+    limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_PROCESS_MEMORY
+        | JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+        | JOB_OBJECT_LIMIT_ACTIVE_PROCESS;
+    limits.BasicLimitInformation.ActiveProcessLimit = 1;
+    limits.ProcessMemoryLimit =
+        usize::try_from(memory).map_err(|_| unavailable("job memory conversion failed"))?;
+    // SAFETY: `limits` has the documented structure/size and `job` is valid.
+    if unsafe {
+        SetInformationJobObject(
+            job.as_raw_handle(),
+            JobObjectExtendedLimitInformation,
+            (&raw const limits).cast(),
+            u32::try_from(size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>())
+                .map_err(|_| unavailable("job size conversion failed"))?,
+        )
+    } == 0
+    {
+        return Err(unavailable("job limit installation failed"));
+    }
+    Ok(job)
+}
+
+struct Pipe {
+    parent: OwnedHandle,
+    child: OwnedHandle,
+}
+impl Pipe {
+    fn new(parent_reads: bool) -> Result<Self, PluginError> {
+        let mut security = SECURITY_ATTRIBUTES {
+            nLength: u32::try_from(size_of::<SECURITY_ATTRIBUTES>())
+                .map_err(|_| unavailable("pipe size conversion failed"))?,
+            lpSecurityDescriptor: std::ptr::null_mut(),
+            bInheritHandle: 1,
+        };
+        let mut read = std::ptr::null_mut();
+        let mut write = std::ptr::null_mut();
+        // SAFETY: all output pointers and the initialized security descriptor are valid.
+        if unsafe { CreatePipe(&raw mut read, &raw mut write, &raw mut security, 0) } == 0 {
+            return Err(unavailable("pipe creation failed"));
+        }
+        // SAFETY: successful CreatePipe returned two newly owned handles.
+        let read = unsafe { OwnedHandle::from_raw_handle(read) };
+        // SAFETY: this is the distinct write handle returned by the same call.
+        let write = unsafe { OwnedHandle::from_raw_handle(write) };
+        let (parent, child) = if parent_reads { (read, write) } else { (write, read) };
+        // SAFETY: `parent` owns a valid pipe handle; the call only clears its inherit bit.
+        if unsafe { SetHandleInformation(parent.as_raw_handle(), HANDLE_FLAG_INHERIT, 0) } == 0 {
+            return Err(unavailable("pipe inheritance failed"));
+        }
+        Ok(Self { parent, child })
+    }
+    fn child_raw(&self) -> HANDLE {
+        self.child.as_raw_handle()
+    }
+    fn into_parent(self) -> File {
+        File::from(self.parent)
+    }
+}
+
+struct AttributeList {
+    bytes: Vec<usize>,
+    pointer: *mut core::ffi::c_void,
+}
+impl AttributeList {
+    fn new(count: u32) -> Result<Self, PluginError> {
+        let mut bytes = 0_usize;
+        // SAFETY: null is the documented sizing probe; `bytes` is writable.
+        unsafe {
+            let _ =
+                InitializeProcThreadAttributeList(std::ptr::null_mut(), count, 0, &raw mut bytes);
+        }
+        if bytes == 0 || bytes > 1024 * 1024 {
+            return Err(unavailable("attribute sizing failed"));
+        }
+        let mut storage = vec![0_usize; bytes.div_ceil(size_of::<usize>())];
+        let pointer = storage.as_mut_ptr().cast();
+        // SAFETY: pointer storage is aligned and at least the probed byte length.
+        if unsafe { InitializeProcThreadAttributeList(pointer, count, 0, &raw mut bytes) } == 0 {
+            return Err(unavailable("attribute initialization failed"));
+        }
+        Ok(Self { bytes: storage, pointer })
+    }
+    fn update(
+        &mut self,
+        attribute: usize,
+        value: *const core::ffi::c_void,
+        bytes: usize,
+    ) -> Result<(), PluginError> {
+        // SAFETY: the list is initialized and the caller keeps the typed value alive through
+        // process creation; `bytes` is the exact value size.
+        if unsafe {
+            UpdateProcThreadAttribute(
+                self.pointer,
+                0,
+                attribute,
+                value,
+                bytes,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        } == 0
+        {
+            return Err(unavailable("attribute update failed"));
+        }
+        Ok(())
+    }
+    fn as_mut_ptr(&mut self) -> *mut core::ffi::c_void {
+        self.pointer
+    }
+}
+impl Drop for AttributeList {
+    fn drop(&mut self) {
+        let _ = self.bytes.len();
+        // SAFETY: `pointer` was initialized once and remains backed by `bytes` until this Drop.
+        unsafe {
+            DeleteProcThreadAttributeList(self.pointer);
+        }
+    }
+}
+
+struct AppContainerSid(PSID);
+impl AppContainerSid {
+    fn derive(name: &str, expected: &str) -> Result<Self, PluginError> {
+        let name = wide_text(name)?;
+        let mut sid = std::ptr::null_mut();
+        // SAFETY: `name` is NUL-terminated and `sid` is a writable result pointer.
+        if unsafe { DeriveAppContainerSidFromAppContainerName(name.as_ptr(), &raw mut sid) } < 0
+            || sid.is_null()
+        {
+            return Err(unavailable("AppContainer SID derivation failed"));
+        }
+        let sid = Self(sid);
+        if sid_text(sid.0)?.eq_ignore_ascii_case(expected) {
+            Ok(sid)
+        } else {
+            Err(unavailable("AppContainer SID mismatch"))
+        }
+    }
+    fn as_ptr(&self) -> PSID {
+        self.0
+    }
+}
+impl Drop for AppContainerSid {
+    fn drop(&mut self) {
+        // SAFETY: the SID was allocated by DeriveAppContainerSidFromAppContainerName and is freed
+        // exactly once by this owner.
+        unsafe {
+            FreeSid(self.0);
+        }
+    }
+}
+
+fn process_token_matches(process: HANDLE, expected: &str) -> Result<bool, PluginError> {
+    let mut token = std::ptr::null_mut();
+    // SAFETY: `process` is a valid process handle and `token` is writable.
+    if unsafe { OpenProcessToken(process, 0x0008, &raw mut token) } == 0 {
+        return Err(unavailable("process token unavailable"));
+    }
+    let result = token_matches(token, expected);
+    // SAFETY: OpenProcessToken returned a newly owned token handle.
+    unsafe {
+        CloseHandle(token);
+    }
+    result
+}
+
+fn token_matches(token: HANDLE, expected: &str) -> Result<bool, PluginError> {
+    let mut is_app = 0_u32;
+    let mut returned = 0_u32;
+    // SAFETY: token is valid; the fixed-size output and returned-length pointers are writable.
+    if unsafe {
+        GetTokenInformation(
+            token,
+            TokenIsAppContainer,
+            (&raw mut is_app).cast(),
+            4,
+            &raw mut returned,
+        )
+    } == 0
+        || is_app != 1
+    {
+        return Ok(false);
+    }
+    let mut needed = 0_u32;
+    // SAFETY: null-buffer sizing is the documented first GetTokenInformation call.
+    unsafe {
+        let _ = GetTokenInformation(
+            token,
+            TokenAppContainerSid,
+            std::ptr::null_mut(),
+            0,
+            &raw mut needed,
+        );
+    }
+    let information_bytes = u32::try_from(size_of::<TOKEN_APPCONTAINER_INFORMATION>())
+        .map_err(|_| unavailable("token SID structure size overflow"))?;
+    if needed < information_bytes || needed > 64 * 1024 {
+        return Err(unavailable("token SID size invalid"));
+    }
+    let mut buffer = vec![0_usize; (needed as usize).div_ceil(size_of::<usize>())];
+    // SAFETY: the aligned buffer is at least `needed` bytes and all output pointers are valid.
+    if unsafe {
+        GetTokenInformation(
+            token,
+            TokenAppContainerSid,
+            buffer.as_mut_ptr().cast(),
+            needed,
+            &raw mut returned,
+        )
+    } == 0
+        || returned != needed
+    {
+        return Err(unavailable("token SID unavailable"));
+    }
+    // SAFETY: the successful call initialized at least one complete, aligned information record.
+    let information = unsafe { &*buffer.as_ptr().cast::<TOKEN_APPCONTAINER_INFORMATION>() };
+    if information.TokenAppContainer.is_null() {
+        return Ok(false);
+    }
+    Ok(sid_text(information.TokenAppContainer)?.eq_ignore_ascii_case(expected))
+}
+
+fn storage_path(sid: PSID) -> Result<std::path::PathBuf, PluginError> {
+    let text = sid_text(sid)?;
+    let text = wide_text(&text)?;
+    let mut raw = std::ptr::null_mut();
+    // SAFETY: `text` is NUL-terminated and `raw` is a writable result pointer.
+    if unsafe { GetAppContainerFolderPath(text.as_ptr(), &raw mut raw) } < 0 || raw.is_null() {
+        return Err(unavailable("AppContainer storage unavailable"));
+    }
+    let result = wide_string(raw)
+        .map(std::path::PathBuf::from)?
+        .canonicalize()
+        .map_err(|_| unavailable("AppContainer storage canonicalization failed"));
+    // SAFETY: the API allocated this string with LocalAlloc and ownership is released once.
+    unsafe {
+        LocalFree(raw.cast());
+    }
+    result
+}
+
+fn sid_text(sid: PSID) -> Result<String, PluginError> {
+    let mut raw = std::ptr::null_mut();
+    // SAFETY: caller supplies a valid SID and `raw` is writable.
+    if unsafe { ConvertSidToStringSidW(sid, &raw mut raw) } == 0 || raw.is_null() {
+        return Err(unavailable("SID rendering failed"));
+    }
+    let result = wide_string(raw);
+    // SAFETY: ConvertSidToStringSidW returned LocalAlloc-owned storage.
+    unsafe {
+        LocalFree(raw.cast());
+    }
+    result
+}
+
+fn wide_path(path: &Path) -> Result<Vec<u16>, PluginError> {
+    wide_os(path.as_os_str())
+}
+fn wide_text(value: &str) -> Result<Vec<u16>, PluginError> {
+    wide_os(std::ffi::OsStr::new(value))
+}
+fn wide_os(value: &std::ffi::OsStr) -> Result<Vec<u16>, PluginError> {
+    let mut value = value.encode_wide().collect::<Vec<_>>();
+    if value.contains(&0) {
+        return Err(unavailable("wide string contains NUL"));
+    }
+    value.push(0);
+    Ok(value)
+}
+fn wide_string(value: *const u16) -> Result<String, PluginError> {
+    if value.is_null() {
+        return Err(unavailable("wide string is null"));
+    }
+    let mut length = 0_usize;
+    // SAFETY: every caller passes an OS-owned NUL-terminated string; the defensive 32 KiB limit
+    // bounds reads even if the operating-system contract is violated.
+    while length <= 32 * 1024 && unsafe { *value.add(length) } != 0 {
+        length += 1;
+    }
+    if length > 32 * 1024 {
+        return Err(unavailable("wide string exceeds limit"));
+    }
+    // SAFETY: the scan above established `length` initialized u16 values before the terminator.
+    String::from_utf16(unsafe { std::slice::from_raw_parts(value, length) })
+        .map_err(|_| unavailable("wide string is invalid"))
+}
+
+fn unavailable(detail: &'static str) -> PluginError {
+    PluginError::new(PluginErrorCode::SandboxUnavailable, detail)
+}

--- a/crates/process-plugin/src/worker.rs
+++ b/crates/process-plugin/src/worker.rs
@@ -1,0 +1,222 @@
+//! Small SDK for implementing a `process-v1` plugin executable.
+
+use crate::protocol::{self, HostMessage, PROTOCOL_V1, PluginMessage};
+use base64::Engine as _;
+use into_markdown_core::{
+    CancellationToken, ConversionResult, Diagnostic, DiagnosticsDto, DtoJsonStyle, ResultDto,
+};
+use std::io;
+use std::sync::{Arc, Mutex};
+
+/// Decoded, bounded request delivered to a plugin implementation.
+#[derive(Debug)]
+pub struct WorkerRequest {
+    /// Host request identifier.
+    pub request_id: String,
+    /// Input format wire name.
+    pub input_format: String,
+    /// Display-only source name.
+    pub source_name: Option<String>,
+    /// Inline source bytes.
+    pub source: Vec<u8>,
+    /// Maximum nested result JSON bytes accepted by the host.
+    pub maximum_output_bytes: u64,
+}
+
+/// Controlled worker failure sent as a terminal protocol error.
+#[derive(Debug, Clone)]
+pub struct WorkerError {
+    /// Stable lowercase token.
+    pub code: String,
+    /// Human-readable detail.
+    pub message: String,
+}
+
+impl WorkerError {
+    /// Construct a bounded controlled error.
+    #[must_use]
+    pub fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self { code: code.into(), message: message.into() }
+    }
+}
+
+/// Ordered event writer shared with plugin conversion code.
+#[derive(Clone)]
+pub struct WorkerEvents {
+    output: Arc<Mutex<WorkerOutput>>,
+    request_id: String,
+    maximum: u32,
+}
+
+struct WorkerOutput {
+    writer: io::Stdout,
+    next_sequence: u64,
+    accepting_events: bool,
+}
+
+impl WorkerEvents {
+    /// Emit one ordered progress event.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error when the host pipe closes or the event exceeds the frame limit.
+    pub fn progress(
+        &self,
+        stage: &str,
+        completed_units: Option<u64>,
+        total_units: Option<u64>,
+        message: Option<String>,
+    ) -> io::Result<()> {
+        self.write_event(|sequence| PluginMessage::Progress {
+            protocol_version: PROTOCOL_V1,
+            request_id: self.request_id.clone(),
+            sequence,
+            stage: stage.to_owned(),
+            completed_units,
+            total_units,
+            message,
+        })
+    }
+
+    /// Emit one validated non-fatal diagnostic.
+    ///
+    /// # Errors
+    ///
+    /// Returns an I/O error for an invalid diagnostic, closed pipe, or oversized frame.
+    pub fn diagnostic(&self, diagnostic: Diagnostic) -> io::Result<()> {
+        let envelope = DiagnosticsDto::try_from_diagnostics(&[diagnostic])
+            .and_then(|value| value.to_json())
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+        self.write_event(|sequence| PluginMessage::Diagnostic {
+            protocol_version: PROTOCOL_V1,
+            request_id: self.request_id.clone(),
+            sequence,
+            diagnostic_json: envelope,
+        })
+    }
+
+    fn write_event(&self, build: impl FnOnce(u64) -> PluginMessage) -> io::Result<()> {
+        let mut output = self.output.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !output.accepting_events {
+            return Err(io::Error::new(io::ErrorKind::BrokenPipe, "terminal already written"));
+        }
+        let sequence = output.next_sequence;
+        output.next_sequence = output.next_sequence.checked_add(1).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "event sequence exhausted")
+        })?;
+        let message = build(sequence);
+        protocol::write_frame(&mut output.writer, &message, self.maximum)
+    }
+}
+
+/// Run one handshake and one request on stdin/stdout.
+///
+/// The reader thread consumes cancellation concurrently while conversion emits progress, so a
+/// full stdout pipe cannot prevent the host from delivering cancellation.
+///
+/// # Errors
+///
+/// Returns an I/O error for a malformed/unsupported host sequence or a failed protocol write.
+pub fn serve(
+    plugin_id: &str,
+    maximum_frame_bytes: u32,
+    handler: impl FnOnce(
+        WorkerRequest,
+        WorkerEvents,
+        CancellationToken,
+    ) -> Result<ConversionResult, WorkerError>,
+) -> io::Result<()> {
+    let mut input = io::stdin();
+    let output = Arc::new(Mutex::new(WorkerOutput {
+        writer: io::stdout(),
+        next_sequence: 1,
+        accepting_events: true,
+    }));
+    let hello = protocol::read_frame::<HostMessage>(&mut input, maximum_frame_bytes)?;
+    let HostMessage::Hello { supported_versions: versions, plugin_id: expected_id, nonce } = hello
+    else {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "hello must be first"));
+    };
+    if expected_id != plugin_id || !versions.contains(&PROTOCOL_V1) {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "no compatible identity/version"));
+    }
+    {
+        let mut writer = output.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        protocol::write_frame(
+            &mut writer.writer,
+            &PluginMessage::Hello {
+                selected_version: PROTOCOL_V1,
+                plugin_id: plugin_id.to_owned(),
+                nonce,
+            },
+            maximum_frame_bytes,
+        )?;
+    }
+    let request = protocol::read_frame::<HostMessage>(&mut input, maximum_frame_bytes)?;
+    let HostMessage::Request {
+        protocol_version: PROTOCOL_V1,
+        request_id,
+        input_format,
+        source_name,
+        source_base64,
+        maximum_output_bytes,
+    } = request
+    else {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "request must follow hello"));
+    };
+    let source =
+        base64::engine::general_purpose::STANDARD.decode(&source_base64).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidData, "source is not canonical base64")
+        })?;
+    if base64::engine::general_purpose::STANDARD.encode(&source) != source_base64 {
+        return Err(io::Error::new(io::ErrorKind::InvalidData, "source is not canonical base64"));
+    }
+    let cancellation = CancellationToken::new();
+    let reader_cancellation = cancellation.clone();
+    let expected_request_id = request_id.clone();
+    std::thread::Builder::new().name("process-plugin-cancel".into()).spawn(move || {
+        if let Ok(HostMessage::Cancel { protocol_version: PROTOCOL_V1, request_id }) =
+            protocol::read_frame::<HostMessage>(&mut input, maximum_frame_bytes)
+            && request_id == expected_request_id
+        {
+            reader_cancellation.cancel();
+        }
+    })?;
+    let events = WorkerEvents {
+        output: Arc::clone(&output),
+        request_id: request_id.clone(),
+        maximum: maximum_frame_bytes,
+    };
+    let request = WorkerRequest {
+        request_id: request_id.clone(),
+        input_format,
+        source_name,
+        source,
+        maximum_output_bytes,
+    };
+    let terminal = match handler(request, events, cancellation) {
+        Ok(result) => {
+            let result_json = ResultDto::json_from_result(&result, DtoJsonStyle::Compact)
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+            if result_json.len() as u64 > maximum_output_bytes {
+                PluginMessage::Error {
+                    protocol_version: PROTOCOL_V1,
+                    request_id: Some(request_id),
+                    code: "outputLimit".into(),
+                    message: "result exceeds declared output limit".into(),
+                }
+            } else {
+                PluginMessage::Response { protocol_version: PROTOCOL_V1, request_id, result_json }
+            }
+        }
+        Err(error) => PluginMessage::Error {
+            protocol_version: PROTOCOL_V1,
+            request_id: Some(request_id),
+            code: error.code,
+            message: error.message,
+        },
+    };
+    let mut writer = output.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    writer.accepting_events = false;
+    protocol::write_frame(&mut writer.writer, &terminal, maximum_frame_bytes)
+}

--- a/crates/process-plugin/tests/runtime.rs
+++ b/crates/process-plugin/tests/runtime.rs
@@ -1,0 +1,471 @@
+//! Real executable and operating-system sandbox integration tests.
+
+use into_markdown_core::{
+    CancellationToken, ExecutionContext, ExecutionOptions, ProgressEvent, ProgressListener,
+    ResourceLimits,
+};
+use into_markdown_process_plugin::{
+    PluginErrorCode, PluginManifest, PluginRequest, ProcessPlugin, RuntimePolicy,
+};
+use sha2::{Digest as _, Sha256};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[test]
+fn real_process_fixture_enforces_protocol_lifecycle_and_capabilities() {
+    let harness = Harness::new();
+    let ok = harness.execute(b"ok", ExecutionOptions::default()).unwrap();
+    assert_eq!(ok.result.markdown, "ok");
+    assert_eq!(ok.result.diagnostics.len(), 1);
+    assert_eq!(ok.result.assets.len(), 1);
+    assert_eq!(ok.result.provenance.len(), 1);
+    assert_eq!(ok.plugin_id, "fixture.process-v1");
+
+    let secret = harness.execute(b"secret", ExecutionOptions::default()).unwrap();
+    assert_eq!(secret.result.markdown, "secret-denied");
+
+    let outside = tempfile::NamedTempFile::new().unwrap();
+    std::fs::write(outside.path(), b"host-secret").unwrap();
+    let file = harness
+        .execute(
+            format!("file:{}", outside.path().display()).as_bytes(),
+            ExecutionOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(file.result.markdown, "file-denied");
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let network = harness
+        .execute(
+            format!("network:{}", listener.local_addr().unwrap()).as_bytes(),
+            ExecutionOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(network.result.markdown, "network-denied");
+
+    for (mode, expected) in [
+        (b"malformed".as_slice(), PluginErrorCode::Protocol),
+        (b"oversize".as_slice(), PluginErrorCode::FrameTooLarge),
+        (b"bad-order".as_slice(), PluginErrorCode::Protocol),
+        (b"invalid-result".as_slice(), PluginErrorCode::InvalidResult),
+        (b"missing-error-id".as_slice(), PluginErrorCode::Protocol),
+        (b"extra-after-response".as_slice(), PluginErrorCode::Protocol),
+        (b"crash".as_slice(), PluginErrorCode::Crashed),
+    ] {
+        let error = harness.execute(mode, ExecutionOptions::default()).unwrap_err();
+        assert_eq!(error.code, expected, "mode {}: {error}", String::from_utf8_lossy(mode));
+    }
+
+    let timeout = harness
+        .execute(
+            b"hang",
+            ExecutionOptions {
+                timeout: Some(Duration::from_millis(100)),
+                ..ExecutionOptions::default()
+            },
+        )
+        .unwrap_err();
+    assert_eq!(timeout.code, PluginErrorCode::Timeout, "unexpected hang result: {timeout}");
+
+    let started = std::time::Instant::now();
+    let flood = harness
+        .execute(
+            b"frame-flood",
+            ExecutionOptions {
+                timeout: Some(Duration::from_millis(500)),
+                ..ExecutionOptions::default()
+            },
+        )
+        .unwrap_err();
+    assert_eq!(flood.code, PluginErrorCode::Timeout, "unexpected flood result: {flood}");
+    assert!(started.elapsed() < Duration::from_secs(5), "frame flood teardown deadlocked");
+
+    let stall = Harness::new_with_mode(Some("stall-request"));
+    let started = std::time::Instant::now();
+    let source = vec![b'x'; 1024 * 1024];
+    let error = stall.execute(&source, ExecutionOptions::default()).unwrap_err();
+    assert_eq!(error.code, PluginErrorCode::Timeout);
+    assert!(started.elapsed() < Duration::from_secs(5), "blocked request write ignored deadline");
+}
+
+#[test]
+fn cancellation_race_is_stable_for_twenty_real_processes() {
+    let harness = Harness::new();
+    for iteration in 0..20 {
+        let cancellation = CancellationToken::new();
+        let trigger = cancellation.clone();
+        let (ready, observed) = std::sync::mpsc::sync_channel(1);
+        let listener = std::sync::Arc::new(CancelReady(ready));
+        let trigger_thread = std::thread::spawn(move || {
+            observed.recv_timeout(Duration::from_secs(5)).unwrap();
+            trigger.cancel();
+        });
+        let context = ExecutionContext::new(
+            ExecutionOptions {
+                cancellation,
+                progress_listener: Some(listener),
+                ..ExecutionOptions::default()
+            },
+            ResourceLimits::default(),
+        );
+        let cancelled = harness.execute_with_context(b"cancel", &context).unwrap_err();
+        trigger_thread.join().unwrap();
+        assert_eq!(
+            cancelled.code,
+            PluginErrorCode::Cancelled,
+            "iteration {iteration}: {cancelled}"
+        );
+        assert_temporary_budget_released(&context);
+        #[cfg(windows)]
+        assert!(
+            !std::fs::read_dir(&harness.profile.storage)
+                .unwrap()
+                .flatten()
+                .any(|entry| entry.file_name().to_string_lossy().starts_with("into-md-plugin-"))
+        );
+    }
+}
+
+#[test]
+fn staged_runtime_isolated_and_raii_releases_temporary_budget() {
+    let harness = Harness::new();
+
+    let success = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+    assert_eq!(harness.execute_with_context(b"ok", &success).unwrap().result.markdown, "ok");
+    assert_temporary_budget_released(&success);
+
+    let failure = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+    assert_eq!(
+        harness.execute_with_context(b"malformed", &failure).unwrap_err().code,
+        PluginErrorCode::Protocol
+    );
+    assert_temporary_budget_released(&failure);
+
+    let (mutated, observed) = std::sync::mpsc::sync_channel(1);
+    let mutation = std::sync::Arc::new(MutateOriginal {
+        executable: harness.executable.clone(),
+        complete: mutated,
+    });
+    let isolated = ExecutionContext::new(
+        ExecutionOptions { progress_listener: Some(mutation), ..ExecutionOptions::default() },
+        ResourceLimits::default(),
+    );
+    assert_eq!(
+        harness.execute_with_context(b"stage-isolated", &isolated).unwrap().result.markdown,
+        "stage-isolated"
+    );
+    observed.recv_timeout(Duration::from_secs(2)).unwrap();
+    assert_eq!(std::fs::read(&harness.executable).unwrap(), b"mutated");
+    assert_temporary_budget_released(&isolated);
+}
+
+struct MutateOriginal {
+    executable: PathBuf,
+    complete: std::sync::mpsc::SyncSender<()>,
+}
+
+impl ProgressListener for MutateOriginal {
+    fn on_progress(&self, event: ProgressEvent) {
+        if event.message.as_deref() == Some("stage-ready") {
+            std::fs::write(&self.executable, b"mutated").unwrap();
+            let _ = self.complete.try_send(());
+        }
+    }
+}
+
+fn assert_temporary_budget_released(context: &ExecutionContext) {
+    assert_eq!(
+        context.reserved_temporary_bytes(),
+        0,
+        "staged runtime temporary reservation leaked"
+    );
+}
+
+struct CancelReady(std::sync::mpsc::SyncSender<()>);
+
+impl ProgressListener for CancelReady {
+    fn on_progress(&self, event: ProgressEvent) {
+        if event.message.as_deref() == Some("cancel-ready") {
+            let _ = self.0.try_send(());
+        }
+    }
+}
+
+#[test]
+fn executable_digest_mutation_fails_before_launch() {
+    let harness = Harness::new();
+    std::fs::write(&harness.executable, b"mutated").unwrap();
+    let error = harness.execute(b"ok", ExecutionOptions::default()).unwrap_err();
+    assert_eq!(error.code, PluginErrorCode::Authority);
+}
+
+#[test]
+fn executable_larger_than_policy_is_rejected_before_launch() {
+    let fixture_bytes = std::fs::metadata(fixture_executable()).unwrap().len();
+    let error =
+        Harness::try_new_with_mode_and_file_limit(None, Some(fixture_bytes.saturating_sub(1)))
+            .err()
+            .expect("oversized fixture unexpectedly accepted");
+    assert_eq!(error.code, PluginErrorCode::Authority);
+}
+
+#[test]
+fn reservation_checkpoint_preserves_cancelled_and_timeout() {
+    let harness = Harness::new();
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let cancelled = harness
+        .execute(b"ok", ExecutionOptions { cancellation, ..ExecutionOptions::default() })
+        .unwrap_err();
+    assert_eq!(cancelled.code, PluginErrorCode::Cancelled, "{cancelled}");
+
+    let timed_out = harness
+        .execute(
+            b"ok",
+            ExecutionOptions { timeout: Some(Duration::ZERO), ..ExecutionOptions::default() },
+        )
+        .unwrap_err();
+    assert_eq!(timed_out.code, PluginErrorCode::Timeout, "{timed_out}");
+}
+
+struct Harness {
+    plugin: ProcessPlugin,
+    executable: PathBuf,
+    _runtime: tempfile::TempDir,
+    #[cfg(windows)]
+    profile: WindowsProfile,
+}
+
+impl Harness {
+    fn new() -> Self {
+        Self::new_with_mode(None)
+    }
+
+    fn new_with_mode(mode: Option<&str>) -> Self {
+        Self::try_new_with_mode_and_file_limit(mode, None).unwrap()
+    }
+
+    fn try_new_with_mode_and_file_limit(
+        mode: Option<&str>,
+        max_file_bytes: Option<u64>,
+    ) -> Result<Self, into_markdown_process_plugin::PluginError> {
+        let fixture = fixture_executable();
+        let runtime =
+            tempfile::Builder::new().prefix("into-md-fixture-runtime-").tempdir().unwrap();
+        let executable = runtime.path().join(if cfg!(windows) { "fixture.exe" } else { "fixture" });
+        std::fs::copy(&fixture, &executable).unwrap();
+        let runtime_root = runtime.path().canonicalize().unwrap();
+        let executable = executable.canonicalize().unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(&executable, std::fs::Permissions::from_mode(0o500)).unwrap();
+        }
+        #[cfg(windows)]
+        let profile = WindowsProfile::new(&runtime_root);
+        let digest = format!("{:x}", Sha256::digest(std::fs::read(&executable).unwrap()));
+        #[allow(unused_mut)]
+        let mut policy = RuntimePolicy {
+            max_frame_bytes: 16 * 1024 * 1024,
+            max_output_bytes: 8 * 1024 * 1024,
+            max_memory_bytes: 256 * 1024 * 1024,
+            handshake_timeout: Duration::from_secs(3),
+            cancellation_grace: Duration::from_millis(50),
+            ..RuntimePolicy::default()
+        };
+        if let Some(max_file_bytes) = max_file_bytes {
+            policy.max_file_bytes = max_file_bytes;
+        }
+        #[cfg(windows)]
+        {
+            policy.windows = profile.authority();
+        }
+        if let Some(mode) = mode {
+            policy.environment.insert("PROCESS_PLUGIN_FIXTURE_MODE".into(), mode.into());
+            policy.request_timeout = Duration::from_millis(250);
+        }
+        let plugin = ProcessPlugin::new(
+            PluginManifest {
+                plugin_id: "fixture.process-v1".into(),
+                executable: executable.clone(),
+                runtime_root,
+                executable_sha256: digest,
+                protocol_versions: vec![1],
+            },
+            policy,
+        )?;
+        Ok(Self {
+            plugin,
+            executable,
+            _runtime: runtime,
+            #[cfg(windows)]
+            profile,
+        })
+    }
+
+    fn execute(
+        &self,
+        source: &[u8],
+        options: ExecutionOptions,
+    ) -> Result<
+        into_markdown_process_plugin::PluginExecution,
+        into_markdown_process_plugin::PluginError,
+    > {
+        let context = ExecutionContext::new(options, ResourceLimits::default());
+        self.execute_with_context(source, &context)
+    }
+
+    fn execute_with_context(
+        &self,
+        source: &[u8],
+        context: &ExecutionContext,
+    ) -> Result<
+        into_markdown_process_plugin::PluginExecution,
+        into_markdown_process_plugin::PluginError,
+    > {
+        self.plugin.execute(
+            PluginRequest {
+                request_id: "fixture-request",
+                input_format: "text",
+                source_name: Some("fixture.txt"),
+                source,
+            },
+            context,
+        )
+    }
+}
+
+fn fixture_executable() -> PathBuf {
+    if let Some(value) = option_env!("CARGO_BIN_EXE_process-plugin-fixture") {
+        return PathBuf::from(value).canonicalize().unwrap();
+    }
+    if let Some(runfiles) = std::env::var_os("RUNFILES_DIR") {
+        let runfiles = PathBuf::from(runfiles);
+        for repository in ["_main", "into_markdown"] {
+            let candidate =
+                runfiles.join(repository).join("crates/process-plugin").join(if cfg!(windows) {
+                    "process-plugin-fixture.exe"
+                } else {
+                    "process-plugin-fixture"
+                });
+            if candidate.is_file() {
+                return candidate.canonicalize().unwrap();
+            }
+        }
+    }
+    let current = std::env::current_exe().unwrap();
+    let debug = current.parent().and_then(Path::parent).unwrap();
+    debug
+        .join(if cfg!(windows) { "process-plugin-fixture.exe" } else { "process-plugin-fixture" })
+        .canonicalize()
+        .unwrap()
+}
+
+#[cfg(windows)]
+struct WindowsProfile {
+    name: String,
+    sid: String,
+    storage: PathBuf,
+}
+
+#[cfg(windows)]
+impl WindowsProfile {
+    fn new(runtime: &Path) -> Self {
+        use std::os::windows::ffi::OsStrExt as _;
+        use windows_sys::Win32::Foundation::LocalFree;
+        use windows_sys::Win32::Security::Authorization::ConvertSidToStringSidW;
+        use windows_sys::Win32::Security::Isolation::{
+            CreateAppContainerProfile, GetAppContainerFolderPath,
+        };
+        use windows_sys::Win32::Security::PSID;
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+        let name = format!(
+            "into-markdown-fixture-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
+        let wide = |value: &str| {
+            std::ffi::OsStr::new(value).encode_wide().chain(Some(0)).collect::<Vec<_>>()
+        };
+        let wide_name = wide(&name);
+        let display = wide("Into Markdown fixture");
+        let description = wide("Ephemeral process-plugin sandbox fixture");
+        let mut sid: PSID = std::ptr::null_mut();
+        // SAFETY: every string is NUL-terminated, capabilities are empty, and `sid` is writable.
+        let result = unsafe {
+            CreateAppContainerProfile(
+                wide_name.as_ptr(),
+                display.as_ptr(),
+                description.as_ptr(),
+                std::ptr::null(),
+                0,
+                &raw mut sid,
+            )
+        };
+        assert!(result >= 0 && !sid.is_null(), "CreateAppContainerProfile HRESULT={result:#x}");
+        let mut text = std::ptr::null_mut();
+        // SAFETY: profile creation returned a valid SID and `text` is writable.
+        assert_ne!(unsafe { ConvertSidToStringSidW(sid, &raw mut text) }, 0);
+        // SAFETY: successful conversion returns a NUL-terminated UTF-16 allocation.
+        let sid_text = unsafe { wide_ptr(text) };
+        // SAFETY: `text` is LocalAlloc-owned and released exactly once.
+        unsafe {
+            LocalFree(text.cast());
+        }
+        let wide_sid = wide(&sid_text);
+        let mut storage = std::ptr::null_mut();
+        // SAFETY: `wide_sid` is NUL-terminated and `storage` is writable.
+        assert!(unsafe { GetAppContainerFolderPath(wide_sid.as_ptr(), &raw mut storage) } >= 0);
+        // SAFETY: the successful call returns a NUL-terminated UTF-16 path.
+        let storage_path = PathBuf::from(unsafe { wide_ptr(storage) }).canonicalize().unwrap();
+        // SAFETY: both allocations are owned by the documented matching allocators.
+        unsafe {
+            LocalFree(storage.cast());
+            windows_sys::Win32::Security::FreeSid(sid);
+        }
+        let grant = format!("*{sid_text}:(OI)(CI)RX");
+        let status = std::process::Command::new("icacls.exe")
+            .arg(runtime)
+            .arg("/grant")
+            .arg(grant)
+            .arg("/T")
+            .arg("/Q")
+            .status()
+            .unwrap();
+        assert!(status.success(), "icacls failed: {status}");
+        Self { name, sid: sid_text, storage: storage_path }
+    }
+
+    fn authority(&self) -> into_markdown_process_plugin::WindowsSandboxAuthority {
+        into_markdown_process_plugin::WindowsSandboxAuthority {
+            profile_name: self.name.clone(),
+            sid: self.sid.clone(),
+            storage_root: self.storage.clone(),
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsProfile {
+    fn drop(&mut self) {
+        use std::os::windows::ffi::OsStrExt as _;
+        use windows_sys::Win32::Security::Isolation::DeleteAppContainerProfile;
+        let name =
+            std::ffi::OsStr::new(&self.name).encode_wide().chain(Some(0)).collect::<Vec<_>>();
+        // SAFETY: profile name is NUL-terminated and remains alive for the call.
+        unsafe {
+            let _ = DeleteAppContainerProfile(name.as_ptr());
+        }
+    }
+}
+
+#[cfg(windows)]
+unsafe fn wide_ptr(value: *const u16) -> String {
+    let mut length = 0_usize;
+    // SAFETY: callers pass a non-null OS-owned NUL-terminated UTF-16 string.
+    while unsafe { *value.add(length) } != 0 {
+        length += 1;
+    }
+    // SAFETY: the scan established `length` initialized elements before the terminator.
+    String::from_utf16(unsafe { std::slice::from_raw_parts(value, length) }).unwrap()
+}

--- a/docs/adr/0002-explicit-plugin-registration.md
+++ b/docs/adr/0002-explicit-plugin-registration.md
@@ -5,5 +5,13 @@
 内置实现和链接扩展都通过 `RegistryBuilder` 注册。项目不公开 Rust 动态库
 ABI。Rust ABI 不足以支持独立升级的插件，加载原生代码也会削弱输入安全边界。
 
-未来可以通过子进程或 WASI 实现带版本的 JSON/二进制协议。预留协议从版本 1
-开始，且必须使用相同的公共 IR、错误、资源和溯源规则。
+进程插件使用 `process-v1`：双方先在 stdin/stdout 上交换长度前缀 JSON 握手，再进行
+一个请求、零个或多个进度/诊断事件，以及唯一终态响应。宿主只接受公共 `ResultDto`，
+并在返回调用方前重新验证 Document IR、资源、诊断和溯源。WASI 是独立协议，不与
+`process-v1` 隐式兼容。
+
+进程隔离必须先于插件执行生效：Linux 使用 Landlock、seccomp、rlimit 和独立进程组；
+macOS 使用 deny-default Seatbelt profile 与 rlimit；Windows 使用零 capability 的
+AppContainer，并在恢复主线程前绑定只允许一个进程的 Job。协议 v1 不授予网络或共享
+文件系统能力；输入与资源均内联通过受限 pipe 传递。父进程环境不会继承，只有宿主策略
+逐项声明的变量可见。任何平台无法安装对应原生边界时都以稳定错误拒绝启动。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,8 +37,9 @@ flowchart LR
 解析器掩盖。
 
 插件代码通过 `RegistryBuilder` 显式注册。Rust 没有稳定的动态 ABI，因此项目
-不支持进程内 Rust 动态库插件。未来为隔离执行和第三方分发预留带版本的进程外
-或 WASI 协议。
+不支持进程内 Rust 动态库插件。`into-markdown-process-plugin` 提供已版本化的
+`process-v1` 进程外运行时；安装与启用层必须先给它经 SHA-256 认证的绝对可执行文件
+authority。WASI 使用独立的 `wasi-v1` 边界。
 
 注册表在构建时拒绝空 ID 和同类重复 ID。检测候选与转换尝试的排序键均完整、稳定：
 显式格式优先，其后依次比较归一化 confidence、实现 priority 和稳定 ID。探测错误

--- a/docs/process-plugins.md
+++ b/docs/process-plugins.md
@@ -1,0 +1,57 @@
+# `process-v1` 隔离插件
+
+`into-markdown-process-plugin` 用于执行已经由安装层认证的第三方转换器。运行时不搜索
+`PATH`、不解释 shell 命令，也不加载进程内动态 ABI。manifest 必须给出规范绝对路径、
+包含该文件的 runtime root、精确小写 SHA-256、插件 ID 和显式协议版本；每次启动前都会
+重新校验文件类型、路径范围和摘要。宿主以固定大小缓冲区把 runtime tree 复制到每请求
+私有目录，对实际复制字节使用 `ExecutionContext` 临时空间账本，并在每个块检查取消和
+期限；最终启动文件在私有目录中再次校验入口摘要，目录及账本在所有退出路径由 RAII 回收。
+`process-v1` 只认证 manifest 声明的入口文件；整个安装包及其库内容的 authority 由 #44
+安装/注册层提供，调用方不得把入口摘要误当成整包摘要。
+
+## 协议
+
+stdin/stdout 仅承载 frame：4 字节 little-endian `u32` JSON 长度，随后为精确数量的
+UTF-8 JSON 字节。绝对上限为 64 MiB，部署策略可以进一步收紧；长度在分配前检查，宿主
+同时向 `ExecutionContext` 预占双向 frame 内存。JSON 后的额外值、未知字段、零长、截断
+和超长 frame 均失败关闭。stderr 与协议分离、持续排空且不进入外部错误 envelope。
+
+状态机固定为：
+
+1. 宿主发送支持版本、预期插件 ID 和请求 nonce；插件只能回一个匹配的握手。
+2. 宿主发送一个包含内联 base64 输入、格式、请求 ID 和输出上限的请求。
+3. 插件可以发送严格递增 sequence 的进度或单条已验证诊断。
+4. 插件发送且只能发送一个 `ResultDto` 响应或稳定错误，然后以成功状态退出。
+
+重复握手、错 request ID/version、倒序事件、响应后的 frame、提前 EOF/崩溃都属于协议
+错误。取消和超时会先发送 `cancel`；短暂协作期后宿主终止整个 Unix 进程组或 Windows
+Job，并等待回收。插件成功响应仍会经过 `ResultDto` 解码及 Document、资源、诊断、
+provenance 的公共验证。
+
+## 能力与平台边界
+
+v1 默认且强制离线，输入和返回资源只经 pipe 传输。子进程环境从空集合构造，仅加入
+`INTO_MARKDOWN_PLUGIN_PROTOCOL=process-v1` 和调用方明确声明的有限变量；代理、凭据、
+HOME 和 loader 变量不会继承。工作目录为每请求私有临时目录。
+
+- Linux：`RLIMIT_AS/FSIZE/NOFILE/CORE`，Landlock 只读 runtime/动态加载器目录且只允许
+  私有临时目录写入，seccomp 拒绝 socket、跨进程信号、fork、namespace、mount、ptrace
+  等调用；只允许同进程线程 clone。
+- macOS：同类 rlimit 加 deny-default Seatbelt；拒绝网络与 fork，只读 runtime/系统库，
+  只写私有临时目录。
+- Windows：安装层预创建并 ACL 授权的 AppContainer SID；启动时 capability 数量为零，
+  仅继承三根协议 handle。主线程在 Job 的单进程、内存和 close-kill 限制安装并复核 token
+  SID 后才恢复。cwd 必须与该 SID 的 storage identity 精确一致。
+
+某个平台不能建立这些边界时，运行时返回 `pluginSandboxUnavailable`，不会降级为普通
+子进程。文件大小、句柄、内存、握手时间、不可关闭的硬请求期限和 frame/output 上限均由宿主策略限制。
+
+## 构建与审计
+
+Cargo 目标为 `into-markdown-process-plugin`，Bazel 目标为
+`//crates/process-plugin:process_plugin`。跨平台 fixture 同时构建为
+`process-plugin-fixture`，真实启动门禁覆盖错误 frame、超大 frame、事件乱序、崩溃、
+超时/取消、父环境秘密、外部文件和 loopback 网络。该 crate 仅使用 Cargo.lock 中已有的
+依赖；workspace manifest 与 lock 摘要由
+`third_party/licenses/cargo-normal-runtime.json` 绑定，发布 license/SBOM 投影继续由
+`license-check` 从同一 normal-runtime authority 推导。

--- a/third_party/licenses/cargo-normal-runtime.json
+++ b/third_party/licenses/cargo-normal-runtime.json
@@ -1,9 +1,9 @@
 {
   "schema_version": 1,
   "root": "into-markdown-cli",
-  "cargo_lock_sha256": "e7f7ada5f4fd29665092793b6809e06ea0f6ddb381e7bdda1a3d5ff76c6b34d1",
+  "cargo_lock_sha256": "07986f6cf24c508c59f6c582a24893987803562c5eff1f6ec63e963098588a5f",
   "workspace_manifest_sha256": {
-    "Cargo.toml": "c0d0695622ff61f65cce90a97a3a4ca60704368ee8961d7903798621df3ad08c",
+    "Cargo.toml": "610466f22088ffd1b3465d4160f52bad047ba2a590a8865148d6822174089d05",
     "apps/cli/Cargo.toml": "76641f48b1fde33ccbdaacfdf1e8d81134a86ff9e8086736a09f3af9eaaae1ed",
     "crates/ai/Cargo.toml": "adffc09c06b695fe830fe58647a2cd1f18df627b1932331b372c690843781eeb",
     "crates/api/Cargo.toml": "af363402eefd58f0f418712a9e9cff3ae3d3a7f0a79ba34c9416610b0970785c",
@@ -18,6 +18,7 @@
     "crates/onnxruntime/Cargo.toml": "60048d910bad52c794a4f0aa6c9f521844783635ede0e1cb44c6db5bd78444cd",
     "crates/pdf-layout/Cargo.toml": "74c04a6a68e6da70d37ca0479738e21d4169baa14c8b1e10ea3c200098c88e45",
     "crates/pdfium/Cargo.toml": "ad6c2f598513a2ad52542a8071cc2a5ddcd88ae31d0710d811677b9cbc0dd070",
+    "crates/process-plugin/Cargo.toml": "f7a8c304ba351613556aa5ee4c42136d612f97ee5cc73675fb3f1bd8fa124932",
     "crates/render-markdown/Cargo.toml": "d5cf0e875d12baaf6e78a0befa0efcb3ac04234d2bb6d8c11324ca18394fb0c8",
     "crates/task-store/Cargo.toml": "0f9f0c0de64be5afdf8d4c4b4092da75877af8b340c015273101c465db1188fd",
     "tests/contracts/Cargo.toml": "2b0bc6bf495f298b497d6d8177bc2a9f67f78f1d24e1e5946d53dfc75e9c8e5f",


### PR DESCRIPTION
## Summary
- add a strict length-prefixed `process-v1` host/worker protocol with version, request identity, ordered events, cancellation and bounded diagnostics
- execute authenticated staged runtimes in Linux Landlock/seccomp, macOS Seatbelt, or Windows AppContainer/Job isolation without inherited secrets or network capability
- revalidate returned ResultDto/Document/resources/provenance and account frame memory plus staged temporary bytes through ExecutionContext
- add real cross-platform malicious fixtures, package authority, Bazel targets, and operator documentation

## Verification
- Windows: 9/9 package tests; `cargo check --all-targets`; strict clippy; fmt/diff checks
- Linux (Ubuntu 24.04, Rust 1.97.1): 9/9 package tests, including real Landlock/seccomp, 20 cancellation races, network/file/secret denial, malformed/oversized/order/crash/timeout cases, staging race and RAII accounting
- license manifest mutation: 1/1; locked offline metadata: pass
- Bazel could not load because the existing rules_rust GitHub archive fetch timed out before analysis

Closes #42