### PR TITLE
Complete bilingual user and developer documentation

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,20 @@
+name: Documentation contract
+
+on:
+  pull_request:
+    paths: ["README*.md", "CONTRIBUTING*.md", "docs/**", "apps/cli/src/**", "crates/converters/src/core_catalog.rs", "tools/docs-check/**", ".github/workflows/documentation.yml"]
+  push:
+    branches: [main]
+    paths: ["README*.md", "CONTRIBUTING*.md", "docs/**", "apps/cli/src/**", "crates/converters/src/core_catalog.rs", "tools/docs-check/**", ".github/workflows/documentation.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  examples:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate bilingual docs, commands, formats, links, and real conversion
+        run: bazel test //tools/docs-check:docs_check_test

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -54,6 +54,7 @@ exports_files([
 filegroup(
     name = "documentation",
     srcs = glob([
+        "CONTRIBUTING*.md",
         "docs/**/*.md",
         "README.en.md",
         "README.md",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,7 +55,9 @@ filegroup(
     name = "documentation",
     srcs = glob([
         "CONTRIBUTING*.md",
-        "docs/**/*.md",
+        "docs/**/*",
+        "LICENSE",
+        "NOTICE",
         "README.en.md",
         "README.md",
         "THIRD_PARTY_NOTICES.md",

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -1,0 +1,76 @@
+# Contributing to Into Markdown
+
+[中文](CONTRIBUTING.md)
+
+Thank you for improving Into Markdown. This repository owns the local-first conversion Core,
+three complete capability plugins, the Agent Skill, installers, and four-platform release
+authority. A change must preserve the common IR, offline default, explicit authority, and
+reproducible release boundary rather than making only one entry point appear to work.
+
+## Before you start
+
+- Search existing issues first. Keep one focused PR per issue and link it in the PR body.
+- Do not disclose exploit details in a public issue. Use the private channel described on the
+  repository Security page.
+- Do not commit customer documents, credentials, private keys, download caches, generated models,
+  capability runtimes, or machine-local test output.
+- A new dependency, source, model, or runtime must update its lockfile, source authority, license
+  inventory, SBOM, and release inventory. A README statement cannot replace machine validation.
+
+## Product and interface constraints
+
+- Conversion produces validated Document IR before the common renderer generates Markdown. CLI,
+  Web, plugins, and providers cannot maintain separate semantic result models.
+- Local input is offline by default. Remote sources and providers access the network only with
+  explicit authority for the current invocation; private destinations require a separate grant.
+- OCR, speech, and legacy Office ship as complete capability plugins. Models are internal plugin
+  resources and have no independent install, replacement, or selection interface.
+- Changes to public commands, DTOs, error codes, the format catalog, plugin or capability IDs, and
+  release paths need compatibility analysis, tests, and synchronized Chinese and English docs.
+- Security failures return stable, parseable errors. They must not panic, silently downgrade, or
+  present incomplete output as success.
+
+## Build and test
+
+Bazel is authoritative for release builds; Cargo provides fast feedback and focused crate tests.
+Run the closest gate first, then the affected higher-level contracts:
+
+```sh
+bazel build //...
+bazel test //...
+cargo fmt --all -- --check
+cargo check --workspace --locked
+```
+
+Format or conversion changes use structurally real documents, images, or media and assert IR,
+Markdown, resources, diagnostics, and provenance. Renamed extensions, random bytes, silent audio,
+or compile-only checks are not substitutes. Native-runtime and capability-plugin claims require
+black-box testing from a fresh release install. See [`docs/testing.md`](docs/testing.md) and
+[`docs/installed-smoke.md`](docs/installed-smoke.md) for the detailed gates.
+
+Run the executable documentation contract for documentation changes:
+
+```sh
+bazel test //tools/docs-check:docs_check_test
+```
+
+It discovers public commands and the current format catalog from the real CLI, checks Chinese and
+English example coverage, command syntax, and local links, and performs real TXT and stdin
+conversion plus a dry-run for every available format. When adding or changing a public command or
+format, update [`docs/cli-examples.md`](docs/cli-examples.md) and its English counterpart.
+
+## Plugin and release changes
+
+Process and WASI plugins follow the `process-v1` and `wasi-v1` isolation contracts. See
+[`docs/plugin-development.en.md`](docs/plugin-development.en.md) for development, signing, and
+lifecycle gates. Release scripts materialize every platform artifact from one canonical source,
+pin inventories, digests, permissions, and signatures, and verify the unpacked result. Do not copy
+an implementation into platform-specific scripts or mutate user agent-skill and configuration
+directories.
+
+## PR completion criteria
+
+Describe the user-visible result, security and compatibility impact, tests executed, and exact
+gates that could not run locally. Before submission, review the README, authoritative docs,
+CLI/Web behavior, install and uninstall paths, four-platform releases, and supply-chain evidence
+as one product. Remove temporary files and debug switches, and ensure `git diff --check` passes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# 参与 Into Markdown 开发
+
+[English](CONTRIBUTING.en.md)
+
+感谢改进 Into Markdown。仓库维护本地优先的转换 Core、三个完整能力插件、Agent Skill、
+安装器和四个平台的发布权威。变更必须保持统一 IR、默认离线、显式授权和可复现发布边界，
+而不能只让某一条入口看起来可用。
+
+## 开始之前
+
+- 先搜索现有 issue；一个 issue 对应一个聚焦的 PR，并在 PR 正文中关联它。
+- 安全漏洞不要公开提交利用细节；按仓库 Security 页面提供的私密渠道报告。
+- 不提交客户文档、凭据、私钥、下载缓存、生成模型、能力运行时或本机测试产物。
+- 新依赖、来源、模型或 runtime 必须同时更新 lockfile、来源权威、许可清单、SBOM 和发布
+  inventory；不能以 README 声明代替机器校验。
+
+## 产品与接口约束
+
+- 转换先生成受验证的 Document IR，再由公共 renderer 生成 Markdown。CLI、Web、插件和
+  Provider 不能各自维护另一套语义结果。
+- 本地文件默认离线；远程来源和 Provider 只在当前调用显式授权后访问网络，私网需要独立授权。
+- OCR、语音和旧版 Office 以完整能力插件发布。模型是插件内部资源，不提供独立安装、替换或
+  选择接口。
+- 公共命令、DTO、错误码、格式 catalog、插件/能力 ID 和发布路径的改动需要兼容性说明、测试和
+  中英文文档同步更新。
+- 安全失败应返回稳定、可解析的错误，不得 panic、静默降级或把不完整结果伪装为成功。
+
+## 构建和测试
+
+Bazel 是发布构建权威；Cargo 用于快速反馈和 crate 定向测试。先运行与改动最接近的门禁，
+再运行受影响的上层契约：
+
+```sh
+bazel build //...
+bazel test //...
+cargo fmt --all -- --check
+cargo check --workspace --locked
+```
+
+格式或转换改动必须使用真实结构的文档、图片或媒体，并断言 IR、Markdown、资源、诊断与
+provenance；不能使用改扩展名、随机字节、静音音频或只检查编译的替代品。原生 runtime 和
+能力插件结论必须来自全新安装发布件的黑盒测试。详细门禁见
+[`docs/testing.md`](docs/testing.md) 与 [`docs/installed-smoke.md`](docs/installed-smoke.md)。
+
+文档改动运行可执行文档契约：
+
+```sh
+bazel test //tools/docs-check:docs_check_test
+```
+
+该测试从真实 CLI 发现公共命令和当前格式 catalog，检查中英文示例覆盖、命令语法、本地链接，
+并执行真实 TXT、stdin 和每种可用格式的 dry-run。新增或修改公共命令、格式时，必须同步更新
+[`docs/cli-examples.md`](docs/cli-examples.md) 和对应英文文档。
+
+## 插件与发布改动
+
+进程插件和 WASI 插件分别遵守 `process-v1` 与 `wasi-v1` 的隔离契约；开发、签名和生命周期
+门禁见 [`docs/plugin-development.md`](docs/plugin-development.md)。发布脚本必须从单一 canonical
+来源装配各平台产物，固定清单、摘要、权限和签名，并在解包后重新验证。不要在平台脚本中复制
+一份实现，也不要修改用户的 agent skill 或配置目录。
+
+## PR 交付标准
+
+PR 应说明用户可见结果、安全与兼容性影响、执行过的测试及不能在本地执行的精确门禁。提交前
+从全局复核 README、权威文档、CLI/Web 行为、安装与卸载、四平台发布和供应链证据是否一致；
+删除临时文件和调试开关，并确认 `git diff --check` 通过。

--- a/README.en.md
+++ b/README.en.md
@@ -32,8 +32,10 @@ MSG, audio, and video. Legacy Office, OCR, transcription, and diarization use th
 capability plugins.
 
 Release targets are macOS ARM64, Linux x86_64, Linux ARM64, and Windows x86_64. macOS x86_64 is
-unsupported. See the [macOS release](docs/macos-arm64-release.md) and
-[Linux/Windows release](docs/platform-modular-release.md) contracts.
+unsupported. See the [installation and deployment guide](docs/user-guide.en.md) for signature
+verification, installation, offline plugin import, troubleshooting, and uninstall. Platform release
+contracts are the [macOS release](docs/macos-arm64-release.md) and
+[Linux/Windows release](docs/platform-modular-release.md).
 
 ## CLI
 
@@ -60,7 +62,7 @@ Remote sources and providers are denied by default. Add `--allow-network` only w
 user request requires it, narrow access with `--allow-host` where possible, and require separate
 `--allow-private-network` authority for private destinations.
 
-The authoritative interface documentation is maintained in Chinese: [CLI](docs/cli.md),
+See the [CLI](docs/cli.md), [executable command and format examples](docs/cli-examples.en.md),
 [configuration](docs/configuration.md), [format matrix](docs/formats.md), and [DTOs](docs/dto.md).
 
 ## Capabilities and local Web workbench
@@ -109,3 +111,6 @@ images, and media. Compilation, mocks, and skill-structure validation are not su
 The [documentation map](docs/README.md) groups the architecture, security, testing, and release
 contracts. Licensing and supply-chain evidence are in [LICENSE](LICENSE),
 [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md), and [license governance](docs/licensing.md).
+Read the [contribution guide](CONTRIBUTING.en.md) before changing the repository and the
+[plugin-development guide](docs/plugin-development.en.md) before extending converters or capability
+providers.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ TXT、Markdown、HTML、CSV/TSV、JSON、XML、RSS/Atom Feed、Jupyter Notebook�
 Outlook MSG、音频和视频。旧版 Office、OCR、语音转写与说话人分离由对应能力插件提供。
 
 支持 macOS ARM64、Linux x86_64、Linux ARM64 和 Windows x86_64；不支持 macOS x86_64。
-平台边界见 [macOS 发布](docs/macos-arm64-release.md)与
+最终用户的签名校验、安装、离线插件导入、排障和卸载见[安装与部署](docs/user-guide.md)；
+平台发布边界见 [macOS 发布](docs/macos-arm64-release.md)与
 [Linux/Windows 发布](docs/platform-modular-release.md)。
 
 ## 使用 CLI
@@ -56,8 +57,8 @@ into-md documents/ --recursive --output-dir markdown/ \
 `--allow-network`，并尽量使用 `--allow-host` 收窄主机；私网还需要单独的
 `--allow-private-network` 授权。
 
-完整接口见 [CLI](docs/cli.md)、[配置](docs/configuration.md)、[格式矩阵](docs/formats.md)和
-[DTO](docs/dto.md)。
+完整接口见 [CLI](docs/cli.md)、[可执行命令与格式示例](docs/cli-examples.md)、
+[配置](docs/configuration.md)、[格式矩阵](docs/formats.md)和 [DTO](docs/dto.md)。
 
 ## 能力与 Web 工作台
 
@@ -100,4 +101,5 @@ Bazel 是发布构建权威；Cargo 用于快速开发检查和定向测试。�
 
 架构、安全、测试和发布文档统一收录在 [docs/README.md](docs/README.md)。许可证与第三方来源
 见 [LICENSE](LICENSE)、[THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md)和
-[许可证治理](docs/licensing.md)。
+[许可证治理](docs/licensing.md)。参与开发前请阅读[贡献指南](CONTRIBUTING.md)；扩展转换器或
+能力 provider 见[插件开发](docs/plugin-development.md)。

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,10 @@
 ## 使用与公共接口
 
 - [CLI](cli.md)：转换、批量、Bundle、能力、Provider、插件、配置和诊断命令。
+- [可执行命令与格式示例](cli-examples.md) / [English](cli-examples.en.md)：全部公共命令和
+  当前可用格式的可运行示例。
+- [安装与部署](user-guide.md) / [English](user-guide.en.md)：四平台校验、安装、离线能力、
+  排障和卸载。
 - [配置](configuration.md)：分层配置、profile、网络授权和能力路由。
 - [格式矩阵](formats.md)：catalog 中的格式、检测、转换和失败边界。
 - [DTO](dto.md)：Document IR、result JSON、batch report 与兼容规则。
@@ -19,6 +23,8 @@
 - [能力插件](capability-plugins.md)：OCR、语音、说话人分离和旧版 Office 的完整插件边界。
 - [插件管理](plugin-management.md)、[进程插件](process-plugins.md)与
   [WASI 插件](wasi-plugins.md)：签名、信任、作用域、隔离与生命周期。
+- [插件开发](plugin-development.md) / [English](plugin-development.en.md)：协议选择、开发、
+  签名、真实执行和发布门禁。
 - [OCR 与 AI](ocr-and-ai.md)：embedded OCR、本地能力和远端 Provider 的证据边界。
 
 本地模型只属于完整能力插件，不提供独立模型安装、更新、替换或选择接口。仓库 `models/`
@@ -34,6 +40,7 @@
   [Linux/Windows 发布](platform-modular-release.md)。
 - [许可证治理](licensing.md)、[许可证检查](license-governance.md)和
   [第三方许可说明](../THIRD_PARTY_NOTICES.md)。
+- [贡献指南](../CONTRIBUTING.md) / [English](../CONTRIBUTING.en.md)。
 
 每个平台产品发布由一个 Core、三个自包含能力插件和一份平台无关 Agent Skill 构成。
 Core 内置 canonical skill 目录；独立 ZIP 与 Core 副本逐文件一致。产品安装器与卸载器不修改
@@ -42,6 +49,8 @@ Core 内置 canonical skill 目录；独立 ZIP 与 Core 副本逐文件一致�
 ## 文档维护规则
 
 - 示例使用真实公开命令，不虚构 `convert` 子命令或独立模型管理接口。
+- 每个公共 CLI 命令和每种当前可用格式必须在中英文可执行示例中各出现一次，并由真实
+  `into-md` 和实时 format catalog 在 CI 中校验。
 - 本地与远端能力都按当前 invocation 的网络授权执行；普通转换默认离线。
 - 发布结论必须来自全新安装包与真实文档、图片、音视频黑盒验收。
 - 历史兼容描述必须明确标为兼容读取或迁移行为，不能冒充当前推荐用法。

--- a/docs/cli-examples.en.md
+++ b/docs/cli-examples.en.md
@@ -128,8 +128,8 @@ Every example invokes `into-md` directly. CI compares coverage with the real `--
 - RTF: `into-md document.rtf --format rtf -o document.md --conflict error`
 <!-- format-example: epub -->
 - EPUB: `into-md book.epub --format epub -o book.md --conflict error`
-<!-- format-example: txt -->
-- TXT: `into-md notes.txt --format txt -o notes.md --conflict error`
+<!-- format-example: text -->
+- TXT: `into-md notes.txt --format text -o notes.md --conflict error`
 <!-- format-example: markdown -->
 - Markdown: `into-md notes.md --format markdown -o normalized.md --conflict error`
 <!-- format-example: html -->
@@ -150,8 +150,8 @@ Every example invokes `into-md` directly. CI compares coverage with the real `--
 - Image: `into-md scan.png --format image --ocr always -o scan.md --conflict error`
 <!-- format-example: zip -->
 - ZIP: `into-md archive.zip --format zip -o archive.md --conflict error`
-<!-- format-example: msg -->
-- MSG: `into-md message.msg --format msg -o message.md --conflict error`
+<!-- format-example: outlook-msg -->
+- MSG: `into-md message.msg --format outlook-msg -o message.md --conflict error`
 <!-- format-example: audio -->
 - Audio: `into-md meeting.wav --format audio --ai audio-transcription=only -o meeting.md --conflict error`
 <!-- format-example: video -->

--- a/docs/cli-examples.en.md
+++ b/docs/cli-examples.en.md
@@ -1,0 +1,160 @@
+# Executable CLI and format examples
+
+[中文](cli-examples.md)
+
+Every example invokes `into-md` directly. CI compares coverage with the real `--help` tree and
+`formats --json` catalog.
+
+## Public commands
+
+<!-- cli-example: convert -->
+- Convert: `into-md report.docx -o report.md --conflict error`
+<!-- cli-example: ui -->
+- Workbench: `into-md ui --no-open`
+<!-- cli-example: formats -->
+- Formats: `into-md formats --json`
+<!-- cli-example: formats show -->
+- Format details: `into-md formats show pdf --json`
+<!-- cli-example: formats detect -->
+- Detect: `into-md formats detect report.pdf --json`
+<!-- cli-example: capabilities -->
+- Capabilities: `into-md capabilities --json`
+<!-- cli-example: capabilities list -->
+- Explicit list: `into-md capabilities list --json`
+<!-- cli-example: capabilities show -->
+- Capability details: `into-md capabilities show ocr --json`
+<!-- cli-example: capabilities verify -->
+- Verify capability: `into-md capabilities verify ocr --json`
+<!-- cli-example: capabilities use -->
+- Select route: `into-md capabilities use ocr --source off --scope project`
+<!-- cli-example: capabilities reset -->
+- Reset route: `into-md capabilities reset ocr --scope project`
+<!-- cli-example: setup -->
+- Setup entry: `into-md setup --help`
+<!-- cli-example: setup ocr -->
+- OCR: `into-md setup ocr`
+<!-- cli-example: setup media -->
+- Media: `into-md setup media`
+<!-- cli-example: setup legacy-office -->
+- Legacy Office: `into-md setup legacy-office`
+<!-- cli-example: transcript -->
+- Transcript processing: `into-md transcript --help`
+<!-- cli-example: transcript relabel -->
+- Rename speakers: `into-md transcript relabel document-ir.json --speaker SPEAKER_00=Alice -o meeting.md`
+<!-- cli-example: providers -->
+- Providers: `into-md providers --json`
+<!-- cli-example: providers show -->
+- Provider details: `into-md providers show team --json`
+<!-- cli-example: providers add -->
+- Add provider: `into-md providers add team --type openai-compatible --base-url https://api.example/v1 --model model-name --api-key-env TEAM_API_KEY --capability image-description --scope project`
+<!-- cli-example: providers remove -->
+- Remove provider: `into-md providers remove team --scope project`
+<!-- cli-example: providers set-default -->
+- Default provider: `into-md providers set-default team --scope project`
+<!-- cli-example: providers capabilities -->
+- Provider capabilities: `into-md providers capabilities team --json`
+<!-- cli-example: providers test -->
+- Provider probe: `into-md providers test team --allow-network --allow-host api.example`
+<!-- cli-example: plugins -->
+- Plugins: `into-md plugins --json`
+<!-- cli-example: plugins show -->
+- Plugin details: `into-md plugins show example.plugin --json`
+<!-- cli-example: plugins install -->
+- Install plugin: `into-md plugins install ./example.imp --scope project`
+<!-- cli-example: plugins verify -->
+- Verify plugin: `into-md plugins verify example.plugin --json --scope project`
+<!-- cli-example: plugins enable -->
+- Enable plugin: `into-md plugins enable example.plugin --scope project`
+<!-- cli-example: plugins disable -->
+- Disable plugin: `into-md plugins disable example.plugin --scope project`
+<!-- cli-example: plugins remove -->
+- Remove plugin: `into-md plugins remove example.plugin --scope project`
+<!-- cli-example: plugins run -->
+- Run plugin: `into-md plugins run example.plugin source.bin --input-format txt --scope project`
+<!-- cli-example: config -->
+- Config entry: `into-md config --help`
+<!-- cli-example: config paths -->
+- Config paths: `into-md config paths --json`
+<!-- cli-example: config show -->
+- Config content: `into-md config show --resolved --format json`
+<!-- cli-example: config init -->
+- Initialize config: `into-md config init --scope project`
+<!-- cli-example: config validate -->
+- Validate config: `into-md config validate into-markdown.toml`
+<!-- cli-example: config get -->
+- Read config: `into-md config get output.conflict`
+<!-- cli-example: config set -->
+- Set config: `into-md config set output.conflict '"error"' --scope project`
+<!-- cli-example: config unset -->
+- Remove config: `into-md config unset output.conflict --scope project`
+<!-- cli-example: config profile -->
+- Profile entry: `into-md config profile --help`
+<!-- cli-example: config profile list -->
+- Profiles: `into-md config profile list`
+<!-- cli-example: config profile create -->
+- Create profile: `into-md config profile create review --scope project`
+<!-- cli-example: config profile remove -->
+- Remove profile: `into-md config profile remove review --scope project`
+<!-- cli-example: doctor -->
+- Diagnose: `into-md doctor --json`
+<!-- cli-example: completions -->
+- Completions: `into-md completions bash`
+<!-- cli-example: version -->
+- Version: `into-md version --json`
+
+## Currently available formats
+
+<!-- format-example: pdf -->
+- PDF: `into-md report.pdf --format pdf -o report.md --conflict error`
+<!-- format-example: doc -->
+- DOC: `into-md legacy.doc --format doc -o legacy.md --conflict error`
+<!-- format-example: docx -->
+- DOCX: `into-md report.docx --format docx -o report.md --conflict error`
+<!-- format-example: ppt -->
+- PPT: `into-md legacy.ppt --format ppt -o legacy.md --conflict error`
+<!-- format-example: pptx -->
+- PPTX: `into-md slides.pptx --format pptx -o slides.md --conflict error`
+<!-- format-example: xls -->
+- XLS: `into-md legacy.xls --format xls -o legacy.md --conflict error`
+<!-- format-example: xlsx -->
+- XLSX: `into-md workbook.xlsx --format xlsx -o workbook.md --conflict error`
+<!-- format-example: odt -->
+- ODT: `into-md document.odt --format odt -o document.md --conflict error`
+<!-- format-example: ods -->
+- ODS: `into-md sheet.ods --format ods -o sheet.md --conflict error`
+<!-- format-example: odp -->
+- ODP: `into-md slides.odp --format odp -o slides.md --conflict error`
+<!-- format-example: rtf -->
+- RTF: `into-md document.rtf --format rtf -o document.md --conflict error`
+<!-- format-example: epub -->
+- EPUB: `into-md book.epub --format epub -o book.md --conflict error`
+<!-- format-example: txt -->
+- TXT: `into-md notes.txt --format txt -o notes.md --conflict error`
+<!-- format-example: markdown -->
+- Markdown: `into-md notes.md --format markdown -o normalized.md --conflict error`
+<!-- format-example: html -->
+- HTML: `into-md page.html --format html -o page.md --conflict error`
+<!-- format-example: csv -->
+- CSV: `into-md table.csv --format csv -o table.md --conflict error`
+<!-- format-example: tsv -->
+- TSV: `into-md table.tsv --format tsv -o table.md --conflict error`
+<!-- format-example: json -->
+- JSON: `into-md data.json --format json -o data.md --conflict error`
+<!-- format-example: xml -->
+- XML: `into-md data.xml --format xml -o data.md --conflict error`
+<!-- format-example: feed -->
+- RSS/Atom: `into-md feed.xml --format feed -o feed.md --conflict error`
+<!-- format-example: ipynb -->
+- Notebook: `into-md notebook.ipynb --format ipynb -o notebook.md --conflict error`
+<!-- format-example: image -->
+- Image: `into-md scan.png --format image --ocr always -o scan.md --conflict error`
+<!-- format-example: zip -->
+- ZIP: `into-md archive.zip --format zip -o archive.md --conflict error`
+<!-- format-example: msg -->
+- MSG: `into-md message.msg --format msg -o message.md --conflict error`
+<!-- format-example: audio -->
+- Audio: `into-md meeting.wav --format audio --ai audio-transcription=only -o meeting.md --conflict error`
+<!-- format-example: video -->
+- Video: `into-md meeting.webm --format video --ai audio-transcription=only -o meeting.md --conflict error`
+
+See the [CLI](cli.md) and [format matrix](formats.md).

--- a/docs/cli-examples.md
+++ b/docs/cli-examples.md
@@ -1,0 +1,159 @@
+# CLI 与格式可执行示例
+
+[English](cli-examples.en.md)
+
+所有示例直接调用 `into-md`。CI 从真实 `--help` 命令树和 `formats --json` 反向核对覆盖率。
+
+## 公开命令
+
+<!-- cli-example: convert -->
+- 转换：`into-md report.docx -o report.md --conflict error`
+<!-- cli-example: ui -->
+- 工作台：`into-md ui --no-open`
+<!-- cli-example: formats -->
+- 格式列表：`into-md formats --json`
+<!-- cli-example: formats show -->
+- 格式详情：`into-md formats show pdf --json`
+<!-- cli-example: formats detect -->
+- 检测：`into-md formats detect report.pdf --json`
+<!-- cli-example: capabilities -->
+- 能力列表：`into-md capabilities --json`
+<!-- cli-example: capabilities list -->
+- 显式列表：`into-md capabilities list --json`
+<!-- cli-example: capabilities show -->
+- 能力详情：`into-md capabilities show ocr --json`
+<!-- cli-example: capabilities verify -->
+- 验证能力：`into-md capabilities verify ocr --json`
+<!-- cli-example: capabilities use -->
+- 选择路由：`into-md capabilities use ocr --source off --scope project`
+<!-- cli-example: capabilities reset -->
+- 重置路由：`into-md capabilities reset ocr --scope project`
+<!-- cli-example: setup -->
+- 准备入口：`into-md setup --help`
+<!-- cli-example: setup ocr -->
+- OCR：`into-md setup ocr`
+<!-- cli-example: setup media -->
+- 语音：`into-md setup media`
+<!-- cli-example: setup legacy-office -->
+- 旧 Office：`into-md setup legacy-office`
+<!-- cli-example: transcript -->
+- 转写后处理：`into-md transcript --help`
+<!-- cli-example: transcript relabel -->
+- 说话人重命名：`into-md transcript relabel document-ir.json --speaker SPEAKER_00=Alice -o meeting.md`
+<!-- cli-example: providers -->
+- Provider 列表：`into-md providers --json`
+<!-- cli-example: providers show -->
+- Provider 详情：`into-md providers show team --json`
+<!-- cli-example: providers add -->
+- 添加 Provider：`into-md providers add team --type openai-compatible --base-url https://api.example/v1 --model model-name --api-key-env TEAM_API_KEY --capability image-description --scope project`
+<!-- cli-example: providers remove -->
+- 删除 Provider：`into-md providers remove team --scope project`
+<!-- cli-example: providers set-default -->
+- 默认 Provider：`into-md providers set-default team --scope project`
+<!-- cli-example: providers capabilities -->
+- Provider 能力：`into-md providers capabilities team --json`
+<!-- cli-example: providers test -->
+- Provider 探测：`into-md providers test team --allow-network --allow-host api.example`
+<!-- cli-example: plugins -->
+- 插件列表：`into-md plugins --json`
+<!-- cli-example: plugins show -->
+- 插件详情：`into-md plugins show example.plugin --json`
+<!-- cli-example: plugins install -->
+- 安装插件：`into-md plugins install ./example.imp --scope project`
+<!-- cli-example: plugins verify -->
+- 验证插件：`into-md plugins verify example.plugin --json --scope project`
+<!-- cli-example: plugins enable -->
+- 启用插件：`into-md plugins enable example.plugin --scope project`
+<!-- cli-example: plugins disable -->
+- 禁用插件：`into-md plugins disable example.plugin --scope project`
+<!-- cli-example: plugins remove -->
+- 删除插件：`into-md plugins remove example.plugin --scope project`
+<!-- cli-example: plugins run -->
+- 运行插件：`into-md plugins run example.plugin source.bin --input-format txt --scope project`
+<!-- cli-example: config -->
+- 配置入口：`into-md config --help`
+<!-- cli-example: config paths -->
+- 配置路径：`into-md config paths --json`
+<!-- cli-example: config show -->
+- 配置内容：`into-md config show --resolved --format json`
+<!-- cli-example: config init -->
+- 初始化配置：`into-md config init --scope project`
+<!-- cli-example: config validate -->
+- 验证配置：`into-md config validate into-markdown.toml`
+<!-- cli-example: config get -->
+- 读取配置：`into-md config get output.conflict`
+<!-- cli-example: config set -->
+- 设置配置：`into-md config set output.conflict '"error"' --scope project`
+<!-- cli-example: config unset -->
+- 删除配置：`into-md config unset output.conflict --scope project`
+<!-- cli-example: config profile -->
+- Profile 入口：`into-md config profile --help`
+<!-- cli-example: config profile list -->
+- Profile 列表：`into-md config profile list`
+<!-- cli-example: config profile create -->
+- 创建 Profile：`into-md config profile create review --scope project`
+<!-- cli-example: config profile remove -->
+- 删除 Profile：`into-md config profile remove review --scope project`
+<!-- cli-example: doctor -->
+- 诊断：`into-md doctor --json`
+<!-- cli-example: completions -->
+- 补全：`into-md completions bash`
+<!-- cli-example: version -->
+- 版本：`into-md version --json`
+
+## 当前可用格式
+
+<!-- format-example: pdf -->
+- PDF：`into-md report.pdf --format pdf -o report.md --conflict error`
+<!-- format-example: doc -->
+- DOC：`into-md legacy.doc --format doc -o legacy.md --conflict error`
+<!-- format-example: docx -->
+- DOCX：`into-md report.docx --format docx -o report.md --conflict error`
+<!-- format-example: ppt -->
+- PPT：`into-md legacy.ppt --format ppt -o legacy.md --conflict error`
+<!-- format-example: pptx -->
+- PPTX：`into-md slides.pptx --format pptx -o slides.md --conflict error`
+<!-- format-example: xls -->
+- XLS：`into-md legacy.xls --format xls -o legacy.md --conflict error`
+<!-- format-example: xlsx -->
+- XLSX：`into-md workbook.xlsx --format xlsx -o workbook.md --conflict error`
+<!-- format-example: odt -->
+- ODT：`into-md document.odt --format odt -o document.md --conflict error`
+<!-- format-example: ods -->
+- ODS：`into-md sheet.ods --format ods -o sheet.md --conflict error`
+<!-- format-example: odp -->
+- ODP：`into-md slides.odp --format odp -o slides.md --conflict error`
+<!-- format-example: rtf -->
+- RTF：`into-md document.rtf --format rtf -o document.md --conflict error`
+<!-- format-example: epub -->
+- EPUB：`into-md book.epub --format epub -o book.md --conflict error`
+<!-- format-example: txt -->
+- TXT：`into-md notes.txt --format txt -o notes.md --conflict error`
+<!-- format-example: markdown -->
+- Markdown：`into-md notes.md --format markdown -o normalized.md --conflict error`
+<!-- format-example: html -->
+- HTML：`into-md page.html --format html -o page.md --conflict error`
+<!-- format-example: csv -->
+- CSV：`into-md table.csv --format csv -o table.md --conflict error`
+<!-- format-example: tsv -->
+- TSV：`into-md table.tsv --format tsv -o table.md --conflict error`
+<!-- format-example: json -->
+- JSON：`into-md data.json --format json -o data.md --conflict error`
+<!-- format-example: xml -->
+- XML：`into-md data.xml --format xml -o data.md --conflict error`
+<!-- format-example: feed -->
+- RSS/Atom：`into-md feed.xml --format feed -o feed.md --conflict error`
+<!-- format-example: ipynb -->
+- Notebook：`into-md notebook.ipynb --format ipynb -o notebook.md --conflict error`
+<!-- format-example: image -->
+- 图片：`into-md scan.png --format image --ocr always -o scan.md --conflict error`
+<!-- format-example: zip -->
+- ZIP：`into-md archive.zip --format zip -o archive.md --conflict error`
+<!-- format-example: msg -->
+- MSG：`into-md message.msg --format msg -o message.md --conflict error`
+<!-- format-example: audio -->
+- 音频：`into-md meeting.wav --format audio --ai audio-transcription=only -o meeting.md --conflict error`
+<!-- format-example: video -->
+- 视频：`into-md meeting.webm --format video --ai audio-transcription=only -o meeting.md --conflict error`
+
+参数与失败边界见 [CLI](cli.md)和[格式矩阵](formats.md)。

--- a/docs/cli-examples.md
+++ b/docs/cli-examples.md
@@ -127,8 +127,8 @@
 - RTF：`into-md document.rtf --format rtf -o document.md --conflict error`
 <!-- format-example: epub -->
 - EPUB：`into-md book.epub --format epub -o book.md --conflict error`
-<!-- format-example: txt -->
-- TXT：`into-md notes.txt --format txt -o notes.md --conflict error`
+<!-- format-example: text -->
+- TXT：`into-md notes.txt --format text -o notes.md --conflict error`
 <!-- format-example: markdown -->
 - Markdown：`into-md notes.md --format markdown -o normalized.md --conflict error`
 <!-- format-example: html -->
@@ -149,8 +149,8 @@
 - 图片：`into-md scan.png --format image --ocr always -o scan.md --conflict error`
 <!-- format-example: zip -->
 - ZIP：`into-md archive.zip --format zip -o archive.md --conflict error`
-<!-- format-example: msg -->
-- MSG：`into-md message.msg --format msg -o message.md --conflict error`
+<!-- format-example: outlook-msg -->
+- MSG：`into-md message.msg --format outlook-msg -o message.md --conflict error`
 <!-- format-example: audio -->
 - 音频：`into-md meeting.wav --format audio --ai audio-transcription=only -o meeting.md --conflict error`
 <!-- format-example: video -->

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,6 +21,7 @@ into-md capabilities
 into-md setup
 into-md providers
 into-md plugins
+into-md transcript
 into-md config
 into-md doctor
 into-md completions
@@ -36,6 +37,9 @@ into-md -- ui
 
 无参数且 stdin 连接管道时自动读取 stdin；无参数且 stdin 为终端时显示帮助。
 `into-md -` 始终显式表示 stdin。stdin 不能与其他输入组合。
+
+全部公共命令和当前可用格式的可执行示例见[命令与格式示例](cli-examples.md)。该文档由
+CI 对真实 CLI 发现结果、语法、格式 catalog 和基础转换逐项校验。
 
 ### 本地 Web 服务
 
@@ -296,7 +300,17 @@ into-md setup media [--insecure] [--allow-private-network]
 into-md setup legacy-office [--insecure] [--allow-private-network]
 ```
 
-转换和状态查询不会隐式调用这两个命令。
+转换和状态查询不会隐式调用这些命令。
+
+### 转写后说话人重标记
+
+```text
+into-md transcript relabel <INPUT.md|RESULT.json> --mapping <FROM=TO>... \
+  [-o <OUTPUT>] [--conflict <error|overwrite|rename>] [--json]
+```
+
+`transcript relabel` 只修改已有转写产物中的说话人标签，不重新解码媒体、不执行 ASR 或
+说话人分离，也不访问网络。输入、mapping 和输出结构会完整校验；默认使用冲突保护。
 
 ### AI Provider
 
@@ -391,11 +405,11 @@ into-md version [--json]
 | 70 | 内部错误 |
 | 130 | 用户取消 |
 
-当前工程仍是转换后端脚手架。格式、模型运行时产物、插件或 Provider 后端缺失时，命令返回
-稳定错误，不会执行网络操作、创建虚假安装状态或 panic。
+当前 Core、格式 catalog、能力路由和插件生命周期均为公开产品接口。格式、能力插件或
+Provider 后端缺失时，命令返回稳定错误，不会执行未授权网络操作、创建虚假安装状态或 panic。
 
 `ir-json` 使用 Document IR 的公共版本化契约；`result-json`、Bundle manifest 和
-`--report` 使用与未来 HTTP 服务共享的公共 DTO。Bundle schema 1 内的
+`--report` 使用与本地 Web 服务共享的公共 DTO。Bundle schema 1 内的
 diagnostics/provenance 保持裸数组成员形状，其版本由 manifest 统辖；独立 HTTP 响应
 使用带 `schemaVersion` 的 envelope。
 `result-json` 通过公共 DTO 的 `Pretty` 借用写接口生成：完整缩进后 wire 预算在任何

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -3,17 +3,22 @@
 运行时的权威列表以 `into-md formats` 输出为准。PDF、DOC/DOCX/DOCM、ODT/ODS/ODP、
 PPT/PPS/POT/PPTX/PPTM/PPSX/PPSM/POTX、XLS/XLSX/XLSM/XLSB、EPUB、RTF、ZIP、TXT、
 Markdown、HTML、CSV、TSV、JSON、XML、RSS/Atom、IPYNB、Outlook MSG，以及
-PNG/JPEG/TIFF/WebP/BMP 图片状态为 `available`。旧 Office 格式还要求安装当前平台的受审
-runtime，缺失时返回 `componentUnavailable`。Audio、Video、YouTube、Wikipedia/MediaWiki、
-ASR、AI provider 与插件能力不进入核心目录，也不会以 `planned` 冒充可用格式。
+PNG/JPEG/TIFF/WebP/BMP 图片以及 Audio/Video 状态为 `available`。旧 Office 格式还要求安装
+当前平台的受审 runtime；Audio/Video 要求完整语音能力插件。能力缺失时返回
+`componentUnavailable`。YouTube、Wikipedia/MediaWiki 等站点适配器不是格式 catalog 条目，
+ASR、AI Provider 与插件本身是能力来源，不会以 `planned` 冒充格式。
 
 | 类别 | 格式 |
 | --- | --- |
 | 文档 | PDF；DOC/DOCX/DOCM；PPT/PPS/POT/PPTX/PPTM/PPSX/PPSM/POTX；XLS/XLSX/XLSM/XLSB；ODT/ODS/ODP；RTF；EPUB |
 | 文本与数据 | TXT；Markdown；HTML；CSV/TSV；JSON；XML；RSS/Atom；IPYNB |
 | 图片 | PNG；JPEG；TIFF；WebP；BMP |
+| 音视频 | Audio；Video（经受认证 FFmpeg 解码并由语音能力插件转写） |
 | 容器与消息 | ZIP；Outlook MSG |
 | 受控输入基础 | HTTP(S) SourceResolver（默认离线，须显式网络授权） |
+
+每种当前可用格式的可执行 dry-run 示例见[命令与格式示例](cli-examples.md)，并由 CI 从
+`into-md formats --json` 实时发现后逐项校验。
 
 ## 图片
 

--- a/docs/macos-arm64-release.md
+++ b/docs/macos-arm64-release.md
@@ -1,5 +1,8 @@
 # macOS ARM64 模块化发布
 
+最终用户应按[安装与部署指南](user-guide.md)校验 DMG、执行安装、离线导入能力插件并排障；
+本文描述发布工程与验收权威。
+
 Apple silicon 每个版本固定发布五个独立构件：
 
 - `into-md-macos-arm64-core.dmg`：Developer ID 签名、Apple 公证并 stapling 的 `into-md`、Document IR、管理界面、PDFium、安装器、Core SBOM 与许可材料；

--- a/docs/platform-modular-release.md
+++ b/docs/platform-modular-release.md
@@ -1,5 +1,8 @@
 # Linux 与 Windows 模块化发布
 
+最终用户应按[安装与部署指南](user-guide.md)校验签名与摘要、安装 Core、离线导入能力插件并
+排障；本文描述跨平台发布装配与验收权威。
+
 Linux x86_64、Linux ARM64 与 Windows x86_64 和 macOS ARM64 使用相同产品边界：一个只含
 Core 能力的归档，以及 `official.ocr.ppocrv6`、`official.media.whisper`、
 `official.legacy-office.libreoffice` 三个自包含 `.imp`。Core 不包含 FFmpeg、ONNX Runtime、

--- a/docs/plugin-development.en.md
+++ b/docs/plugin-development.en.md
@@ -1,0 +1,87 @@
+# Plugin development
+
+Into Markdown accepts only plugins that are signed, explicitly installed, and executed inside an
+isolation boundary. A plugin cannot bypass the common Document IR, resource validation, output
+transaction, or per-invocation network authority. User-facing OCR, speech, and legacy Office
+capabilities must ship as complete `.imp` packages containing their runtime, models, licenses, and
+SBOM. Models are not managed separately.
+
+## Choose a protocol
+
+| Protocol | Use it for | Default authority | Result boundary |
+| --- | --- | --- | --- |
+| `process-v1` | Converters and capability providers that need native libraries, authenticated helpers, or platform runtimes | Empty environment, no network, and only request-private input and temporary storage | Length-prefixed JSON, stable events, and a `ResultDto` or typed capability DTO |
+| `wasi-v1` | Portable converters that compile to a WASI Preview 2 command component | Files, clocks, random, and network are all denied until individually granted | Bounded JSON envelope, common IR, and resource inventory |
+
+See [`process-plugins.md`](process-plugins.md) and [`wasi-plugins.md`](wasi-plugins.md) for the wire
+protocols and sandbox boundaries. Capability providers must also follow the identity, readiness,
+DTO, and routing rules in [`capability-plugins.md`](capability-plugins.md).
+
+## Develop and verify `process-v1`
+
+The entrypoint implements the handshake, one request, strictly increasing events, and one terminal
+response. It must not interpret shell commands, read the inherited environment, or accept arbitrary
+host paths. Start with the repository fixture and the real manager end-to-end gate:
+
+```sh
+cargo test --locked -p into-markdown-process-plugin
+bazel test //crates/process-plugin:process_plugin_test
+bazel test //crates/plugin-manager:plugin_manager_process_e2e_test
+```
+
+A capability provider's `provider.json`, entrypoint, helpers, fixed models, dictionaries, licenses,
+and SBOM all enter the signed `plugin.json` file inventory. Results must pass the public DTO
+validators; a plugin cannot emit unvalidated Markdown instead of IR.
+
+## Develop and verify `wasi-v1`
+
+The component implements `wasi:cli/run@0.2.x` and its manifest pins `wasiPreview`, the Wasmtime
+version, component SHA-256, and supported host targets. Rebuild the checked-in fixture before
+running the real component:
+
+```sh
+python crates/plugin-wasi/tests/verify_fixture.py --rebuild
+cargo test --locked -p into-markdown-plugin-wasi --test runtime -j1
+bazel test //crates/plugin-wasi:plugin_wasi_runtime_test --jobs=1 --local_resources=memory=4096
+```
+
+Grant a preopen, clock, random source, or exact IP/port network destination only when the capability
+requires it. A private destination also requires a separate `allowPrivate` grant. The host still
+validates paths, resources, IR, and provenance at execution time.
+
+## Build a signed package
+
+The source directory contains only required regular runtime files. `manifest-template.json`
+declares the package ID, version, protocol, supported targets, entrypoints, and optional runtime
+manifest. Never commit the release private key.
+
+```sh
+openssl genpkey -algorithm Ed25519 -outform DER -out developer-ed25519.pk8
+cargo run --locked -p into-markdown-plugin-manager --bin package_plugin -- \
+  plugin-root manifest-template.json developer-ed25519.pk8 developer.example example.imp
+```
+
+The packager sorts files deterministically and rejects links, special files, unsafe paths, existing
+output, and undeclared content before signing the complete inventory. The transfer SHA-256 of the
+`.imp` file and the signing public-key fingerprint are independent pins; record both in a release.
+See [`plugin-management.md`](plugin-management.md) for the complete schema and signed bytes.
+
+## Accept the complete lifecycle
+
+Use an isolated user-data directory and real input to verify install through removal:
+
+```sh
+into-md plugins install ./example.imp --sha256 <PACKAGE_SHA256> \
+  --signing-key-id developer.example --signing-key-sha256 <PUBLIC_KEY_SHA256> --scope global
+into-md plugins verify <PLUGIN_ID> --scope global --json
+into-md plugins enable <PLUGIN_ID> --scope global
+into-md plugins run <PLUGIN_ID> sample.bin --input-format application/example --scope global
+into-md plugins disable <PLUGIN_ID> --scope global
+into-md plugins remove <PLUGIN_ID> --scope global
+```
+
+Cover invalid signatures, added or changed files, target mismatch, unavailable capabilities,
+cancellation, timeouts, resource limits, default network denial, and explicit grants. Native
+plugins must execute a real binary on every declared platform; cross-compilation is not runtime
+evidence. Release packages include third-party licenses, SBOM, source and runtime inventories, and
+must pass the repository license, plugin-manager, installed-smoke, and archive-check gates.

--- a/docs/plugin-development.md
+++ b/docs/plugin-development.md
@@ -1,0 +1,81 @@
+# 插件开发
+
+Into Markdown 只接受经过签名、显式安装并在隔离边界内运行的插件。插件不能绕过统一
+Document IR、资源校验、输出事务或当前调用的网络授权。面向最终用户的 OCR、语音和旧版
+Office 能力应交付为包含运行时、模型、许可和 SBOM 的完整 `.imp` 包，不提供独立模型管理。
+
+## 选择协议
+
+| 协议 | 适用场景 | 默认权限 | 结果边界 |
+| --- | --- | --- | --- |
+| `process-v1` | 需要原生库、受认证 helper 或平台运行时的转换器与能力 provider | 空环境、无网络、仅请求私有输入与临时目录 | 长度前缀 JSON、稳定事件、`ResultDto` 或类型化能力 DTO |
+| `wasi-v1` | 可编译为 WASI Preview 2 command component 的可移植转换器 | 文件、时钟、随机和网络全部关闭，逐项授予 | 有界 JSON envelope、统一 IR 与资源清单 |
+
+详细的线协议和沙箱约束分别见 [`process-plugins.md`](process-plugins.md) 与
+[`wasi-plugins.md`](wasi-plugins.md)。能力 provider 还必须遵守
+[`capability-plugins.md`](capability-plugins.md) 中的身份、readiness、DTO 和路由规则。
+
+## 开发与验证 `process-v1`
+
+插件入口必须实现握手、一次请求、严格递增事件和一个终态响应。不要解释 shell 命令、读取
+继承环境或接受任意宿主路径。先用仓库 fixture 和真实管理器端到端门禁验证协议：
+
+```sh
+cargo test --locked -p into-markdown-process-plugin
+bazel test //crates/process-plugin:process_plugin_test
+bazel test //crates/plugin-manager:plugin_manager_process_e2e_test
+```
+
+能力 provider 的 `provider.json` 与入口、helper、固定模型、字典、许可和 SBOM 一起进入
+`plugin.json` 的签名文件清单。返回值必须通过公共 DTO 校验；插件不能直接生成未验证的
+Markdown 来代替 IR。
+
+## 开发与验证 `wasi-v1`
+
+component 必须实现 `wasi:cli/run@0.2.x`，并在 manifest 中固定 `wasiPreview`、Wasmtime
+版本、component SHA-256 和支持的 host target。先重建 checked-in fixture，再运行真实
+component：
+
+```sh
+python crates/plugin-wasi/tests/verify_fixture.py --rebuild
+cargo test --locked -p into-markdown-plugin-wasi --test runtime -j1
+bazel test //crates/plugin-wasi:plugin_wasi_runtime_test --jobs=1 --local_resources=memory=4096
+```
+
+只有业务确实需要时才在 manifest 中授予 preopen、clock、random 或精确 IP/端口网络访问；
+私网目标还必须设置独立的 `allowPrivate`。宿主会在运行时继续执行路径、资源、IR 和
+provenance 校验。
+
+## 生成签名包
+
+源码目录只包含运行所需的普通文件。`manifest-template.json` 声明包 ID、版本、协议、支持
+target、入口和可选 runtime manifest；发布私钥不得提交到仓库。
+
+```sh
+openssl genpkey -algorithm Ed25519 -outform DER -out developer-ed25519.pk8
+cargo run --locked -p into-markdown-plugin-manager --bin package_plugin -- \
+  plugin-root manifest-template.json developer-ed25519.pk8 developer.example example.imp
+```
+
+打包器稳定排序文件，拒绝链接、特殊文件、不安全路径、已有输出和未声明内容，并签署完整
+文件清单。传输用 `.imp` SHA-256 与签名公钥指纹是两个独立校验值；发布流程必须同时记录。
+完整 schema 与签名字节见 [`plugin-management.md`](plugin-management.md)。
+
+## 从安装到移除的验收
+
+在隔离的用户数据目录中，以真实输入验证完整生命周期：
+
+```sh
+into-md plugins install ./example.imp --sha256 <PACKAGE_SHA256> \
+  --signing-key-id developer.example --signing-key-sha256 <PUBLIC_KEY_SHA256> --scope global
+into-md plugins verify <PLUGIN_ID> --scope global --json
+into-md plugins enable <PLUGIN_ID> --scope global
+into-md plugins run <PLUGIN_ID> sample.bin --input-format application/example --scope global
+into-md plugins disable <PLUGIN_ID> --scope global
+into-md plugins remove <PLUGIN_ID> --scope global
+```
+
+测试应覆盖错误签名、文件增删或变更、目标不匹配、能力缺失、取消、超时、资源上限、默认
+网络拒绝和显式授权。原生插件还要在每个声明平台运行真实二进制；交叉编译不能替代运行证据。
+发布包必须包含第三方许可、SBOM、来源和 runtime inventory，并通过仓库 license、插件管理器、
+installed-smoke 与 archive-check 门禁。

--- a/docs/process-plugins.md
+++ b/docs/process-plugins.md
@@ -63,3 +63,4 @@ Cargo 目标为 `into-markdown-process-plugin`，Bazel 目标为
 
 签名 `.imp` 安装、类型化 OCR/转写/说话人分离 DTO、readiness 路由和官方包见
 [`capability-plugins.md`](capability-plugins.md)。
+从协议选择、实现、签名到真实生命周期验收见[插件开发](plugin-development.md)。

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,13 @@
 # 测试策略
 
+## 可执行文档契约
+
+`bazel test //tools/docs-check:docs_check_test` 从构建出的真实 `into-md` 递归发现公共命令，
+读取 `formats --json` 的当前可用 catalog，并要求中英文命令/格式示例精确覆盖。它逐条执行
+命令语法检查和格式 dry-run，完成真实 TXT 与 stdin 转换，解析 version、capabilities 与
+doctor JSON，并验证本地 Markdown 链接及 README 双语入口。公共命令、格式或文档入口发生
+变化而示例未同步时，CI 会失败。
+
 跨格式语义布局、阅读顺序、表格拓扑、资源关联和 IR/GFM hash 门禁见
 [`semantic-layout-quality.md`](semantic-layout-quality.md)。平台无关核心及真实 package
 fixture 由 `//crates/layout-quality:layout_quality_test` 和

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -1,0 +1,134 @@
+# User installation, offline deployment, and troubleshooting
+
+[中文](user-guide.md) · [CLI examples](cli-examples.en.md)
+
+A release contains one platform Core, three self-contained capability plugins, and the Agent Skill.
+Every Core/plugin has SHA-256, signature, SPDX, source, and notice sidecars. Combine only artifacts
+from the same version and target.
+
+| Capability | Artifact |
+| --- | --- |
+| Ordinary documents, PDF, and Web workbench | Platform Core |
+| OCR | `official.ocr.ppocrv6.imp` |
+| Transcription and diarization | `official.media.whisper.imp` |
+| DOC/XLS/PPT | `official.legacy-office.libreoffice.imp` |
+| Agent instructions | `into-markdown-skill.zip` |
+
+## Install Core
+
+On macOS ARM64, verify digest, notarization, and mounted content before running the DMG installer:
+
+```sh
+shasum -a 256 -c into-md-macos-arm64-core.dmg.sha256
+spctl --assess --type open --verbose=2 into-md-macos-arm64-core.dmg
+hdiutil attach into-md-macos-arm64-core.dmg
+cd "/Volumes/Into Markdown"
+./bin/archive-check .
+./install "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
+```
+
+Use the volume name printed by `hdiutil`; macOS x86_64 is unsupported.
+
+On Linux, select the x86_64 or ARM64 archive matching `uname -m`:
+
+```sh
+sha256sum -c into-md-linux-x86_64-core.tar.gz.sha256
+gpg --verify into-md-linux-x86_64-core.tar.gz.sig into-md-linux-x86_64-core.tar.gz
+mkdir into-md-core
+tar -xzf into-md-linux-x86_64-core.tar.gz -C into-md-core
+cd into-md-core
+./bin/archive-check .
+./install "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
+```
+
+Use `into-md-linux-arm64-core.tar.gz` on ARM64. The installer never edits shell profiles.
+
+On Windows x86_64, verify the ZIP digest and Authenticode of project executables inside it:
+
+```powershell
+(Get-FileHash -Algorithm SHA256 .\into-md-windows-x86_64-core.zip).Hash
+Expand-Archive .\into-md-windows-x86_64-core.zip .\into-md-core
+Get-AuthenticodeSignature .\into-md-core\bin\into-md.exe | Format-List
+& .\into-md-core\bin\archive-check.exe .\into-md-core
+& .\into-md-core\Install.ps1
+```
+
+The digest must match the release sidecar and Authenticode `Status` must be `Valid`.
+
+## Verify and install capabilities
+
+```sh
+into-md version --json
+into-md formats --json
+into-md capabilities list --json
+into-md doctor --json
+into-md setup ocr
+into-md setup media
+into-md setup legacy-office
+```
+
+`setup` uses the network only for that explicit installation. Conversion and status commands never
+download plugins or models; models remain internal to complete plugins.
+
+## Complete offline deployment
+
+Verify Core, all three `.imp` files, and sidecars on a connected machine, then transfer them through
+controlled media. Install Core and use its pinned official publisher identity:
+
+```sh
+installed="$HOME/.local/share/into-markdown/current"
+catalog="$installed/share/into-markdown/plugins/official-publisher.json"
+signer_id=$(jq -r .signingKeyId "$catalog")
+signer_sha=$(jq -r .signingKeySha256 "$catalog")
+for package in official.ocr.ppocrv6 official.media.whisper official.legacy-office.libreoffice; do
+  file="/media/release/$package.imp"
+  sha=$(sha256sum "$file" | awk '{print $1}')
+  into-md plugins install "$file" --sha256 "$sha" \
+    --signing-key-id "$signer_id" --signing-key-sha256 "$signer_sha" --scope global
+  into-md plugins verify "$package" --scope global
+done
+into-md capabilities list --json
+```
+
+Use `shasum -a 256` on macOS and `Get-FileHash` plus the same catalog fields on Windows. Do not add
+`--allow-network` during offline installation.
+
+## Conversion and networking
+
+```sh
+into-md report.docx -o report.md --conflict error --log-format json
+into-md documents --recursive --output-dir markdown --conflict error --dry-run
+into-md documents --recursive --output-dir markdown --conflict error \
+  --report conversion-report.json --log-format json
+into-md meeting.webm --ai audio-transcription=only --diarize \
+  -o meeting.md --conflict error --log-format json
+```
+
+Remote input needs per-invocation `--allow-network`; narrow it with `--allow-host` and separately
+authorize loopback/private targets. See [CLI examples](cli-examples.en.md).
+
+## Troubleshoot and uninstall
+
+Preserve the exit status and stable `--log-format json` event, then run `into-md doctor --json`.
+
+| Signal | Action |
+| --- | --- |
+| `componentUnavailable` | Use `capabilities show <ID> --json`, then run `setup` or reinstall offline. |
+| `networkDenied` | Confirm remote intent, authorize the exact host, and authorize private networking separately. |
+| `outputConflict` | Preserve the old file and overwrite only with explicit authority. |
+| `malformed` / `invalidMedia` | The input is damaged or mismatched; do not rename it. |
+| `pluginSandboxUnavailable` | Check Core/plugin targets and platform isolation. |
+| `hashMismatch` / `invalidManifest` | Stop and obtain a verified official artifact. |
+
+Use `doctor --deep` only when ordinary diagnostics cannot locate damage. Do not expose API keys,
+query-bearing URLs, private paths, or sensitive content in public issues.
+
+```sh
+./uninstall "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
+```
+
+```powershell
+& .\into-md-core\Uninstall.ps1
+```
+
+The uninstaller removes only the product tree and command shim, never a user-copied or linked Agent Skill.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,132 @@
+# 用户安装、离线部署与故障排查
+
+[English](user-guide.en.md) · [CLI 示例](cli-examples.md)
+
+正式发布由一个平台 Core、三个自包含能力插件和 Agent Skill 组成。每个 Core/插件同时发布
+SHA-256、签名、SPDX、来源与第三方声明 sidecar。只组合相同版本和目标平台的构件。
+
+| 能力 | 构件 |
+| --- | --- |
+| 普通文档、PDF、Web 工作台 | 对应平台 Core |
+| OCR | `official.ocr.ppocrv6.imp` |
+| 转写与说话人分离 | `official.media.whisper.imp` |
+| DOC/XLS/PPT | `official.legacy-office.libreoffice.imp` |
+| Agent 指令 | `into-markdown-skill.zip` |
+
+## 安装 Core
+
+macOS ARM64 校验摘要、公证与挂载内容后运行 DMG 根目录安装器：
+
+```sh
+shasum -a 256 -c into-md-macos-arm64-core.dmg.sha256
+spctl --assess --type open --verbose=2 into-md-macos-arm64-core.dmg
+hdiutil attach into-md-macos-arm64-core.dmg
+cd "/Volumes/Into Markdown"
+./bin/archive-check .
+./install "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
+```
+
+卷名以 `hdiutil` 输出为准；不支持 macOS x86_64。
+
+Linux 选择与 `uname -m` 匹配的 x86_64 或 ARM64 归档：
+
+```sh
+sha256sum -c into-md-linux-x86_64-core.tar.gz.sha256
+gpg --verify into-md-linux-x86_64-core.tar.gz.sig into-md-linux-x86_64-core.tar.gz
+mkdir into-md-core
+tar -xzf into-md-linux-x86_64-core.tar.gz -C into-md-core
+cd into-md-core
+./bin/archive-check .
+./install "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
+```
+
+ARM64 使用 `into-md-linux-arm64-core.tar.gz`。安装器不修改 shell profile。
+
+Windows x86_64 在 PowerShell 校验 ZIP 摘要及内部项目可执行文件的 Authenticode：
+
+```powershell
+(Get-FileHash -Algorithm SHA256 .\into-md-windows-x86_64-core.zip).Hash
+Expand-Archive .\into-md-windows-x86_64-core.zip .\into-md-core
+Get-AuthenticodeSignature .\into-md-core\bin\into-md.exe | Format-List
+& .\into-md-core\bin\archive-check.exe .\into-md-core
+& .\into-md-core\Install.ps1
+```
+
+摘要必须匹配发布 sidecar，Authenticode `Status` 必须为 `Valid`。
+
+## 验证与能力安装
+
+```sh
+into-md version --json
+into-md formats --json
+into-md capabilities list --json
+into-md doctor --json
+into-md setup ocr
+into-md setup media
+into-md setup legacy-office
+```
+
+`setup` 只在明确安装动作中联网。转换和状态查询不下载插件或模型；模型属于完整插件内部。
+
+## 完整离线部署
+
+在联网机器验证 Core、三个 `.imp` 和 sidecar，通过受控介质传入隔离环境。安装 Core 后使用其
+固定的官方发布者身份：
+
+```sh
+installed="$HOME/.local/share/into-markdown/current"
+catalog="$installed/share/into-markdown/plugins/official-publisher.json"
+signer_id=$(jq -r .signingKeyId "$catalog")
+signer_sha=$(jq -r .signingKeySha256 "$catalog")
+for package in official.ocr.ppocrv6 official.media.whisper official.legacy-office.libreoffice; do
+  file="/media/release/$package.imp"
+  sha=$(sha256sum "$file" | awk '{print $1}')
+  into-md plugins install "$file" --sha256 "$sha" \
+    --signing-key-id "$signer_id" --signing-key-sha256 "$signer_sha" --scope global
+  into-md plugins verify "$package" --scope global
+done
+into-md capabilities list --json
+```
+
+macOS 用 `shasum -a 256`；Windows 用 `Get-FileHash` 和同一 catalog 字段。离线安装不增加
+`--allow-network`。
+
+## 转换与网络
+
+```sh
+into-md report.docx -o report.md --conflict error --log-format json
+into-md documents --recursive --output-dir markdown --conflict error --dry-run
+into-md documents --recursive --output-dir markdown --conflict error \
+  --report conversion-report.json --log-format json
+into-md meeting.webm --ai audio-transcription=only --diarize \
+  -o meeting.md --conflict error --log-format json
+```
+
+远程来源由当前调用增加 `--allow-network`，尽量用 `--allow-host` 收窄；回环/私网还需
+`--allow-private-network`。完整覆盖见 [CLI 示例](cli-examples.md)。
+
+## 故障排查与卸载
+
+保留退出码和 `--log-format json` 稳定事件，再运行 `into-md doctor --json`。
+
+| 信号 | 处理 |
+| --- | --- |
+| `componentUnavailable` | 用 `capabilities show <ID> --json` 定位插件，执行 `setup` 或离线重装。 |
+| `networkDenied` | 确认远端意图，只授权精确 host；私网另行授权。 |
+| `outputConflict` | 保留原文件，明确授权后才 overwrite。 |
+| `malformed` / `invalidMedia` | 输入损坏或不匹配，不改扩展名重试。 |
+| `pluginSandboxUnavailable` | 核对 Core/插件目标和平台隔离能力。 |
+| `hashMismatch` / `invalidManifest` | 停止使用并从正式发布源重新取得。 |
+
+普通诊断不能定位损坏时才运行 `doctor --deep`。公开 issue 不粘贴 API Key、带 query 的 URL、
+私有路径或敏感内容。
+
+```sh
+./uninstall "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
+```
+
+```powershell
+& .\into-md-core\Uninstall.ps1
+```
+
+卸载器只删除产品树和命令 shim，不删除用户自行复制或链接的 Agent Skill。

--- a/docs/wasi-plugins.md
+++ b/docs/wasi-plugins.md
@@ -73,3 +73,5 @@ bazel test //crates/plugin-wasi:plugin_wasi_runtime_test --jobs=1 --local_resour
 macOS ARM64 的真实 runner 上执行同一重建、Cargo 与 Bazel 门禁；没有 ignored 或异平台
 别名测试。Wasmtime source/tag/commit、crate checksums/features、完整 license 与四 target
 authority 位于 `third_party/wasmtime/`，由 license-check mutation tests 绑定。
+
+从协议选择、manifest、签名到安装与移除验收见[插件开发](plugin-development.md)。

--- a/tools/docs-check/BUILD.bazel
+++ b/tools/docs-check/BUILD.bazel
@@ -1,0 +1,11 @@
+load("@rules_python//python:defs.bzl", "py_test")
+
+package(default_visibility = ["//visibility:public"])
+
+py_test(
+    name = "docs_check_test",
+    srcs = ["docs_check.py"],
+    main = "docs_check.py",
+    args = ["--into-md", "$(rootpath //apps/cli:into-md)"],
+    data = ["//:documentation", "//apps/cli:into-md"],
+)

--- a/tools/docs-check/docs_check.py
+++ b/tools/docs-check/docs_check.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Validate public Markdown against the built CLI and format catalog."""
+
+from __future__ import annotations
+
+import argparse, json, os, pathlib, re, shlex, subprocess, sys, tempfile, urllib.parse
+
+MARKER = re.compile(r"<!--\s*(cli|format)-example:\s*([^>]+?)\s*-->\s*\n[^\n]*?`([^`\n]+)`", re.M)
+LINK = re.compile(r"(?<!!)\[[^\]]*\]\(([^)]+)\)")
+FENCE = re.compile(r"```[^\n]*\n(.*?)```", re.S)
+STALE = ("当前工程仍是转换后端脚手架", "与未来 HTTP 服务共享", "转换和状态查询不会隐式调用这两个命令")
+TOKENS = ("official.ocr.ppocrv6", "official.media.whisper", "official.legacy-office.libreoffice", "into-markdown-skill.zip", "macOS ARM64", "Linux x86_64", "Linux ARM64", "Windows x86_64")
+
+
+class CheckError(RuntimeError): pass
+
+
+def invoke(binary, args, cwd, env, stdin=None):
+    result = subprocess.run([str(binary), *args], cwd=cwd, env=env, input=stdin, capture_output=True, text=True)
+    if result.returncode:
+        raise CheckError(f"into-md {' '.join(args)} failed ({result.returncode})\n{result.stderr}")
+    return result.stdout
+
+
+def children(text):
+    lines = text.splitlines()
+    if "Commands:" not in lines: return []
+    found = []
+    for line in lines[lines.index("Commands:") + 1:]:
+        if not line.strip(): break
+        match = re.match(r"  ([a-z0-9][a-z0-9-]*)\s", line)
+        if match and match.group(1) != "help": found.append(match.group(1))
+    return found
+
+
+def command_tree(binary, root, env):
+    found, pending = set(), [()]
+    while pending:
+        parent = pending.pop()
+        for child in children(invoke(binary, [*parent, "--help"], root, env)):
+            path = (*parent, child); label = " ".join(path)
+            if label not in found: found.add(label); pending.append(path)
+    return found
+
+
+def examples(path):
+    groups = {"cli": {}, "format": {}}
+    for kind, raw, command in MARKER.findall(path.read_text(encoding="utf-8")):
+        label = " ".join(raw.split())
+        if label in groups[kind]: raise CheckError(f"duplicate {kind} example {label} in {path.name}")
+        groups[kind][label] = command.strip()
+    return groups["cli"], groups["format"]
+
+
+def syntax(binary, command, cwd, env):
+    tokens = shlex.split(command)
+    if not tokens or tokens[0] != "into-md": raise CheckError(f"invalid example: {command}")
+    if any(x in {"|", ">", "<", "&&", ";"} for x in tokens): raise CheckError(f"nonportable example: {command}")
+    args = tokens[1:]
+    if "--help" not in args and "-h" not in args: args.append("--help")
+    invoke(binary, args, cwd, env)
+    return tokens
+
+
+def check_examples(binary, root, env):
+    zh, zf = examples(root / "docs/cli-examples.md"); en, ef = examples(root / "docs/cli-examples.en.md")
+    if zh != en or zf != ef: raise CheckError("Chinese and English executable examples differ")
+    expected = {"convert", *command_tree(binary, root, env)}
+    if set(zh) != expected: raise CheckError(f"CLI coverage drifted; missing={sorted(expected-set(zh))}, extra={sorted(set(zh)-expected)}")
+    top = {x.split()[0] for x in expected if x != "convert"}
+    for label, command in sorted(zh.items()):
+        tokens = syntax(binary, command, root, env)
+        if label == "convert":
+            if len(tokens) < 2 or tokens[1] in top: raise CheckError("conversion example has no input")
+        elif tokens[1:1+len(label.split())] != label.split(): raise CheckError(f"wrong command example: {label}")
+    catalog = json.loads(invoke(binary, ["formats", "--json", "--no-config"], root, env))
+    available = {x["format"]: x for x in catalog if x["status"] == "available"}
+    if set(zf) != set(available): raise CheckError(f"format coverage drifted; missing={sorted(set(available)-set(zf))}, extra={sorted(set(zf)-set(available))}")
+    with tempfile.TemporaryDirectory(prefix="into-md-doc-formats-") as name:
+        temp = pathlib.Path(name)
+        for format_id, descriptor in sorted(available.items()):
+            tokens = syntax(binary, zf[format_id], root, env)
+            if "--format" not in tokens or tokens[tokens.index("--format")+1] != format_id: raise CheckError(f"wrong format example: {format_id}")
+            source = temp / f"source.{descriptor['extensions'][0]}"; source.write_bytes(b"")
+            invoke(binary, [str(source), "--format", format_id, "-o", str(temp/f"{format_id}.md"), "--conflict", "error", "--dry-run", "--no-config"], temp, env)
+
+
+def check_real(binary, env):
+    with tempfile.TemporaryDirectory(prefix="into-md-doc-smoke-") as name:
+        temp = pathlib.Path(name); source = temp/"source.txt"; output = temp/"source.md"
+        source.write_text("Alpha documentation example\n", encoding="utf-8")
+        invoke(binary, [str(source), "-o", str(output), "--conflict", "error", "--no-config"], temp, env)
+        if not output.read_text(encoding="utf-8").strip(): raise CheckError("empty file conversion")
+        stdin_output = temp/"stdin.md"
+        invoke(binary, ["-", "--format", "txt", "--asset-mode", "embed", "-o", str(stdin_output), "--conflict", "error", "--no-config"], temp, env, "stdin example\n")
+        if not stdin_output.read_text(encoding="utf-8").strip(): raise CheckError("empty stdin conversion")
+        for args in (["version", "--json", "--no-config"], ["capabilities", "list", "--json", "--no-config"], ["doctor", "--json", "--no-config"]): json.loads(invoke(binary, args, temp, env))
+
+
+def check_markdown(root):
+    paths = [root/"README.md", root/"README.en.md", root/"CONTRIBUTING.md", root/"CONTRIBUTING.en.md", *sorted((root/"docs").rglob("*.md"))]
+    if any(not x.is_file() for x in paths): raise CheckError("required bilingual documentation is missing")
+    for source in paths:
+        text = source.read_text(encoding="utf-8")
+        for phrase in STALE:
+            if phrase in text: raise CheckError(f"stale phrase in {source.relative_to(root)}: {phrase}")
+        for raw in LINK.findall(text):
+            target = raw.split(maxsplit=1)[0].strip("<>")
+            if not target or target.startswith(("#", "http://", "https://", "mailto:")): continue
+            relative = urllib.parse.unquote(target.split("#", 1)[0])
+            if relative and not (source.parent/relative).resolve().exists(): raise CheckError(f"broken link: {source.relative_to(root)} -> {relative}")
+    zh = (root/"README.md").read_text(encoding="utf-8"); en = (root/"README.en.md").read_text(encoding="utf-8")
+    for token in TOKENS:
+        if token not in zh or token not in en: raise CheckError(f"README contract drifted: {token}")
+    if FENCE.findall(zh) != FENCE.findall(en): raise CheckError("README command blocks differ")
+    for left, right in (("docs/user-guide.md","docs/user-guide.en.md"),("docs/cli-examples.md","docs/cli-examples.en.md"),("docs/plugin-development.md","docs/plugin-development.en.md"),("CONTRIBUTING.md","CONTRIBUTING.en.md")):
+        if left not in zh or right not in en: raise CheckError(f"README missing bilingual links: {left}, {right}")
+
+
+def main():
+    parser = argparse.ArgumentParser(); parser.add_argument("--into-md", required=True, type=pathlib.Path); parser.add_argument("--repository", type=pathlib.Path); args = parser.parse_args()
+    if args.repository: root = args.repository.resolve()
+    elif os.environ.get("TEST_SRCDIR"): root = (pathlib.Path(os.environ["TEST_SRCDIR"])/os.environ["TEST_WORKSPACE"]).resolve()
+    else: root = pathlib.Path(subprocess.run(["git","rev-parse","--show-toplevel"], check=True, capture_output=True, text=True).stdout.strip()).resolve()
+    binary = next((x.resolve() for x in (args.into_md, root/args.into_md, pathlib.Path.cwd()/args.into_md) if x.is_file()), None)
+    if binary is None: raise CheckError(f"into-md unavailable: {args.into_md}")
+    with tempfile.TemporaryDirectory(prefix="into-md-doc-user-") as user:
+        env = dict(os.environ); env["INTO_MARKDOWN_USER_DATA_HOME"] = user; env.pop("INTO_MARKDOWN_CONFIG", None)
+        check_markdown(root); check_examples(binary, root, env); check_real(binary, env)
+    print("documentation contract passed")
+
+
+if __name__ == "__main__":
+    try: main()
+    except (CheckError, json.JSONDecodeError, ValueError) as error:
+        print(f"docs-check: {error}", file=sys.stderr); raise SystemExit(1)


### PR DESCRIPTION
Closes #67

## Summary
- add equivalent Chinese and English command/format examples, installation and offline deployment guides, plugin development guides, and contribution guides
- align the README, CLI, format, testing, and release documentation with the current Core + capability-plugin + Agent Skill product
- add an executable documentation contract that discovers the real CLI command tree and live format catalog, checks bilingual coverage and links, and performs real TXT/stdin conversion

## Validation
- Agent Skill `quick_validate.py`
- `bazel test //tools/docs-check:docs_check_test //tools/skill-release:skill_release_test`
- `bazel build //:documentation`
- parsed documentation workflow and Agent Skill metadata with PyYAML
- `git diff --check`
- `cargo fmt --all -- --check`