### PR TITLE
Harden and verify local Web security boundary

### DIFF
--- a/.github/workflows/web-security.yml
+++ b/.github/workflows/web-security.yml
@@ -1,0 +1,79 @@
+name: Local Web security boundary
+
+on:
+  pull_request:
+    paths:
+      - "apps/cli/**"
+      - "web/console/**"
+      - "docs/ui.md"
+      - "docs/security.md"
+      - "docs/testing.md"
+      - "docs/web-security-threat-model.md"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/web-security.yml"
+  push:
+    branches: [main]
+    paths:
+      - "apps/cli/**"
+      - "web/console/**"
+      - "docs/ui.md"
+      - "docs/security.md"
+      - "docs/testing.md"
+      - "docs/web-security-threat-model.md"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/web-security.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-boundary:
+    name: ${{ matrix.target }} loopback and storage security
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15
+            target: aarch64-apple-darwin
+          - os: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - os: windows-2025
+            target: x86_64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
+          targets: ${{ matrix.target }}
+      - name: Run local Web request, content, and storage boundary
+        run: >-
+          cargo test --locked -p into-markdown-cli --bin into-md
+          --target ${{ matrix.target }} -j1 ui::tests -- --test-threads=1
+      - name: Run task storage path and artifact boundary
+        run: >-
+          cargo test --locked -p into-markdown-cli
+          --target ${{ matrix.target }} -j1 web_tasks::tests -- --test-threads=1
+
+  bazel-and-console:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: bazelbuild/setup-bazel@v3
+        with:
+          bazelisk-cache: true
+          disk-cache: local-web-security
+          repository-cache: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
+      - name: Run production CLI and embedded-console security gates
+        run: >-
+          bazel test //apps/cli:web_security_test //web/console:web_security_test
+          --jobs=1 --local_resources=memory=4096 --test_output=errors

--- a/.github/workflows/web-security.yml
+++ b/.github/workflows/web-security.yml
@@ -11,6 +11,9 @@ on:
       - "docs/web-security-threat-model.md"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - ".github/workflows/web-security.yml"
   push:
     branches: [main]
@@ -23,6 +26,9 @@ on:
       - "docs/web-security-threat-model.md"
       - "Cargo.toml"
       - "Cargo.lock"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - ".github/workflows/web-security.yml"
 
 permissions:
@@ -77,3 +83,30 @@ jobs:
         run: >-
           bazel test //apps/cli:web_security_test //web/console:web_security_test
           --jobs=1 --local_resources=memory=4096 --test_output=errors
+
+  browser-e2e:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.13.0
+      - name: Install locked browser test dependencies
+        run: |
+          corepack enable
+          corepack pnpm install --frozen-lockfile
+          corepack pnpm --filter @into-markdown/console exec playwright install --with-deps chromium
+      - name: Build the production local Web server
+        run: cargo build --locked -p into-markdown-cli --bin into-md
+      - name: Type-check the browser security test
+        run: corepack pnpm --filter @into-markdown/console exec tsc -p tsconfig.e2e.json
+      - name: Run hostile-content browser E2E
+        env:
+          INTO_MD_CLI: ${{ github.workspace }}/target/debug/into-md
+        run: >-
+          corepack pnpm --filter @into-markdown/console exec playwright test
+          tests/web-security.e2e.spec.ts --workers=1 --reporter=line

--- a/apps/cli/BUILD.bazel
+++ b/apps/cli/BUILD.bazel
@@ -40,6 +40,14 @@ rust_test(
     compile_data = ["//web/console:checked_assets"],
 )
 
+# Named security gate for the complete loopback HTTP, storage, and embedded
+# console boundary. Keep this alias pointed at the production CLI test crate so
+# private route helpers cannot be tested through a weaker duplicate harness.
+test_suite(
+    name = "web_security_test",
+    tests = [":cli_test"],
+)
+
 rust_test(
     name = "exit_contract_test",
     srcs = ["tests/exit_contract.rs"],

--- a/apps/cli/src/ui.rs
+++ b/apps/cli/src/ui.rs
@@ -36,6 +36,11 @@ const TASK_REQUEST_HEADER: HeaderName = HeaderName::from_static("x-into-md-reque
 const TASK_FILENAME_HEADER: HeaderName = HeaderName::from_static("x-into-md-filename-b64");
 const SEC_FETCH_MODE_HEADER: HeaderName = HeaderName::from_static("sec-fetch-mode");
 const SEC_FETCH_SITE_HEADER: HeaderName = HeaderName::from_static("sec-fetch-site");
+const CROSS_ORIGIN_OPENER_POLICY_HEADER: HeaderName =
+    HeaderName::from_static("cross-origin-opener-policy");
+const CROSS_ORIGIN_RESOURCE_POLICY_HEADER: HeaderName =
+    HeaderName::from_static("cross-origin-resource-policy");
+const PERMISSIONS_POLICY_HEADER: HeaderName = HeaderName::from_static("permissions-policy");
 const SESSION_FRAGMENT: &str = "into-md-session";
 const SESSION_BYTES: usize = 32;
 const SESSION_ENCODED_LEN: usize = 43;
@@ -1558,6 +1563,14 @@ fn apply_security_headers(mut response: Response) -> Response {
     }
     headers.insert(header::REFERRER_POLICY, HeaderValue::from_static("no-referrer"));
     headers.insert(header::X_CONTENT_TYPE_OPTIONS, HeaderValue::from_static("nosniff"));
+    headers.insert(CROSS_ORIGIN_OPENER_POLICY_HEADER, HeaderValue::from_static("same-origin"));
+    headers.insert(CROSS_ORIGIN_RESOURCE_POLICY_HEADER, HeaderValue::from_static("same-origin"));
+    headers.insert(
+        PERMISSIONS_POLICY_HEADER,
+        HeaderValue::from_static(
+            "camera=(), display-capture=(self), geolocation=(), microphone=(self), payment=(), usb=()",
+        ),
+    );
     headers.insert(
         header::CONTENT_SECURITY_POLICY,
         HeaderValue::from_static("default-src 'none'; script-src 'self'; style-src 'self'; connect-src 'self'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'"),
@@ -1800,6 +1813,12 @@ mod tests {
         assert!(lowercase.contains("referrer-policy: no-referrer\r\n"), "{response}");
         assert!(lowercase.contains("x-content-type-options: nosniff\r\n"), "{response}");
         assert!(lowercase.contains("content-security-policy: default-src 'none';"), "{response}");
+        assert!(lowercase.contains("cross-origin-opener-policy: same-origin\r\n"), "{response}");
+        assert!(lowercase.contains("cross-origin-resource-policy: same-origin\r\n"), "{response}");
+        assert!(
+            lowercase.contains("permissions-policy: camera=(), display-capture=(self)"),
+            "{response}"
+        );
     }
 
     fn assert_schema_error(response: &str, status: &str, code: &str) {
@@ -2056,6 +2075,16 @@ mod tests {
             format!(
                 "Host: {host}\r\nOrigin: {origin}, http://evil.invalid\r\nX-Into-Md-Session: {session}"
             ),
+            format!("Host: {host}\r\nOrigin: null\r\nX-Into-Md-Session: {session}"),
+            format!(
+                "Host: {host}\r\nOrigin: http://user@127.0.0.1:{port}\r\nX-Into-Md-Session: {session}"
+            ),
+            format!(
+                "Host: {host}\r\nOrigin: {origin}\r\nOrigin: {origin}\r\nX-Into-Md-Session: {session}"
+            ),
+            format!(
+                "Host: {host}\r\nOrigin: {origin}\r\nX-Into-Md-Session: {session}\r\nX-Into-Md-Session: {session}"
+            ),
         ] {
             let response = request(
                 port,
@@ -2070,6 +2099,15 @@ mod tests {
         assert!(preflight.starts_with("HTTP/1.1 403"), "{preflight}");
         assert_security_headers(&preflight);
         assert!(!preflight.to_ascii_lowercase().contains("access-control-allow-origin"));
+        let ambient_auth = request(
+            port,
+            &format!(
+                "POST /api/status?session={session} HTTP/1.1\r\nHost: {host}\r\nOrigin: {origin}\r\nCookie: X-Into-Md-Session={session}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            ),
+        )
+        .await;
+        assert_schema_error(&ambient_auth, "HTTP/1.1 401", "invalidSession");
+        assert!(!ambient_auth.contains(&session));
         let unknown_api = request(
             port,
             &format!("GET /api/future HTTP/1.1\r\nHost: {host}\r\nOrigin: http://evil.invalid\r\nConnection: close\r\n\r\n"),
@@ -2087,6 +2125,31 @@ mod tests {
         assert_schema_error(&unexpected_body, "HTTP/1.1 400", "requestBodyNotAllowed");
         shutdown.send(()).unwrap();
         task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn session_from_a_stopped_server_cannot_be_replayed_after_restart() {
+        let (_first_directory, _first_port, first_session, first_shutdown, first_task) =
+            start().await;
+        first_shutdown.send(()).unwrap();
+        first_task.await.unwrap().unwrap();
+
+        let (_second_directory, second_port, second_session, second_shutdown, second_task) =
+            start().await;
+        assert_ne!(first_session, second_session);
+        let host = format!("127.0.0.1:{second_port}");
+        let origin = format!("http://{host}");
+        let replay = request(
+            second_port,
+            &format!(
+                "POST /api/status HTTP/1.1\r\nHost: {host}\r\nOrigin: {origin}\r\nX-Into-Md-Session: {first_session}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n"
+            ),
+        )
+        .await;
+        assert_schema_error(&replay, "HTTP/1.1 401", "invalidSession");
+        assert!(!replay.contains(&first_session));
+        second_shutdown.send(()).unwrap();
+        second_task.await.unwrap().unwrap();
     }
 
     #[cfg(unix)]

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,7 +4,8 @@ WASI 插件是非信任输入边界：固定 runtime/hash、默认无 ambient �
 fuel/epoch/memory/output/resource 限制，以及统一 IR/provenance 重验共同生效。详细威胁模型、
 稳定错误和真实 guest 门禁见 [`wasi-plugins.md`](wasi-plugins.md)。
 
-本地 Web 入口的权威威胁边界与请求校验规则见[本地 Web 服务](ui.md)。该入口只监听
+本地 Web 入口的攻击者、剩余风险和验证矩阵见[本地 Web 控制台威胁模型](web-security-threat-model.md)，
+请求与产品契约见[本地 Web 服务](ui.md)。该入口只监听
 IPv4 回环地址，不把转换网络授权扩展到 Web 服务，也不接受配置文件提供监听地址或
 会话秘密。
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,8 +31,9 @@ Web 安全的权威范围和剩余风险见 [`web-security-threat-model.md`](web
 into-markdown-cli --bin into-md ui::tests -- --test-threads=1`、`cargo test --locked -p
 into-markdown-cli web_tasks::tests -- --test-threads=1`、`bazel test //web/console:unit_test_preview
 //web/console:admin_unit_test //web/console:dist_integration_test` 和 `bazel test
-//apps/cli:web_security_test //web/console:web_security_test`。前端用恶意 HTML、`javascript:`、
-`file:` 与远程图片语法验证预览 DOM
+//apps/cli:web_security_test //web/console:web_security_test`。CI 另在真实 Chromium 中运行
+`web/console/tests/web-security.e2e.spec.ts`，从生产 `into-md ui` 的私有启动 URL 进入、上传敌意
+文本、等待实际转换结果并刷新恢复。前端用恶意 HTML、`javascript:`、`file:` 与远程图片语法验证预览 DOM
 不产生任何可执行或资源加载元素；另验证 256 KiB 截断、IR/provenance 树上限、资源浏览与 axe。
 Unix loopback 集成测试把真实 Markdown artifact 做完整、开放区间和非法区间下载，校验状态、
 长度、Content-Range、MIME、Content-Disposition 与安全响应头。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,10 +26,13 @@ into-markdown-cli retention_`。测试覆盖分页/筛选、固定、重试、�
 SQLite commit 前后注入失败的目录/checkpoint 重启恢复。前端单测覆盖 cursor 编码、筛选、固定/
 重试/删除/立即清理 API、不可恢复提示与键盘/axe 可访问性。
 
-Web 预览与下载的定向门禁为 `cargo test -p into-markdown-cli
-download_ranges_and_names_are_canonical_and_header_safe`、`bazel test
-//web/console:unit_test //web/console:admin_unit_test //web/console:dist_integration_test` 和 `bazel test
-//apps/cli:into_md_test`。前端用恶意 HTML、`javascript:`、`file:` 与远程图片语法验证预览 DOM
+Web 安全的权威范围和剩余风险见 [`web-security-threat-model.md`](web-security-threat-model.md)。
+会话、Host/Origin、重启重放、预览与下载的定向门禁为 `cargo test --locked -p
+into-markdown-cli --bin into-md ui::tests -- --test-threads=1`、`cargo test --locked -p
+into-markdown-cli web_tasks::tests -- --test-threads=1`、`bazel test //web/console:unit_test_preview
+//web/console:admin_unit_test //web/console:dist_integration_test` 和 `bazel test
+//apps/cli:web_security_test //web/console:web_security_test`。前端用恶意 HTML、`javascript:`、
+`file:` 与远程图片语法验证预览 DOM
 不产生任何可执行或资源加载元素；另验证 256 KiB 截断、IR/provenance 树上限、资源浏览与 axe。
 Unix loopback 集成测试把真实 Markdown artifact 做完整、开放区间和非法区间下载，校验状态、
 长度、Content-Range、MIME、Content-Disposition 与安全响应头。

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,6 +1,7 @@
 # 本地 Web 服务
 
-`into-md ui` 提供安全的本机 HTTP 入口和嵌入式 React + TypeScript 控制台壳。控制台
+`into-md ui` 提供安全的本机 HTTP 入口和嵌入式 React + TypeScript 控制台壳。权威攻击者、
+信任边界、控制项、剩余风险和验收证据见[本地 Web 控制台威胁模型](web-security-threat-model.md)。控制台
 包含响应式批量转换工作台、格式/模型/Provider/插件/配置/doctor 管理页、服务状态路由、主题、简体中文/英文、错误边界与受约束 API
 客户端。状态响应把 `localApi.available` 与 `documentConsole.available` 都标为 `true`。
 
@@ -30,11 +31,13 @@ http://127.0.0.1:<port>/#into-md-session=<private-value>
 fragment 不会进入 HTTP request target。外部 content-hash bootstrap 脚本只接受完整且
 唯一的 `#into-md-session=<值>`，值的固定长度和字符集都必须合法。脚本同步通过
 `history.replaceState` 清除整个 fragment，之后才动态导入 React 应用；非法交接在不加载
-应用和不发请求的情况下显示安全错误。会话值只保存在 bootstrap 闭包与 API client 内存中，
-不写入 localStorage、sessionStorage、DOM、日志或错误消息。静态资产不嵌入会话值；响应设置
-`Referrer-Policy: no-referrer`、`Cache-Control: no-store`、
-`X-Content-Type-Options: nosniff`，CSP 仅允许同源脚本和连接并禁止 framing、base URI
-及表单提交；样式也只允许同源外部 CSS，不允许 inline style 或 `eval`。
+应用和不发请求的情况下显示安全错误。会话值保存在 bootstrap/API client 内存中，并只为
+当前标签页刷新恢复写入 `sessionStorage`；它不写入 localStorage、DOM、日志、错误消息或 HTTP
+URL。静态资产不嵌入会话值；响应设置 `Referrer-Policy: no-referrer`、
+`Cache-Control: no-store`、`X-Content-Type-Options: nosniff`、
+`Cross-Origin-Opener-Policy: same-origin`、`Cross-Origin-Resource-Policy: same-origin` 和最小
+`Permissions-Policy`；CSP 仅允许同源脚本和连接并禁止 framing、base URI 及表单提交，样式也只
+允许同源外部 CSS，不允许 inline style 或 `eval`。
 
 合法交接后的动态模块加载或同步启动失败使用独立的通用启动错误，不复述交接错误、异常或
 会话值。React 树外的 bootstrap 负责这类失败；React `ErrorBoundary` 负责 Provider、render

--- a/docs/web-security-threat-model.md
+++ b/docs/web-security-threat-model.md
@@ -1,0 +1,106 @@
+# 本地 Web 控制台威胁模型
+
+本文是 `into-md ui` 的权威威胁模型。实现细节和 HTTP 契约见 [`ui.md`](ui.md)，通用解析、
+运行时与插件安全边界见 [`security.md`](security.md)。本模型覆盖会话交接、回环 HTTP、上传、
+任务与制品存储、Markdown/IR 预览、下载和浏览器运行环境；它不把“只监听本机”视为天然安全。
+
+## 保护目标
+
+- 本地文档、录音、转换产物、任务历史、配置和 Provider 环境变量的机密性。
+- 任务、配置、插件、模型和下载制品的完整性。
+- 转换服务在敌意输入、慢连接、超限输入、取消和关闭时的可用性及资源有界释放。
+- 每次启动的 256-bit 会话值、一次性管理授权和 capability-bound artifact 句柄。
+
+文档正文、文件名、MIME、归档成员、Markdown、Document IR、诊断、Provider 响应、模型、
+插件包以及浏览器可访问的其他站点均为不可信输入。源码树、固定并校验的发布资产、当前进程
+生成的会话值和通过 descriptor-bound 校验打开的私有存储是受信边界。
+
+## 攻击者与边界
+
+| 攻击者 | 能力 | 必须阻断的结果 |
+|---|---|---|
+| 恶意网页、广告或 iframe | 向回环端口发起导航、表单、fetch、预检和 DNS rebinding | 调用 API、读取响应、探测任务或下载制品 |
+| 同机其他普通用户 | 连接回环端口、猜测端口、观察公开进程信息 | 获取会话值、读取数据目录或复用历史请求 |
+| 恶意文档或归档 | 控制正文、文件名、关系、资源、压缩结构和转换输出 | 路径穿越、符号链接逃逸、脚本执行、任意资源加载或无界资源占用 |
+| 获得旧会话请求的攻击者 | 重放旧 Header、URL、Cookie、查询参数或管理 grant | 在新进程或 grant 消费后重新取得权限 |
+| 慢客户端 | 不完整上传、停止读取下载、在关闭时保持连接 | 无限占用临时文件、匿名 inode、配额或 worker |
+| 带页面访问权限的浏览器扩展 | 读取或修改页面、发起同源请求 | 属于剩余风险；用户必须只在可信浏览器配置中使用控制台 |
+| 当前用户下的恶意进程、调试器或已提权攻击者 | 读取进程内存、终端、浏览器数据或私有目录 | 超出本地 Web 协议可防御边界，不宣称隔离 |
+
+## 请求认证、CSRF 与 DNS rebinding
+
+服务只绑定 IPv4 `127.0.0.1`，不存在可配置的外部监听地址。所有请求先验证唯一 ASCII `Host`
+恰好等于本次 `127.0.0.1:<port>`；因此 `localhost`、IPv6、尾点域名、其他端口、重复值和由
+攻击域名重绑定到回环地址的请求均在路由前拒绝。
+
+所有 `/api` 请求还必须同时满足：
+
+1. `Origin` 恰好等于本次 origin；浏览器不发送 `Origin` 的 GET/HEAD 只接受
+   `Sec-Fetch-Site: same-origin` 与 `Sec-Fetch-Mode: cors` 的精确组合；
+2. `X-Into-Md-Session` 是唯一、固定 43 字符的当前进程会话值，并以固定时长比较；
+3. Cookie、URL query、fragment、表单字段和请求体均不能提供认证；
+4. CORS 预检和跨源 origin 不得到 `Access-Control-Allow-Origin`；鉴权早于 method/fallback；
+5. 响应不包含会话值，并统一使用 `no-store`、`no-referrer`、`nosniff`、严格 CSP、
+   `Cross-Origin-Opener-Policy: same-origin` 与 `Cross-Origin-Resource-Policy: same-origin`。
+
+会话只通过启动 URL 的 fragment 交接。bootstrap 在加载应用前清除完整 fragment；当前标签页为
+刷新恢复把值保存在 `sessionStorage`，不会进入 localStorage、DOM、HTTP URL、access log 或错误
+文本。每次服务启动重新生成值，旧进程请求在重启后返回 `401 invalidSession`。该重放保证针对
+进程会话，而非为每个普通读取/转换请求建立 nonce；危险管理操作另使用绑定完整 action 的
+30 秒单次 grant，消费、失败或并发竞争后都不能重放。
+
+## 上传、任务与内容安全
+
+- 上传只接收流式 body；展示名称必须是有界 UTF-8 单文件名，拒绝 `/`、`\\`、`.`、`..`、
+  控制字符和路径语义。名称永不用于存储路径，任务、输入和 artifact 使用服务生成的 opaque ID。
+- `Content-Length`、实际输入、解压、资源、页数、内存、临时空间、worker 数、idle/total deadline
+  与全局 managed-tree 配额同时约束。断连、取消、超时和关闭会 drop capability 并清理 stage。
+- ZIP、Office、PDF、图像、媒体与插件入口继续执行各自的结构、预算和隔离校验；Web 授权不会
+  绕过 Engine 的网络、私网、Provider 或资源策略。
+- 任务根、incoming、stage、published、snapshot 与 trash 只允许私有普通单链接文件；路径、
+  symlink/reparse、hardlink、额外成员、identity swap 或 manifest 摘要漂移均 fail closed。
+- 上传和 API 错误只返回稳定 schema/code，不反射文件正文、自由文本错误、会话值、Provider
+  secret 或本地绝对路径。
+
+## 预览、下载与浏览器能力
+
+Markdown 预览只创建 React text node 以及固定的标题、段落、列表、表格和代码 DOM；不使用
+`innerHTML`，不创建 `a`、`img`、`script`、`iframe`、`object`、`embed` 或其他可加载资源的
+元素。`javascript:`、`file:`、data URI、远程图片、原始 HTML 和事件属性只作为文本显示。
+IR/诊断树限制深度、节点和单容器成员，Markdown 限制 block 数；预览仅请求 artifact 的前
+256 KiB。
+
+下载端点只接受任务 manifest 中的 opaque storage key，打开后复制、校验 byte count/SHA-256，
+再通过匿名只读 snapshot 流式返回。单区间 Range、MIME 和 `Content-Disposition` 全部由服务端
+规范化；不可信文件名不能进入 Header 或路径。所有 API 响应不可被跨源读取，控制台也不加载
+CDN、远程字体或远程运行时代码。`Permissions-Policy` 只向同源开放会议所需 microphone 与
+display-capture，显式关闭 camera、geolocation、payment 和 USB。
+
+## 本地用户、浏览器扩展与剩余风险
+
+Unix 数据目录逐组件 no-follow 并要求最终目录 `0700`；Windows 拒绝 reparse point 并复核
+volume/file identity。会话不出现在进程参数或普通启动日志。同机其他普通用户即使找到端口，
+没有当前会话、精确 Origin 和 Host 也不能调用 API；操作系统仍必须正确隔离用户进程和目录。
+
+浏览器扩展若已获得该 origin 的页面读取或脚本注入权限，可能取得 `sessionStorage` 中的会话并
+以用户身份操作。当前用户下的恶意进程、调试器、屏幕/终端监控、内核或管理员攻击者同样可能
+越过本协议。控制台不尝试对这些已进入用户信任域的攻击者提供密码学隔离；应使用可信浏览器
+配置、最小扩展权限和受保护的本地账户，私有启动 URL不得进入聊天、工单或共享日志。
+
+HTTP 回环通信不是 TLS。安全性依赖操作系统回环隔离、每进程高熵会话、精确 Host/Origin 和
+私有数据目录；不支持把端口转发、反向代理、容器映射或远程桌面共享后的入口视为等价部署。
+
+## 验证门禁
+
+以下门禁共同构成证据，任何单项都不能替代其他层：
+
+```shell
+cargo test --locked -p into-markdown-cli --bin into-md ui::tests -- --test-threads=1
+cargo test --locked -p into-markdown-cli web_tasks::tests -- --test-threads=1
+bazel test //apps/cli:web_security_test //web/console:web_security_test --test_output=errors
+```
+
+真实浏览器验收从新进程打印的 private URL 进入，确认 fragment 在首个应用请求前清除；随后
+上传包含 raw HTML、脚本、`javascript:`、`file:`、data URI 和远程图片的 Markdown，确认预览
+只显示文本、没有外部网络请求和可执行/资源型 DOM；再验证刷新恢复、制品下载、错误 Origin、
+旧会话重放以及服务关闭后连接释放。测试证据不得包含真实会话值或用户文档。

--- a/docs/web-security-threat-model.md
+++ b/docs/web-security-threat-model.md
@@ -98,9 +98,12 @@ HTTP 回环通信不是 TLS。安全性依赖操作系统回环隔离、每进�
 cargo test --locked -p into-markdown-cli --bin into-md ui::tests -- --test-threads=1
 cargo test --locked -p into-markdown-cli web_tasks::tests -- --test-threads=1
 bazel test //apps/cli:web_security_test //web/console:web_security_test --test_output=errors
+INTO_MD_CLI=target/debug/into-md pnpm --filter @into-markdown/console exec playwright test tests/web-security.e2e.spec.ts --workers=1
 ```
 
-真实浏览器验收从新进程打印的 private URL 进入，确认 fragment 在首个应用请求前清除；随后
+真实浏览器门禁从新进程打印的 private URL 进入，且不会把该 URL 写入测试报告；它确认 fragment
+在首个应用请求前清除，随后
 上传包含 raw HTML、脚本、`javascript:`、`file:`、data URI 和远程图片的 Markdown，确认预览
-只显示文本、没有外部网络请求和可执行/资源型 DOM；再验证刷新恢复、制品下载、错误 Origin、
-旧会话重放以及服务关闭后连接释放。测试证据不得包含真实会话值或用户文档。
+只显示文本、没有外部网络请求和可执行/资源型 DOM，并验证同一标签页刷新恢复。Cargo loopback
+门禁负责制品下载、错误 Origin、旧会话重放以及服务关闭后连接释放。测试证据不得包含真实
+会话值或用户文档。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
         specifier: 19.2.8
         version: 19.2.8(react@19.2.8)
     devDependencies:
+      '@playwright/test':
+        specifier: 1.62.1
+        version: 1.62.1
       '@types/node':
         specifier: 24.10.0
         version: 24.10.0
@@ -45,6 +48,11 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
@@ -75,6 +83,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   happy-dom@18.0.1:
     resolution: {integrity: sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==}
     engines: {node: '>=20.0.0'}
@@ -84,6 +97,16 @@ packages:
     peerDependencies:
       '@types/react': ^19.0.0
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   react-dom@19.2.8:
     resolution: {integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==}
@@ -114,6 +137,10 @@ packages:
 
 snapshots:
 
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
+
   '@types/node@20.19.43':
     dependencies:
       undici-types: 6.21.0
@@ -138,6 +165,9 @@ snapshots:
 
   esbuild-wasm@0.28.2: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   happy-dom@18.0.1:
     dependencies:
       '@types/node': 20.19.43
@@ -148,6 +178,14 @@ snapshots:
     dependencies:
       '@types/react': 19.2.2
       react: 19.2.8
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   react-dom@19.2.8(react@19.2.8):
     dependencies:

--- a/web/console/BUILD.bazel
+++ b/web/console/BUILD.bazel
@@ -150,6 +150,15 @@ js_test(
     env = {"INTO_MD_DIST": "web/console/dist"},
 )
 
+test_suite(
+    name = "web_security_test",
+    tests = [
+        ":dist_integration_test",
+        ":unit_test_core",
+        ":unit_test_preview",
+    ],
+)
+
 js_run_binary(
     name = "generated_assets",
     out_dirs = ["generated_assets"],

--- a/web/console/package.json
+++ b/web/console/package.json
@@ -8,6 +8,7 @@
     "react-dom": "19.2.8"
   },
   "devDependencies": {
+    "@playwright/test": "1.62.1",
     "@types/node": "24.10.0",
     "@types/react": "19.2.2",
     "@types/react-dom": "19.2.2",

--- a/web/console/tests/web-security.e2e.spec.ts
+++ b/web/console/tests/web-security.e2e.spec.ts
@@ -1,0 +1,137 @@
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Readable } from "node:stream";
+import { test, expect, type Page } from "@playwright/test";
+
+const CLI = process.env.INTO_MD_CLI;
+const PRIVATE_URL_PREFIX = "open this private session URL: ";
+type LocalServer = ChildProcessByStdio<null, Readable, Readable>;
+
+test.describe("local Web security boundary", () => {
+  test.skip(!CLI, "INTO_MD_CLI must point to the production into-md binary");
+  test.setTimeout(90_000);
+
+  test("clears the launch secret and renders hostile Markdown as inert text", async ({ page }) => {
+    const dataDirectory = await mkdtemp(join(tmpdir(), "into-md-browser-security-"));
+    const server = spawn(CLI!, ["ui", "--no-open", "--no-config", "--data-dir", dataDirectory], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    server.stderr.resume();
+
+    try {
+      const launchUrl = await privateLaunchUrl(server);
+      const expectedOrigin = new URL(launchUrl).origin;
+      const externalRequests = new Set<string>();
+      page.on("request", (request) => recordExternalOrigin(request.url(), expectedOrigin, externalRequests));
+
+      const response = await openPrivateConsole(page, launchUrl);
+      expect(response.headers()["cache-control"]).toContain("no-store");
+      expect(response.headers()["content-security-policy"]).toContain("default-src 'none'");
+      expect(response.headers()["cross-origin-opener-policy"]).toBe("same-origin");
+      expect(response.headers()["cross-origin-resource-policy"]).toBe("same-origin");
+      expect(response.headers()["permissions-policy"]).toContain("camera=()");
+      assertLaunchSecretCleared(page);
+
+      await page.locator('input[type="file"]:not([webkitdirectory])').setInputFiles({
+        name: "hostile.txt",
+        mimeType: "text/plain",
+        buffer: Buffer.from(hostileMarkdown()),
+      });
+      await page.locator(".convert-button").click();
+      await page.locator(".markdown-preview").waitFor({ state: "visible" });
+
+      const preview = page.locator(".markdown-preview");
+      expect(await preview.textContent()).toContain("__intoMdBrowserSecurityProbe");
+      expect(await preview.locator("a, img, script, iframe, object, embed, link, style, video, audio, source").count()).toBe(0);
+      expect(await page.evaluate(() => "__intoMdBrowserSecurityProbe" in globalThis)).toBe(false);
+      if (externalRequests.size !== 0) throw new Error("hostile preview initiated an external request");
+
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await page.locator(".markdown-preview").waitFor({ state: "visible" });
+      assertLaunchSecretCleared(page);
+    } finally {
+      await stopServer(server);
+      await rm(dataDirectory, { recursive: true, force: true });
+    }
+  });
+});
+
+async function privateLaunchUrl(server: LocalServer): Promise<string> {
+  return await new Promise((resolve, reject) => {
+    let stdout = "";
+    const timeout = setTimeout(() => reject(new Error("local Web server did not become ready")), 30_000);
+    const finish = (callback: () => void) => { clearTimeout(timeout); callback(); };
+    server.stdout.setEncoding("utf8");
+    server.stdout.on("data", (chunk: string) => {
+      stdout += chunk;
+      const line = stdout.split(/\r?\n/).find((entry) => entry.startsWith(PRIVATE_URL_PREFIX));
+      if (!line) return;
+      const value = line.slice(PRIVATE_URL_PREFIX.length);
+      if (!/^http:\/\/127\.0\.0\.1:\d+\/#into-md-session=[A-Za-z0-9_-]{43}$/.test(value)) {
+        finish(() => reject(new Error("local Web server returned an invalid private URL")));
+        return;
+      }
+      finish(() => resolve(value));
+    });
+    server.once("exit", () => finish(() => reject(new Error("local Web server stopped before it became ready"))));
+    server.once("error", () => finish(() => reject(new Error("local Web server could not start"))));
+  });
+}
+
+async function openPrivateConsole(page: Page, launchUrl: string) {
+  try {
+    const response = await page.goto(launchUrl, { waitUntil: "domcontentloaded" });
+    if (!response) throw new Error("missing navigation response");
+    return response;
+  } catch {
+    // Playwright navigation errors include the requested URL. Replace them so
+    // the fragment-delivered session value cannot enter CI output.
+    throw new Error("failed to open the private local console");
+  }
+}
+
+function assertLaunchSecretCleared(page: Page): void {
+  if (new URL(page.url()).hash !== "") throw new Error("private launch fragment was not cleared");
+}
+
+function recordExternalOrigin(url: string, expectedOrigin: string, external: Set<string>): void {
+  try {
+    const parsed = new URL(url);
+    if ((parsed.protocol === "http:" || parsed.protocol === "https:") && parsed.origin !== expectedOrigin) {
+      external.add(parsed.origin);
+    }
+  } catch {
+    throw new Error("browser emitted an invalid request URL");
+  }
+}
+
+function hostileMarkdown(): string {
+  return [
+    "# Safe heading",
+    '<script>globalThis.__intoMdBrowserSecurityProbe = true</script>',
+    "![remote](https://browser-security.invalid/tracker.png)",
+    "[javascript](javascript:alert(document.domain))",
+    "[local](file:///etc/passwd)",
+    '<img src="data:text/html,<script>globalThis.__intoMdBrowserSecurityProbe=true</script>" onerror="globalThis.__intoMdBrowserSecurityProbe=true">',
+    '<iframe src="https://browser-security.invalid/frame"></iframe>',
+  ].join("\n");
+}
+
+async function stopServer(server: LocalServer): Promise<void> {
+  if (server.exitCode !== null || server.signalCode !== null) return;
+  server.kill("SIGINT");
+  await Promise.race([
+    new Promise<void>((resolve) => server.once("exit", () => resolve())),
+    new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+  ]);
+  if (server.exitCode === null && server.signalCode === null) {
+    const forcedExit = new Promise<void>((resolve) => {
+      if (server.exitCode !== null || server.signalCode !== null) resolve();
+      else server.once("exit", () => resolve());
+    });
+    server.kill("SIGKILL");
+    await forcedExit;
+  }
+}

--- a/web/console/tsconfig.e2e.json
+++ b/web/console/tsconfig.e2e.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["tests/web-security.e2e.spec.ts"]
+}


### PR DESCRIPTION
Closes #54

## What changed

- harden every local Web response with COOP, CORP, and a minimal Permissions Policy in addition to the existing CSP, no-store, referrer, and content-type protections
- extend the real loopback attack matrix for null/userinfo/duplicate origins, duplicate session headers, cookie/query ambient-auth attempts, and stale-session replay after restart
- add named Cargo/Bazel security gates and a four-platform GitHub Actions workflow covering the production CLI storage/request boundary and embedded console preview boundary
- add a real Chromium E2E that launches the production server, consumes and clears its private fragment, uploads hostile content, proves the preview creates no executable/resource DOM or external request, and verifies same-tab refresh recovery
- keep the private launch URL out of browser-test errors, traces, stdout, and artifacts
- add a complete Chinese threat model for DNS rebinding, other local users, browser extensions, malicious uploads/archives, artifact downloads, preview safety, replay semantics, and residual risks
- correct the session documentation to match the same-tab refresh implementation

## Verification

- `cargo fmt --all --check`
- `cargo test --locked -p into-markdown-cli --bin into-md ui::tests -- --test-threads=1` — 16 passed
- `cargo test --locked -p into-markdown-cli web_tasks::tests -- --test-threads=1` — 62 passed
- `bazel test //web/console:web_security_test --test_output=errors` — 3 targets passed
- `bazel test //apps/cli:web_security_test --test_output=errors` — full 220-test CLI target passed
- `pnpm --filter @into-markdown/console exec tsc -p tsconfig.e2e.json` — passed
- Playwright discovery registered the Chromium security E2E; its production flow was also run manually in the in-app browser against a fresh server: launch fragment cleared, hostile input rendered only as text, zero executable/resource DOM elements, and no console warnings/errors
- workflow YAML parsed successfully

## CI state

GitHub did not start any job because the repository account reports failed recent payments or an exceeded spending limit. Every failed check has zero steps and the same billing annotation. Local Cargo, Bazel, TypeScript, lockfile, YAML, and real-browser gates above were reviewed instead.

## Review notes

`cargo clippy --locked -p into-markdown-cli --bin into-md -- -D warnings` is blocked by two existing warnings in `crates/core` (`too_many_lines` in `ir.rs` and `needless_pass_by_value` in `ocr_binding.rs`). Neither file is changed here. Bazel's full production CLI test target passes.
