### PR TITLE
feat: complete typed AI capability routing and IR patches

### DIFF
--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -3796,7 +3796,7 @@ fn apply_ai_provider_overrides(
 
 fn provider_backed_ai_capability_is_enabled(options: &ConversionOptions) -> bool {
     [
-        options.ai.vision_ocr,
+        options.ai.image_description,
         options.ai.layout_repair,
         options.ai.table_repair,
         options.ai.formula_repair,

--- a/apps/cli/src/config.rs
+++ b/apps/cli/src/config.rs
@@ -8,6 +8,7 @@ use into_markdown::{
     AiMode, AssetMode, ChineseScript, ConversionOptions, OcrPolicy, RaggedRowsMode,
     TableHeaderMode, TextDecodingMode,
 };
+use into_markdown_provider_plugin::CapabilitySourceRef;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -159,7 +160,7 @@ pub struct AsrConfig {
     pub max_native_memory_bytes: Option<u64>,
 }
 
-/// Primary and ordered readiness fallbacks for isolated local capabilities.
+/// Primary and ordered local-plugin or remote-provider capability sources.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct CapabilityRoutesConfig {
@@ -168,10 +169,14 @@ pub struct CapabilityRoutesConfig {
     pub diarization: CapabilityRouteConfig,
 }
 
-/// One capability route using `plugin-id/capability-id` references.
+/// One capability route using `plugin:ID/CAPABILITY` or
+/// `provider:ID/CAPABILITY` references. The unprefixed plugin spelling remains
+/// readable for configuration migration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct CapabilityRouteConfig {
+    /// Invocation behavior for the ordered sources.
+    pub mode: Option<AiMode>,
     pub primary: Option<String>,
     pub fallbacks: Vec<String>,
 }
@@ -677,17 +682,62 @@ fn validate_capability_routes(routes: &CapabilityRoutesConfig) -> Result<(), Cli
         ("transcription", &routes.transcription),
         ("diarization", &routes.diarization),
     ] {
+        if route.mode == Some(AiMode::Off)
+            && (route.primary.as_deref().is_some_and(|source| source != "off")
+                || !route.fallbacks.is_empty())
+        {
+            return Err(CliError::config(format!(
+                "capability route '{name}' off mode cannot contain active sources"
+            )));
+        }
+        if route.mode.is_some_and(|mode| mode != AiMode::Off)
+            && route.primary.as_deref() == Some("off")
+        {
+            return Err(CliError::config(format!(
+                "capability route '{name}' active mode cannot use an off primary"
+            )));
+        }
+        if route.primary.as_deref() == Some("off") && !route.fallbacks.is_empty() {
+            return Err(CliError::config(format!(
+                "capability route '{name}' cannot combine an off primary with fallbacks"
+            )));
+        }
+        if route.fallbacks.iter().any(|reference| reference == "off") {
+            return Err(CliError::config(format!(
+                "capability route '{name}' cannot use off as a fallback"
+            )));
+        }
+        let mut seen = BTreeSet::new();
         for reference in route.primary.iter().chain(&route.fallbacks) {
-            let Some((plugin, capability)) = reference.split_once('/') else {
+            if reference == "off" {
+                continue;
+            }
+            let (kind, qualified) = reference
+                .split_once(':')
+                .map_or(("plugin", reference.as_str()), |(kind, value)| (kind, value));
+            if !matches!(kind, "plugin" | "provider") {
                 return Err(CliError::config(format!(
-                    "capability route '{name}' must use plugin-id/capability-id"
+                    "capability route '{name}' uses unknown source kind '{kind}'"
+                )));
+            }
+            let Some((source, capability)) = qualified.split_once('/') else {
+                return Err(CliError::config(format!(
+                    "capability route '{name}' must use plugin:ID/CAPABILITY or provider:ID/CAPABILITY"
                 )));
             };
-            validate_id("plugin", plugin)?;
+            validate_id(kind, source)?;
             validate_id("capability", capability)?;
             if capability.contains('/') {
                 return Err(CliError::config(format!(
                     "capability route '{name}' contains an invalid capability ID"
+                )));
+            }
+            let canonical = reference.parse::<CapabilitySourceRef>().map_err(|error| {
+                CliError::config(format!("capability route '{name}' is invalid: {error}"))
+            })?;
+            if !seen.insert(canonical) {
+                return Err(CliError::config(format!(
+                    "capability route '{name}' contains a duplicate source"
                 )));
             }
         }
@@ -1896,6 +1946,34 @@ conflict = "rename"
 mod tests {
     use super::*;
     use std::collections::BTreeSet;
+
+    #[test]
+    fn heterogeneous_capability_routes_reject_contradictions_and_alias_duplicates() {
+        let mut routes = CapabilityRoutesConfig::default();
+        routes.ocr = CapabilityRouteConfig {
+            mode: Some(AiMode::Prefer),
+            primary: Some("provider:bailian/vision-ocr".into()),
+            fallbacks: vec!["plugin:official.ocr.ppocrv6/ocr".into()],
+        };
+        assert!(validate_capability_routes(&routes).is_ok());
+
+        routes.ocr.mode = Some(AiMode::Off);
+        assert!(validate_capability_routes(&routes).is_err());
+
+        routes.ocr = CapabilityRouteConfig {
+            mode: Some(AiMode::Prefer),
+            primary: Some("official.ocr.ppocrv6/ocr".into()),
+            fallbacks: vec!["plugin:official.ocr.ppocrv6/ocr".into()],
+        };
+        assert!(validate_capability_routes(&routes).is_err());
+
+        routes.ocr = CapabilityRouteConfig {
+            mode: Some(AiMode::Only),
+            primary: Some("off".into()),
+            fallbacks: Vec::new(),
+        };
+        assert!(validate_capability_routes(&routes).is_err());
+    }
 
     fn temporary_directory(name: &str) -> PathBuf {
         let thread_name = std::thread::current()

--- a/apps/cli/src/services.rs
+++ b/apps/cli/src/services.rs
@@ -3,14 +3,211 @@
 use crate::config::{CapabilityRouteConfig, LoadedConfig};
 use crate::error::CliError;
 use into_markdown::{
-    AiMode, ConversionError, ConversionOptions, ExecutionContext, ExecutionOptions, OcrPolicy,
-    OpenAiCompatibleClient, OpenAiImageDescriptionProvider,
-    ProviderConfig as TransportProviderConfig, ProviderNetworkPolicy, Services,
+    AiCapability, AiMode, BoxFuture, CompositeAiProvider, ConversionError, ConversionOptions,
+    ExecutionContext, ExecutionOptions, OcrEngine, OcrOutputPlan, OcrPolicy, OcrRecognition,
+    OcrRequest, OcrResult, OpenAiCompatibleClient, OpenAiDocumentPatchProvider,
+    OpenAiImageDescriptionProvider, OpenAiRemoteOcr, OpenAiRemoteTranscriber,
+    ProviderConfig as TransportProviderConfig, ProviderNetworkPolicy, Services, Transcriber,
+    TranscriptionRequest, TranscriptionResult,
+};
+use into_markdown_provider_plugin::{
+    CapabilityId, CapabilityRouteMode, CapabilitySourceRef, UnifiedCapabilityRoute,
 };
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::UNIX_EPOCH;
+
+struct RoutedOcrEngine {
+    id: String,
+    mode: CapabilityRouteMode,
+    sources: Vec<Arc<dyn OcrEngine>>,
+}
+
+impl OcrEngine for RoutedOcrEngine {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn planned_bound_output(
+        &self,
+        request: OcrRequest<'_>,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        let mut plans = Vec::new();
+        let mut last_error = None;
+        for source in &self.sources {
+            match source.planned_bound_output(request, options, context) {
+                Ok(plan) => plans.push(plan),
+                Err(error) if can_route_fallback(self.mode, &error) => last_error = Some(error),
+                Err(error) => return Err(error),
+            }
+        }
+        if plans.is_empty() {
+            return Err(last_error.unwrap_or_else(|| ConversionError::ComponentUnavailable {
+                component: self.id.clone(),
+                detail: "no OCR capability source is ready".into(),
+            }));
+        }
+        aggregate_ocr_plans(&plans)
+    }
+
+    fn planned_normalized_png_output(
+        &self,
+        width: u32,
+        height: u32,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        let mut plans = Vec::new();
+        let mut last_error = None;
+        for source in &self.sources {
+            match source.planned_normalized_png_output(width, height, options, context) {
+                Ok(plan) => plans.push(plan),
+                Err(error) if can_route_fallback(self.mode, &error) => last_error = Some(error),
+                Err(error) => return Err(error),
+            }
+        }
+        if plans.is_empty() {
+            return Err(last_error.unwrap_or_else(|| ConversionError::ComponentUnavailable {
+                component: self.id.clone(),
+                detail: "no OCR capability source can accept a normalized PNG".into(),
+            }));
+        }
+        aggregate_ocr_plans(&plans)
+    }
+
+    fn recognize<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+        Box::pin(async move {
+            let mut last_error = None;
+            for source in &self.sources {
+                match source.recognize(request, context).await {
+                    Ok(result) => return Ok(result),
+                    Err(error) if can_route_fallback(self.mode, &error) => {
+                        last_error = Some(error);
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(last_error.unwrap_or_else(|| ConversionError::ComponentUnavailable {
+                component: self.id.clone(),
+                detail: "no OCR capability source is ready".into(),
+            }))
+        })
+    }
+
+    fn recognize_bound<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+        Box::pin(async move {
+            let mut last_error = None;
+            for source in &self.sources {
+                match source.recognize_bound(request, context).await {
+                    Ok(OcrRecognition::Remote(result)) if result.provider != source.id() => {
+                        return Err(ConversionError::Ocr {
+                            provider: source.id().into(),
+                            detail:
+                                "remote OCR result does not match the selected capability source"
+                                    .into(),
+                        });
+                    }
+                    Ok(result) => return Ok(result),
+                    Err(error) if can_route_fallback(self.mode, &error) => {
+                        last_error = Some(error);
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(last_error.unwrap_or_else(|| ConversionError::ComponentUnavailable {
+                component: self.id.clone(),
+                detail: "no OCR capability source is ready".into(),
+            }))
+        })
+    }
+}
+
+fn aggregate_ocr_plans(plans: &[OcrOutputPlan]) -> Result<OcrOutputPlan, ConversionError> {
+    let working = plans.iter().map(|plan| plan.max_working_bytes()).max().unwrap_or(0);
+    let regions = plans.iter().map(|plan| plan.max_regions()).max().unwrap_or(0);
+    let text = plans.iter().map(|plan| plan.max_text_bytes()).max().unwrap_or(0);
+    let structural = u64::from(regions)
+        .checked_mul(256)
+        .and_then(|bytes| bytes.checked_add(text))
+        .ok_or_else(|| ConversionError::ResourceLimit {
+            limit: "max_memory_bytes",
+            detail: "OCR route output plan overflow".into(),
+        })?;
+    let retained =
+        plans.iter().map(|plan| plan.max_retained_bytes()).max().unwrap_or(0).max(structural);
+    OcrOutputPlan::try_new_with_working(retained, working, regions, text)
+}
+
+struct RoutedTranscriber {
+    id: String,
+    mode: CapabilityRouteMode,
+    sources: Vec<Arc<dyn Transcriber>>,
+}
+
+impl Transcriber for RoutedTranscriber {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn transcribe<'a>(
+        &'a self,
+        request: TranscriptionRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<TranscriptionResult, ConversionError>> {
+        Box::pin(async move {
+            let mut last_error = None;
+            for source in &self.sources {
+                match source.transcribe(request, context).await {
+                    Ok(result) if result.provider != source.id() => {
+                        return Err(ConversionError::Ai {
+                            provider: source.id().into(),
+                            detail:
+                                "transcription result does not match the selected capability source"
+                                    .into(),
+                        });
+                    }
+                    Ok(result) => return Ok(result),
+                    Err(error) if can_route_fallback(self.mode, &error) => {
+                        last_error = Some(error);
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            Err(last_error.unwrap_or_else(|| ConversionError::ComponentUnavailable {
+                component: self.id.clone(),
+                detail: "no transcription capability source is ready".into(),
+            }))
+        })
+    }
+}
+
+fn can_route_fallback(mode: CapabilityRouteMode, error: &ConversionError) -> bool {
+    match mode {
+        CapabilityRouteMode::Off | CapabilityRouteMode::Only => false,
+        CapabilityRouteMode::Fallback => {
+            matches!(error, ConversionError::ComponentUnavailable { .. })
+        }
+        CapabilityRouteMode::Prefer => matches!(
+            error,
+            ConversionError::ComponentUnavailable { .. }
+                | ConversionError::Network { .. }
+                | ConversionError::Timeout
+                | ConversionError::Ai { .. }
+                | ConversionError::Ocr { .. }
+        ),
+    }
+}
 
 pub(crate) fn assemble(
     loaded: &LoadedConfig,
@@ -130,14 +327,15 @@ impl WebMediaServiceCache {
     }
 }
 
-/// Verify the exact local OCR distribution used by conversion without any
-/// download or network access.
+/// Verify construction of the effective OCR route without downloading models
+/// or issuing a Provider request.
 pub(crate) fn verify_ocr_runtime(loaded: &LoadedConfig, cwd: &Path) -> Result<(), ConversionError> {
     let context = ExecutionContext::new(ExecutionOptions::default(), loaded.options.limits.clone());
     assemble_ocr(loaded, &context, cwd).map(drop)
 }
 
-/// Verify the exact offline ASR distribution used by the Web workbench.
+/// Verify construction of the effective transcription route without issuing a
+/// Provider request.
 pub(crate) fn verify_asr_runtime(loaded: &LoadedConfig, cwd: &Path) -> Result<(), ConversionError> {
     let context = ExecutionContext::new(
         ExecutionOptions::default(),
@@ -191,17 +389,22 @@ fn assemble_at(
 ) -> Result<Services, CliError> {
     let mut services = Services::default();
     let context = ExecutionContext::new(execution.clone(), loaded.options.limits.clone());
-    if loaded.options.ocr.policy != OcrPolicy::Off {
+    if loaded.options.ocr.policy != OcrPolicy::Off
+        || loaded.options.ai.vision_ocr != AiMode::Off
+        || configured_route_is_active(&loaded.effective.capability_routes.ocr)
+    {
         match assemble_ocr(loaded, &context, cwd) {
             Ok(engine) => services.ocr = Some(engine),
             Err(error) if can_degrade_ocr(loaded.options.ocr.policy, &error) => {}
             Err(error) => return Err(CliError::from(error)),
         }
     }
-    if loaded.options.ai.image_description != AiMode::Off {
-        services.ai = assemble_image_description(loaded)?;
+    if ai_provider_service_enabled(&loaded.options) {
+        services.ai = assemble_ai_provider(loaded)?;
     }
-    if loaded.options.ai.audio_transcription != AiMode::Off {
+    if loaded.options.ai.audio_transcription != AiMode::Off
+        || configured_route_is_active(&loaded.effective.capability_routes.transcription)
+    {
         services.transcriber = Some(assemble_asr(loaded, &context, cwd)?);
     }
     if loaded.options.diarization.enabled {
@@ -211,6 +414,10 @@ fn assemble_at(
         );
     }
     Ok(services)
+}
+
+fn configured_route_is_active(route: &CapabilityRouteConfig) -> bool {
+    route.mode.is_some_and(|mode| mode != AiMode::Off)
 }
 
 fn strict_media_mode(options: &ConversionOptions) -> into_markdown_provider_plugin::ResolutionMode {
@@ -286,7 +493,7 @@ fn resolve_process_capability(
         {
             registration_errors.insert(key, error.to_string());
             continue;
-        };
+        }
         packages.insert(reference.plugin_id.clone(), (installed, manifest));
     }
     let roots = provider_model_roots()?;
@@ -428,19 +635,57 @@ fn assemble_asr_options(
     context: &ExecutionContext,
     cwd: &Path,
 ) -> Result<Arc<dyn into_markdown::Transcriber>, CliError> {
-    resolve_process_capability(
-        loaded,
-        cwd,
-        into_markdown_provider_plugin::CapabilityKind::Transcription,
+    let route = unified_route(
+        CapabilityId::Transcription,
         &loaded.effective.capability_routes.transcription,
-        "official.media.whisper/transcription",
-        Some(options.asr.model_bundle.clone()),
-        strict_media_mode(options),
-        context,
+        "plugin:official.media.whisper/transcription",
+        options.ai.audio_transcription,
     )
-    .and_then(|capability| capability.transcriber(options.clone()))
-    .map(|provider| Arc::new(provider) as Arc<dyn into_markdown::Transcriber>)
-    .map_err(CliError::from)
+    .map_err(CliError::from)?;
+    let eligible = route.eligible_sources().map_err(|error| {
+        CliError::component(format!("invalid transcription capability route: {error}"))
+    })?;
+    let mut sources = Vec::new();
+    let mut errors = Vec::new();
+    for source in eligible {
+        let built = match source {
+            CapabilitySourceRef::Plugin { plugin_id, capability_id } => {
+                let configured = single_plugin_route(plugin_id, capability_id);
+                resolve_process_capability(
+                    loaded,
+                    cwd,
+                    into_markdown_provider_plugin::CapabilityKind::Transcription,
+                    &configured,
+                    &format!("{plugin_id}/{capability_id}"),
+                    Some(options.asr.model_bundle.clone()),
+                    into_markdown_provider_plugin::ResolutionMode::RequiredPrimary,
+                    context,
+                )
+                .and_then(|capability| capability.transcriber(options.clone()))
+                .map(|provider| Arc::new(provider) as Arc<dyn Transcriber>)
+            }
+            CapabilitySourceRef::Provider { provider_id, capability_id } => {
+                build_remote_transcriber(loaded, provider_id, capability_id)
+            }
+            CapabilitySourceRef::Off => continue,
+        };
+        match built {
+            Ok(source) => sources.push(source),
+            Err(error) if route.mode != CapabilityRouteMode::Only => errors.push(error.to_string()),
+            Err(error) => return Err(CliError::from(error)),
+        }
+    }
+    if sources.is_empty() {
+        return Err(CliError::component(if errors.is_empty() {
+            "transcription capability is disabled".into()
+        } else {
+            errors.join("; ")
+        }));
+    }
+    if sources.len() == 1 {
+        return Ok(sources.remove(0));
+    }
+    Ok(Arc::new(RoutedTranscriber { id: "route.transcription".into(), mode: route.mode, sources }))
 }
 
 fn can_degrade_ocr(policy: OcrPolicy, error: &into_markdown::ConversionError) -> bool {
@@ -455,26 +700,209 @@ fn assemble_ocr(
 ) -> Result<Arc<dyn into_markdown::OcrEngine>, into_markdown::ConversionError> {
     let model_bundle =
         loaded.options.ocr.model_bundle.clone().unwrap_or_else(|| "pp-ocrv6-tiny-zh-en".into());
-    let mode = if loaded.options.ocr.policy == OcrPolicy::Always {
-        into_markdown_provider_plugin::ResolutionMode::RequiredPrimary
+    let default_mode = if loaded.options.ai.vision_ocr == AiMode::Off {
+        AiMode::Only
     } else {
-        into_markdown_provider_plugin::ResolutionMode::ReadinessFallback
+        loaded.options.ai.vision_ocr
     };
-    resolve_process_capability(
-        loaded,
-        cwd,
-        into_markdown_provider_plugin::CapabilityKind::Ocr,
+    let route = unified_route(
+        CapabilityId::Ocr,
         &loaded.effective.capability_routes.ocr,
-        "official.ocr.ppocrv6/ocr",
-        Some(model_bundle),
-        mode,
-        context,
-    )?
-    .ocr(loaded.options.clone())
-    .map(|provider| Arc::new(provider) as Arc<dyn into_markdown::OcrEngine>)
+        "plugin:official.ocr.ppocrv6/ocr",
+        default_mode,
+    )?;
+    let eligible =
+        route.eligible_sources().map_err(|error| ConversionError::ComponentUnavailable {
+            component: "capability-routing".into(),
+            detail: error.to_string(),
+        })?;
+    let mut sources = Vec::new();
+    let mut errors = Vec::new();
+    for source in eligible {
+        let built = match source {
+            CapabilitySourceRef::Plugin { plugin_id, capability_id } => {
+                let configured = single_plugin_route(plugin_id, capability_id);
+                resolve_process_capability(
+                    loaded,
+                    cwd,
+                    into_markdown_provider_plugin::CapabilityKind::Ocr,
+                    &configured,
+                    &format!("{plugin_id}/{capability_id}"),
+                    Some(model_bundle.clone()),
+                    into_markdown_provider_plugin::ResolutionMode::RequiredPrimary,
+                    context,
+                )
+                .and_then(|capability| capability.ocr(loaded.options.clone()))
+                .map(|provider| Arc::new(provider) as Arc<dyn OcrEngine>)
+            }
+            CapabilitySourceRef::Provider { provider_id, capability_id } => {
+                build_remote_ocr(loaded, provider_id, capability_id)
+            }
+            CapabilitySourceRef::Off => continue,
+        };
+        match built {
+            Ok(source) => sources.push(source),
+            Err(error) if route.mode != CapabilityRouteMode::Only => errors.push(error.to_string()),
+            Err(error) => return Err(error),
+        }
+    }
+    if sources.is_empty() {
+        return Err(ConversionError::ComponentUnavailable {
+            component: "ocr".into(),
+            detail: if errors.is_empty() {
+                "OCR capability is disabled".into()
+            } else {
+                errors.join("; ")
+            },
+        });
+    }
+    if sources.len() == 1 {
+        return Ok(sources.remove(0));
+    }
+    Ok(Arc::new(RoutedOcrEngine { id: "route.ocr".into(), mode: route.mode, sources }))
 }
 
-fn assemble_image_description(
+fn unified_route(
+    capability: CapabilityId,
+    configured: &CapabilityRouteConfig,
+    default_primary: &str,
+    default_mode: AiMode,
+) -> Result<UnifiedCapabilityRoute, ConversionError> {
+    let mode =
+        configured.mode.map_or_else(|| capability_route_mode(default_mode), capability_route_mode);
+    let primary = configured
+        .primary
+        .as_deref()
+        .unwrap_or(if mode == CapabilityRouteMode::Off { "off" } else { default_primary })
+        .parse::<CapabilitySourceRef>()
+        .map_err(|error| ConversionError::ComponentUnavailable {
+            component: "capability-routing".into(),
+            detail: error.to_string(),
+        })?;
+    let fallbacks = configured
+        .fallbacks
+        .iter()
+        .map(|source| source.parse::<CapabilitySourceRef>())
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| ConversionError::ComponentUnavailable {
+            component: "capability-routing".into(),
+            detail: error.to_string(),
+        })?;
+    let route = UnifiedCapabilityRoute { capability, mode, primary, fallbacks };
+    route.validate().map_err(|error| ConversionError::ComponentUnavailable {
+        component: "capability-routing".into(),
+        detail: error.to_string(),
+    })?;
+    Ok(route)
+}
+
+const fn capability_route_mode(mode: AiMode) -> CapabilityRouteMode {
+    match mode {
+        AiMode::Off => CapabilityRouteMode::Off,
+        AiMode::Fallback => CapabilityRouteMode::Fallback,
+        AiMode::Prefer => CapabilityRouteMode::Prefer,
+        AiMode::Only => CapabilityRouteMode::Only,
+    }
+}
+
+fn single_plugin_route(plugin_id: &str, capability_id: &str) -> CapabilityRouteConfig {
+    CapabilityRouteConfig {
+        mode: Some(AiMode::Only),
+        primary: Some(format!("{plugin_id}/{capability_id}")),
+        fallbacks: Vec::new(),
+    }
+}
+
+fn build_remote_ocr(
+    loaded: &LoadedConfig,
+    provider_name: &str,
+    capability_id: &str,
+) -> Result<Arc<dyn OcrEngine>, ConversionError> {
+    if capability_id != "vision-ocr" && capability_id != "ocr" {
+        return Err(remote_route_error(provider_name, capability_id));
+    }
+    let (client, network, _) = remote_client(loaded, provider_name, "vision-ocr")?;
+    OpenAiRemoteOcr::new(client, network, format!("provider.{provider_name}.vision-ocr"))
+        .map(|provider| Arc::new(provider) as Arc<dyn OcrEngine>)
+}
+
+fn build_remote_transcriber(
+    loaded: &LoadedConfig,
+    provider_name: &str,
+    capability_id: &str,
+) -> Result<Arc<dyn Transcriber>, ConversionError> {
+    if capability_id != "audio-transcription" && capability_id != "transcription" {
+        return Err(remote_route_error(provider_name, capability_id));
+    }
+    let (client, _, model) = remote_client(loaded, provider_name, "audio-transcription")?;
+    OpenAiRemoteTranscriber::new(
+        client,
+        format!("provider.{provider_name}.audio-transcription"),
+        model,
+    )
+    .map(|provider| Arc::new(provider) as Arc<dyn Transcriber>)
+}
+
+fn remote_client(
+    loaded: &LoadedConfig,
+    provider_name: &str,
+    capability: &str,
+) -> Result<(OpenAiCompatibleClient, ProviderNetworkPolicy, String), ConversionError> {
+    let configured = loaded.effective.providers.get(provider_name).ok_or_else(|| {
+        ConversionError::ComponentUnavailable {
+            component: format!("provider.{provider_name}"),
+            detail: "configured provider does not exist".into(),
+        }
+    })?;
+    if !configured.capabilities.iter().any(|value| value == capability) {
+        return Err(ConversionError::ComponentUnavailable {
+            component: format!("provider.{provider_name}"),
+            detail: format!("provider does not declare {capability}"),
+        });
+    }
+    let model = configured.model.clone();
+    let timeout = std::time::Duration::from_millis(
+        configured.timeout_ms.or(loaded.timeout_ms).unwrap_or(30_000),
+    );
+    let config = TransportProviderConfig::parse(
+        &configured.base_url,
+        &model,
+        &configured.api_key_env,
+        timeout,
+        configured.capabilities.clone(),
+    )
+    .map_err(|error| ConversionError::ComponentUnavailable {
+        component: format!("provider.{provider_name}"),
+        detail: error.code_str().into(),
+    })?;
+    let network = ProviderNetworkPolicy {
+        allow_network: loaded.options.network.enabled,
+        allow_private_network: !loaded.options.network.deny_private_networks,
+        allowed_hosts: loaded.options.network.allowed_hosts.clone(),
+    };
+    Ok((OpenAiCompatibleClient::new(config, network.clone()), network, model))
+}
+
+fn remote_route_error(provider: &str, capability: &str) -> ConversionError {
+    ConversionError::ComponentUnavailable {
+        component: format!("provider.{provider}"),
+        detail: format!("provider route uses incompatible capability {capability}"),
+    }
+}
+
+fn ai_provider_service_enabled(options: &ConversionOptions) -> bool {
+    [
+        options.ai.image_description,
+        options.ai.layout_repair,
+        options.ai.table_repair,
+        options.ai.formula_repair,
+        options.ai.markdown_postprocess,
+    ]
+    .into_iter()
+    .any(|mode| mode != AiMode::Off)
+}
+
+fn assemble_ai_provider(
     loaded: &LoadedConfig,
 ) -> Result<Option<Arc<dyn into_markdown::AiProvider>>, CliError> {
     let Some(name) = loaded.ai_provider.as_deref() else {
@@ -483,27 +911,67 @@ fn assemble_image_description(
     let Some(configured) = loaded.effective.providers.get(name) else {
         return Ok(None);
     };
-    if !configured.capabilities.iter().any(|value| value == "image-description") {
-        return Ok(None);
-    }
     let model = loaded.ai_model.as_deref().unwrap_or(&configured.model);
     let timeout = std::time::Duration::from_millis(
         configured.timeout_ms.or(loaded.timeout_ms).unwrap_or(30_000),
     );
-    let config = TransportProviderConfig::parse(
-        &configured.base_url,
-        model,
-        &configured.api_key_env,
-        timeout,
-        configured.capabilities.clone(),
-    )?;
     let network = ProviderNetworkPolicy {
         allow_network: loaded.options.network.enabled,
         allow_private_network: !loaded.options.network.deny_private_networks,
         allowed_hosts: loaded.options.network.allowed_hosts.clone(),
     };
-    let client = OpenAiCompatibleClient::new(config, network.clone());
-    Ok(Some(Arc::new(OpenAiImageDescriptionProvider::new(client, network))))
+    let provider_id = format!("provider.{name}");
+    let client = || {
+        TransportProviderConfig::parse(
+            &configured.base_url,
+            model,
+            &configured.api_key_env,
+            timeout,
+            configured.capabilities.clone(),
+        )
+        .map(|config| OpenAiCompatibleClient::new(config, network.clone()))
+        .map_err(CliError::from)
+    };
+    let mut adapters = Vec::<Arc<dyn into_markdown::AiProvider>>::new();
+    if loaded.options.ai.image_description != AiMode::Off
+        && configured.capabilities.iter().any(|value| value == "image-description")
+    {
+        adapters.push(Arc::new(OpenAiImageDescriptionProvider::new_with_id(
+            client()?,
+            network.clone(),
+            provider_id.clone(),
+        )?));
+    }
+    let patch_capabilities = [
+        (AiCapability::LayoutRepair, "layout-repair", loaded.options.ai.layout_repair),
+        (AiCapability::TableRepair, "table-repair", loaded.options.ai.table_repair),
+        (AiCapability::FormulaRepair, "formula-repair", loaded.options.ai.formula_repair),
+        (
+            AiCapability::MarkdownPostprocess,
+            "markdown-postprocess",
+            loaded.options.ai.markdown_postprocess,
+        ),
+    ]
+    .into_iter()
+    .filter(|(_, capability, mode)| {
+        *mode != AiMode::Off
+            && configured.capabilities.iter().any(|declared| declared == capability)
+    })
+    .map(|(capability, _, _)| capability)
+    .collect::<Vec<_>>();
+    if !patch_capabilities.is_empty() {
+        adapters.push(Arc::new(OpenAiDocumentPatchProvider::new(
+            client()?,
+            network,
+            provider_id.clone(),
+            patch_capabilities,
+        )?));
+    }
+    match adapters.len() {
+        0 => Ok(None),
+        1 => Ok(adapters.pop()),
+        _ => Ok(Some(Arc::new(CompositeAiProvider::new(provider_id, adapters)?))),
+    }
 }
 
 fn writable_model_root() -> Result<PathBuf, into_markdown::ConversionError> {
@@ -531,7 +999,82 @@ fn canonical_executable() -> Result<PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::future::Future;
+    use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn loaded_config(name: &str, contents: &str) -> (PathBuf, LoadedConfig) {
+        let thread = std::thread::current()
+            .name()
+            .unwrap_or("test")
+            .chars()
+            .map(|character| if character.is_ascii_alphanumeric() { character } else { '-' })
+            .collect::<String>();
+        let root = std::env::temp_dir().join(format!(
+            "into-md-services-{name}-{}-{}",
+            std::process::id(),
+            thread
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let path = root.join("config.toml");
+        std::fs::write(&path, contents).unwrap();
+        let loaded = crate::config::load(&root, &[path], true, None, None).unwrap();
+        (root, loaded)
+    }
+
+    struct FixtureOcr {
+        id: &'static str,
+        outcome: Result<OcrResult, ConversionError>,
+        calls: AtomicUsize,
+    }
+
+    impl OcrEngine for FixtureOcr {
+        fn id(&self) -> &str {
+            self.id
+        }
+
+        fn planned_bound_output(
+            &self,
+            _request: OcrRequest<'_>,
+            _options: &ConversionOptions,
+            _context: &ExecutionContext,
+        ) -> Result<OcrOutputPlan, ConversionError> {
+            OcrOutputPlan::try_new_with_working(1024, 1024, 1, 256)
+        }
+
+        fn planned_normalized_png_output(
+            &self,
+            _width: u32,
+            _height: u32,
+            _options: &ConversionOptions,
+            _context: &ExecutionContext,
+        ) -> Result<OcrOutputPlan, ConversionError> {
+            OcrOutputPlan::try_new_with_working(1024, 1024, 1, 256)
+        }
+
+        fn recognize<'a>(
+            &'a self,
+            _request: OcrRequest<'a>,
+            _context: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let outcome = self.outcome.clone();
+            Box::pin(async move { outcome })
+        }
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        let mut future = std::pin::pin!(future);
+        let waker = std::task::Waker::noop();
+        let mut context = std::task::Context::from_waker(waker);
+        loop {
+            match future.as_mut().poll(&mut context) {
+                std::task::Poll::Ready(value) => return value,
+                std::task::Poll::Pending => std::thread::yield_now(),
+            }
+        }
+    }
 
     #[test]
     fn auto_degrades_only_component_absence_and_preserves_execution_failures() {
@@ -550,6 +1093,75 @@ mod tests {
                 detail: "low memory".into(),
             },
         ));
+    }
+
+    #[test]
+    fn runtime_route_modes_have_fail_closed_and_recovery_contracts() {
+        let unavailable = ConversionError::ComponentUnavailable {
+            component: "fixture".into(),
+            detail: "missing".into(),
+        };
+        let network = ConversionError::Network { detail: "offline".into() };
+        let cancelled = ConversionError::Cancelled;
+        assert!(!can_route_fallback(CapabilityRouteMode::Off, &unavailable));
+        assert!(!can_route_fallback(CapabilityRouteMode::Only, &unavailable));
+        assert!(can_route_fallback(CapabilityRouteMode::Fallback, &unavailable));
+        assert!(!can_route_fallback(CapabilityRouteMode::Fallback, &network));
+        assert!(can_route_fallback(CapabilityRouteMode::Prefer, &unavailable));
+        assert!(can_route_fallback(CapabilityRouteMode::Prefer, &network));
+        assert!(!can_route_fallback(CapabilityRouteMode::Prefer, &cancelled));
+        assert!(!can_route_fallback(
+            CapabilityRouteMode::Prefer,
+            &ConversionError::ResourceLimit { limit: "max_memory_bytes", detail: "fixture".into() },
+        ));
+    }
+
+    #[test]
+    fn routed_ocr_uses_ordered_fallback_without_swallowing_disallowed_failures() {
+        let successful = || {
+            Arc::new(FixtureOcr {
+                id: "fallback",
+                outcome: Ok(OcrResult { regions: Vec::new(), provider: "fallback".into() }),
+                calls: AtomicUsize::new(0),
+            })
+        };
+        let request = OcrRequest { image: b"fixture", media_type: "image/png", languages: &[] };
+        let context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            into_markdown::ResourceLimits::default(),
+        );
+
+        let primary = Arc::new(FixtureOcr {
+            id: "primary",
+            outcome: Err(ConversionError::Network { detail: "offline".into() }),
+            calls: AtomicUsize::new(0),
+        });
+        let fallback = successful();
+        let route = RoutedOcrEngine {
+            id: "route".into(),
+            mode: CapabilityRouteMode::Prefer,
+            sources: vec![primary.clone(), fallback.clone()],
+        };
+        assert!(block_on(route.recognize_bound(request, &context)).is_ok());
+        assert_eq!(primary.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fallback.calls.load(Ordering::SeqCst), 1);
+
+        let primary = Arc::new(FixtureOcr {
+            id: "primary",
+            outcome: Err(ConversionError::Network { detail: "offline".into() }),
+            calls: AtomicUsize::new(0),
+        });
+        let fallback = successful();
+        let route = RoutedOcrEngine {
+            id: "route".into(),
+            mode: CapabilityRouteMode::Fallback,
+            sources: vec![primary, fallback.clone()],
+        };
+        assert!(matches!(
+            block_on(route.recognize_bound(request, &context)),
+            Err(ConversionError::Network { .. })
+        ));
+        assert_eq!(fallback.calls.load(Ordering::SeqCst), 0);
     }
 
     #[test]
@@ -583,5 +1195,68 @@ mod tests {
             .unwrap();
         assert_eq!(replacement, "two");
         assert_eq!(builds.load(Ordering::Relaxed), 2);
+    }
+
+    #[test]
+    fn configured_provider_composes_image_and_structured_patch_adapters() {
+        let (root, loaded) = loaded_config(
+            "composite-provider",
+            r#"
+schema_version = 1
+default_provider = "bailian"
+
+[conversion.ai]
+image_description = "prefer"
+table_repair = "only"
+
+[providers.bailian]
+type = "openai-compatible"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+model = "fixture-model"
+api_key_env = "DASHSCOPE_API_KEY"
+capabilities = ["image-description", "table-repair"]
+"#,
+        );
+        let provider = assemble_ai_provider(&loaded).unwrap().unwrap();
+        assert_eq!(provider.id(), "provider.bailian");
+        assert_eq!(
+            provider.capabilities(),
+            std::collections::BTreeSet::from([
+                AiCapability::ImageDescription,
+                AiCapability::TableRepair,
+            ])
+        );
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn explicit_remote_transcription_route_activates_with_legacy_ai_mode_off() {
+        let (root, loaded) = loaded_config(
+            "remote-transcription-route",
+            r#"
+schema_version = 1
+
+[conversion.ocr]
+policy = "off"
+
+[providers.bailian]
+type = "openai-compatible"
+base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+model = "qwen3-asr-flash"
+api_key_env = "DASHSCOPE_API_KEY"
+capabilities = ["audio-transcription"]
+
+[capability_routes.transcription]
+mode = "only"
+primary = "provider:bailian/audio-transcription"
+fallbacks = []
+"#,
+        );
+        let services = assemble(&loaded, &ExecutionOptions::default(), &root).unwrap();
+        assert_eq!(
+            services.transcriber.as_deref().map(Transcriber::id),
+            Some("provider.bailian.audio-transcription")
+        );
+        std::fs::remove_dir_all(root).unwrap();
     }
 }

--- a/crates/ai/src/composite.rs
+++ b/crates/ai/src/composite.rs
@@ -1,0 +1,121 @@
+//! Exact-capability composition for adapters sharing one provider identity.
+
+use into_markdown_core::{
+    AiCapability, AiOutput, AiProvider, AiRequest, BoxFuture, ConversionError, ConversionOptions,
+    ExecutionContext,
+};
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+/// One configured provider assembled from non-overlapping typed adapters.
+pub struct CompositeAiProvider {
+    provider_id: String,
+    capabilities: BTreeSet<AiCapability>,
+    adapters: Vec<Arc<dyn AiProvider>>,
+}
+
+impl std::fmt::Debug for CompositeAiProvider {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("CompositeAiProvider")
+            .field("provider_id", &self.provider_id)
+            .field("capabilities", &self.capabilities)
+            .field("adapter_count", &self.adapters.len())
+            .finish()
+    }
+}
+
+impl CompositeAiProvider {
+    /// Compose typed adapters which all carry the same provider identity and
+    /// advertise disjoint capabilities.
+    ///
+    /// # Errors
+    ///
+    /// Rejects an empty set, identity mismatches, empty capability sets, and
+    /// overlapping capability authority.
+    pub fn new(
+        provider_id: impl Into<String>,
+        adapters: Vec<Arc<dyn AiProvider>>,
+    ) -> Result<Self, ConversionError> {
+        let provider_id = provider_id.into();
+        if provider_id.is_empty() || adapters.is_empty() {
+            return Err(invalid("provider identity and adapter set must be non-empty"));
+        }
+        let mut capabilities = BTreeSet::new();
+        for adapter in &adapters {
+            if adapter.id() != provider_id {
+                return Err(invalid("adapter provider identity does not match the route"));
+            }
+            let advertised = adapter.capabilities();
+            if advertised.is_empty() {
+                return Err(invalid("adapter advertises no capabilities"));
+            }
+            for capability in advertised {
+                if !capabilities.insert(capability) {
+                    return Err(invalid("multiple adapters claim the same capability"));
+                }
+            }
+        }
+        Ok(Self { provider_id, capabilities, adapters })
+    }
+
+    fn adapter(&self, capability: AiCapability) -> Result<&dyn AiProvider, ConversionError> {
+        self.adapters
+            .iter()
+            .find(|adapter| adapter.capabilities().contains(&capability))
+            .map(AsRef::as_ref)
+            .ok_or_else(|| ConversionError::ComponentUnavailable {
+                component: self.provider_id.clone(),
+                detail: "provider does not implement the requested capability".into(),
+            })
+    }
+}
+
+impl AiProvider for CompositeAiProvider {
+    fn id(&self) -> &str {
+        &self.provider_id
+    }
+
+    fn capabilities(&self) -> BTreeSet<AiCapability> {
+        self.capabilities.clone()
+    }
+
+    fn planned_output_bytes(
+        &self,
+        request: AiRequest<'_>,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        self.adapter(request.capability)?.planned_output_bytes(request, options, context)
+    }
+
+    fn execute_with_options<'a>(
+        &'a self,
+        request: AiRequest<'a>,
+        options: &'a ConversionOptions,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<AiOutput, ConversionError>> {
+        match self.adapter(request.capability) {
+            Ok(adapter) => adapter.execute_with_options(request, options, context),
+            Err(error) => Box::pin(async move { Err(error) }),
+        }
+    }
+
+    fn execute<'a>(
+        &'a self,
+        request: AiRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<AiOutput, ConversionError>> {
+        match self.adapter(request.capability) {
+            Ok(adapter) => adapter.execute(request, context),
+            Err(error) => Box::pin(async move { Err(error) }),
+        }
+    }
+}
+
+fn invalid(detail: impl Into<String>) -> ConversionError {
+    ConversionError::ComponentUnavailable {
+        component: "composite-ai-provider".into(),
+        detail: detail.into(),
+    }
+}

--- a/crates/ai/src/image_description.rs
+++ b/crates/ai/src/image_description.rs
@@ -20,6 +20,7 @@ const FIXED_WORKING_BYTES: u64 = 512 * 1024;
 pub struct OpenAiImageDescriptionProvider {
     client: OpenAiCompatibleClient,
     network: ProviderNetworkPolicy,
+    provider_id: String,
 }
 
 impl std::fmt::Debug for OpenAiImageDescriptionProvider {
@@ -28,6 +29,7 @@ impl std::fmt::Debug for OpenAiImageDescriptionProvider {
             .debug_struct("OpenAiImageDescriptionProvider")
             .field("client", &self.client)
             .field("network", &self.network)
+            .field("provider_id", &self.provider_id)
             .finish()
     }
 }
@@ -36,13 +38,38 @@ impl OpenAiImageDescriptionProvider {
     /// Bind a validated transport to the exact invocation network policy.
     #[must_use]
     pub fn new(client: OpenAiCompatibleClient, network: ProviderNetworkPolicy) -> Self {
-        Self { client, network }
+        Self { client, network, provider_id: PROVIDER_ID.into() }
+    }
+
+    /// Bind a transport to an exact configured provider identity.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, oversized, or non-canonical provider IDs.
+    pub fn new_with_id(
+        client: OpenAiCompatibleClient,
+        network: ProviderNetworkPolicy,
+        provider_id: impl Into<String>,
+    ) -> Result<Self, ConversionError> {
+        let provider_id = provider_id.into();
+        if provider_id.is_empty()
+            || provider_id.len() > 512
+            || !provider_id
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
+        {
+            return Err(ConversionError::ComponentUnavailable {
+                component: "image-description-provider".into(),
+                detail: "provider identity is invalid".into(),
+            });
+        }
+        Ok(Self { client, network, provider_id })
     }
 }
 
 impl AiProvider for OpenAiImageDescriptionProvider {
-    fn id(&self) -> &'static str {
-        PROVIDER_ID
+    fn id(&self) -> &str {
+        &self.provider_id
     }
 
     fn capabilities(&self) -> BTreeSet<AiCapability> {
@@ -56,8 +83,8 @@ impl AiProvider for OpenAiImageDescriptionProvider {
         context: &ExecutionContext,
     ) -> Result<u64, ConversionError> {
         context.checkpoint()?;
-        let (bytes, media_type, page) = page_image(request)?;
-        validate_request(request, media_type, page, options, &self.network)?;
+        let (bytes, media_type, page) = page_image(request, &self.provider_id)?;
+        validate_request(request, media_type, page, options, &self.network, &self.provider_id)?;
         let encoded_peak = u64::try_from(bytes.len())
             .map_err(|_| memory("image size is unrepresentable"))?
             .checked_mul(5)
@@ -80,8 +107,8 @@ impl AiProvider for OpenAiImageDescriptionProvider {
     ) -> BoxFuture<'a, Result<AiOutput, ConversionError>> {
         Box::pin(async move {
             context.checkpoint()?;
-            let (bytes, media_type, page) = page_image(request)?;
-            validate_request(request, media_type, page, options, &self.network)?;
+            let (bytes, media_type, page) = page_image(request, &self.provider_id)?;
+            validate_request(request, media_type, page, options, &self.network, &self.provider_id)?;
             let result = self
                 .client
                 .generate(
@@ -94,17 +121,17 @@ impl AiProvider for OpenAiImageDescriptionProvider {
                     },
                     context,
                 )
-                .map_err(|error| map_provider_error(&error))?;
+                .map_err(|error| map_provider_error(&self.provider_id, &error))?;
             let text = result.text.trim();
             if text.is_empty() || text.len() as u64 > options.limits.max_field_bytes {
                 return Err(ConversionError::Ai {
-                    provider: PROVIDER_ID.into(),
+                    provider: self.provider_id.clone(),
                     detail: "provider returned an empty or oversized image description".into(),
                 });
             }
             let provenance = Provenance {
                 kind: ProvenanceKind::AiProvider,
-                provider: PROVIDER_ID.into(),
+                provider: self.provider_id.clone(),
                 locator: SourceLocator { page: Some(page), ..SourceLocator::default() },
                 confidence: None,
             };
@@ -130,18 +157,21 @@ impl AiProvider for OpenAiImageDescriptionProvider {
         Box::pin(async move {
             context.checkpoint()?;
             Err(ConversionError::ComponentUnavailable {
-                component: PROVIDER_ID.into(),
+                component: self.provider_id.clone(),
                 detail: "policy-bound execution options are required".into(),
             })
         })
     }
 }
 
-fn page_image(request: AiRequest<'_>) -> Result<(&[u8], &str, u32), ConversionError> {
+fn page_image<'a>(
+    request: AiRequest<'a>,
+    provider: &str,
+) -> Result<(&'a [u8], &'a str, u32), ConversionError> {
     match request.input {
         AiInput::PageImage { bytes, media_type, page } if page > 0 => Ok((bytes, media_type, page)),
         _ => Err(ConversionError::Ai {
-            provider: PROVIDER_ID.into(),
+            provider: provider.into(),
             detail: "image description requires a page-bound encoded image".into(),
         }),
     }
@@ -153,6 +183,7 @@ fn validate_request(
     page: u32,
     options: &ConversionOptions,
     network: &ProviderNetworkPolicy,
+    provider: &str,
 ) -> Result<(), ConversionError> {
     if request.capability != AiCapability::ImageDescription
         || request.prompt.is_some()
@@ -160,7 +191,7 @@ fn validate_request(
         || page == 0
     {
         return Err(ConversionError::Ai {
-            provider: PROVIDER_ID.into(),
+            provider: provider.into(),
             detail: "image-description request contract is invalid".into(),
         });
     }
@@ -177,7 +208,7 @@ fn validate_request(
     Ok(())
 }
 
-fn map_provider_error(error: &ProviderError) -> ConversionError {
+fn map_provider_error(provider: &str, error: &ProviderError) -> ConversionError {
     match error.code() {
         ProviderErrorCode::Cancelled => ConversionError::Cancelled,
         ProviderErrorCode::Timeout => ConversionError::Timeout,
@@ -193,7 +224,7 @@ fn map_provider_error(error: &ProviderError) -> ConversionError {
         | ProviderErrorCode::RedirectDenied => {
             ConversionError::Network { detail: error.code_str().into() }
         }
-        _ => ConversionError::Ai { provider: PROVIDER_ID.into(), detail: error.code_str().into() },
+        _ => ConversionError::Ai { provider: provider.into(), detail: error.code_str().into() },
     }
 }
 

--- a/crates/ai/src/lib.rs
+++ b/crates/ai/src/lib.rs
@@ -1,13 +1,18 @@
 //! AI provider contracts, bounded direct transport, and placeholder implementations.
 
+mod composite;
 mod image_description;
 mod openai;
+mod remote_capabilities;
+mod structured_patch;
 
 pub use image_description::OpenAiImageDescriptionProvider;
+pub use remote_capabilities::{OpenAiRemoteOcr, OpenAiRemoteTranscriber};
+pub use structured_patch::{OpenAiDocumentPatchProvider, StructuredAiPatchEnricher};
 
 pub use openai::{
-    GenerationEndpoint, GenerationInput, GenerationRequest, GenerationResult,
-    OpenAiCompatibleClient, ProviderConfig, ProviderError, ProviderErrorCode,
+    AudioGenerationMetadata, GenerationEndpoint, GenerationInput, GenerationRequest,
+    GenerationResult, OpenAiCompatibleClient, ProviderConfig, ProviderError, ProviderErrorCode,
     ProviderNetworkPolicy, ProviderTestResult,
 };
 
@@ -109,3 +114,4 @@ impl Transcriber for PlaceholderTranscriber {
         })
     }
 }
+pub use composite::CompositeAiProvider;

--- a/crates/ai/src/openai.rs
+++ b/crates/ai/src/openai.rs
@@ -26,8 +26,9 @@ use zeroize::Zeroize;
 const MAX_SECRET_BYTES: usize = 16 * 1024;
 const MAX_BASE_URL_BYTES: usize = 4 * 1024;
 const MAX_ENVIRONMENT_NAME_BYTES: usize = 256;
-const MAX_REQUEST_BYTES: usize = 8 * 1024 * 1024;
+const MAX_REQUEST_BYTES: usize = 16 * 1024 * 1024;
 const MAX_IMAGE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_AUDIO_BYTES: usize = 10 * 1024 * 1024;
 const MAX_PROMPT_BYTES: usize = 256 * 1024;
 const MAX_OUTPUT_TOKENS: u32 = 16_384;
 const MAX_HEADER_BYTES: usize = 32 * 1024;
@@ -406,6 +407,15 @@ pub enum GenerationInput<'a> {
         /// Text instruction paired with the image.
         prompt: &'a str,
     },
+    /// One Base64-encoded audio input for an OpenAI-compatible chat request.
+    Audio {
+        /// Encoded audio bytes. Public URLs and local paths are intentionally unsupported.
+        bytes: &'a [u8],
+        /// Exact supported audio MIME media type.
+        media_type: &'a str,
+        /// Optional BCP-47 language hint accepted by the configured provider.
+        language: Option<&'a str>,
+    },
 }
 
 /// One explicitly authorized generation request.
@@ -431,6 +441,20 @@ pub struct GenerationResult {
     pub schema_version: u32,
     /// Provider-generated text, not yet interpreted as an IR patch.
     pub text: String,
+    /// Validated audio response metadata, present only for audio requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio: Option<AudioGenerationMetadata>,
+}
+
+/// Bounded metadata returned by an audio-transcription request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioGenerationMetadata {
+    /// Provider-reported source duration in milliseconds.
+    pub duration_ms: u64,
+    /// Provider-reported BCP-47-like language code when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
 }
 
 /// Direct client whose default implementation performs no proxy discovery.
@@ -576,6 +600,7 @@ impl OpenAiCompatibleClient {
             let mut result = parse_generation_response(
                 response,
                 request.endpoint,
+                matches!(request.input, GenerationInput::Audio { .. }),
                 context,
                 deadline,
                 &mut memory,
@@ -876,8 +901,40 @@ fn validate_generation_request(
         {
             Ok(())
         }
+        GenerationInput::Audio { bytes, media_type, language }
+            if request.endpoint == GenerationEndpoint::ChatCompletions
+                && !bytes.is_empty()
+                && bytes.len() <= MAX_AUDIO_BYTES
+                && supported_audio_media_type(media_type)
+                && language.is_none_or(valid_language_hint) =>
+        {
+            Ok(())
+        }
         _ => Err(ProviderError::new(ProviderErrorCode::ResourceLimit)),
     }
+}
+
+fn supported_audio_media_type(value: &str) -> bool {
+    matches!(
+        value,
+        "audio/aac"
+            | "audio/flac"
+            | "audio/m4a"
+            | "audio/mp4"
+            | "audio/mpeg"
+            | "audio/ogg"
+            | "audio/opus"
+            | "audio/wav"
+            | "audio/webm"
+            | "video/mp4"
+            | "video/webm"
+    )
+}
+
+fn valid_language_hint(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 35
+        && value.bytes().all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
 }
 
 fn generation_body_bound(
@@ -892,6 +949,15 @@ fn generation_body_bound(
             .and_then(|size| size.checked_div(3))
             .and_then(|groups| groups.checked_mul(4))
             .and_then(|encoded| encoded.checked_add(prompt.len().saturating_mul(6)))
+            .ok_or_else(|| ProviderError::new(ProviderErrorCode::ResourceLimit))?,
+        GenerationInput::Audio { bytes, language, .. } => bytes
+            .len()
+            .checked_add(2)
+            .and_then(|size| size.checked_div(3))
+            .and_then(|groups| groups.checked_mul(4))
+            .and_then(|encoded| {
+                encoded.checked_add(language.map_or(0, |value| value.len().saturating_mul(6)))
+            })
             .ok_or_else(|| ProviderError::new(ProviderErrorCode::ResourceLimit))?,
     };
     input_bytes
@@ -910,7 +976,12 @@ fn encode_generation_request(
     struct ChatRequest<'a> {
         model: &'a str,
         messages: [ChatMessage<'a>; 1],
-        max_tokens: u32,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        max_tokens: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        stream: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        asr_options: Option<ChatAsrOptions<'a>>,
     }
     #[derive(Serialize)]
     struct ChatMessage<'a> {
@@ -921,7 +992,8 @@ fn encode_generation_request(
     #[serde(untagged)]
     enum ChatContent<'a> {
         Text(&'a str),
-        Parts([ChatPart<'a>; 2]),
+        ImageParts([ChatPart<'a>; 2]),
+        AudioParts([ChatPart<'a>; 1]),
     }
     #[derive(Serialize)]
     #[serde(tag = "type")]
@@ -930,10 +1002,22 @@ fn encode_generation_request(
         Text { text: &'a str },
         #[serde(rename = "image_url")]
         ImageUrl { image_url: ChatImageUrl<'a> },
+        #[serde(rename = "input_audio")]
+        InputAudio { input_audio: ChatInputAudio<'a> },
     }
     #[derive(Serialize)]
     struct ChatImageUrl<'a> {
         url: &'a str,
+    }
+    #[derive(Serialize)]
+    struct ChatInputAudio<'a> {
+        data: &'a str,
+    }
+    #[derive(Serialize)]
+    struct ChatAsrOptions<'a> {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        language: Option<&'a str>,
+        enable_itn: bool,
     }
     #[derive(Serialize)]
     struct ResponsesRequest<'a> {
@@ -966,8 +1050,9 @@ fn encode_generation_request(
         Image { image_url: &'a str },
     }
 
-    let image_url = match request.input {
-        GenerationInput::Image { bytes, media_type, .. } => Some(format!(
+    let data_url = match request.input {
+        GenerationInput::Image { bytes, media_type, .. }
+        | GenerationInput::Audio { bytes, media_type, .. } => Some(format!(
             "data:{media_type};base64,{}",
             base64::engine::general_purpose::STANDARD.encode(bytes)
         )),
@@ -975,23 +1060,41 @@ fn encode_generation_request(
     };
     let body = match request.endpoint {
         GenerationEndpoint::ChatCompletions => {
-            let content = match (request.input, image_url.as_deref()) {
-                (GenerationInput::Text(text), None) => ChatContent::Text(text),
-                (GenerationInput::Image { prompt, .. }, Some(url)) => ChatContent::Parts([
-                    ChatPart::Text { text: prompt },
-                    ChatPart::ImageUrl { image_url: ChatImageUrl { url } },
-                ]),
-                _ => return Err(ProviderError::new(ProviderErrorCode::InvalidConfiguration)),
-            };
+            let (content, max_tokens, stream, asr_options) =
+                match (request.input, data_url.as_deref()) {
+                    (GenerationInput::Text(text), None) => {
+                        (ChatContent::Text(text), Some(request.max_output_tokens), None, None)
+                    }
+                    (GenerationInput::Image { prompt, .. }, Some(url)) => (
+                        ChatContent::ImageParts([
+                            ChatPart::Text { text: prompt },
+                            ChatPart::ImageUrl { image_url: ChatImageUrl { url } },
+                        ]),
+                        Some(request.max_output_tokens),
+                        None,
+                        None,
+                    ),
+                    (GenerationInput::Audio { language, .. }, Some(data)) => (
+                        ChatContent::AudioParts([ChatPart::InputAudio {
+                            input_audio: ChatInputAudio { data },
+                        }]),
+                        None,
+                        Some(false),
+                        Some(ChatAsrOptions { language, enable_itn: false }),
+                    ),
+                    _ => return Err(ProviderError::new(ProviderErrorCode::InvalidConfiguration)),
+                };
             serde_json::to_vec(&ChatRequest {
                 model,
                 messages: [ChatMessage { role: "user", content }],
-                max_tokens: request.max_output_tokens,
+                max_tokens,
+                stream,
+                asr_options,
             })
             .map(|body| ("/chat/completions", body))
         }
         GenerationEndpoint::Responses => {
-            let content = match (request.input, image_url.as_deref()) {
+            let content = match (request.input, data_url.as_deref()) {
                 (GenerationInput::Text(text), None) => {
                     ResponsesContent::Text([ResponsesText { r#type: "input_text", text }])
                 }
@@ -1000,6 +1103,9 @@ fn encode_generation_request(
                         ResponsesPart::Text { text: prompt },
                         ResponsesPart::Image { image_url },
                     ])
+                }
+                (GenerationInput::Audio { .. }, _) => {
+                    return Err(ProviderError::new(ProviderErrorCode::InvalidConfiguration));
                 }
                 _ => return Err(ProviderError::new(ProviderErrorCode::InvalidConfiguration)),
             };
@@ -1609,30 +1715,34 @@ fn parse_models_response(
 fn parse_generation_response(
     response: HttpResponse,
     endpoint: GenerationEndpoint,
+    expects_audio: bool,
     context: &ExecutionContext,
     deadline: Instant,
     memory: &mut MemoryBudget,
 ) -> Result<GenerationResult, ProviderError> {
     ensure_success_status(response.status)?;
-    let text = match endpoint {
+    let (text, audio) = match endpoint {
         GenerationEndpoint::ChatCompletions => {
             let parsed: ParsedJson<ChatResponseWire> =
                 parse_json_bounded(&response.body, context, deadline, memory)?;
-            let text = parse_chat_text(parsed.value)?;
+            let (text, audio) = parse_chat_text(parsed.value, expects_audio)?;
             memory.grow(text.capacity())?;
             memory.shrink(parsed.reserved)?;
-            text
+            (text, audio)
         }
         GenerationEndpoint::Responses => {
+            if expects_audio {
+                return Err(ProviderError::new(ProviderErrorCode::InvalidResponse));
+            }
             let parsed: ParsedJson<ResponsesResponseWire> =
                 parse_json_bounded(&response.body, context, deadline, memory)?;
             let text = parse_responses_text(parsed.value, memory)?;
             memory.shrink(parsed.reserved)?;
-            text
+            (text, None)
         }
     };
     memory.shrink(response.body.capacity())?;
-    Ok(GenerationResult { schema_version: 1, text })
+    Ok(GenerationResult { schema_version: 1, text, audio })
 }
 
 #[derive(Deserialize)]
@@ -1704,7 +1814,10 @@ impl ApiErrorWire {
     }
 }
 
-fn parse_chat_text(value: ChatResponseWire) -> Result<String, ProviderError> {
+fn parse_chat_text(
+    value: ChatResponseWire,
+    expects_audio: bool,
+) -> Result<(String, Option<AudioGenerationMetadata>), ProviderError> {
     if value.object != "chat.completion" || value.id.is_empty() || value.model.is_empty() {
         return Err(ProviderError::new(ProviderErrorCode::InvalidResponse));
     }
@@ -1712,13 +1825,8 @@ fn parse_chat_text(value: ChatResponseWire) -> Result<String, ProviderError> {
         let _ = error.is_well_formed();
         return Err(ProviderError::new(ProviderErrorCode::InvalidResponse));
     }
-    let _ = (
-        value.created,
-        value.usage,
-        value.service_tier,
-        value.system_fingerprint,
-        value.moderation,
-    );
+    let usage = value.usage;
+    let _ = (value.created, value.service_tier, value.system_fingerprint, value.moderation);
     let mut choices =
         value.choices.ok_or_else(|| ProviderError::new(ProviderErrorCode::InvalidResponse))?;
     if choices.len() != 1 {
@@ -1746,13 +1854,41 @@ fn parse_chat_text(value: ChatResponseWire) -> Result<String, ProviderError> {
     {
         return Err(ProviderError::new(ProviderErrorCode::InvalidResponse));
     }
-    let _ = message.annotations;
+    let audio = if expects_audio {
+        let seconds = usage
+            .as_ref()
+            .and_then(|usage| usage.get("seconds"))
+            .and_then(serde_json::Value::as_u64)
+            .filter(|seconds| (1..=300).contains(seconds))
+            .ok_or_else(|| ProviderError::new(ProviderErrorCode::InvalidResponse))?;
+        let language = message
+            .annotations
+            .as_ref()
+            .and_then(|annotations| {
+                annotations.iter().find_map(|annotation| {
+                    (annotation.get("type").and_then(serde_json::Value::as_str)
+                        == Some("audio_info"))
+                    .then(|| annotation.get("language").and_then(serde_json::Value::as_str))
+                    .flatten()
+                })
+            })
+            .map(str::to_owned);
+        if language.as_deref().is_some_and(|value| !valid_language_hint(value)) {
+            return Err(ProviderError::new(ProviderErrorCode::InvalidResponse));
+        }
+        Some(AudioGenerationMetadata { duration_ms: seconds.saturating_mul(1_000), language })
+    } else {
+        if message.annotations.as_ref().is_some_and(|values| !values.is_empty()) {
+            return Err(ProviderError::new(ProviderErrorCode::InvalidResponse));
+        }
+        None
+    };
     let content =
         message.content.ok_or_else(|| ProviderError::new(ProviderErrorCode::InvalidResponse))?;
     if content.is_empty() || content.len() > MAX_JSON_STRING_BYTES {
         return Err(ProviderError::new(ProviderErrorCode::InvalidResponse));
     }
-    Ok(content)
+    Ok((content, audio))
 }
 
 #[derive(Deserialize)]
@@ -2326,6 +2462,7 @@ mod tests {
         parse_generation_response(
             HttpResponse { status: 200, retry_after: None, body },
             endpoint,
+            false,
             &context,
             Instant::now() + Duration::from_secs(1),
             &mut memory,
@@ -2476,6 +2613,47 @@ mod tests {
         assert_eq!(
             std::str::from_utf8(&responses_body).unwrap(),
             r#"{"model":"model","input":[{"role":"user","content":[{"type":"input_text","text":"describe"},{"type":"input_image","image_url":"data:image/png;base64,YWJj"}]}],"max_output_tokens":42}"#
+        );
+    }
+
+    #[test]
+    fn audio_generation_uses_bounded_base64_chat_contract_and_validates_metadata() {
+        let request = GenerationRequest {
+            endpoint: GenerationEndpoint::ChatCompletions,
+            capability: "audio-transcription",
+            input: GenerationInput::Audio {
+                bytes: b"abc",
+                media_type: "audio/wav",
+                language: Some("zh"),
+            },
+            max_output_tokens: 42,
+            idempotency_key: None,
+        };
+        let (_, body) = encode_generation_request(&request, "qwen3-asr-flash").unwrap();
+        assert_eq!(
+            std::str::from_utf8(&body).unwrap(),
+            r#"{"model":"qwen3-asr-flash","messages":[{"role":"user","content":[{"type":"input_audio","input_audio":{"data":"data:audio/wav;base64,YWJj"}}]}],"stream":false,"asr_options":{"language":"zh","enable_itn":false}}"#
+        );
+
+        let context = context();
+        let mut memory = memory_budget(&context);
+        let body = r#"{"id":"chatcmpl-asr","object":"chat.completion","created":1720000000,"model":"qwen3-asr-flash","choices":[{"index":0,"message":{"role":"assistant","content":"欢迎使用。","annotations":[{"type":"audio_info","language":"zh","emotion":"neutral"}]},"finish_reason":"stop"}],"usage":{"seconds":3,"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#
+            .as_bytes()
+            .to_vec();
+        memory.grow(body.capacity()).unwrap();
+        let result = parse_generation_response(
+            HttpResponse { status: 200, retry_after: None, body },
+            GenerationEndpoint::ChatCompletions,
+            true,
+            &context,
+            Instant::now() + Duration::from_secs(1),
+            &mut memory,
+        )
+        .unwrap();
+        assert_eq!(result.text, "欢迎使用。");
+        assert_eq!(
+            result.audio,
+            Some(AudioGenerationMetadata { duration_ms: 3_000, language: Some("zh".into()) })
         );
     }
 

--- a/crates/ai/src/remote_capabilities.rs
+++ b/crates/ai/src/remote_capabilities.rs
@@ -1,0 +1,553 @@
+//! Typed, policy-bound OpenAI-compatible OCR and transcription adapters.
+
+use crate::{
+    GenerationEndpoint, GenerationInput, GenerationRequest, OpenAiCompatibleClient, ProviderError,
+    ProviderErrorCode, ProviderNetworkPolicy,
+};
+use into_markdown_core::{
+    Block, BlockNode, BoxFuture, ConversionError, ConversionOptions, ExecutionContext, Inline,
+    NodeId, OcrEngine, OcrOutputPlan, OcrRecognition, OcrRegion, OcrRequest, OcrResult, Provenance,
+    ProvenanceKind, SourceLocator, TimeRange, Transcriber, TranscriptionRequest,
+    TranscriptionResult,
+};
+
+const OCR_PROMPT: &str =
+    "Extract all visible text in reading order. Return text only, without commentary.";
+const OCR_MAX_OUTPUT_TOKENS: u32 = 16_384;
+const ASR_MAX_OUTPUT_TOKENS: u32 = 16_384;
+const MAX_REMOTE_IMAGE_BYTES: usize = 4 * 1024 * 1024;
+const MAX_REMOTE_AUDIO_BYTES: usize = 10 * 1024 * 1024;
+const MAX_REMOTE_TEXT_BYTES: u64 = 256 * 1024;
+const FIXED_WORKING_BYTES: u64 = 1024 * 1024;
+
+/// OpenAI-compatible remote OCR exposed through the same typed OCR contract as local plugins.
+pub struct OpenAiRemoteOcr {
+    client: OpenAiCompatibleClient,
+    network: ProviderNetworkPolicy,
+    provider_id: String,
+}
+
+impl std::fmt::Debug for OpenAiRemoteOcr {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OpenAiRemoteOcr")
+            .field("client", &self.client)
+            .field("network", &self.network)
+            .field("provider_id", &self.provider_id)
+            .finish()
+    }
+}
+
+impl OpenAiRemoteOcr {
+    /// Bind a validated client to a stable, non-secret provenance identity.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, oversized, or control-bearing provider identities.
+    pub fn new(
+        client: OpenAiCompatibleClient,
+        network: ProviderNetworkPolicy,
+        provider_id: impl Into<String>,
+    ) -> Result<Self, ConversionError> {
+        let provider_id = provider_id.into();
+        validate_provider_id(&provider_id)?;
+        Ok(Self { client, network, provider_id })
+    }
+}
+
+impl OcrEngine for OpenAiRemoteOcr {
+    fn id(&self) -> &str {
+        &self.provider_id
+    }
+
+    fn provenance_kind(&self) -> ProvenanceKind {
+        ProvenanceKind::AiProvider
+    }
+
+    fn planned_bound_output(
+        &self,
+        request: OcrRequest<'_>,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        context.checkpoint()?;
+        validate_network(options, &self.network)?;
+        if request.image.is_empty()
+            || request.image.len() > MAX_REMOTE_IMAGE_BYTES
+            || !matches!(
+                request.media_type,
+                "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+            )
+        {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_input_bytes",
+                detail: "remote OCR image is empty, oversized, or unsupported".into(),
+            });
+        }
+        let text_bytes = options.limits.max_field_bytes.clamp(1, MAX_REMOTE_TEXT_BYTES);
+        let retained = text_bytes.checked_add(16 * 1024).ok_or_else(memory_overflow)?;
+        let working = u64::try_from(request.image.len())
+            .map_err(|_| memory_overflow())?
+            .checked_mul(5)
+            .and_then(|bytes| bytes.checked_add(FIXED_WORKING_BYTES))
+            .ok_or_else(memory_overflow)?;
+        let total = retained.checked_add(working).ok_or_else(memory_overflow)?;
+        if total > options.limits.max_memory_bytes || total > context.available_memory_bytes() {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_memory_bytes",
+                detail: "remote OCR request exceeds the available memory budget".into(),
+            });
+        }
+        OcrOutputPlan::try_new_with_working(retained, working, 1, text_bytes)
+    }
+
+    fn planned_normalized_png_output(
+        &self,
+        width: u32,
+        height: u32,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        context.checkpoint()?;
+        validate_network(options, &self.network)?;
+        if width == 0 || height == 0 {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_input_bytes",
+                detail: "remote OCR normalized image dimensions must be non-zero".into(),
+            });
+        }
+        let pixels = u64::from(width).checked_mul(u64::from(height)).ok_or_else(memory_overflow)?;
+        let decoded = pixels.checked_mul(4).ok_or_else(memory_overflow)?;
+        let encoded = u64::try_from(MAX_REMOTE_IMAGE_BYTES).map_err(|_| memory_overflow())?;
+        let text_bytes = options.limits.max_field_bytes.clamp(1, MAX_REMOTE_TEXT_BYTES);
+        let retained = text_bytes.checked_add(16 * 1024).ok_or_else(memory_overflow)?;
+        let working = decoded
+            .checked_add(encoded.checked_mul(5).ok_or_else(memory_overflow)?)
+            .and_then(|bytes| bytes.checked_add(FIXED_WORKING_BYTES))
+            .ok_or_else(memory_overflow)?;
+        let total = retained.checked_add(working).ok_or_else(memory_overflow)?;
+        if total > options.limits.max_memory_bytes || total > context.available_memory_bytes() {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_memory_bytes",
+                detail: "remote OCR normalized image exceeds the available memory budget".into(),
+            });
+        }
+        OcrOutputPlan::try_new_with_working(retained, working, 1, text_bytes)
+    }
+
+    fn recognize<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+        Box::pin(async move {
+            context.checkpoint()?;
+            let result = self
+                .client
+                .generate(
+                    GenerationRequest {
+                        endpoint: GenerationEndpoint::ChatCompletions,
+                        capability: "vision-ocr",
+                        input: GenerationInput::Image {
+                            bytes: request.image,
+                            media_type: request.media_type,
+                            prompt: OCR_PROMPT,
+                        },
+                        max_output_tokens: OCR_MAX_OUTPUT_TOKENS,
+                        idempotency_key: None,
+                    },
+                    context,
+                )
+                .map_err(|error| map_provider_error(&self.provider_id, &error))?;
+            let text = result.text.trim();
+            if text.is_empty()
+                || u64::try_from(text.len()).unwrap_or(u64::MAX) > MAX_REMOTE_TEXT_BYTES
+            {
+                return Err(ConversionError::Ocr {
+                    provider: self.provider_id.clone(),
+                    detail: "remote OCR returned empty or oversized text".into(),
+                });
+            }
+            Ok(OcrResult {
+                regions: vec![OcrRegion {
+                    text: text.into(),
+                    // Geometry and confidence are deliberately not invented.
+                    // The remote result remains `OcrRecognition::Unbound` and
+                    // is materialized as page-scoped AI text by the converter.
+                    polygon: [(0.0, 0.0); 4],
+                    confidence: 0.0,
+                }],
+                provider: self.provider_id.clone(),
+            })
+        })
+    }
+
+    fn recognize_bound<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+        Box::pin(async move { self.recognize(request, context).await.map(OcrRecognition::Remote) })
+    }
+}
+
+/// OpenAI-compatible remote transcription exposed through the typed media contract.
+pub struct OpenAiRemoteTranscriber {
+    client: OpenAiCompatibleClient,
+    provider_id: String,
+    model_id: String,
+}
+
+impl std::fmt::Debug for OpenAiRemoteTranscriber {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OpenAiRemoteTranscriber")
+            .field("client", &self.client)
+            .field("provider_id", &self.provider_id)
+            .field("model_id", &self.model_id)
+            .finish()
+    }
+}
+
+impl OpenAiRemoteTranscriber {
+    /// Bind a validated client to exact provider and model identities.
+    ///
+    /// # Errors
+    ///
+    /// Rejects empty, oversized, or control-bearing identities.
+    pub fn new(
+        client: OpenAiCompatibleClient,
+        provider_id: impl Into<String>,
+        model_id: impl Into<String>,
+    ) -> Result<Self, ConversionError> {
+        let provider_id = provider_id.into();
+        let model_id = model_id.into();
+        validate_provider_id(&provider_id)?;
+        if model_id.is_empty() || model_id.len() > 512 || model_id.chars().any(char::is_control) {
+            return Err(ConversionError::ComponentUnavailable {
+                component: "remote-transcription".into(),
+                detail: "remote transcription model identity is invalid".into(),
+            });
+        }
+        Ok(Self { client, provider_id, model_id })
+    }
+}
+
+impl Transcriber for OpenAiRemoteTranscriber {
+    fn id(&self) -> &str {
+        &self.provider_id
+    }
+
+    fn transcribe<'a>(
+        &'a self,
+        request: TranscriptionRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<TranscriptionResult, ConversionError>> {
+        Box::pin(async move {
+            context.checkpoint()?;
+            if request.media.is_empty() || request.media.len() > MAX_REMOTE_AUDIO_BYTES {
+                return Err(ConversionError::ResourceLimit {
+                    limit: "max_input_bytes",
+                    detail: "remote transcription media is empty or exceeds 10 MiB".into(),
+                });
+            }
+            let result = self
+                .client
+                .generate(
+                    GenerationRequest {
+                        endpoint: GenerationEndpoint::ChatCompletions,
+                        capability: "audio-transcription",
+                        input: GenerationInput::Audio {
+                            bytes: request.media,
+                            media_type: request.media_type,
+                            language: request.language,
+                        },
+                        max_output_tokens: ASR_MAX_OUTPUT_TOKENS,
+                        idempotency_key: None,
+                    },
+                    context,
+                )
+                .map_err(|error| map_provider_error(&self.provider_id, &error))?;
+            let text = result.text.trim();
+            let audio = result.audio.ok_or_else(|| ConversionError::Ai {
+                provider: self.provider_id.clone(),
+                detail: "remote transcription response omitted bounded audio metadata".into(),
+            })?;
+            if text.is_empty()
+                || u64::try_from(text.len()).unwrap_or(u64::MAX) > MAX_REMOTE_TEXT_BYTES
+            {
+                return Err(ConversionError::Ai {
+                    provider: self.provider_id.clone(),
+                    detail: "remote transcription returned empty or oversized text".into(),
+                });
+            }
+            let range = TimeRange { start_ms: 0, end_ms: audio.duration_ms };
+            let segment = BlockNode {
+                id: NodeId("remote-transcript-0".into()),
+                block: Block::TimedSegment {
+                    range,
+                    speaker: None,
+                    speaker_confidence: None,
+                    tokens: Vec::new(),
+                    content: vec![Inline::Text { value: text.into(), marks: Vec::new() }],
+                },
+                provenance: Provenance {
+                    kind: ProvenanceKind::AiProvider,
+                    provider: self.provider_id.clone(),
+                    locator: SourceLocator { time: Some(range), ..SourceLocator::default() },
+                    confidence: None,
+                },
+            };
+            Ok(TranscriptionResult {
+                segments: vec![segment],
+                provider: self.provider_id.clone(),
+                model: self.model_id.clone(),
+                language: audio.language.or_else(|| request.language.map(str::to_owned)),
+                language_confidence: None,
+            })
+        })
+    }
+}
+
+fn validate_provider_id(value: &str) -> Result<(), ConversionError> {
+    if value.is_empty()
+        || value.len() > 512
+        || value.chars().any(char::is_control)
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
+    {
+        return Err(ConversionError::ComponentUnavailable {
+            component: "remote-provider".into(),
+            detail: "remote provider identity is invalid".into(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_network(
+    options: &ConversionOptions,
+    actual: &ProviderNetworkPolicy,
+) -> Result<(), ConversionError> {
+    let expected = ProviderNetworkPolicy {
+        allow_network: options.network.enabled,
+        allow_private_network: !options.network.deny_private_networks,
+        allowed_hosts: options.network.allowed_hosts.clone(),
+    };
+    if &expected != actual {
+        return Err(ConversionError::Network {
+            detail: "remote capability network policy does not match this invocation".into(),
+        });
+    }
+    Ok(())
+}
+
+fn map_provider_error(provider: &str, error: &ProviderError) -> ConversionError {
+    match error.code() {
+        ProviderErrorCode::Cancelled => ConversionError::Cancelled,
+        ProviderErrorCode::Timeout => ConversionError::Timeout,
+        ProviderErrorCode::ResourceLimit | ProviderErrorCode::ResponseTooLarge => {
+            ConversionError::ResourceLimit {
+                limit: "max_memory_bytes",
+                detail: error.code_str().into(),
+            }
+        }
+        ProviderErrorCode::NetworkDenied
+        | ProviderErrorCode::HostDenied
+        | ProviderErrorCode::PrivateNetworkDenied
+        | ProviderErrorCode::Dns
+        | ProviderErrorCode::Connect
+        | ProviderErrorCode::Tls
+        | ProviderErrorCode::RedirectDenied => {
+            ConversionError::Network { detail: error.code_str().into() }
+        }
+        _ => ConversionError::Ai { provider: provider.into(), detail: error.code_str().into() },
+    }
+}
+
+fn memory_overflow() -> ConversionError {
+    ConversionError::ResourceLimit {
+        limit: "max_memory_bytes",
+        detail: "remote capability memory plan overflow".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ProviderConfig;
+    use into_markdown_core::{
+        Block, ExecutionOptions, OcrRecognition, ResourceLimits, TranscriptionRequest,
+    };
+    use std::future::Future;
+    use std::io::{Read as _, Write as _};
+    use std::net::TcpListener;
+    use std::time::Duration;
+
+    fn context() -> ExecutionContext {
+        ExecutionContext::new(
+            ExecutionOptions {
+                timeout: Some(Duration::from_secs(2)),
+                ..ExecutionOptions::default()
+            },
+            ResourceLimits { max_memory_bytes: 64 * 1024 * 1024, ..ResourceLimits::default() },
+        )
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        let mut future = std::pin::pin!(future);
+        let waker = std::task::Waker::noop();
+        let mut context = std::task::Context::from_waker(waker);
+        loop {
+            match future.as_mut().poll(&mut context) {
+                std::task::Poll::Ready(value) => return value,
+                std::task::Poll::Pending => std::thread::yield_now(),
+            }
+        }
+    }
+
+    fn client(
+        address: std::net::SocketAddr,
+        capability: &str,
+        network: bool,
+        secret_environment: &str,
+    ) -> (OpenAiCompatibleClient, ProviderNetworkPolicy) {
+        let config = ProviderConfig::parse(
+            &format!("http://{address}/v1"),
+            if capability == "audio-transcription" { "qwen3-asr-flash" } else { "qwen3.5-ocr" },
+            secret_environment,
+            Duration::from_secs(2),
+            [capability.into()],
+        )
+        .unwrap();
+        let policy = ProviderNetworkPolicy {
+            allow_network: network,
+            allow_private_network: true,
+            allowed_hosts: vec!["127.0.0.1".into()],
+        };
+        (OpenAiCompatibleClient::new(config, policy.clone()), policy)
+    }
+
+    fn serve(body: &'static [u8]) -> (std::net::SocketAddr, std::thread::JoinHandle<Vec<u8>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let worker = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream.set_read_timeout(Some(Duration::from_secs(2))).unwrap();
+            let mut request = Vec::new();
+            let mut byte = [0_u8];
+            while !request.ends_with(b"\r\n\r\n") {
+                stream.read_exact(&mut byte).unwrap();
+                request.push(byte[0]);
+            }
+            let header_end = request.len();
+            let headers = std::str::from_utf8(&request).unwrap();
+            let length = headers
+                .lines()
+                .find_map(|line| {
+                    line.strip_prefix("Content-Length: ")
+                        .or_else(|| line.strip_prefix("content-length: "))
+                })
+                .unwrap()
+                .parse::<usize>()
+                .unwrap();
+            request.resize(header_end + length, 0);
+            stream.read_exact(&mut request[header_end..]).unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            )
+            .unwrap();
+            stream.write_all(body).unwrap();
+            request
+        });
+        (address, worker)
+    }
+
+    #[test]
+    fn remote_ocr_returns_typed_unbound_text_with_exact_provider_identity() {
+        let response = br#"{"id":"chatcmpl-ocr","object":"chat.completion","created":1,"model":"qwen3.5-ocr","choices":[{"index":0,"message":{"role":"assistant","content":"\u53d1\u7968\u53f7\u7801 12345","annotations":[]},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":4,"total_tokens":5}}"#;
+        let (address, worker) = serve(response);
+        let (client, policy) = client(address, "vision-ocr", true, "PATH");
+        let provider = OpenAiRemoteOcr::new(client, policy, "provider.bailian.vision-ocr").unwrap();
+        let mut options = ConversionOptions::default();
+        options.network.enabled = true;
+        options.network.deny_private_networks = false;
+        options.network.allowed_hosts = vec!["127.0.0.1".into()];
+        let context = context();
+        let request = OcrRequest {
+            image: b"\x89PNG\r\n\x1a\nfixture",
+            media_type: "image/png",
+            languages: &["zh-Hans"],
+        };
+        provider.planned_bound_output(request, &options, &context).unwrap();
+        provider.planned_normalized_png_output(2480, 3508, &options, &context).unwrap();
+        let recognition = block_on(provider.recognize_bound(request, &context)).unwrap();
+        let OcrRecognition::Remote(result) = recognition else {
+            panic!("remote OCR must use the typed remote result")
+        };
+        assert_eq!(result.provider, "provider.bailian.vision-ocr");
+        assert_eq!(result.regions[0].text, "发票号码 12345");
+        assert!(result.regions[0].confidence.abs() < f32::EPSILON);
+        let request = worker.join().unwrap();
+        assert!(request.starts_with(b"POST /v1/chat/completions HTTP/1.1\r\n"));
+        assert!(request.windows(16).any(|window| window == b"data:image/png;b"));
+    }
+
+    #[test]
+    fn remote_transcription_requires_audio_metadata_and_preserves_provenance() {
+        let response = br#"{"id":"chatcmpl-asr","object":"chat.completion","created":1,"model":"qwen3-asr-flash","choices":[{"index":0,"message":{"role":"assistant","content":"\u6b22\u8fce\u4f7f\u7528\u3002","annotations":[{"type":"audio_info","language":"zh"}]},"finish_reason":"stop"}],"usage":{"seconds":3,"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#;
+        let (address, worker) = serve(response);
+        let (client, _) = client(address, "audio-transcription", true, "PATH");
+        let provider = OpenAiRemoteTranscriber::new(
+            client,
+            "provider.bailian.audio-transcription",
+            "qwen3-asr-flash",
+        )
+        .unwrap();
+        let context = context();
+        let result = block_on(provider.transcribe(
+            TranscriptionRequest {
+                media: b"RIFFfixture",
+                media_type: "audio/wav",
+                language: Some("zh"),
+            },
+            &context,
+        ))
+        .unwrap();
+        assert_eq!(result.provider, "provider.bailian.audio-transcription");
+        assert_eq!(result.model, "qwen3-asr-flash");
+        assert_eq!(result.language.as_deref(), Some("zh"));
+        let Block::TimedSegment { range, content, .. } = &result.segments[0].block else {
+            panic!("remote transcription must return a timed segment")
+        };
+        assert_eq!((range.start_ms, range.end_ms), (0, 3_000));
+        assert_eq!(result.segments[0].provenance.provider, result.provider);
+        assert_eq!(result.segments[0].provenance.locator.time, Some(*range));
+        assert!(!content.is_empty());
+        let request = worker.join().unwrap();
+        assert!(request.windows(16).any(|window| window == b"data:audio/wav;b"));
+        assert!(request.windows(12).any(|window| window == b"asr_options\""));
+    }
+
+    #[test]
+    fn network_denial_happens_before_secret_lookup() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let (client, policy) =
+            client(address, "vision-ocr", false, "INTO_MD_DELIBERATELY_MISSING_REMOTE_TEST_KEY");
+        let provider = OpenAiRemoteOcr::new(client, policy, "provider.denied.vision-ocr").unwrap();
+        let context = context();
+        let error = block_on(provider.recognize(
+            OcrRequest { image: b"png", media_type: "image/png", languages: &[] },
+            &context,
+        ))
+        .unwrap_err();
+        assert!(matches!(error, ConversionError::Network { .. }));
+        listener.set_nonblocking(true).unwrap();
+        assert!(
+            matches!(listener.accept(), Err(error) if error.kind() == std::io::ErrorKind::WouldBlock)
+        );
+    }
+}

--- a/crates/ai/src/structured_patch.rs
+++ b/crates/ai/src/structured_patch.rs
@@ -1,0 +1,792 @@
+//! Policy-bound structured document repair and post-processing.
+
+use crate::{
+    GenerationEndpoint, GenerationInput, GenerationRequest, OpenAiCompatibleClient, ProviderError,
+    ProviderErrorCode, ProviderNetworkPolicy,
+};
+use into_markdown_core::{
+    AiCapability, AiInput, AiMode, AiOutput, AiProvider, AiRequest, Block, BlockNode, BoxFuture,
+    ConversionError, ConversionOptions, ConverterOutput, Diagnostic, DiagnosticSeverity, Document,
+    EnrichmentPlan, ExecutionContext, InputFormat, OutputEnricher, Services,
+    estimate_retained_output,
+};
+use std::collections::BTreeSet;
+
+const ENRICHER_ID: &str = "builtin.ai.structured-patch";
+const MAX_PATCH_INPUT_BYTES: usize = 192 * 1024;
+const MAX_PATCH_OUTPUT_TOKENS: u32 = 16_384;
+const FIXED_WORKING_BYTES: u64 = 1024 * 1024;
+
+/// OpenAI-compatible provider that accepts a validated Document IR snapshot and
+/// returns only the versioned [`into_markdown_core::DocumentPatch`] schema.
+pub struct OpenAiDocumentPatchProvider {
+    client: OpenAiCompatibleClient,
+    network: ProviderNetworkPolicy,
+    provider_id: String,
+    capabilities: BTreeSet<AiCapability>,
+}
+
+impl std::fmt::Debug for OpenAiDocumentPatchProvider {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("OpenAiDocumentPatchProvider")
+            .field("client", &self.client)
+            .field("network", &self.network)
+            .field("provider_id", &self.provider_id)
+            .field("capabilities", &self.capabilities)
+            .finish()
+    }
+}
+
+impl OpenAiDocumentPatchProvider {
+    /// Bind a transport to an exact provider identity and the structured repair
+    /// capabilities explicitly declared by configuration.
+    ///
+    /// # Errors
+    ///
+    /// Rejects invalid identities, empty capability sets, and capabilities
+    /// whose output is not represented by a Document Patch.
+    pub fn new(
+        client: OpenAiCompatibleClient,
+        network: ProviderNetworkPolicy,
+        provider_id: impl Into<String>,
+        capabilities: impl IntoIterator<Item = AiCapability>,
+    ) -> Result<Self, ConversionError> {
+        let provider_id = provider_id.into();
+        validate_provider_id(&provider_id)?;
+        let capabilities = capabilities.into_iter().collect::<BTreeSet<_>>();
+        if capabilities.is_empty()
+            || capabilities.iter().any(|capability| !is_patch_capability(*capability))
+        {
+            return Err(ConversionError::ComponentUnavailable {
+                component: provider_id,
+                detail: "structured patch provider capabilities are invalid".into(),
+            });
+        }
+        Ok(Self { client, network, provider_id, capabilities })
+    }
+}
+
+impl AiProvider for OpenAiDocumentPatchProvider {
+    fn id(&self) -> &str {
+        &self.provider_id
+    }
+
+    fn capabilities(&self) -> BTreeSet<AiCapability> {
+        self.capabilities.clone()
+    }
+
+    fn planned_output_bytes(
+        &self,
+        request: AiRequest<'_>,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        context.checkpoint()?;
+        let document = validate_patch_request(request, options, &self.network, &self.capabilities)?;
+        document.validate().map_err(|error| ConversionError::Ai {
+            provider: self.provider_id.clone(),
+            detail: format!("structured patch input is invalid at {}", error.path),
+        })?;
+        let retained = estimate_retained_output(document, &Vec::new(), &Vec::new())?;
+        if retained > u64::try_from(MAX_PATCH_INPUT_BYTES).map_err(|_| memory_overflow())? {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_input_bytes",
+                detail: "structured patch input exceeds its bounded transport envelope".into(),
+            });
+        }
+        let response = options.limits.max_field_bytes.min(256 * 1024);
+        let plan = retained
+            .checked_mul(8)
+            .and_then(|value| value.checked_add(response))
+            .and_then(|value| value.checked_add(FIXED_WORKING_BYTES))
+            .ok_or_else(memory_overflow)?;
+        if plan > options.limits.max_memory_bytes || plan > context.available_memory_bytes() {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_memory_bytes",
+                detail: "structured patch request exceeds the available memory budget".into(),
+            });
+        }
+        Ok(plan)
+    }
+
+    fn execute_with_options<'a>(
+        &'a self,
+        request: AiRequest<'a>,
+        options: &'a ConversionOptions,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<AiOutput, ConversionError>> {
+        Box::pin(async move {
+            context.checkpoint()?;
+            let document =
+                validate_patch_request(request, options, &self.network, &self.capabilities)?;
+            let document_json = document.to_json().map_err(|error| ConversionError::Ai {
+                provider: self.provider_id.clone(),
+                detail: format!("structured patch input is invalid at {}", error.path),
+            })?;
+            if document_json.len() > MAX_PATCH_INPUT_BYTES {
+                return Err(ConversionError::ResourceLimit {
+                    limit: "max_input_bytes",
+                    detail: "structured patch input exceeds 192 KiB".into(),
+                });
+            }
+            let capability = capability_name(request.capability);
+            let prompt = format!(
+                "Return JSON only. Propose a version 1 DocumentPatch for {capability}. \
+                 The exact schema is {{\"version\":1,\"operations\":[{{\"op\":\"append\",\"nodes\":[BlockNode]}},{{\"op\":\"replace\",\"target\":NodeId,\"nodes\":[BlockNode]}}]}}. \
+                 Every returned node and nested node must use provenance.kind=\"aiProvider\" and provenance.provider=\"{}\". \
+                 Do not return raw Markdown, commentary, diagnostics, unknown fields, or operations outside this schema. Document IR: {document_json}",
+                self.provider_id
+            );
+            let result = self
+                .client
+                .generate(
+                    GenerationRequest {
+                        endpoint: GenerationEndpoint::ChatCompletions,
+                        capability,
+                        input: GenerationInput::Text(&prompt),
+                        max_output_tokens: MAX_PATCH_OUTPUT_TOKENS,
+                        idempotency_key: None,
+                    },
+                    context,
+                )
+                .map_err(|error| map_provider_error(&self.provider_id, &error))?;
+            let patch =
+                serde_json::from_str(result.text.trim()).map_err(|_| ConversionError::Ai {
+                    provider: self.provider_id.clone(),
+                    detail: "provider returned an invalid structured patch".into(),
+                })?;
+            Ok(AiOutput { patch: Some(patch), ..AiOutput::default() })
+        })
+    }
+
+    fn execute<'a>(
+        &'a self,
+        _request: AiRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<AiOutput, ConversionError>> {
+        Box::pin(async move {
+            context.checkpoint()?;
+            Err(ConversionError::ComponentUnavailable {
+                component: self.provider_id.clone(),
+                detail: "policy-bound structured patch execution is required".into(),
+            })
+        })
+    }
+}
+
+/// Transactional engine stage for layout, table, formula, and Markdown repair.
+/// Provider output is never copied directly into the final document: it must be
+/// a single validated patch which is atomically applied to the current IR.
+#[derive(Debug, Default)]
+pub struct StructuredAiPatchEnricher;
+
+impl OutputEnricher for StructuredAiPatchEnricher {
+    fn id(&self) -> &'static str {
+        ENRICHER_ID
+    }
+
+    fn planned_enrichment_bytes(
+        &self,
+        output: &ConverterOutput,
+        _converter_id: &str,
+        _format: InputFormat,
+        options: &ConversionOptions,
+        services: &Services,
+        context: &ExecutionContext,
+    ) -> Result<EnrichmentPlan, ConversionError> {
+        let selected = selected_capabilities(output, options);
+        if selected.is_empty() {
+            return Ok(EnrichmentPlan::Skip);
+        }
+        let Some(provider) = services.ai.as_deref() else {
+            return if selected.iter().any(|(_, mode)| *mode == AiMode::Only) {
+                Err(ConversionError::ComponentUnavailable {
+                    component: ENRICHER_ID.into(),
+                    detail: "a required structured AI capability has no provider".into(),
+                })
+            } else {
+                Ok(EnrichmentPlan::Skip)
+            };
+        };
+        let advertised = provider.capabilities();
+        let retained =
+            estimate_retained_output(&output.document, &output.assets, &output.diagnostics)?;
+        let mut plan = retained.checked_mul(2).ok_or_else(memory_overflow)?;
+        let mut invoked = false;
+        for (capability, mode) in selected {
+            if !advertised.contains(&capability) {
+                if mode == AiMode::Only {
+                    return Err(ConversionError::ComponentUnavailable {
+                        component: provider.id().into(),
+                        detail: format!(
+                            "provider does not declare {}",
+                            capability_name(capability)
+                        ),
+                    });
+                }
+                continue;
+            }
+            let request =
+                AiRequest { capability, input: AiInput::Document(&output.document), prompt: None };
+            match provider.planned_output_bytes(request, options, context) {
+                Ok(bytes) => {
+                    plan = plan.checked_add(bytes).ok_or_else(memory_overflow)?;
+                    invoked = true;
+                }
+                Err(error) if mode != AiMode::Only && recoverable_provider_error(&error) => {
+                    return Ok(EnrichmentPlan::Skip);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        if invoked { Ok(EnrichmentPlan::Reserve(plan)) } else { Ok(EnrichmentPlan::Skip) }
+    }
+
+    fn enrich<'a>(
+        &'a self,
+        mut output: ConverterOutput,
+        _converter_id: &'a str,
+        _format: InputFormat,
+        options: &'a ConversionOptions,
+        services: &'a Services,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        Box::pin(async move {
+            let Some(provider) = services.ai.as_deref() else {
+                return Ok(output);
+            };
+            let advertised = provider.capabilities();
+            for (capability, mode) in selected_capabilities(&output, options) {
+                context.checkpoint()?;
+                if !advertised.contains(&capability) {
+                    if mode == AiMode::Only {
+                        return Err(ConversionError::ComponentUnavailable {
+                            component: provider.id().into(),
+                            detail: format!(
+                                "provider does not declare {}",
+                                capability_name(capability)
+                            ),
+                        });
+                    }
+                    continue;
+                }
+                let request = AiRequest {
+                    capability,
+                    input: AiInput::Document(&output.document),
+                    prompt: None,
+                };
+                let response = provider.execute_with_options(request, options, context).await;
+                let ai = match response {
+                    Ok(ai) => ai,
+                    Err(error) if mode != AiMode::Only && recoverable_provider_error(&error) => {
+                        output.diagnostics.push(Diagnostic {
+                            code: "aiCapabilityFallback".into(),
+                            severity: DiagnosticSeverity::Warning,
+                            message: format!(
+                                "{} was unavailable; deterministic output was retained",
+                                capability_name(capability)
+                            ),
+                            locator: None,
+                        });
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                };
+                if !ai.nodes.is_empty() || !ai.diagnostics.is_empty() {
+                    return Err(ConversionError::Ai {
+                        provider: provider.id().into(),
+                        detail: "structured repair returned direct nodes or diagnostics".into(),
+                    });
+                }
+                let patch = ai.patch.ok_or_else(|| ConversionError::Ai {
+                    provider: provider.id().into(),
+                    detail: "structured repair response omitted a DocumentPatch".into(),
+                })?;
+                let candidate = patch.apply(&output.document, provider.id())?;
+                validate_patch_asset_references(
+                    &candidate.blocks,
+                    &output.assets.iter().map(|asset| asset.id.0.as_str()).collect::<BTreeSet<_>>(),
+                    provider.id(),
+                )?;
+                output.document = candidate;
+            }
+            Ok(output)
+        })
+    }
+}
+
+fn validate_patch_asset_references(
+    nodes: &[BlockNode],
+    inventory: &BTreeSet<&str>,
+    provider: &str,
+) -> Result<(), ConversionError> {
+    for node in nodes {
+        match &node.block {
+            Block::Image { asset, .. } if !inventory.contains(asset.0.as_str()) => {
+                return Err(ConversionError::Ai {
+                    provider: provider.into(),
+                    detail: "structured patch references an unknown asset".into(),
+                });
+            }
+            Block::Footnote { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => {
+                validate_patch_asset_references(blocks, inventory, provider)?;
+            }
+            Block::List { items, .. } => {
+                for item in items {
+                    validate_patch_asset_references(&item.blocks, inventory, provider)?;
+                }
+            }
+            Block::Table { rows, .. } => {
+                for row in rows {
+                    for cell in &row.cells {
+                        validate_patch_asset_references(&cell.blocks, inventory, provider)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn selected_capabilities(
+    output: &ConverterOutput,
+    options: &ConversionOptions,
+) -> Vec<(AiCapability, AiMode)> {
+    [
+        (AiCapability::LayoutRepair, options.ai.layout_repair),
+        (AiCapability::TableRepair, options.ai.table_repair),
+        (AiCapability::FormulaRepair, options.ai.formula_repair),
+        (AiCapability::MarkdownPostprocess, options.ai.markdown_postprocess),
+    ]
+    .into_iter()
+    .filter(|(capability, mode)| {
+        *mode != AiMode::Off && (*mode != AiMode::Fallback || needs_fallback(output, *capability))
+    })
+    .collect()
+}
+
+fn needs_fallback(output: &ConverterOutput, capability: AiCapability) -> bool {
+    let needle = capability_name(capability).replace('-', "");
+    output.diagnostics.iter().any(|diagnostic| {
+        let code = diagnostic.code.to_ascii_lowercase().replace(['-', '_'], "");
+        diagnostic.severity != DiagnosticSeverity::Info && code.contains(&needle)
+    }) || match capability {
+        AiCapability::LayoutRepair => contains_block(&output.document.blocks, |block| {
+            matches!(block, Block::Page { .. } | Block::Slide { .. })
+        }),
+        AiCapability::TableRepair => {
+            contains_block(&output.document.blocks, |block| matches!(block, Block::Table { .. }))
+        }
+        AiCapability::FormulaRepair => {
+            contains_block(&output.document.blocks, |block| matches!(block, Block::Formula(_)))
+        }
+        AiCapability::MarkdownPostprocess => !output.diagnostics.is_empty(),
+        _ => false,
+    }
+}
+
+fn contains_block(nodes: &[BlockNode], predicate: impl Fn(&Block) -> bool + Copy) -> bool {
+    nodes.iter().any(|node| {
+        predicate(&node.block)
+            || match &node.block {
+                Block::Footnote { blocks, .. }
+                | Block::Page { blocks, .. }
+                | Block::Slide { blocks, .. }
+                | Block::Sheet { blocks, .. } => contains_block(blocks, predicate),
+                Block::List { items, .. } => {
+                    items.iter().any(|item| contains_block(&item.blocks, predicate))
+                }
+                Block::Table { rows, .. } => rows.iter().any(|row| {
+                    row.cells.iter().any(|cell| contains_block(&cell.blocks, predicate))
+                }),
+                _ => false,
+            }
+    })
+}
+
+fn validate_patch_request<'a>(
+    request: AiRequest<'a>,
+    options: &ConversionOptions,
+    network: &ProviderNetworkPolicy,
+    capabilities: &BTreeSet<AiCapability>,
+) -> Result<&'a Document, ConversionError> {
+    if request.prompt.is_some()
+        || !capabilities.contains(&request.capability)
+        || !is_patch_capability(request.capability)
+    {
+        return Err(ConversionError::Ai {
+            provider: "structured-patch".into(),
+            detail: "structured patch request contract is invalid".into(),
+        });
+    }
+    let AiInput::Document(document) = request.input else {
+        return Err(ConversionError::Ai {
+            provider: "structured-patch".into(),
+            detail: "structured patch requires Document IR input".into(),
+        });
+    };
+    let expected = ProviderNetworkPolicy {
+        allow_network: options.network.enabled,
+        allow_private_network: !options.network.deny_private_networks,
+        allowed_hosts: options.network.allowed_hosts.clone(),
+    };
+    if network != &expected {
+        return Err(ConversionError::Network {
+            detail: "structured patch network policy does not match this invocation".into(),
+        });
+    }
+    Ok(document)
+}
+
+const fn is_patch_capability(capability: AiCapability) -> bool {
+    matches!(
+        capability,
+        AiCapability::LayoutRepair
+            | AiCapability::TableRepair
+            | AiCapability::FormulaRepair
+            | AiCapability::MarkdownPostprocess
+    )
+}
+
+const fn capability_name(capability: AiCapability) -> &'static str {
+    match capability {
+        AiCapability::LayoutRepair => "layout-repair",
+        AiCapability::TableRepair => "table-repair",
+        AiCapability::FormulaRepair => "formula-repair",
+        AiCapability::MarkdownPostprocess => "markdown-postprocess",
+        AiCapability::VisionOcr => "vision-ocr",
+        AiCapability::ImageDescription => "image-description",
+        AiCapability::AudioTranscription => "audio-transcription",
+    }
+}
+
+fn validate_provider_id(value: &str) -> Result<(), ConversionError> {
+    if value.is_empty()
+        || value.len() > 512
+        || value.chars().any(char::is_control)
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_'))
+    {
+        return Err(ConversionError::ComponentUnavailable {
+            component: "structured-patch-provider".into(),
+            detail: "provider identity is invalid".into(),
+        });
+    }
+    Ok(())
+}
+
+fn recoverable_provider_error(error: &ConversionError) -> bool {
+    matches!(
+        error,
+        ConversionError::ComponentUnavailable { .. }
+            | ConversionError::Network { .. }
+            | ConversionError::Timeout
+            | ConversionError::Ai { .. }
+    )
+}
+
+fn map_provider_error(provider: &str, error: &ProviderError) -> ConversionError {
+    match error.code() {
+        ProviderErrorCode::Cancelled => ConversionError::Cancelled,
+        ProviderErrorCode::Timeout => ConversionError::Timeout,
+        ProviderErrorCode::ResourceLimit | ProviderErrorCode::ResponseTooLarge => {
+            ConversionError::ResourceLimit {
+                limit: "max_memory_bytes",
+                detail: error.code_str().into(),
+            }
+        }
+        ProviderErrorCode::NetworkDenied
+        | ProviderErrorCode::HostDenied
+        | ProviderErrorCode::PrivateNetworkDenied
+        | ProviderErrorCode::Dns
+        | ProviderErrorCode::Connect
+        | ProviderErrorCode::Tls
+        | ProviderErrorCode::RedirectDenied => {
+            ConversionError::Network { detail: error.code_str().into() }
+        }
+        _ => ConversionError::Ai { provider: provider.into(), detail: error.code_str().into() },
+    }
+}
+
+fn memory_overflow() -> ConversionError {
+    ConversionError::ResourceLimit {
+        limit: "max_memory_bytes",
+        detail: "structured patch memory plan overflow".into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown_core::{
+        AssetId, Block, DocumentPatch, ExecutionOptions, Inline, NodeId, PatchOperation,
+        Provenance, ProvenanceKind, ResourceLimits, SourceLocator,
+    };
+    use std::future::Future;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Debug)]
+    struct FixtureProvider {
+        result: Result<AiOutput, ConversionError>,
+        calls: AtomicUsize,
+    }
+
+    impl AiProvider for FixtureProvider {
+        fn id(&self) -> &'static str {
+            "fixture.remote"
+        }
+
+        fn capabilities(&self) -> BTreeSet<AiCapability> {
+            BTreeSet::from([
+                AiCapability::LayoutRepair,
+                AiCapability::TableRepair,
+                AiCapability::FormulaRepair,
+                AiCapability::MarkdownPostprocess,
+            ])
+        }
+
+        fn planned_output_bytes(
+            &self,
+            _request: AiRequest<'_>,
+            _options: &ConversionOptions,
+            _context: &ExecutionContext,
+        ) -> Result<u64, ConversionError> {
+            Ok(4_096)
+        }
+
+        fn execute_with_options<'a>(
+            &'a self,
+            _request: AiRequest<'a>,
+            _options: &'a ConversionOptions,
+            _context: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<AiOutput, ConversionError>> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            let result = self.result.clone();
+            Box::pin(async move { result })
+        }
+
+        fn execute<'a>(
+            &'a self,
+            _request: AiRequest<'a>,
+            _context: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<AiOutput, ConversionError>> {
+            Box::pin(async {
+                Err(ConversionError::Internal {
+                    detail: "legacy execution must not be used".into(),
+                })
+            })
+        }
+    }
+
+    fn node(id: &str, text: &str, provider: &str) -> BlockNode {
+        BlockNode {
+            id: NodeId(id.into()),
+            block: Block::Paragraph(vec![Inline::Text { value: text.into(), marks: Vec::new() }]),
+            provenance: Provenance {
+                kind: if provider == "native" {
+                    ProvenanceKind::NativeParser
+                } else {
+                    ProvenanceKind::AiProvider
+                },
+                provider: provider.into(),
+                locator: SourceLocator::default(),
+                confidence: None,
+            },
+        }
+    }
+
+    fn output() -> ConverterOutput {
+        ConverterOutput::new(
+            Document { blocks: vec![node("source", "before", "native")], ..Document::default() },
+            Vec::new(),
+            Vec::new(),
+        )
+    }
+
+    fn patch_output() -> AiOutput {
+        AiOutput {
+            patch: Some(DocumentPatch {
+                version: 1,
+                operations: vec![PatchOperation::Replace {
+                    target: NodeId("source".into()),
+                    nodes: vec![node("replacement", "after", "fixture.remote")],
+                }],
+            }),
+            ..AiOutput::default()
+        }
+    }
+
+    fn context() -> ExecutionContext {
+        ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default())
+    }
+
+    fn block_on<F: Future>(future: F) -> F::Output {
+        let mut future = std::pin::pin!(future);
+        let waker = std::task::Waker::noop();
+        let mut context = std::task::Context::from_waker(waker);
+        loop {
+            match future.as_mut().poll(&mut context) {
+                std::task::Poll::Ready(value) => return value,
+                std::task::Poll::Pending => std::thread::yield_now(),
+            }
+        }
+    }
+
+    fn run(
+        provider: Arc<FixtureProvider>,
+        mode: AiMode,
+        mut output: ConverterOutput,
+    ) -> Result<ConverterOutput, ConversionError> {
+        let mut options = ConversionOptions::default();
+        options.ai.markdown_postprocess = mode;
+        if mode == AiMode::Fallback {
+            output.diagnostics.push(Diagnostic {
+                code: "markdownPostprocessRequired".into(),
+                severity: DiagnosticSeverity::Warning,
+                message: "fixture".into(),
+                locator: None,
+            });
+        }
+        let services = Services { ai: Some(provider), ..Services::default() };
+        let context = context();
+        assert!(matches!(
+            StructuredAiPatchEnricher.planned_enrichment_bytes(
+                &output,
+                "fixture",
+                InputFormat::Text,
+                &options,
+                &services,
+                &context,
+            )?,
+            EnrichmentPlan::Reserve(_)
+        ));
+        block_on(StructuredAiPatchEnricher.enrich(
+            output,
+            "fixture",
+            InputFormat::Text,
+            &options,
+            &services,
+            &context,
+        ))
+    }
+
+    #[test]
+    fn valid_patch_is_applied_for_prefer_and_fallback() {
+        for mode in [AiMode::Prefer, AiMode::Fallback, AiMode::Only] {
+            let provider = Arc::new(FixtureProvider {
+                result: Ok(patch_output()),
+                calls: AtomicUsize::new(0),
+            });
+            let result = run(Arc::clone(&provider), mode, output()).unwrap();
+            assert_eq!(provider.calls.load(Ordering::SeqCst), 1);
+            assert_eq!(result.document.blocks[0].id.0, "replacement");
+            assert_eq!(result.document.blocks[0].provenance.provider, "fixture.remote");
+        }
+    }
+
+    #[test]
+    fn off_and_unneeded_fallback_never_invoke_provider() {
+        for mode in [AiMode::Off, AiMode::Fallback] {
+            let provider = Arc::new(FixtureProvider {
+                result: Ok(patch_output()),
+                calls: AtomicUsize::new(0),
+            });
+            let mut options = ConversionOptions::default();
+            options.ai.markdown_postprocess = mode;
+            let services = Services { ai: Some(provider.clone()), ..Services::default() };
+            let context = context();
+            assert_eq!(
+                StructuredAiPatchEnricher
+                    .planned_enrichment_bytes(
+                        &output(),
+                        "fixture",
+                        InputFormat::Text,
+                        &options,
+                        &services,
+                        &context,
+                    )
+                    .unwrap(),
+                EnrichmentPlan::Skip
+            );
+            assert_eq!(provider.calls.load(Ordering::SeqCst), 0);
+        }
+    }
+
+    #[test]
+    fn prefer_and_fallback_recover_provider_failures_but_only_fails_closed() {
+        for mode in [AiMode::Prefer, AiMode::Fallback] {
+            let provider = Arc::new(FixtureProvider {
+                result: Err(ConversionError::Network { detail: "fixture".into() }),
+                calls: AtomicUsize::new(0),
+            });
+            let result = run(provider, mode, output()).unwrap();
+            assert_eq!(result.document.blocks[0].id.0, "source");
+            assert!(result.diagnostics.iter().any(|item| item.code == "aiCapabilityFallback"));
+        }
+
+        let provider = Arc::new(FixtureProvider {
+            result: Err(ConversionError::Network { detail: "fixture".into() }),
+            calls: AtomicUsize::new(0),
+        });
+        assert!(matches!(
+            run(provider, AiMode::Only, output()),
+            Err(ConversionError::Network { .. })
+        ));
+    }
+
+    #[test]
+    fn direct_nodes_and_fatal_failures_never_fall_back_into_final_ir() {
+        let provider = Arc::new(FixtureProvider {
+            result: Ok(AiOutput {
+                nodes: vec![node("direct", "bypass", "fixture.remote")],
+                ..AiOutput::default()
+            }),
+            calls: AtomicUsize::new(0),
+        });
+        assert!(matches!(run(provider, AiMode::Prefer, output()), Err(ConversionError::Ai { .. })));
+
+        let provider = Arc::new(FixtureProvider {
+            result: Err(ConversionError::Cancelled),
+            calls: AtomicUsize::new(0),
+        });
+        assert!(matches!(run(provider, AiMode::Prefer, output()), Err(ConversionError::Cancelled)));
+    }
+
+    #[test]
+    fn patch_cannot_create_a_dangling_asset_reference() {
+        let mut image = node("image", "unused", "fixture.remote");
+        image.block = Block::Image {
+            asset: AssetId("provider-invented".into()),
+            alt: Some("invented".into()),
+        };
+        let provider = Arc::new(FixtureProvider {
+            result: Ok(AiOutput {
+                patch: Some(DocumentPatch {
+                    version: 1,
+                    operations: vec![PatchOperation::Replace {
+                        target: NodeId("source".into()),
+                        nodes: vec![image],
+                    }],
+                }),
+                ..AiOutput::default()
+            }),
+            calls: AtomicUsize::new(0),
+        });
+        assert!(matches!(run(provider, AiMode::Only, output()), Err(ConversionError::Ai { .. })));
+    }
+
+    #[test]
+    fn wire_schema_rejects_unknown_fields_and_unknown_operations() {
+        let unknown_field = r#"{"version":1,"operations":[],"rawMarkdown":"bypass"}"#;
+        let unknown_operation = r#"{"version":1,"operations":[{"op":"remove","target":"source"}]}"#;
+        assert!(serde_json::from_str::<DocumentPatch>(unknown_field).is_err());
+        assert!(serde_json::from_str::<DocumentPatch>(unknown_operation).is_err());
+    }
+}

--- a/crates/api/src/embedded_visual_ocr_tests.rs
+++ b/crates/api/src/embedded_visual_ocr_tests.rs
@@ -19,6 +19,63 @@ struct SourceBoundOcr(AtomicUsize);
 
 struct PdfGeometryOcr(AtomicUsize);
 
+struct RemoteEmbeddedOcr(AtomicUsize);
+
+impl OcrEngine for RemoteEmbeddedOcr {
+    fn id(&self) -> &'static str {
+        "provider.fixture.vision-ocr"
+    }
+
+    fn provenance_kind(&self) -> ProvenanceKind {
+        ProvenanceKind::AiProvider
+    }
+
+    fn recognize<'a>(
+        &'a self,
+        _: OcrRequest<'a>,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+        Box::pin(async {
+            Ok(OcrResult {
+                regions: vec![OcrRegion {
+                    text: "remote embedded text".into(),
+                    polygon: [(0.0, 0.0); 4],
+                    confidence: 0.0,
+                }],
+                provider: "provider.fixture.vision-ocr".into(),
+            })
+        })
+    }
+
+    fn planned_bound_output(
+        &self,
+        _: OcrRequest<'_>,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new_with_working(16 * 1024, 16 * 1024, 1, 128)
+    }
+
+    fn planned_normalized_png_output(
+        &self,
+        _: u32,
+        _: u32,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new_with_working(16 * 1024, 16 * 1024, 1, 128)
+    }
+
+    fn recognize_bound<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+        self.0.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move { self.recognize(request, context).await.map(OcrRecognition::Remote) })
+    }
+}
+
 impl OcrEngine for PdfGeometryOcr {
     fn id(&self) -> &'static str {
         "test.api.pdf-geometry-ocr"
@@ -221,6 +278,26 @@ fn dynamically_created_docx_obeys_embedded_visual_ocr_and_asset_modes() {
     let result = block_on(engine.convert(request)).unwrap();
     assert!(!result.markdown.contains("text from embedded picture"));
     assert_eq!(ocr.0.load(Ordering::SeqCst), 6);
+}
+
+#[test]
+fn remote_vision_ocr_enriches_container_images_when_local_ocr_is_off() {
+    let mut file = tempfile::Builder::new().suffix(".docx").tempfile().unwrap();
+    file.write_all(&docx_with_png()).unwrap();
+    file.flush().unwrap();
+    let ocr = Arc::new(RemoteEmbeddedOcr(AtomicUsize::new(0)));
+    let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+    let engine = default_engine_with_services(services).unwrap();
+    let mut request = ConversionRequest::new(InputRef::Path(file.path().to_path_buf()));
+    request.options.ocr.policy = OcrPolicy::Off;
+    request.options.ai.vision_ocr = AiMode::Only;
+    request.options.output.asset_mode = AssetMode::Omit;
+    let result = block_on(engine.convert(request)).unwrap();
+    assert_eq!(result.markdown.matches("remote embedded text").count(), 4);
+    assert!(result.provenance.iter().any(|item| {
+        item.kind == ProvenanceKind::AiProvider && item.provider == "provider.fixture.vision-ocr"
+    }));
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 2);
 }
 
 #[test]

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -25,9 +25,11 @@ pub use diarization_service::{
     installed_diarization_service_in_read_only_sandbox,
 };
 pub use into_markdown_ai::{
-    AiProviderDescriptor, GenerationEndpoint, GenerationInput, GenerationRequest, GenerationResult,
-    OpenAiCompatibleClient, OpenAiCompatibleConfig, OpenAiImageDescriptionProvider, ProviderConfig,
-    ProviderError, ProviderErrorCode, ProviderNetworkPolicy, ProviderTestResult,
+    AiProviderDescriptor, AudioGenerationMetadata, CompositeAiProvider, GenerationEndpoint,
+    GenerationInput, GenerationRequest, GenerationResult, OpenAiCompatibleClient,
+    OpenAiCompatibleConfig, OpenAiDocumentPatchProvider, OpenAiImageDescriptionProvider,
+    OpenAiRemoteOcr, OpenAiRemoteTranscriber, ProviderConfig, ProviderError, ProviderErrorCode,
+    ProviderNetworkPolicy, ProviderTestResult, StructuredAiPatchEnricher,
 };
 #[cfg(feature = "official-provider-runtime")]
 pub use into_markdown_asr::{WhisperConfig, WhisperSmallTranscriber};
@@ -83,6 +85,7 @@ pub fn default_engine_builder_with_services(services: Services) -> EngineBuilder
     let mut builder = EngineBuilder::new()
         .renderer(Arc::new(into_markdown_render_markdown::GfmRenderer))
         .enricher(Arc::new(into_markdown_converters::EmbeddedVisualOcrEnricher))
+        .enricher(Arc::new(StructuredAiPatchEnricher))
         .services(services);
     if let Err(error) = into_markdown_converters::register_core_components(builder.registry_mut()) {
         builder.registry_mut().record_validation_error(error.to_string());

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -3,10 +3,10 @@
 use crate::image_converter::{decode, encode, envelope, format};
 use image::{AnimationDecoder, ImageDecoder};
 use into_markdown_core::{
-    AssetId, Block, BlockNode, BoxFuture, ConversionError, ConversionOptions, ConverterOutput,
-    Diagnostic, DiagnosticSeverity, EnrichmentPlan, ExecutionContext, Inline, InputFormat, NodeId,
-    OcrInputIdentity, OcrPolicy, OutputEnricher, Provenance, ResourceReservation, Services,
-    SourceLocator, estimate_validation_working_set,
+    AiMode, AssetId, Block, BlockNode, BoxFuture, ConversionError, ConversionOptions,
+    ConverterOutput, Diagnostic, DiagnosticSeverity, EnrichmentPlan, ExecutionContext, Inline,
+    InputFormat, NodeId, OcrInputIdentity, OcrPolicy, OutputEnricher, Provenance,
+    ResourceReservation, Services, SourceLocator, estimate_validation_working_set,
 };
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
@@ -198,7 +198,7 @@ fn plan_enrichment(
     services: &Services,
     context: &ExecutionContext,
 ) -> Result<EnrichmentPlan, ConversionError> {
-    if options.ocr.policy == OcrPolicy::Off
+    if !ocr_enabled(options)
         || input_format == InputFormat::Image
         || !eligible_container(input_format)
     {
@@ -222,7 +222,7 @@ fn plan_enrichment(
     if reference_counts.is_empty() {
         return Ok(EnrichmentPlan::Skip);
     }
-    if options.ocr.policy == OcrPolicy::Always {
+    if effective_ocr_policy(options) == OcrPolicy::Always {
         let mut supported_references = 0_u64;
         for asset in &output.assets {
             if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
@@ -364,14 +364,14 @@ fn plan_enrichment(
                         (plan.max_retained_bytes(), plan.max_working_bytes(), plan.max_regions())
                     }
                     Err(ConversionError::ComponentUnavailable { .. })
-                        if options.ocr.policy == OcrPolicy::Auto =>
+                        if effective_ocr_policy(options) == OcrPolicy::Auto =>
                     {
                         (0, 0, 0)
                     }
                     Err(error) => return Err(error),
                 }
             }
-            None if options.ocr.policy == OcrPolicy::Auto => (0, 0, 0),
+            None if effective_ocr_policy(options) == OcrPolicy::Auto => (0, 0, 0),
             None => {
                 return Err(ConversionError::ComponentUnavailable {
                     component: "ocr".into(),
@@ -442,7 +442,10 @@ fn candidate_dimensions_for_policy(
 ) -> Result<Option<(u32, u32)>, ConversionError> {
     match validated_candidate_dimensions(asset, options, context) {
         Ok(dimensions) => Ok(Some(dimensions)),
-        Err(error) if options.ocr.policy == OcrPolicy::Auto && auto_skippable_raster(&error) => {
+        Err(error)
+            if effective_ocr_policy(options) == OcrPolicy::Auto
+                && auto_skippable_raster(&error) =>
+        {
             Ok(None)
         }
         Err(error) => Err(error),
@@ -454,7 +457,7 @@ fn auto_excluded_raster(
     options: &ConversionOptions,
     context: &ExecutionContext,
 ) -> Result<bool, ConversionError> {
-    if options.ocr.policy != OcrPolicy::Auto {
+    if effective_ocr_policy(options) != OcrPolicy::Auto {
         return Ok(false);
     }
     // Classification must not consume OCR reference limits: otherwise an
@@ -735,7 +738,7 @@ async fn enrich(
     services: &Services,
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
-    if options.ocr.policy == OcrPolicy::Off
+    if !ocr_enabled(options)
         || input_format == InputFormat::Image
         || !eligible_container(input_format)
     {
@@ -851,7 +854,7 @@ async fn enrich(
         let normalized = match normalize(asset, options, context) {
             Ok(value) => value,
             Err(error)
-                if options.ocr.policy == OcrPolicy::Auto
+                if effective_ocr_policy(options) == OcrPolicy::Auto
                     && auto_degradable_normalization(&error) =>
             {
                 cache.insert(
@@ -886,7 +889,7 @@ async fn enrich(
         match normalized_plan {
             Ok(_) => {}
             Err(error)
-                if options.ocr.policy == OcrPolicy::Auto
+                if effective_ocr_policy(options) == OcrPolicy::Auto
                     && matches!(error, ConversionError::ComponentUnavailable { .. }) =>
             {
                 cache.insert(
@@ -957,6 +960,20 @@ async fn enrich(
         output = crate::pdf_ocr::reconstruct_enriched_pdf(output, options, context)?;
     }
     Ok(output)
+}
+
+fn ocr_enabled(options: &ConversionOptions) -> bool {
+    effective_ocr_policy(options) != OcrPolicy::Off
+}
+
+fn effective_ocr_policy(options: &ConversionOptions) -> OcrPolicy {
+    match options.ai.vision_ocr {
+        AiMode::Only => OcrPolicy::Always,
+        AiMode::Fallback | AiMode::Prefer if options.ocr.policy == OcrPolicy::Off => {
+            OcrPolicy::Auto
+        }
+        _ => options.ocr.policy,
+    }
 }
 
 fn auto_degradable_normalization(error: &ConversionError) -> bool {

--- a/crates/converters/src/image_converter/mod.rs
+++ b/crates/converters/src/image_converter/mod.rs
@@ -130,7 +130,8 @@ async fn convert_image(
         context.checkpoint()?;
         let page = u32::try_from(index + 1).map_err(|_| resource("max_pages", "page overflow"))?;
         let needs_normalized_asset = summary.frames > 1 || decoded.orientation != 1;
-        let ocr_enabled = options.ocr.policy != into_markdown_core::OcrPolicy::Off;
+        let ocr_enabled = options.ocr.policy != into_markdown_core::OcrPolicy::Off
+            || options.ai.vision_ocr != AiMode::Off;
         let ai_enabled = options.ai.image_description != AiMode::Off;
         let needs_normalized =
             needs_normalized_asset || ai_enabled || (ocr_enabled && !frame.has_alpha);

--- a/crates/converters/src/image_converter/ocr.rs
+++ b/crates/converters/src/image_converter/ocr.rs
@@ -1,11 +1,11 @@
 //! Policy-bound OCR routing and evidence-preserving IR construction.
 
 use into_markdown_core::{
-    Asset, Block, BlockNode, ConversionError, ConversionOptions, Diagnostic, DiagnosticSeverity,
-    Document, ExecutionContext, Inline, NodeId, OcrEvidence, OcrEvidenceStage, OcrEvidenceStep,
-    OcrInputIdentity, OcrOutputPlan, OcrPolicy, OcrRecognition, OcrRequest, OcrResult,
-    OcrSourceRegion, Provenance, ProvenanceKind, ResourceReservation, Services, SourceLocator,
-    SourcePoint, estimate_retained_output,
+    AiMode, Asset, Block, BlockNode, ConversionError, ConversionOptions, Diagnostic,
+    DiagnosticSeverity, Document, ExecutionContext, Inline, NodeId, OcrEvidence, OcrEvidenceStage,
+    OcrEvidenceStep, OcrInputIdentity, OcrOutputPlan, OcrPolicy, OcrRecognition, OcrRequest,
+    OcrResult, OcrSourceRegion, Provenance, ProvenanceKind, ResourceReservation, Services,
+    SourceLocator, SourcePoint, estimate_retained_output,
 };
 
 const MERGE_PROVIDER: &str = "builtin.converter.image.ocr-merge";
@@ -56,19 +56,20 @@ async fn recognize_inner(
     services: &Services,
     context: &ExecutionContext,
 ) -> Result<OcrContribution, ConversionError> {
-    if options.ocr.policy == OcrPolicy::Off {
+    let policy = effective_ocr_policy(options);
+    if policy == OcrPolicy::Off {
         return Ok(empty());
     }
     context.checkpoint()?;
     validate_options(options)?;
     let Some(engine) = services.ocr.as_deref() else {
-        return unavailable(options.ocr.policy, page, "no OCR engine is configured");
+        return unavailable(policy, page, "no OCR engine is configured");
     };
     let request =
         OcrRequest { image, media_type: "image/png", languages: &["zh-Hans", "en", "zh-Hant"] };
     let plan = match engine.planned_bound_output(request, options, context) {
         Ok(plan) => plan,
-        Err(error) => return preflight_unavailable(options.ocr.policy, page, engine.id(), error),
+        Err(error) => return preflight_unavailable(policy, page, engine.id(), error),
     };
     validate_plan(plan, options, context)?;
     let planned_bytes = plan
@@ -91,21 +92,49 @@ async fn recognize_inner(
     let provider_context = credited.as_deref().unwrap_or(context);
     let recognition = match context.run(engine.recognize_bound(request, provider_context)).await? {
         Ok(value) => value,
-        Err(error @ ConversionError::ComponentUnavailable { .. })
-            if options.ocr.policy == OcrPolicy::Auto =>
-        {
+        Err(error @ ConversionError::ComponentUnavailable { .. }) if policy == OcrPolicy::Auto => {
             return Ok(degraded(page, format!("OCR was unavailable ({error}); {INSTALL_HINT}")));
         }
-        Err(error) if options.ocr.policy == OcrPolicy::Auto => return Err(error),
+        Err(error) if policy == OcrPolicy::Auto => return Err(error),
         Err(error) => return Err(map_unavailable(engine.id(), error)),
     };
     drop(credited);
-    let OcrRecognition::Bound(bound) = recognition else {
-        return unavailable(
-            options.ocr.policy,
-            page,
-            "the configured OCR engine returned legacy output without bound detector/model evidence",
-        );
+    let bound = match recognition {
+        OcrRecognition::Bound(bound) => bound,
+        OcrRecognition::Remote(result) => {
+            let (document, diagnostics) =
+                materialize_remote_unbound(result, page, plan, options, context)?;
+            let assets = Vec::<Asset>::new();
+            let retained = estimate_retained_output(&document, &assets, &diagnostics)?;
+            if retained > plan.max_retained_bytes() {
+                return Err(ConversionError::Ocr {
+                    provider: engine.id().into(),
+                    detail: format!("remote OCR retained {retained} bytes beyond its plan"),
+                });
+            }
+            if retained < reservation_bytes {
+                memory.shrink(reservation_bytes - retained)?;
+            }
+            return Ok(OcrContribution {
+                accepted_text: !document.blocks.is_empty(),
+                nodes: document.blocks,
+                diagnostics,
+                memory: Some(memory),
+            });
+        }
+        OcrRecognition::Unbound(_) => {
+            return unavailable(
+                policy,
+                page,
+                "the configured local OCR engine returned legacy output without bound detector/model evidence",
+            );
+        }
+        _ => {
+            return Err(ConversionError::Ocr {
+                provider: engine.id().into(),
+                detail: "OCR provider returned an unsupported recognition contract".into(),
+            });
+        }
     };
     if let Some(expected) = expected_identity
         && bound.input_identity() != Some(expected)
@@ -163,6 +192,82 @@ async fn recognize_inner(
         diagnostics,
         memory: Some(memory),
     })
+}
+
+fn effective_ocr_policy(options: &ConversionOptions) -> OcrPolicy {
+    match options.ai.vision_ocr {
+        AiMode::Only => OcrPolicy::Always,
+        AiMode::Fallback | AiMode::Prefer if options.ocr.policy == OcrPolicy::Off => {
+            OcrPolicy::Auto
+        }
+        _ => options.ocr.policy,
+    }
+}
+
+fn materialize_remote_unbound(
+    result: OcrResult,
+    page: u32,
+    plan: OcrOutputPlan,
+    options: &ConversionOptions,
+    execution: &ExecutionContext,
+) -> Result<(Document, Vec<Diagnostic>), ConversionError> {
+    let provider = result.provider.clone();
+    if provider.trim().is_empty()
+        || result.regions.len() > usize::try_from(plan.max_regions()).unwrap_or(usize::MAX)
+    {
+        return Err(ConversionError::Ocr {
+            provider,
+            detail: "remote OCR provider identity or region count is invalid".into(),
+        });
+    }
+    let mut total_text = 0_u64;
+    let mut nodes = Vec::new();
+    for (index, region) in result.regions.into_iter().enumerate() {
+        if index % 64 == 0 {
+            execution.checkpoint()?;
+        }
+        let text = region.text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        total_text = total_text
+            .checked_add(u64::try_from(text.len()).map_err(|_| ConversionError::ResourceLimit {
+                limit: "max_field_bytes",
+                detail: "remote OCR text size is unrepresentable".into(),
+            })?)
+            .ok_or_else(|| ConversionError::ResourceLimit {
+                limit: "max_field_bytes",
+                detail: "remote OCR text size overflow".into(),
+            })?;
+        if total_text > plan.max_text_bytes() || total_text > options.limits.max_field_bytes {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_field_bytes",
+                detail: "remote OCR text exceeds the configured output bound".into(),
+            });
+        }
+        nodes.push(BlockNode {
+            id: NodeId(format!("remote-ocr-page-{page}-{index}")),
+            block: Block::Paragraph(vec![Inline::Text { value: text.into(), marks: Vec::new() }]),
+            provenance: Provenance {
+                kind: ProvenanceKind::AiProvider,
+                provider: provider.clone(),
+                locator: SourceLocator { page: Some(page), ..SourceLocator::default() },
+                confidence: None,
+            },
+        });
+    }
+    if nodes.is_empty() {
+        return Err(ConversionError::Ocr {
+            provider,
+            detail: "remote OCR returned no usable text".into(),
+        });
+    }
+    let document = Document { blocks: nodes, ..Document::default() };
+    document.validate().map_err(|error| ConversionError::Ocr {
+        provider,
+        detail: format!("remote OCR returned invalid IR at {}: {}", error.path, error.detail),
+    })?;
+    Ok((document, Vec::new()))
 }
 
 struct MaterializeContext<'a> {

--- a/crates/converters/src/image_converter/tests.rs
+++ b/crates/converters/src/image_converter/tests.rs
@@ -550,6 +550,76 @@ struct BoundOcr;
 
 struct WorkingSetOcr;
 
+struct RemoteOcr;
+
+impl OcrEngine for RemoteOcr {
+    fn id(&self) -> &'static str {
+        "provider.fixture.vision-ocr"
+    }
+
+    fn provenance_kind(&self) -> ProvenanceKind {
+        ProvenanceKind::AiProvider
+    }
+
+    fn recognize<'a>(
+        &'a self,
+        _: OcrRequest<'a>,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+        Box::pin(async {
+            Ok(OcrResult {
+                regions: vec![OcrRegion {
+                    text: "remote text".into(),
+                    polygon: [(0.0, 0.0); 4],
+                    confidence: 0.0,
+                }],
+                provider: "provider.fixture.vision-ocr".into(),
+            })
+        })
+    }
+
+    fn planned_bound_output(
+        &self,
+        _: OcrRequest<'_>,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new_with_working(16 * 1024, 4 * 1024, 1, 4096)
+    }
+
+    fn recognize_bound<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+        Box::pin(async move { self.recognize(request, context).await.map(OcrRecognition::Remote) })
+    }
+}
+
+#[test]
+fn remote_vision_ocr_runs_when_local_ocr_is_off_without_fabricating_local_evidence() {
+    let mut options = options();
+    options.ai.vision_ocr = AiMode::Only;
+    let services = Services { ocr: Some(Arc::new(RemoteOcr)), ..Services::default() };
+    let output = block_on(convert_image(
+        &input(encoded(ImageFormat::Png), "remote.png"),
+        &options,
+        &services,
+        &context(&options),
+    ))
+    .unwrap();
+    let Block::Page { blocks, .. } = &output.document.blocks[0].block else {
+        panic!("page expected")
+    };
+    let remote = blocks
+        .iter()
+        .find(|node| node.provenance.provider == "provider.fixture.vision-ocr")
+        .expect("remote OCR paragraph");
+    assert_eq!(remote.provenance.kind, ProvenanceKind::AiProvider);
+    let Block::Paragraph(inlines) = &remote.block else { panic!("remote paragraph expected") };
+    assert!(matches!(inlines.as_slice(), [Inline::Text { value, .. }] if value == "remote text"));
+}
+
 impl OcrEngine for WorkingSetOcr {
     fn id(&self) -> &'static str {
         "test.ocr.working-set"

--- a/crates/core/src/ocr_binding.rs
+++ b/crates/core/src/ocr_binding.rs
@@ -421,4 +421,7 @@ pub enum OcrRecognition {
     Bound(BoundOcrResult),
     /// Legacy OCR output without evidence sufficient for `Inline::OcrText`.
     Unbound(OcrResult),
+    /// Remote OCR text without fabricated detector geometry or confidence.
+    /// Consumers may materialize this only as page-scoped AI provenance.
+    Remote(OcrResult),
 }

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -4,7 +4,7 @@ use crate::{
     OcrRecognition, OcrResult, Provenance, ResolvedInput, ResolvedSource, ResourceReservation,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::mem::size_of;
 use std::pin::Pin;
@@ -1262,6 +1262,14 @@ pub struct OcrRequest<'a> {
 pub trait OcrEngine: Send + Sync {
     /// Stable provider ID.
     fn id(&self) -> &str;
+    /// Provenance class emitted by this engine.
+    ///
+    /// Local engines retain the default. Remote model adapters must return
+    /// [`crate::ProvenanceKind::AiProvider`] so callers never mislabel remote
+    /// processing as local OCR.
+    fn provenance_kind(&self) -> crate::ProvenanceKind {
+        crate::ProvenanceKind::LocalOcr
+    }
     /// Recognize text and geometry.
     fn recognize<'a>(
         &'a self,
@@ -1472,6 +1480,7 @@ pub struct AiRequest<'a> {
 
 /// Versioned, validated changes an AI provider may propose.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct DocumentPatch {
     /// Protocol version. The initial contract is `1`.
     pub version: u32,
@@ -1479,8 +1488,12 @@ pub struct DocumentPatch {
     pub operations: Vec<PatchOperation>,
 }
 
+/// Maximum operations accepted from one untrusted AI response.
+pub const MAX_PATCH_OPERATIONS: usize = 1_024;
+
 /// Allowed structured IR edits. Raw provider-specific mutation is forbidden.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "kebab-case", deny_unknown_fields)]
 #[non_exhaustive]
 pub enum PatchOperation {
     /// Append new nodes at the document root.
@@ -1511,8 +1524,234 @@ impl DocumentPatch {
                 detail: format!("unsupported document patch version {}", self.version),
             });
         }
+        if self.operations.len() > MAX_PATCH_OPERATIONS {
+            return Err(patch_error(format!(
+                "document patch contains {} operations, above the limit of {MAX_PATCH_OPERATIONS}",
+                self.operations.len()
+            )));
+        }
+        for (index, operation) in self.operations.iter().enumerate() {
+            let nodes = match operation {
+                PatchOperation::Append { nodes } | PatchOperation::Replace { nodes, .. } => nodes,
+            };
+            if nodes.is_empty() {
+                return Err(patch_error(format!(
+                    "document patch operation {index} contains no replacement nodes"
+                )));
+            }
+        }
         Ok(())
     }
+
+    /// Validate and atomically apply this patch to document-root nodes.
+    ///
+    /// Replacement targets are deliberately limited to root nodes. This keeps
+    /// the target scope explicit and prevents a provider from addressing nested
+    /// structures through an ambiguous traversal rule. Every inserted node must
+    /// carry provenance for the exact provider that returned the patch. The
+    /// source document is never modified when validation fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConversionError::Ai`] for duplicate, missing, nested, or
+    /// conflicting targets, invalid provider provenance, or invalid resulting
+    /// document IR.
+    pub fn apply(&self, document: &Document, provider: &str) -> Result<Document, ConversionError> {
+        self.apply_with_limits(document, provider, &crate::ValidationLimits::default())
+    }
+
+    /// Apply this patch under explicit document-validation limits.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same controlled failures as [`Self::apply`], including a
+    /// resource-limit error when the candidate document exceeds `limits`.
+    pub fn apply_with_limits(
+        &self,
+        document: &Document,
+        provider: &str,
+        limits: &crate::ValidationLimits,
+    ) -> Result<Document, ConversionError> {
+        self.validate()?;
+        document.validate_with_limits(limits).map_err(|error| {
+            patch_error(format!("source document is invalid at {}: {}", error.path, error.detail))
+        })?;
+        if provider.trim().is_empty() {
+            return Err(patch_error("patch provider identity is empty"));
+        }
+
+        let root_ids =
+            document.blocks.iter().map(|node| node.id.0.as_str()).collect::<BTreeSet<_>>();
+        let all_ids = document_node_ids(document);
+        let mut replacements = BTreeMap::<String, Vec<BlockNode>>::new();
+        let mut appended = Vec::new();
+
+        for (index, operation) in self.operations.iter().enumerate() {
+            let (target, nodes) = match operation {
+                PatchOperation::Append { nodes } => (None, nodes),
+                PatchOperation::Replace { target, nodes } => (Some(target), nodes),
+            };
+            validate_patch_nodes(nodes, provider, index)?;
+            if let Some(target) = target {
+                if !all_ids.contains(target.0.as_str()) {
+                    return Err(patch_error(format!(
+                        "document patch operation {index} targets unknown node {}",
+                        target.0
+                    )));
+                }
+                if !root_ids.contains(target.0.as_str()) {
+                    return Err(patch_error(format!(
+                        "document patch operation {index} targets nested node {}; only document-root targets are allowed",
+                        target.0
+                    )));
+                }
+                if replacements.insert(target.0.clone(), nodes.clone()).is_some() {
+                    return Err(patch_error(format!(
+                        "document patch contains conflicting replacements for {}",
+                        target.0
+                    )));
+                }
+            } else {
+                appended.extend(nodes.iter().cloned());
+            }
+        }
+
+        let output_len = document.blocks.iter().try_fold(0_usize, |total, node| {
+            total.checked_add(replacements.get(&node.id.0).map_or(1, Vec::len)).ok_or_else(|| {
+                ConversionError::ResourceLimit {
+                    limit: "documentNodes",
+                    detail: "document patch root-node count overflow".into(),
+                }
+            })
+        })?;
+        let output_len = output_len.checked_add(appended.len()).ok_or_else(|| {
+            ConversionError::ResourceLimit {
+                limit: "documentNodes",
+                detail: "document patch appended-node count overflow".into(),
+            }
+        })?;
+        let mut blocks = Vec::new();
+        blocks.try_reserve(output_len).map_err(|_| ConversionError::ResourceLimit {
+            limit: "max_memory_bytes",
+            detail: "document patch output allocation failed".into(),
+        })?;
+        for node in &document.blocks {
+            if let Some(nodes) = replacements.remove(&node.id.0) {
+                blocks.extend(nodes);
+            } else {
+                blocks.push(node.clone());
+            }
+        }
+        blocks.extend(appended);
+
+        let candidate = Document {
+            schema_version: document.schema_version,
+            metadata: document.metadata.clone(),
+            blocks,
+        };
+        candidate.validate_with_limits(limits).map_err(|error| {
+            patch_error(format!(
+                "document patch produced invalid IR at {}: {}",
+                error.path, error.detail
+            ))
+        })?;
+        Ok(candidate)
+    }
+}
+
+fn patch_error(detail: impl Into<String>) -> ConversionError {
+    ConversionError::Ai { provider: "patch-validator".into(), detail: detail.into() }
+}
+
+fn validate_patch_nodes(
+    nodes: &[BlockNode],
+    provider: &str,
+    operation: usize,
+) -> Result<(), ConversionError> {
+    let candidate = Document { blocks: nodes.to_vec(), ..Document::default() };
+    candidate.validate().map_err(|error| {
+        patch_error(format!(
+            "document patch operation {operation} contains invalid IR at {}: {}",
+            error.path, error.detail
+        ))
+    })?;
+    for node in nodes {
+        validate_ai_provenance(node, provider, operation)?;
+    }
+    Ok(())
+}
+
+fn validate_ai_provenance(
+    node: &BlockNode,
+    provider: &str,
+    operation: usize,
+) -> Result<(), ConversionError> {
+    if node.provenance.kind != crate::ProvenanceKind::AiProvider
+        || node.provenance.provider != provider
+    {
+        return Err(patch_error(format!(
+            "document patch operation {operation} contains a node without exact provider provenance"
+        )));
+    }
+    match &node.block {
+        crate::Block::Footnote { blocks: nodes, .. }
+        | crate::Block::Page { blocks: nodes, .. }
+        | crate::Block::Slide { blocks: nodes, .. }
+        | crate::Block::Sheet { blocks: nodes, .. } => {
+            for child in nodes {
+                validate_ai_provenance(child, provider, operation)?;
+            }
+        }
+        crate::Block::List { items, .. } => {
+            for item in items {
+                for child in &item.blocks {
+                    validate_ai_provenance(child, provider, operation)?;
+                }
+            }
+        }
+        crate::Block::Table { rows, .. } => {
+            for row in rows {
+                for cell in &row.cells {
+                    for child in &cell.blocks {
+                        validate_ai_provenance(child, provider, operation)?;
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn document_node_ids(document: &Document) -> BTreeSet<&str> {
+    fn visit<'a>(nodes: &'a [BlockNode], ids: &mut BTreeSet<&'a str>) {
+        for node in nodes {
+            ids.insert(node.id.0.as_str());
+            match &node.block {
+                crate::Block::Footnote { blocks: nodes, .. }
+                | crate::Block::Page { blocks: nodes, .. }
+                | crate::Block::Slide { blocks: nodes, .. }
+                | crate::Block::Sheet { blocks: nodes, .. } => visit(nodes, ids),
+                crate::Block::List { items, .. } => {
+                    for item in items {
+                        visit(&item.blocks, ids);
+                    }
+                }
+                crate::Block::Table { rows, .. } => {
+                    for row in rows {
+                        for cell in &row.cells {
+                            visit(&cell.blocks, ids);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let mut ids = BTreeSet::new();
+    visit(&document.blocks, &mut ids);
+    ids
 }
 
 /// Structured output returned by an AI provider.
@@ -1529,7 +1768,7 @@ pub struct AiOutput {
 /// Capability-negotiated LLM or multimodal provider.
 pub trait AiProvider: Send + Sync {
     /// Stable provider ID.
-    fn id(&self) -> &'static str;
+    fn id(&self) -> &str;
     /// Capabilities available under current configuration.
     fn capabilities(&self) -> BTreeSet<AiCapability>;
     /// Declare a conservative allocation peak for one policy-bound operation.
@@ -1645,6 +1884,141 @@ mod tests {
     fn document_patch_rejects_unknown_versions() {
         let patch = DocumentPatch { version: 2, operations: vec![] };
         assert_eq!(patch.validate().unwrap_err().code(), crate::ErrorCode::Ai);
+    }
+
+    fn patch_node(id: &str, provider: &str) -> BlockNode {
+        BlockNode {
+            id: crate::NodeId(id.into()),
+            block: crate::Block::Paragraph(vec![crate::Inline::Text {
+                value: id.into(),
+                marks: Vec::new(),
+            }]),
+            provenance: crate::Provenance {
+                kind: crate::ProvenanceKind::AiProvider,
+                provider: provider.into(),
+                locator: crate::SourceLocator::default(),
+                confidence: None,
+            },
+        }
+    }
+
+    fn source_node(id: &str, block: crate::Block) -> BlockNode {
+        BlockNode {
+            id: crate::NodeId(id.into()),
+            block,
+            provenance: crate::Provenance {
+                kind: crate::ProvenanceKind::NativeParser,
+                provider: "fixture".into(),
+                locator: crate::SourceLocator::default(),
+                confidence: None,
+            },
+        }
+    }
+
+    #[test]
+    fn document_patch_applies_atomically_with_exact_provider_provenance() {
+        let source = Document {
+            blocks: vec![
+                source_node("keep", crate::Block::Rule),
+                source_node("replace", crate::Block::Rule),
+            ],
+            ..Document::default()
+        };
+        let patch = DocumentPatch {
+            version: 1,
+            operations: vec![
+                PatchOperation::Replace {
+                    target: crate::NodeId("replace".into()),
+                    nodes: vec![patch_node("replacement", "remote.fixture")],
+                },
+                PatchOperation::Append { nodes: vec![patch_node("append", "remote.fixture")] },
+            ],
+        };
+
+        let output = patch.apply(&source, "remote.fixture").unwrap();
+        assert_eq!(
+            output.blocks.iter().map(|node| node.id.0.as_str()).collect::<Vec<_>>(),
+            ["keep", "replacement", "append"]
+        );
+        assert_eq!(source.blocks[1].id.0, "replace");
+    }
+
+    #[test]
+    fn document_patch_rejects_unknown_nested_and_conflicting_targets() {
+        let source = Document {
+            blocks: vec![source_node(
+                "page",
+                crate::Block::Page {
+                    number: 1,
+                    blocks: vec![source_node("nested", crate::Block::Rule)],
+                },
+            )],
+            ..Document::default()
+        };
+        for target in ["missing", "nested"] {
+            let patch = DocumentPatch {
+                version: 1,
+                operations: vec![PatchOperation::Replace {
+                    target: crate::NodeId(target.into()),
+                    nodes: vec![patch_node("replacement", "remote.fixture")],
+                }],
+            };
+            assert_eq!(
+                patch.apply(&source, "remote.fixture").unwrap_err().code(),
+                crate::ErrorCode::Ai
+            );
+        }
+
+        let source = Document {
+            blocks: vec![source_node("target", crate::Block::Rule)],
+            ..Document::default()
+        };
+        let patch = DocumentPatch {
+            version: 1,
+            operations: vec![
+                PatchOperation::Replace {
+                    target: crate::NodeId("target".into()),
+                    nodes: vec![patch_node("one", "remote.fixture")],
+                },
+                PatchOperation::Replace {
+                    target: crate::NodeId("target".into()),
+                    nodes: vec![patch_node("two", "remote.fixture")],
+                },
+            ],
+        };
+        assert_eq!(
+            patch.apply(&source, "remote.fixture").unwrap_err().code(),
+            crate::ErrorCode::Ai
+        );
+    }
+
+    #[test]
+    fn document_patch_rejects_forged_provenance_and_duplicate_ids() {
+        let source = Document {
+            blocks: vec![source_node("source", crate::Block::Rule)],
+            ..Document::default()
+        };
+        let forged = DocumentPatch {
+            version: 1,
+            operations: vec![PatchOperation::Append {
+                nodes: vec![patch_node("forged", "other.provider")],
+            }],
+        };
+        assert_eq!(
+            forged.apply(&source, "remote.fixture").unwrap_err().code(),
+            crate::ErrorCode::Ai
+        );
+
+        let duplicate = DocumentPatch {
+            version: 1,
+            operations: vec![PatchOperation::Append {
+                nodes: vec![patch_node("source", "remote.fixture")],
+            }],
+        };
+        assert_eq!(
+            duplicate.apply(&source, "remote.fixture").unwrap_err().code(),
+            crate::ErrorCode::Ai
+        );
     }
 
     #[test]

--- a/crates/provider-plugin/src/lib.rs
+++ b/crates/provider-plugin/src/lib.rs
@@ -20,8 +20,8 @@ pub use process::{
     TranscriptionParameters,
 };
 pub use routing::{
-    CapabilityRegistry, CapabilityRoute, ProviderBinding, ProviderReference, ResolutionMode,
-    RouteError,
+    CapabilityId, CapabilityRegistry, CapabilityRoute, CapabilityRouteMode, CapabilitySourceRef,
+    ProviderBinding, ProviderReference, ResolutionMode, RouteError, UnifiedCapabilityRoute,
 };
 
 /// Capability-provider host API implemented by this build.

--- a/crates/provider-plugin/src/process.rs
+++ b/crates/provider-plugin/src/process.rs
@@ -509,11 +509,17 @@ fn validate_media_result(
     if provider != expected_provider || model.trim().is_empty() || model.trim() != model {
         return Err(unavailable(expected_provider, "provider or model identity is invalid"));
     }
-    if segments.iter().any(|node| !matches!(node.block, Block::TimedSegment { .. })) {
-        return Err(unavailable(expected_provider, "media provider returned a non-timed node"));
+    if segments.iter().any(|node| {
+        !matches!(node.block, Block::TimedSegment { .. })
+            || node.provenance.kind != into_markdown_core::ProvenanceKind::AiProvider
+            || node.provenance.provider != expected_provider
+    }) {
+        return Err(unavailable(
+            expected_provider,
+            "media provider returned an invalid timed node or provenance identity",
+        ));
     }
-    let mut document = Document::default();
-    document.blocks = segments.to_vec();
+    let document = Document { blocks: segments.to_vec(), ..Document::default() };
     document
         .validate()
         .map_err(|_| unavailable(expected_provider, "media provider returned invalid IR"))

--- a/crates/provider-plugin/src/routing.rs
+++ b/crates/provider-plugin/src/routing.rs
@@ -1,8 +1,217 @@
 use crate::{CapabilityKind, PluginCapabilityDescriptor, PluginManifest};
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
 use thiserror::Error;
+
+/// Product-level capability routed across Core, local plugins, and remote providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CapabilityId {
+    /// Legacy binary Office document normalization.
+    LegacyOffice,
+    /// Image or rendered-page OCR.
+    Ocr,
+    /// Audio/video transcription.
+    Transcription,
+    /// Anonymous speaker diarization.
+    Diarization,
+}
+
+impl CapabilityId {
+    /// Stable configuration and CLI spelling.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::LegacyOffice => "legacy-office",
+            Self::Ocr => "ocr",
+            Self::Transcription => "transcription",
+            Self::Diarization => "diarization",
+        }
+    }
+}
+
+impl FromStr for CapabilityId {
+    type Err = RouteError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "legacy-office" => Ok(Self::LegacyOffice),
+            "ocr" => Ok(Self::Ocr),
+            "transcription" => Ok(Self::Transcription),
+            "diarization" => Ok(Self::Diarization),
+            _ => Err(RouteError::InvalidSource(value.into())),
+        }
+    }
+}
+
+/// One exact capability implementation source.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CapabilitySourceRef {
+    /// Capability implemented by a signed local plugin.
+    Plugin {
+        /// Signed package identity.
+        plugin_id: String,
+        /// Package-local capability identity.
+        capability_id: String,
+    },
+    /// Capability implemented by a configured remote provider.
+    Provider {
+        /// Provider configuration identity.
+        provider_id: String,
+        /// Provider capability identity.
+        capability_id: String,
+    },
+    /// Capability is explicitly disabled.
+    Off,
+}
+
+impl std::fmt::Display for CapabilitySourceRef {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Plugin { plugin_id, capability_id } => {
+                write!(formatter, "plugin:{plugin_id}/{capability_id}")
+            }
+            Self::Provider { provider_id, capability_id } => {
+                write!(formatter, "provider:{provider_id}/{capability_id}")
+            }
+            Self::Off => formatter.write_str("off"),
+        }
+    }
+}
+
+impl FromStr for CapabilitySourceRef {
+    type Err = RouteError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value == "off" {
+            return Ok(Self::Off);
+        }
+        let (kind, qualified) =
+            value.split_once(':').map_or(("plugin", value), |(kind, qualified)| (kind, qualified));
+        let (source, capability) = qualified
+            .split_once('/')
+            .filter(|(source, capability)| {
+                valid_id(source) && valid_id(capability) && !capability.contains('/')
+            })
+            .ok_or_else(|| RouteError::InvalidSource(value.into()))?;
+        match kind {
+            "plugin" => {
+                Ok(Self::Plugin { plugin_id: source.into(), capability_id: capability.into() })
+            }
+            "provider" => {
+                Ok(Self::Provider { provider_id: source.into(), capability_id: capability.into() })
+            }
+            _ => Err(RouteError::InvalidSource(value.into())),
+        }
+    }
+}
+
+fn valid_id(value: &str) -> bool {
+    !value.is_empty()
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+}
+
+/// Per-capability routing behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CapabilityRouteMode {
+    /// Do not invoke any source.
+    Off,
+    /// Use the ordered fallback only when the primary cannot serve the request.
+    Fallback,
+    /// Prefer the primary and recover through ordered fallbacks.
+    Prefer,
+    /// Require the primary and fail closed.
+    Only,
+}
+
+/// Ordered heterogeneous sources for one product capability.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnifiedCapabilityRoute {
+    /// Product capability being routed.
+    pub capability: CapabilityId,
+    /// Invocation behavior.
+    pub mode: CapabilityRouteMode,
+    /// Preferred exact source.
+    pub primary: CapabilitySourceRef,
+    /// Ordered recovery sources.
+    pub fallbacks: Vec<CapabilitySourceRef>,
+}
+
+impl UnifiedCapabilityRoute {
+    /// Validate route invariants before configuration is accepted.
+    ///
+    /// # Errors
+    ///
+    /// Rejects contradictory off sources and duplicate source identities.
+    pub fn validate(&self) -> Result<(), RouteError> {
+        if self.mode == CapabilityRouteMode::Off {
+            if self.primary != CapabilitySourceRef::Off || !self.fallbacks.is_empty() {
+                return Err(RouteError::InvalidSource(
+                    "off mode must contain only the off source".into(),
+                ));
+            }
+            return Ok(());
+        }
+        if self.primary == CapabilitySourceRef::Off
+            || self.fallbacks.contains(&CapabilitySourceRef::Off)
+        {
+            return Err(RouteError::InvalidSource(
+                "active routes cannot contain the off source".into(),
+            ));
+        }
+        let mut seen = BTreeSet::new();
+        for source in std::iter::once(&self.primary).chain(&self.fallbacks) {
+            if !seen.insert(source) {
+                return Err(RouteError::InvalidSource(format!("duplicate source {source}")));
+            }
+            let source_capability = match source {
+                CapabilitySourceRef::Plugin { capability_id, .. }
+                | CapabilitySourceRef::Provider { capability_id, .. } => capability_id.as_str(),
+                CapabilitySourceRef::Off => continue,
+            };
+            if !self.capability.accepts_source_capability(source_capability) {
+                return Err(RouteError::InvalidSource(format!(
+                    "source {source} cannot implement {}",
+                    self.capability.as_str()
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Sources eligible during pre-execution readiness resolution.
+    ///
+    /// # Errors
+    ///
+    /// Returns route validation failures before exposing an iterator.
+    pub fn eligible_sources(&self) -> Result<Vec<&CapabilitySourceRef>, RouteError> {
+        self.validate()?;
+        Ok(match self.mode {
+            CapabilityRouteMode::Off => Vec::new(),
+            CapabilityRouteMode::Only => vec![&self.primary],
+            CapabilityRouteMode::Fallback | CapabilityRouteMode::Prefer => {
+                std::iter::once(&self.primary).chain(&self.fallbacks).collect()
+            }
+        })
+    }
+}
+
+impl CapabilityId {
+    fn accepts_source_capability(self, source: &str) -> bool {
+        match self {
+            Self::LegacyOffice => source == "legacy-office",
+            Self::Ocr => matches!(source, "ocr" | "vision-ocr"),
+            Self::Transcription => matches!(source, "transcription" | "audio-transcription"),
+            Self::Diarization => source == "diarization",
+        }
+    }
+}
 
 /// One configured provider and optional provider-owned model bundle.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -78,6 +287,9 @@ pub enum RouteError {
     /// No acceptable provider is ready.
     #[error("provider unavailable: {0}")]
     Unavailable(String),
+    /// Product capability source reference is malformed or contradictory.
+    #[error("invalid capability source: {0}")]
+    InvalidSource(String),
 }
 
 impl CapabilityRegistry {
@@ -303,5 +515,45 @@ mod tests {
             })
             .unwrap();
         assert_eq!(binding.provider_id, "fallback.provider");
+    }
+
+    #[test]
+    fn heterogeneous_sources_have_one_strict_canonical_contract() {
+        let plugin: CapabilitySourceRef = "plugin:official.ocr/ocr".parse().unwrap();
+        let provider: CapabilitySourceRef = "provider:bailian/vision-ocr".parse().unwrap();
+        assert_eq!(plugin.to_string(), "plugin:official.ocr/ocr");
+        assert_eq!(provider.to_string(), "provider:bailian/vision-ocr");
+        assert_eq!("official.ocr/ocr".parse::<CapabilitySourceRef>().unwrap(), plugin);
+        for invalid in ["", "core:x/y", "provider:/ocr", "provider:x/ocr/extra"] {
+            assert!(invalid.parse::<CapabilitySourceRef>().is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn unified_route_rejects_off_conflicts_and_duplicate_sources() {
+        let source: CapabilitySourceRef = "provider:bailian/vision-ocr".parse().unwrap();
+        let route = UnifiedCapabilityRoute {
+            capability: CapabilityId::Ocr,
+            mode: CapabilityRouteMode::Prefer,
+            primary: source.clone(),
+            fallbacks: vec![source],
+        };
+        assert!(route.validate().is_err());
+
+        let off = UnifiedCapabilityRoute {
+            capability: CapabilityId::Ocr,
+            mode: CapabilityRouteMode::Off,
+            primary: CapabilitySourceRef::Off,
+            fallbacks: Vec::new(),
+        };
+        assert!(off.eligible_sources().unwrap().is_empty());
+
+        let incompatible = UnifiedCapabilityRoute {
+            capability: CapabilityId::Ocr,
+            mode: CapabilityRouteMode::Only,
+            primary: "provider:bailian/audio-transcription".parse().unwrap(),
+            fallbacks: Vec::new(),
+        };
+        assert!(incompatible.validate().is_err());
     }
 }

--- a/docs/capability-plugins.md
+++ b/docs/capability-plugins.md
@@ -63,25 +63,36 @@ provider ID 和模型 ID 必须与路由绑定一致。
 
 ## 路由与失败语义
 
-配置引用格式为 `plugin-id/capability-id`：
+能力来源使用同一规范引用：本地来源为 `plugin:ID/CAPABILITY`，远端来源为
+`provider:ID/CAPABILITY`。旧的无前缀插件引用只用于兼容读取：
 
 ```toml
 [capability_routes.ocr]
-primary = "official.ocr.ppocrv6/ocr"
-fallbacks = []
+mode = "prefer"
+primary = "provider:bailian/vision-ocr"
+fallbacks = ["plugin:official.ocr.ppocrv6/ocr"]
 
 [capability_routes.transcription]
-primary = "official.media.whisper/transcription"
-fallbacks = []
+mode = "fallback"
+primary = "plugin:official.media.whisper/transcription"
+fallbacks = ["provider:bailian/audio-transcription"]
 
 [capability_routes.diarization]
-primary = "official.media.whisper/diarization"
+mode = "only"
+primary = "plugin:official.media.whisper/diarization"
 fallbacks = []
 ```
 
-`ocr=always` 与 `audio_transcription=only` 要求 primary 就绪，失败时不会改走其它 provider。
-自动模式只允许在执行前的 readiness 阶段按配置顺序选择 fallback。开始处理输入后，崩溃、
-超时、资源超限或无效结果都会直接失败，不会把同一敏感输入静默交给另一个插件。
+`only` 要求 primary 就绪并对执行失败关闭；`fallback` 只允许来源不可用时切换；`prefer`
+还允许网络、超时和受控 Provider/OCR 失败按显式顺序恢复。取消、资源超限、内部不变量、
+来源身份不匹配和无效结构化结果始终直接失败，绝不把它们伪装成成功。每个候选来源均由
+用户配置明确列出，不会发现或调用未列出的 Provider。
+
+远端 OCR 只产生页级 AI 文本，不伪造本地检测框、置信度或模型证据；远端转写必须携带
+经过校验的时长、Provider 和模型身份，并生成单调的时间范围。布局、表格、公式和 Markdown
+后处理只能返回版本化 Document Patch：未知操作、未知或嵌套目标、冲突替换、悬空资源引用、
+重复 ID、越界结构和非精确 AI provenance 在应用前被拒绝，Provider 返回的直接节点不会进入
+最终 Document IR。
 
 ## 隔离边界
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,15 +111,18 @@ protocol = "wasi-v1"
 enabled = true
 
 [capability_routes.ocr]
-primary = "official.ocr.ppocrv6/ocr"
-fallbacks = []
+mode = "prefer"
+primary = "provider:local-vision/vision-ocr"
+fallbacks = ["plugin:official.ocr.ppocrv6/ocr"]
 
 [capability_routes.transcription]
-primary = "official.media.whisper/transcription"
-fallbacks = ["corporate.media/transcription"]
+mode = "only"
+primary = "plugin:official.media.whisper/transcription"
+fallbacks = []
 
 [capability_routes.diarization]
-primary = "official.media.whisper/diarization"
+mode = "only"
+primary = "plugin:official.media.whisper/diarization"
 fallbacks = []
 
 [profiles.quality.conversion.ocr]
@@ -137,9 +140,13 @@ formula_repair = "prefer"
 和 literal-IP TCP grant；缺少的能力保持拒绝。完整清单和协议见
 [`wasi-plugins.md`](wasi-plugins.md)。
 
-Capability 引用必须是 `plugin-id/capability-id`。显式模式要求 primary 就绪；自动模式只在
-处理输入前按顺序尝试 readiness fallback，运行中的失败不会切换 provider。签名安装、官方
-包和隔离边界见 [`capability-plugins.md`](capability-plugins.md)。
+Capability 引用的规范形式是 `plugin:ID/CAPABILITY` 或
+`provider:ID/CAPABILITY`；旧的 `plugin-id/capability-id` 仍可读取并规范化为插件来源。
+`off` 禁用能力，`only` 对 primary 失败关闭，`fallback` 只在来源不可用时按顺序恢复，
+`prefer` 还允许从显式的网络、超时或 Provider/OCR 失败恢复。取消、资源超限、内部不变量和
+无效 IR 不会触发回退。远端 OCR、转写和结构化修复结果必须先经过类型、大小、来源及
+provenance 校验；结构化修复只能提交版本化 Document Patch，不能直接写入最终 IR。签名
+安装、官方包和隔离边界见 [`capability-plugins.md`](capability-plugins.md)。
 
 配置中的 `allowed_hosts`、重定向和私网策略只能收窄权限，不能启用网络。上例调用
 本机 Provider 时仍需：


### PR DESCRIPTION
## Outcome

Completes #41 by making local plugins and remote providers explicit, typed capability sources and by preventing provider text or nodes from bypassing Document IR validation.

## Changes

- add canonical `plugin:ID/CAPABILITY`, `provider:ID/CAPABILITY`, and `off` source references with `off/fallback/prefer/only` routes and semantic capability/source validation
- add OpenAI-compatible Base64 audio transport plus typed remote OCR and transcription adapters with exact provider/model provenance
- route OCR and transcription across ordered local-plugin and remote-provider sources without falling back on cancellation, resource limits, invalid identity, or internal failures
- support remote vision OCR for direct images and embedded/rendered container images while deliberately omitting fabricated detector geometry, confidence, and local-model evidence
- add a versioned, closed Document Patch wire schema and atomic root-scoped application with conflict, target, provenance, duplicate-ID, reference, size, and resulting-IR validation
- add a transactional structured AI enricher for layout, table, formula, and Markdown repair; direct provider nodes and diagnostics are rejected
- compose capability-specific adapters under one exact configured provider identity
- tighten isolated transcription result provenance checks and update capability routing documentation

## Verification

- `cargo check --workspace --all-targets`
- `cargo test -p into-markdown-core -p into-markdown-ai -p into-markdown-provider-plugin -p into-markdown-converters -p into-markdown`
  - API: 41 passed, 2 environment-dependent PDFium tests ignored
  - AI: 38 passed
  - converters: 420 passed, 2 environment-dependent native-runtime tests ignored
  - Core: 96 passed
  - provider plugin: 5 passed
- `cargo test -p into-markdown-cli --bin into-md`: 223 passed
- new-code Clippy passes with warnings denied for AI and provider-plugin; the workspace-wide warnings-denied run still encounters pre-existing main-branch lints in Core, Engine, OCR, process sandbox, and unrelated CLI files
- `cargo fmt --all -- --check`
- `git diff --check`
- diff secret scan: no key or Authorization credential added

The real installed-package/local-model/Bailian E2E matrix remains the explicit release gate of the second modular-plugin PR; this PR supplies and tests the route and validation contracts it depends on.

Closes #41
