### PR TITLE
Fix speaker diarization gaps and unnatural turns

### DIFF
--- a/crates/asr/src/diarization.rs
+++ b/crates/asr/src/diarization.rs
@@ -12,7 +12,7 @@ use into_markdown_ocr::{
     Dimension, ModelContract, ModelIdentity, ModelManager, ModelManagerError, ModelResolver,
     ResolvedModel, TensorElementType, TensorSpec,
 };
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::f32::consts::PI;
 use std::sync::{Arc, Mutex};
 
@@ -23,12 +23,14 @@ const VAD_MODEL_ID: &str = "silero-vad";
 const EMBEDDING_MODEL_ID: &str = "3dspeaker-embedding";
 const VAD_WINDOW: usize = 512;
 const EMBEDDING_DIMENSION: usize = 512;
-const MIN_EMBEDDING_SAMPLES: usize = 8_000;
+const MIN_EMBEDDING_SAMPLES: usize = 16_000;
 const MAX_EMBEDDING_SAMPLES: usize = 160_000;
-const AUTO_CREATE_THRESHOLD: f32 = 0.52;
+const AUTO_CREATE_THRESHOLD: f32 = 0.20;
+const EXPECTED_CREATE_THRESHOLD: f32 = 0.45;
 const ASSIGN_THRESHOLD: f32 = 0.58;
 const AMBIGUITY_MARGIN: f32 = 0.035;
 const TURN_WINDOW_MS: u64 = 3_000;
+const SAME_SPEAKER_MERGE_GAP_MS: u64 = 1_500;
 const CHECKPOINT_INTERVAL_MS: u64 = 30_000;
 
 /// Product resolver for the two hash-verified diarization ONNX models.
@@ -235,7 +237,12 @@ impl OnlineCosineClustering {
         Ok(Self { clusters: Vec::new(), expected_speakers, max_speakers })
     }
 
-    /// Assign one normalized embedding, or leave it ambiguous rather than guessing.
+    /// Assign one normalized embedding to the closest bounded cluster.
+    ///
+    /// Low-separation assignments keep a reduced confidence and do not update a
+    /// centroid. A transcript token is known speech, so dropping its speaker
+    /// entirely produces alternating labelled and anonymous fragments without
+    /// improving the underlying clustering decision.
     pub fn assign(&mut self, embedding: &[f32]) -> Option<(String, f32)> {
         if embedding.len() != EMBEDDING_DIMENSION
             || embedding.iter().any(|value| !value.is_finite())
@@ -256,27 +263,74 @@ impl OnlineCosineClustering {
         let (best_index, best) = ranked[0];
         let runner_up = ranked.get(1).map_or(-1.0, |value| value.1);
         let target = usize::from(self.expected_speakers.unwrap_or(self.max_speakers));
-        let should_create = self.clusters.len() < target
-            && best
-                < if self.expected_speakers.is_some() {
-                    ASSIGN_THRESHOLD
-                } else {
-                    AUTO_CREATE_THRESHOLD
-                };
+        let create_threshold = if self.expected_speakers.is_some() {
+            EXPECTED_CREATE_THRESHOLD
+        } else {
+            AUTO_CREATE_THRESHOLD
+        };
+        let should_create = self.clusters.len() < target && best < create_threshold;
         if should_create {
             return self.create(embedding);
         }
-        if best < ASSIGN_THRESHOLD || best - runner_up < AMBIGUITY_MARGIN {
-            return None;
-        }
+        let separation = best - runner_up;
+        let reliable = best >= ASSIGN_THRESHOLD && separation >= AMBIGUITY_MARGIN;
         let cluster = &mut self.clusters[best_index];
         cluster.observations = cluster.observations.saturating_add(1);
-        let weight = 1.0 / f32::from(cluster.observations);
-        for (centroid, value) in cluster.centroid.iter_mut().zip(embedding) {
-            *centroid += (*value - *centroid) * weight;
+        if reliable {
+            let weight = 1.0 / f32::from(cluster.observations);
+            for (centroid, value) in cluster.centroid.iter_mut().zip(embedding) {
+                *centroid += (*value - *centroid) * weight;
+            }
+            normalize(&mut cluster.centroid);
         }
-        normalize(&mut cluster.centroid);
-        Some((format!("speaker-{}", best_index + 1), confidence(best)))
+        let separation_confidence =
+            (separation / AMBIGUITY_MARGIN).clamp(0.0, 1.0).mul_add(0.5, 0.5);
+        Some((format!("speaker-{}", best_index + 1), confidence(best) * separation_confidence))
+    }
+
+    fn automatic_singleton_remap(&self) -> BTreeMap<String, String> {
+        if self.expected_speakers.is_some() {
+            return BTreeMap::new();
+        }
+        let stable = self
+            .clusters
+            .iter()
+            .enumerate()
+            .filter(|(_, cluster)| cluster.observations >= 2)
+            .collect::<Vec<_>>();
+        if stable.is_empty() {
+            return BTreeMap::new();
+        }
+        let singletons = self
+            .clusters
+            .iter()
+            .enumerate()
+            .filter(|(_, cluster)| cluster.observations == 1)
+            .collect::<Vec<_>>();
+        if singletons.len() <= 1 {
+            return BTreeMap::new();
+        }
+        let keep = singletons
+            .iter()
+            .min_by(|left, right| {
+                closest_similarity(left.1, &stable).total_cmp(&closest_similarity(right.1, &stable))
+            })
+            .map(|(index, _)| *index);
+        singletons
+            .into_iter()
+            .filter(|(index, _)| Some(*index) != keep)
+            .filter_map(|(index, cluster)| {
+                stable
+                    .iter()
+                    .max_by(|left, right| {
+                        cosine(&left.1.centroid, &cluster.centroid)
+                            .total_cmp(&cosine(&right.1.centroid, &cluster.centroid))
+                    })
+                    .map(|(target, _)| {
+                        (format!("speaker-{}", index + 1), format!("speaker-{}", target + 1))
+                    })
+            })
+            .collect()
     }
 
     /// Restore a bounded clustering state after its durable identity was verified.
@@ -328,6 +382,14 @@ impl OnlineCosineClustering {
         self.clusters.push(Cluster { centroid, observations: 1 });
         Some((format!("speaker-{}", self.clusters.len()), 1.0))
     }
+}
+
+fn closest_similarity(cluster: &Cluster, candidates: &[(usize, &Cluster)]) -> f32 {
+    candidates
+        .iter()
+        .map(|(_, candidate)| cosine(&candidate.centroid, &cluster.centroid))
+        .max_by(f32::total_cmp)
+        .unwrap_or(-1.0)
 }
 
 fn recovery(detail: impl Into<String>) -> ConversionError {
@@ -499,8 +561,9 @@ impl LocalSpeakerDiarizer {
                 }
             };
             if turns.is_empty() {
-                let assignment =
-                    self.assign_range(&audio, segment_range, &mut clustering, context).await?;
+                let assignment = self
+                    .assign_range(&audio, segment_range, false, &mut clustering, context)
+                    .await?;
                 let Block::TimedSegment { speaker, speaker_confidence, .. } =
                     &mut segments[index].block
                 else {
@@ -518,8 +581,9 @@ impl LocalSpeakerDiarizer {
                 }
             } else {
                 for turn in turns {
-                    let assignment =
-                        self.assign_range(&audio, turn.range, &mut clustering, context).await?;
+                    let assignment = self
+                        .assign_range(&audio, turn.range, true, &mut clustering, context)
+                        .await?;
                     let Block::TimedSegment { tokens, .. } = &mut segments[index].block else {
                         return Err(ConversionError::Ai {
                             provider: PROVIDER_ID.into(),
@@ -578,7 +642,12 @@ impl LocalSpeakerDiarizer {
                 next_checkpoint_ms = segment_range.end_ms.saturating_add(CHECKPOINT_INTERVAL_MS);
             }
         }
-        let segments = split_token_speaker_turns(segments)?;
+        remap_speakers(&mut segments, &clustering.automatic_singleton_remap())?;
+        if request.expected_speakers.is_none() {
+            compact_speaker_labels(&mut segments)?;
+        }
+        repair_unassigned_speech(&mut segments)?;
+        let segments = merge_adjacent_speaker_turns(split_token_speaker_turns(segments)?)?;
         context.report(ExecutionStage::Ai, Some(950), Some(1_000), Some("diarization.complete"))?;
         Ok(DiarizationResult {
             segments,
@@ -591,14 +660,16 @@ impl LocalSpeakerDiarizer {
         &self,
         audio: &NormalizedAudio,
         range: TimeRange,
+        known_speech: bool,
         clustering: &mut OnlineCosineClustering,
         context: &ExecutionContext,
     ) -> Result<Option<(String, f32)>, ConversionError> {
         let start = milliseconds_to_frame(range.start_ms, audio.frames);
         let end = milliseconds_to_frame(range.end_ms, audio.frames).max(start);
         let samples = read_segment_samples(audio, start, end, context)?;
-        let voice = self.voice_probability(&samples, context).await?;
-        if voice < 0.45 || samples.len() < MIN_EMBEDDING_SAMPLES / 2 {
+        let voice =
+            if known_speech { 1.0 } else { self.voice_probability(&samples, context).await? };
+        if voice < 0.45 || samples.len() < MIN_EMBEDDING_SAMPLES {
             return Ok(None);
         }
         let features = log_mel_fbank(&samples)?;
@@ -632,8 +703,13 @@ impl LocalSpeakerDiarizer {
         context: &ExecutionContext,
     ) -> Result<f32, ConversionError> {
         let mut state = vec![0.0; 2 * 128];
-        let mut total = 0.0_f64;
-        let mut count = 0_u32;
+        let mut probabilities = Vec::new();
+        probabilities.try_reserve(samples.len().div_ceil(VAD_WINDOW)).map_err(|_| {
+            ConversionError::ResourceLimit {
+                limit: "max_memory_bytes",
+                detail: "speaker VAD probability allocation failed".into(),
+            }
+        })?;
         for chunk in samples.chunks(VAD_WINDOW) {
             context.checkpoint()?;
             let mut input = vec![0.0; VAD_WINDOW];
@@ -668,11 +744,10 @@ impl LocalSpeakerDiarizer {
                     detail: "Silero VAD returned non-finite values".into(),
                 });
             }
-            total += f64::from(probability.clamp(0.0, 1.0));
-            count = count.saturating_add(1);
+            probabilities.push(probability.clamp(0.0, 1.0));
             state = outputs.into_iter().nth(1).expect("checked output count").values;
         }
-        Ok(if count == 0 { 0.0 } else { (total / f64::from(count)) as f32 })
+        Ok(robust_voice_probability(&mut probabilities))
     }
 }
 
@@ -687,15 +762,30 @@ fn token_turns(tokens: &[TimedToken], fallback: TimeRange) -> Vec<TokenTurn> {
     if tokens.is_empty() {
         return Vec::new();
     }
-    let mut turns = Vec::new();
+    let first_start = tokens[0].range.start_ms.max(fallback.start_ms);
+    let final_end = tokens[tokens.len() - 1].range.end_ms.min(fallback.end_ms);
+    let duration = final_end.saturating_sub(first_start);
+    let group_count = usize::try_from(duration.div_ceil(TURN_WINDOW_MS))
+        .unwrap_or(tokens.len())
+        .clamp(1, tokens.len());
+    let mut turns = Vec::with_capacity(group_count);
     let mut start = 0_usize;
-    while start < tokens.len() {
-        let turn_start = tokens[start].range.start_ms;
-        let mut end = start + 1;
-        while end < tokens.len()
-            && tokens[end].range.end_ms.saturating_sub(turn_start) <= TURN_WINDOW_MS
-        {
-            end += 1;
+    for boundary in 1..=group_count {
+        let end = if boundary == group_count {
+            tokens.len()
+        } else {
+            let ideal = first_start.saturating_add(
+                duration.saturating_mul(u64::try_from(boundary).unwrap_or(u64::MAX))
+                    / u64::try_from(group_count).unwrap_or(1),
+            );
+            let remaining_groups = group_count - boundary;
+            let latest = tokens.len() - remaining_groups;
+            (start + 1..=latest)
+                .min_by_key(|candidate| tokens[candidate - 1].range.end_ms.abs_diff(ideal))
+                .unwrap_or(start + 1)
+        };
+        if end <= start {
+            continue;
         }
         let range = TimeRange {
             start_ms: tokens[start].range.start_ms.max(fallback.start_ms),
@@ -707,6 +797,134 @@ fn token_turns(tokens: &[TimedToken], fallback: TimeRange) -> Vec<TokenTurn> {
         start = end;
     }
     turns
+}
+
+fn robust_voice_probability(probabilities: &mut [f32]) -> f32 {
+    if probabilities.is_empty() {
+        return 0.0;
+    }
+    probabilities.sort_unstable_by(|left, right| right.total_cmp(left));
+    let speech_frames = probabilities.len().div_ceil(4).max(1);
+    let total = probabilities[..speech_frames].iter().sum::<f32>();
+    let count = u16::try_from(speech_frames).unwrap_or(u16::MAX);
+    total / f32::from(count)
+}
+
+fn repair_unassigned_speech(segments: &mut [BlockNode]) -> Result<(), ConversionError> {
+    let mut speakers = BTreeSet::new();
+    for node in segments.iter() {
+        let Block::TimedSegment { speaker, tokens, .. } = &node.block else {
+            return Err(ConversionError::Ai {
+                provider: PROVIDER_ID.into(),
+                detail: "diarization input contains a non-timed node".into(),
+            });
+        };
+        if let Some(speaker) = speaker {
+            speakers.insert(speaker.clone());
+        }
+        speakers.extend(tokens.iter().filter_map(|token| token.speaker.clone()));
+    }
+    let only_speaker = (speakers.len() == 1).then(|| speakers.into_iter().next()).flatten();
+    for node in segments {
+        let has_tokens = {
+            let Block::TimedSegment { speaker, speaker_confidence, tokens, .. } = &mut node.block
+            else {
+                return Err(ConversionError::Ai {
+                    provider: PROVIDER_ID.into(),
+                    detail: "diarization input contains a non-timed node".into(),
+                });
+            };
+            if let Some(id) = &only_speaker {
+                for token in tokens.iter_mut().filter(|token| token.speaker.is_none()) {
+                    token.speaker = Some(id.clone());
+                    token.speaker_confidence = Some(0.0);
+                }
+                if tokens.is_empty() && speaker.is_none() {
+                    *speaker = Some(id.clone());
+                    *speaker_confidence = Some(0.0);
+                }
+            } else {
+                repair_bracketed_token_gaps(tokens);
+            }
+            !tokens.is_empty()
+        };
+        if has_tokens {
+            summarize_token_speaker(node)?;
+        }
+    }
+    Ok(())
+}
+
+fn remap_speakers(
+    segments: &mut [BlockNode],
+    remap: &BTreeMap<String, String>,
+) -> Result<(), ConversionError> {
+    if remap.is_empty() {
+        return Ok(());
+    }
+    for node in segments {
+        let Block::TimedSegment { speaker, tokens, .. } = &mut node.block else {
+            return Err(ConversionError::Ai {
+                provider: PROVIDER_ID.into(),
+                detail: "diarization input contains a non-timed node".into(),
+            });
+        };
+        if let Some(target) = speaker.as_ref().and_then(|id| remap.get(id)) {
+            *speaker = Some(target.clone());
+        }
+        for token in tokens {
+            if let Some(target) = token.speaker.as_ref().and_then(|id| remap.get(id)) {
+                token.speaker = Some(target.clone());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn compact_speaker_labels(segments: &mut [BlockNode]) -> Result<(), ConversionError> {
+    let mut remap = BTreeMap::new();
+    for node in segments.iter() {
+        let Block::TimedSegment { speaker, tokens, .. } = &node.block else {
+            return Err(ConversionError::Ai {
+                provider: PROVIDER_ID.into(),
+                detail: "diarization input contains a non-timed node".into(),
+            });
+        };
+        for id in tokens.iter().filter_map(|token| token.speaker.as_ref()).chain(speaker) {
+            if !remap.contains_key(id) {
+                remap.insert(id.clone(), format!("speaker-{}", remap.len() + 1));
+            }
+        }
+    }
+    remap_speakers(segments, &remap)
+}
+
+fn repair_bracketed_token_gaps(tokens: &mut [TimedToken]) {
+    let mut start = 0_usize;
+    while start < tokens.len() {
+        if tokens[start].speaker.is_some() {
+            start += 1;
+            continue;
+        }
+        let mut end = start + 1;
+        while end < tokens.len() && tokens[end].speaker.is_none() {
+            end += 1;
+        }
+        let before = start.checked_sub(1).and_then(|index| tokens[index].speaker.clone());
+        let after = tokens.get(end).and_then(|token| token.speaker.clone());
+        if let Some(id) = before.filter(|id| after.as_ref() == Some(id)) {
+            let confidence = start
+                .checked_sub(1)
+                .and_then(|index| tokens[index].speaker_confidence)
+                .zip(tokens.get(end).and_then(|token| token.speaker_confidence))
+                .map_or(0.0, |(left, right)| left.min(right) * 0.5);
+            for token in &mut tokens[start..end] {
+                token.speaker = Some(id.clone());
+                token.speaker_confidence = Some(confidence);
+            }
+        }
+        start = end;
+    }
 }
 
 fn summarize_token_speaker(node: &mut BlockNode) -> Result<(), ConversionError> {
@@ -833,6 +1051,113 @@ fn split_token_speaker_turns(segments: Vec<BlockNode>) -> Result<Vec<BlockNode>,
     Ok(output)
 }
 
+fn merge_adjacent_speaker_turns(
+    segments: Vec<BlockNode>,
+) -> Result<Vec<BlockNode>, ConversionError> {
+    let mut output = Vec::<BlockNode>::new();
+    output.try_reserve(segments.len()).map_err(|_| ConversionError::ResourceLimit {
+        limit: "max_memory_bytes",
+        detail: "speaker turn merge allocation failed".into(),
+    })?;
+    for node in segments {
+        if output.last_mut().is_some_and(|previous| can_merge_speaker_turns(previous, &node)) {
+            let previous = output.last_mut().expect("checked previous speaker turn");
+            merge_speaker_turn(previous, node)?;
+        } else {
+            output.push(node);
+        }
+    }
+    Ok(output)
+}
+
+fn can_merge_speaker_turns(left: &BlockNode, right: &BlockNode) -> bool {
+    let Block::TimedSegment { range: left_range, speaker: left_speaker, .. } = &left.block else {
+        return false;
+    };
+    let Block::TimedSegment { range: right_range, speaker: right_speaker, .. } = &right.block
+    else {
+        return false;
+    };
+    left_speaker.is_some()
+        && left_speaker == right_speaker
+        && right_range.start_ms >= left_range.end_ms
+        && right_range.start_ms - left_range.end_ms <= SAME_SPEAKER_MERGE_GAP_MS
+}
+
+fn merge_speaker_turn(left: &mut BlockNode, right: BlockNode) -> Result<(), ConversionError> {
+    let Block::TimedSegment {
+        range: right_range,
+        speaker: _,
+        speaker_confidence: right_confidence,
+        tokens: right_tokens,
+        content: right_content,
+    } = right.block
+    else {
+        return Err(ConversionError::Ai {
+            provider: PROVIDER_ID.into(),
+            detail: "speaker turn merge received a non-timed node".into(),
+        });
+    };
+    let Block::TimedSegment {
+        range: left_range,
+        speaker: _,
+        speaker_confidence: left_confidence,
+        tokens: left_tokens,
+        content: left_content,
+    } = &mut left.block
+    else {
+        return Err(ConversionError::Ai {
+            provider: PROVIDER_ID.into(),
+            detail: "speaker turn merge received a non-timed node".into(),
+        });
+    };
+    let left_weight = f32::from(u16::try_from(left_tokens.len()).unwrap_or(u16::MAX).max(1));
+    let right_weight = f32::from(u16::try_from(right_tokens.len()).unwrap_or(u16::MAX).max(1));
+    *left_confidence = match (*left_confidence, right_confidence) {
+        (Some(left), Some(right)) => {
+            Some((left * left_weight + right * right_weight) / (left_weight + right_weight))
+        }
+        (Some(value), None) | (None, Some(value)) => Some(value),
+        (None, None) => None,
+    };
+    left_tokens.try_reserve(right_tokens.len()).map_err(|_| ConversionError::ResourceLimit {
+        limit: "max_memory_bytes",
+        detail: "speaker turn token merge allocation failed".into(),
+    })?;
+    left_tokens.extend(right_tokens);
+    let [Inline::Text { value: left_text, marks: left_marks }] = left_content.as_slice() else {
+        return Err(ConversionError::Ai {
+            provider: PROVIDER_ID.into(),
+            detail: "speaker turn merge received invalid timed content".into(),
+        });
+    };
+    let [Inline::Text { value: right_text, marks: right_marks }] = right_content.as_slice() else {
+        return Err(ConversionError::Ai {
+            provider: PROVIDER_ID.into(),
+            detail: "speaker turn merge received invalid timed content".into(),
+        });
+    };
+    if !left_marks.is_empty() || !right_marks.is_empty() {
+        return Err(ConversionError::Ai {
+            provider: PROVIDER_ID.into(),
+            detail: "speaker turn merge received marked timed content".into(),
+        });
+    }
+    let mut merged_text = String::new();
+    merged_text.try_reserve(left_text.len().saturating_add(right_text.len())).map_err(|_| {
+        ConversionError::ResourceLimit {
+            limit: "max_memory_bytes",
+            detail: "speaker turn content merge allocation failed".into(),
+        }
+    })?;
+    merged_text.push_str(left_text);
+    merged_text.push_str(right_text);
+    *left_content = vec![Inline::Text { value: merged_text, marks: Vec::new() }];
+    left_range.end_ms = right_range.end_ms;
+    left.provenance.locator.time = Some(*left_range);
+    Ok(())
+}
+
 impl Diarizer for LocalSpeakerDiarizer {
     fn id(&self) -> &'static str {
         PROVIDER_ID
@@ -857,12 +1182,14 @@ fn read_segment_samples(
     end: u64,
     context: &ExecutionContext,
 ) -> Result<Vec<f32>, ConversionError> {
-    let desired = end.saturating_sub(start);
-    let desired = desired.clamp(
-        u64::try_from(MIN_EMBEDDING_SAMPLES).unwrap_or(8_000),
+    let requested = end.saturating_sub(start);
+    let desired = requested.clamp(
+        u64::try_from(MIN_EMBEDDING_SAMPLES).unwrap_or(16_000),
         u64::try_from(MAX_EMBEDDING_SAMPLES).unwrap_or(160_000),
     );
-    let available_start = start.min(audio.frames.saturating_sub(desired));
+    let context_before = desired.saturating_sub(requested) / 2;
+    let centered_start = start.saturating_sub(context_before);
+    let available_start = centered_start.min(audio.frames.saturating_sub(desired));
     let available_end = available_start.saturating_add(desired).min(audio.frames);
     let window = audio.read_mono_s16le(available_start, available_end, context)?;
     let mut samples = Vec::new();
@@ -932,10 +1259,6 @@ fn hz_to_mel(hz: f32) -> f32 {
     1127.0 * (1.0 + hz / 700.0).ln()
 }
 
-fn mel_to_hz(mel: f32) -> f32 {
-    700.0 * (mel / 1127.0).exp_m1()
-}
-
 fn log_mel_fbank(samples: &[f32]) -> Result<Vec<f32>, ConversionError> {
     const FRAME: usize = 400;
     const SHIFT: usize = 160;
@@ -951,24 +1274,20 @@ fn log_mel_fbank(samples: &[f32]) -> Result<Vec<f32>, ConversionError> {
         }
     })?;
     let low_mel = hz_to_mel(20.0);
-    let high_mel = hz_to_mel(7_600.0);
-    let mel_points = (0..MEL_BINS + 2)
-        .map(|index| {
-            let mel = low_mel + (high_mel - low_mel) * index as f32 / (MEL_BINS + 1) as f32;
-            (mel_to_hz(mel) * FFT_SIZE as f32 / SAMPLE_RATE as f32)
-                .floor()
-                .clamp(0.0, (BINS - 1) as f32) as usize
-        })
-        .collect::<Vec<_>>();
+    let high_mel = hz_to_mel(SAMPLE_RATE as f32 / 2.0);
+    let mel_step = (high_mel - low_mel) / (MEL_BINS + 1) as f32;
+    let fft_bin_width = SAMPLE_RATE as f32 / FFT_SIZE as f32;
     let mut spectrum = vec![Complex { real: 0.0, imag: 0.0 }; FFT_SIZE];
     for frame_index in 0..frame_count {
         spectrum.fill(Complex { real: 0.0, imag: 0.0 });
         let start = frame_index * SHIFT;
+        let mean = samples[start..start + FRAME].iter().sum::<f32>() / FRAME as f32;
         for index in 0..FRAME {
-            let current = samples[start + index];
-            let previous = if index == 0 { 0.0 } else { samples[start + index - 1] };
-            let hamming = 0.54 - 0.46 * (2.0 * PI * index as f32 / (FRAME - 1) as f32).cos();
-            spectrum[index].real = (current - 0.97 * previous) * hamming;
+            let current = samples[start + index] - mean;
+            let previous = if index == 0 { current } else { samples[start + index - 1] - mean };
+            let hann = 0.5 - 0.5 * (2.0 * PI * index as f32 / (FRAME - 1) as f32).cos();
+            let povey = hann.powf(0.85);
+            spectrum[index].real = (current - 0.97 * previous) * povey;
         }
         fft(&mut spectrum);
         let powers = spectrum[..BINS]
@@ -976,17 +1295,22 @@ fn log_mel_fbank(samples: &[f32]) -> Result<Vec<f32>, ConversionError> {
             .map(|value| value.real.mul_add(value.real, value.imag * value.imag))
             .collect::<Vec<_>>();
         for mel in 0..MEL_BINS {
-            let left = mel_points[mel];
-            let center = mel_points[mel + 1].max(left + 1).min(BINS - 1);
-            let right = mel_points[mel + 2].max(center + 1).min(BINS);
+            let left = low_mel + mel_step * mel as f32;
+            let center = left + mel_step;
+            let right = center + mel_step;
             let mut energy = 0.0_f32;
-            for (bin, value) in powers.iter().enumerate().take(center).skip(left) {
-                energy += *value * (bin - left) as f32 / (center - left) as f32;
+            for (bin, value) in powers.iter().enumerate() {
+                let frequency_mel = hz_to_mel(bin as f32 * fft_bin_width);
+                let weight = if frequency_mel > left && frequency_mel <= center {
+                    (frequency_mel - left) / (center - left)
+                } else if frequency_mel > center && frequency_mel < right {
+                    (right - frequency_mel) / (right - center)
+                } else {
+                    0.0
+                };
+                energy += *value * weight;
             }
-            for (bin, value) in powers.iter().enumerate().take(right).skip(center) {
-                energy += *value * (right - bin) as f32 / (right - center) as f32;
-            }
-            output.push(energy.max(1.0e-10).ln());
+            output.push(energy.max(f32::EPSILON).ln());
         }
     }
     for bin in 0..MEL_BINS {
@@ -1010,7 +1334,7 @@ mod tests {
     }
 
     #[test]
-    fn clustering_is_stable_bounded_and_leaves_ambiguous_samples_unassigned() {
+    fn clustering_is_stable_bounded_and_keeps_ambiguous_samples_low_confidence() {
         let mut state = OnlineCosineClustering::new(None, 2).unwrap();
         assert_eq!(state.assign(&embedding(0, 1.0)).unwrap().0, "speaker-1");
         assert_eq!(state.assign(&embedding(1, 1.0)).unwrap().0, "speaker-2");
@@ -1018,7 +1342,9 @@ mod tests {
         let mut ambiguous = embedding(0, 1.0);
         ambiguous[1] = 1.0;
         normalize(&mut ambiguous);
-        assert!(state.assign(&ambiguous).is_none());
+        let (speaker, confidence) = state.assign(&ambiguous).unwrap();
+        assert!(["speaker-1", "speaker-2"].contains(&speaker.as_str()));
+        assert!(confidence < 0.5);
         assert_eq!(state.clusters.len(), 2);
         assert!(state.assign(&vec![0.0; EMBEDDING_DIMENSION]).is_none());
 
@@ -1034,7 +1360,82 @@ mod tests {
         assert!(OnlineCosineClustering::new(None, 65).is_err());
         let mut state = OnlineCosineClustering::new(Some(1), 16).unwrap();
         assert_eq!(state.assign(&embedding(0, 1.0)).unwrap().0, "speaker-1");
-        assert!(state.assign(&embedding(1, 1.0)).is_none());
+        let (speaker, confidence) = state.assign(&embedding(1, 1.0)).unwrap();
+        assert_eq!(speaker, "speaker-1");
+        assert_eq!(confidence, 0.5);
+    }
+
+    #[test]
+    fn expected_speaker_count_does_not_force_a_new_cluster() {
+        let mut state = OnlineCosineClustering::new(Some(2), 16).unwrap();
+        assert_eq!(state.assign(&embedding(0, 1.0)).unwrap().0, "speaker-1");
+        let mut similar = embedding(0, 0.48);
+        similar[1] = (1.0_f32 - 0.48_f32.powi(2)).sqrt();
+        let (speaker, _) = state.assign(&similar).unwrap();
+        assert_eq!(speaker, "speaker-1");
+        assert_eq!(state.clusters.len(), 1);
+    }
+
+    #[test]
+    fn automatic_speaker_count_avoids_one_off_cluster_fragmentation() {
+        let mut state = OnlineCosineClustering::new(None, 16).unwrap();
+        assert_eq!(state.assign(&embedding(0, 1.0)).unwrap().0, "speaker-1");
+        let mut similar = embedding(0, 0.37);
+        similar[1] = (1.0_f32 - 0.37_f32.powi(2)).sqrt();
+        let (speaker, _) = state.assign(&similar).unwrap();
+        assert_eq!(speaker, "speaker-1");
+        assert_eq!(state.clusters.len(), 1);
+    }
+
+    #[test]
+    fn automatic_singletons_require_follow_up_evidence() {
+        let mut state = OnlineCosineClustering::new(None, 16).unwrap();
+        state.assign(&embedding(0, 1.0)).unwrap();
+        state.assign(&embedding(0, 1.0)).unwrap();
+        assert_eq!(state.assign(&embedding(1, 1.0)).unwrap().0, "speaker-2");
+        assert!(state.automatic_singleton_remap().is_empty());
+        assert_eq!(state.assign(&embedding(2, 1.0)).unwrap().0, "speaker-3");
+        assert_eq!(state.automatic_singleton_remap().len(), 1);
+        state.assign(&embedding(1, 1.0)).unwrap();
+        assert!(state.automatic_singleton_remap().is_empty());
+
+        let mut expected = OnlineCosineClustering::new(Some(2), 16).unwrap();
+        expected.assign(&embedding(0, 1.0)).unwrap();
+        expected.assign(&embedding(1, 1.0)).unwrap();
+        assert!(expected.automatic_singleton_remap().is_empty());
+    }
+
+    #[test]
+    fn voice_probability_uses_speech_frames_instead_of_diluting_them_with_pauses() {
+        let mut probabilities = vec![0.02; 12];
+        probabilities.extend([0.91, 0.88, 0.84, 0.81]);
+        let score = robust_voice_probability(&mut probabilities);
+        assert!((score - 0.86).abs() < 0.001);
+        assert_eq!(robust_voice_probability(&mut []), 0.0);
+    }
+
+    #[test]
+    fn token_windows_are_balanced_without_a_short_tail() {
+        let token = |start_ms, end_ms| TimedToken {
+            range: TimeRange { start_ms, end_ms },
+            text: "x".into(),
+            confidence: Some(0.9),
+            speaker: None,
+            speaker_confidence: None,
+        };
+        let range = TimeRange { start_ms: 4_260, end_ms: 10_200 };
+        let tokens = vec![
+            token(4_260, 4_690),
+            token(4_690, 5_340),
+            token(5_450, 6_720),
+            token(6_740, 9_410),
+            token(9_490, 10_200),
+        ];
+        let turns = token_turns(&tokens, range);
+        assert_eq!(turns.len(), 2);
+        assert_eq!(turns[0].range, TimeRange { start_ms: 4_260, end_ms: 6_720 });
+        assert_eq!(turns[1].range, TimeRange { start_ms: 6_740, end_ms: 10_200 });
+        assert!(turns.iter().all(|turn| turn.range.end_ms - turn.range.start_ms >= 2_000));
     }
 
     #[test]
@@ -1046,6 +1447,43 @@ mod tests {
         assert_eq!(features.len() % 80, 0);
         assert!(!features.is_empty());
         assert!(features.iter().all(|value| value.is_finite()));
+    }
+
+    #[test]
+    fn fbank_matches_kaldi_native_reference() {
+        let samples = (0..16_000)
+            .map(|index| {
+                let phase = index as f32 / 16_000.0;
+                0.23 * (2.0 * PI * 233.0 * phase).sin() + 0.11 * (2.0 * PI * 817.0 * phase).cos()
+            })
+            .collect::<Vec<_>>();
+        let features = log_mel_fbank(&samples).unwrap();
+        let selected = [
+            features[0],
+            features[1],
+            features[80],
+            features[81],
+            features[20 * 80],
+            features[20 * 80 + 1],
+            features[97 * 80],
+            features[97 * 80 + 1],
+        ];
+        let reference = [
+            0.195_941_9,
+            0.439_239_5,
+            1.190_955_6,
+            0.282_332_4,
+            -1.781_001,
+            -0.171_912_2,
+            -0.588_023_2,
+            0.341_694_8,
+        ];
+        assert!(
+            selected
+                .into_iter()
+                .zip(reference)
+                .all(|(actual, expected)| (actual - expected).abs() < 0.003)
+        );
     }
 
     #[test]
@@ -1098,5 +1536,93 @@ mod tests {
             vec![(Some("speaker-1"), "Hello"), (Some("speaker-2"), " there"), (None, "."),]
         );
         assert_eq!(values.iter().map(|(_, text)| *text).collect::<String>(), "Hello there.");
+    }
+
+    #[test]
+    fn single_speaker_gaps_are_filled_and_nearby_segments_merge() {
+        let token = |start_ms, end_ms, text: &str, speaker: Option<&str>| TimedToken {
+            range: TimeRange { start_ms, end_ms },
+            text: text.into(),
+            confidence: Some(0.9),
+            speaker: speaker.map(str::to_owned),
+            speaker_confidence: speaker.map(|_| 0.8),
+        };
+        let node = |id: &str, range: TimeRange, tokens: Vec<TimedToken>, text: &str| BlockNode {
+            id: NodeId(id.into()),
+            block: Block::TimedSegment {
+                range,
+                speaker: None,
+                speaker_confidence: None,
+                tokens,
+                content: vec![Inline::Text { value: text.into(), marks: Vec::new() }],
+            },
+            provenance: into_markdown_core::Provenance {
+                kind: into_markdown_core::ProvenanceKind::AiProvider,
+                provider: "test/model".into(),
+                locator: into_markdown_core::SourceLocator {
+                    time: Some(range),
+                    ..into_markdown_core::SourceLocator::default()
+                },
+                confidence: Some(0.9),
+            },
+        };
+        let mut segments = vec![
+            node(
+                "segment-1",
+                TimeRange { start_ms: 0, end_ms: 2_000 },
+                vec![
+                    token(0, 900, "We", Some("speaker-1")),
+                    token(900, 2_000, " should meet", None),
+                ],
+                "We should meet",
+            ),
+            node(
+                "segment-2",
+                TimeRange { start_ms: 2_100, end_ms: 3_000 },
+                vec![token(2_100, 3_000, " tomorrow.", None)],
+                " tomorrow.",
+            ),
+        ];
+        repair_unassigned_speech(&mut segments).unwrap();
+        let merged =
+            merge_adjacent_speaker_turns(split_token_speaker_turns(segments).unwrap()).unwrap();
+        assert_eq!(merged.len(), 1);
+        assert!(
+            into_markdown_core::Document {
+                blocks: merged.clone(),
+                ..into_markdown_core::Document::default()
+            }
+            .validate()
+            .is_ok()
+        );
+        let Block::TimedSegment { range, speaker, tokens, content, .. } = &merged[0].block else {
+            panic!("timed segment")
+        };
+        assert_eq!(*range, TimeRange { start_ms: 0, end_ms: 3_000 });
+        assert_eq!(speaker.as_deref(), Some("speaker-1"));
+        assert!(tokens.iter().all(|token| token.speaker.as_deref() == Some("speaker-1")));
+        let text = content
+            .iter()
+            .map(|inline| match inline {
+                Inline::Text { value, .. } => value.as_str(),
+                _ => panic!("text"),
+            })
+            .collect::<String>();
+        assert_eq!(text, "We should meet tomorrow.");
+        assert_eq!(merged[0].provenance.locator.time, Some(*range));
+
+        let mut noncontiguous = merged.clone();
+        let Block::TimedSegment { speaker, tokens, .. } = &mut noncontiguous[0].block else {
+            panic!("timed segment")
+        };
+        *speaker = Some("speaker-5".into());
+        for token in tokens {
+            token.speaker = Some("speaker-5".into());
+        }
+        compact_speaker_labels(&mut noncontiguous).unwrap();
+        let Block::TimedSegment { speaker, .. } = &noncontiguous[0].block else {
+            panic!("timed segment")
+        };
+        assert_eq!(speaker.as_deref(), Some("speaker-1"));
     }
 }


### PR DESCRIPTION
## Summary

- align 3D-Speaker filterbank extraction with the model's Kaldi feature contract
- treat timestamped ASR tokens as known speech instead of rejecting them with a second VAD pass
- make automatic speaker creation conservative, retain explicit expected-speaker behavior, and collapse unsupported singleton clusters
- balance embedding windows, repair safe speaker gaps, merge adjacent same-speaker segments, and keep IR/token text invariants intact
- compact automatic speaker IDs so the UI never exposes gaps such as Speaker 1/2/3/5

## Real-audio validation

Tested with the two reported WebM recordings and three 45-second AMI Corpus meeting excerpts (ES2002a, ES2004a, IS1009a):

- reported single-speaker WebM: 7 alternating labelled/anonymous fragments -> 1 complete Speaker 1 turn
- reported two-speaker WebM: 7 fragments -> 2 complete speaker turns
- AMI anonymous transcript duration: 73.1% / 74.1% / 78.8% -> 0% for all three
- AMI turn blocks: 46 total -> 19 total
- AMI single-speaker-frame mapping accuracy: 97.7% / 94.1% / 92.8%
- release-mode diarization stage for each 45-second excerpt: 3.5-4.1 seconds on the local test machine

## Tests

- `cargo test -p into-markdown-asr --lib` (24 passed)
- `cargo test -p into-markdown-asr -p into-markdown-converters -p into-markdown-render-markdown` (ASR 24, converter 419, renderer 28 passed; runtime-gated tests ignored)
- `cargo clippy -p into-markdown-asr --lib --tests` (passes with existing workspace/third-party warnings)
- `cargo fmt --all -- --check`
- `git diff --check`
