### PR TITLE
fix(release): use canonical Rocky Linux image

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -25,12 +25,12 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             archive: into-md-linux-x86_64-core.tar.gz
-            container: docker.io/library/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
+            container: docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
             bazel_config: linux_x86_64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             archive: into-md-linux-arm64-core.tar.gz
-            container: docker.io/library/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
+            container: docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
             bazel_config: linux_arm64
           - runner: windows-2025
             target: x86_64-pc-windows-msvc

--- a/tools/platform-release/authority.json
+++ b/tools/platform-release/authority.json
@@ -8,7 +8,7 @@
       "architecture": "x86_64",
       "archive": "tar.gz",
       "buildBaseline": {
-        "container": "docker.io/library/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6",
+        "container": "docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6",
         "cpu": "x86-64",
         "glibcMaximum": "2.28",
         "kernelMinimum": "5.15"
@@ -32,7 +32,7 @@
       "architecture": "aarch64",
       "archive": "tar.gz",
       "buildBaseline": {
-        "container": "docker.io/library/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6",
+        "container": "docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6",
         "cpu": "armv8-a",
         "glibcMaximum": "2.28",
         "kernelMinimum": "5.15"

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -69,6 +69,12 @@ class PlatformReleaseTests(unittest.TestCase):
             if config["os"] == "linux":
                 self.assertEqual(baseline["glibcMaximum"], "2.28")
                 self.assertEqual(baseline["kernelMinimum"], "5.15")
+                self.assertTrue(
+                    baseline["container"].startswith(
+                        "docker.io/rockylinux/rockylinux:8.10@sha256:"
+                    ),
+                    (target, baseline["container"]),
+                )
                 self.assertRegex(baseline["container"], r"@sha256:[0-9a-f]{64}$")
             else:
                 self.assertRegex(baseline["msvcTools"], r"^\d+\.\d+\.\d+$")


### PR DESCRIPTION
The formal Linux release failed before checkout because the pinned Rocky Linux 8.10 digest belongs to the RESF-published ockylinux/rockylinux repository, not library/rockylinux. This keeps the exact multi-architecture digest and baseline while correcting the canonical namespace in both the workflow and release authority.\n\nValidation: 23 platform-release unit tests pass, including an exact namespace assertion.\n\nReference: https://hub.docker.com/layers/rockylinux/rockylinux/8.10