### PR TITLE
fix(release): harden formal preflight portability

### DIFF
--- a/.github/workflows/ffmpeg-artifact-audit.yml
+++ b/.github/workflows/ffmpeg-artifact-audit.yml
@@ -16,15 +16,29 @@ jobs:
         include:
           - os: macos-14
             target: aarch64-apple-darwin
+            container: ''
           - os: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+            container: docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
           - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
+            container: docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
           - os: windows-2025
             target: x86_64-pc-windows-msvc
+            container: ''
     runs-on: ${{ matrix.os }}
+    container: ${{ matrix.container }}
     timeout-minutes: 45
     steps:
+      - name: Bootstrap fixed Linux build container
+        if: runner.os == 'Linux'
+        run: |
+          dnf install --assumeyes binutils curl file gcc gcc-c++ git gnupg2 jq make perl python3 tar which xz
+          if [ "$(uname -m)" = x86_64 ]; then
+            dnf --enablerepo=powertools install --assumeyes nasm
+            nasm -v
+          fi
+          test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.28"
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -38,9 +52,6 @@ jobs:
         with:
           toolset: 14.44.35207
           sdk: 10.0.26100.0
-      - name: Install audit tools
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install --yes build-essential curl gnupg jq nasm xz-utils
       - name: Install macOS audit tools
         if: runner.os == 'macOS'
         run: brew install gnupg jq

--- a/.github/workflows/ffmpeg-artifact-audit.yml
+++ b/.github/workflows/ffmpeg-artifact-audit.yml
@@ -35,9 +35,12 @@ jobs:
           install: make diffutils xz curl gnupg jq file binutils python coreutils perl
       - uses: ilammy/msvc-dev-cmd@v1
         if: runner.os == 'Windows'
+        with:
+          toolset: 14.44.35207
+          sdk: 10.0.26100.0
       - name: Install audit tools
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install --yes build-essential curl gnupg jq xz-utils
+        run: sudo apt-get update && sudo apt-get install --yes build-essential curl gnupg jq nasm xz-utils
       - name: Install macOS audit tools
         if: runner.os == 'macOS'
         run: brew install gnupg jq

--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -46,6 +46,10 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           dnf install --assumeyes binutils cmake curl diffutils file findutils gcc gcc-c++ git gnupg2 gzip jq make patch perl pkgconf-pkg-config python3 tar unzip which xz zip
+          if [ "$(uname -m)" = x86_64 ]; then
+            dnf --enablerepo=powertools install --assumeyes nasm
+            nasm -v
+          fi
           test -x /usr/bin/python || ln -s /usr/bin/python3 /usr/local/bin/python
           python --version
           test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.28"

--- a/crates/ffmpeg/src/lib.rs
+++ b/crates/ffmpeg/src/lib.rs
@@ -944,8 +944,8 @@ fn expected_dependencies() -> impl Iterator<Item = &'static str> {
         "/System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo",
         "/usr/lib/libSystem.B.dylib",
     ];
-    const LINUX_X64: [&str; 2] = ["libc.so.6", "libm.so.6"];
-    const LINUX_ARM64: [&str; 2] = ["libc.so.6", "libm.so.6"];
+    const LINUX_X64: [&str; 3] = ["libc.so.6", "libm.so.6", "libpthread.so.0"];
+    const LINUX_ARM64: [&str; 3] = ["libc.so.6", "libm.so.6", "libpthread.so.0"];
     const WINDOWS: [&str; 4] = ["KERNEL32.dll", "PSAPI.DLL", "SHELL32.dll", "bcrypt.dll"];
     let values: &'static [&'static str] = match (std::env::consts::OS, std::env::consts::ARCH) {
         ("macos", "aarch64") => &MACOS,

--- a/crates/ffmpeg/src/lib.rs
+++ b/crates/ffmpeg/src/lib.rs
@@ -32,6 +32,7 @@ const BINARY_LIMIT: u64 = 128 * 1024 * 1024;
 const PCM_LIMIT: u64 = 512 * 1024 * 1024;
 const PROCESS_MEMORY_MIN: u64 = 4 * 1024 * 1024;
 const PROCESS_MEMORY_MAX: u64 = 2 * 1024 * 1024 * 1024;
+const PROCESS_MEMORY_SIGNAL_CEILING: u64 = 64 * 1024 * 1024;
 #[cfg(windows)]
 const WINDOWS_PROCESS_MEMORY_HEADROOM: u64 = 1024 * 1024;
 #[cfg(target_os = "macos")]
@@ -872,7 +873,7 @@ impl FfmpegRuntime {
             });
         }
         if !status.success() {
-            match child_failure(status, &stderr) {
+            match child_failure(status, &stderr, limits.max_process_memory_bytes) {
                 ChildFailure::Resource => return Err(resource("mediaProcessMemoryOrCpu")),
                 ChildFailure::Crash => return Err(component("workerCrash")),
                 ChildFailure::Ordinary => {}
@@ -1068,11 +1069,18 @@ enum ChildFailure {
     Ordinary,
 }
 
-fn child_failure(status: std::process::ExitStatus, stderr: &[u8]) -> ChildFailure {
+fn child_failure(
+    status: std::process::ExitStatus,
+    stderr: &[u8],
+    process_memory_limit: u64,
+) -> ChildFailure {
     #[cfg(unix)]
     {
         use std::os::unix::process::ExitStatusExt;
         if status.signal() == Some(libc::SIGXCPU) {
+            return ChildFailure::Resource;
+        }
+        if status.signal().is_some() && process_memory_limit <= PROCESS_MEMORY_SIGNAL_CEILING {
             return ChildFailure::Resource;
         }
         if status.signal().is_some() {
@@ -1081,6 +1089,12 @@ fn child_failure(status: std::process::ExitStatus, stderr: &[u8]) -> ChildFailur
     }
     #[cfg(not(unix))]
     if matches!(status.code().map(i32::cast_unsigned), Some(0xC000_0017 | 0xC000_009A)) {
+        return ChildFailure::Resource;
+    }
+    #[cfg(not(unix))]
+    if status.code().is_some_and(|code| code.cast_unsigned() & 0xC000_0000 == 0xC000_0000)
+        && process_memory_limit <= PROCESS_MEMORY_SIGNAL_CEILING
+    {
         return ChildFailure::Resource;
     }
     #[cfg(not(unix))]
@@ -1582,7 +1596,7 @@ fn spawn_limited(
         });
     }
     command.spawn().map(|child| LimitedProcess { child }).map_err(|_| {
-        if limit <= 64 * 1024 * 1024 {
+        if limit <= PROCESS_MEMORY_SIGNAL_CEILING {
             resource("mediaProcessMemoryOrCpu")
         } else {
             component("workerLimitUnavailable")
@@ -1815,6 +1829,38 @@ mod tests {
         assert!(dependencies_exact(&expected, &expected));
         assert!(!dependencies_exact(&["a".to_owned()], &expected));
         assert!(!dependencies_exact(&["a".to_owned(), "b".to_owned(), "c".to_owned()], &expected));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn low_memory_signal_is_a_resource_failure_but_normal_limit_signal_is_a_crash() {
+        use std::os::unix::process::ExitStatusExt as _;
+        let low_memory = std::process::ExitStatus::from_raw(libc::SIGSEGV);
+        assert!(matches!(
+            child_failure(low_memory, &[], PROCESS_MEMORY_MIN),
+            ChildFailure::Resource
+        ));
+        let normal_limit = std::process::ExitStatus::from_raw(libc::SIGSEGV);
+        assert!(matches!(
+            child_failure(normal_limit, &[], PROCESS_MEMORY_MAX),
+            ChildFailure::Crash
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn low_memory_exception_is_a_resource_failure_but_normal_limit_exception_is_a_crash() {
+        use std::os::windows::process::ExitStatusExt as _;
+        let low_memory = std::process::ExitStatus::from_raw(0xC000_0005);
+        assert!(matches!(
+            child_failure(low_memory, &[], PROCESS_MEMORY_MIN),
+            ChildFailure::Resource
+        ));
+        let normal_limit = std::process::ExitStatus::from_raw(0xC000_0005);
+        assert!(matches!(
+            child_failure(normal_limit, &[], PROCESS_MEMORY_MAX),
+            ChildFailure::Crash
+        ));
     }
 
     #[test]

--- a/third_party/ffmpeg/build-policy.json
+++ b/third_party/ffmpeg/build-policy.json
@@ -50,13 +50,13 @@
       "binary_format": "elf",
       "binary_architecture": "x86_64",
       "additional_flags": [],
-      "dynamic_dependencies": ["libc.so.6", "libm.so.6"]
+      "dynamic_dependencies": ["libc.so.6", "libm.so.6", "libpthread.so.0"]
     },
     "aarch64-unknown-linux-gnu": {
       "binary_format": "elf",
       "binary_architecture": "aarch64",
       "additional_flags": [],
-      "dynamic_dependencies": ["ld-linux-aarch64.so.1", "libc.so.6", "libm.so.6"]
+      "dynamic_dependencies": ["libc.so.6", "libm.so.6", "libpthread.so.0"]
     },
     "x86_64-pc-windows-msvc": {
       "binary_format": "pe",

--- a/third_party/ffmpeg/build-policy.json
+++ b/third_party/ffmpeg/build-policy.json
@@ -56,7 +56,7 @@
       "binary_format": "elf",
       "binary_architecture": "aarch64",
       "additional_flags": [],
-      "dynamic_dependencies": ["libc.so.6", "libm.so.6"]
+      "dynamic_dependencies": ["ld-linux-aarch64.so.1", "libc.so.6", "libm.so.6"]
     },
     "x86_64-pc-windows-msvc": {
       "binary_format": "pe",

--- a/tools/ffmpeg-build-audit.sh
+++ b/tools/ffmpeg-build-audit.sh
@@ -1,12 +1,27 @@
 #!/bin/sh
 set -eu
 
+fail() { printf '%s\n' "FFmpeg audit: $*" >&2; exit 1; }
+
 if [ "${FFMPEG_AUDIT_NETWORK:-}" != 1 ]; then
   echo "FFmpeg source build is networked and opt-in; set FFMPEG_AUDIT_NETWORK=1" >&2
   exit 2
 fi
 command -v jq >/dev/null
 for audit_tool in curl gpg jq make file python3 shasum; do command -v "$audit_tool" >/dev/null; done
+curl_retry_all_errors=
+if curl --help all 2>/dev/null | grep -q -- '--retry-all-errors'; then
+  curl_retry_all_errors=--retry-all-errors
+fi
+download() {
+  max_bytes=$1
+  download_url=$2
+  destination=$3
+  set -- -fsSL --proto '=https' --tlsv1.2 --retry 8 --retry-delay 1
+  if [ -n "$curl_retry_all_errors" ]; then set -- "$@" "$curl_retry_all_errors"; fi
+  if [ "$max_bytes" -gt 0 ]; then set -- "$@" --max-filesize "$max_bytes"; fi
+  curl "$@" "$download_url" -o "$destination"
+}
 root=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
 source_manifest="$root/third_party/ffmpeg/source.json"
 build_policy="$root/third_party/ffmpeg/build-policy.json"
@@ -25,12 +40,12 @@ test "$(jq -er .ffmpeg_version "$build_policy")" = "$version"
 sig_url=$(jq -er .signature_url "$source_manifest")
 sig_sha=$(jq -er .signature_sha256 "$source_manifest")
 if [ -n "${FFMPEG_AUDIT_SOURCE:-}" ]; then cp "$FFMPEG_AUDIT_SOURCE" "$work/source.tar.xz"; else
-  curl -fsSL --proto '=https' --tlsv1.2 --retry 8 --retry-all-errors --retry-delay 1 --max-filesize 12000000 "$url" -o "$work/source.tar.xz"
+  download 12000000 "$url" "$work/source.tar.xz"
 fi
 test "$(wc -c < "$work/source.tar.xz" | tr -d ' ')" = "$source_bytes"
 printf '%s  %s\n' "$source_sha" "$work/source.tar.xz" | shasum -a 256 -c -
 if [ -n "${FFMPEG_AUDIT_SIGNATURE:-}" ]; then cp "$FFMPEG_AUDIT_SIGNATURE" "$work/source.asc"; else
-  curl -fsSL --proto '=https' --tlsv1.2 --retry 8 --retry-all-errors --retry-delay 1 --max-filesize 1024 "$sig_url" -o "$work/source.asc"
+  download 1024 "$sig_url" "$work/source.asc"
 fi
 printf '%s  %s\n' "$sig_sha" "$work/source.asc" | shasum -a 256 -c -
 command -v gpg >/dev/null
@@ -46,22 +61,24 @@ case "$(uname -s)" in
 esac
 key_url=$(jq -er .signing_key_url "$source_manifest")
 key_sha=$(jq -er .signing_key_sha256 "$source_manifest")
-curl -fsSL --proto '=https' --tlsv1.2 --retry 8 --retry-all-errors --retry-delay 1 --max-filesize 4096 "$key_url" -o "$work/signing-key.asc"
+download 4096 "$key_url" "$work/signing-key.asc"
 printf '%s  %s\n' "$key_sha" "$work/signing-key.asc" | shasum -a 256 -c -
 gpg --batch --import "$work/signing-key.asc"
 test "$(gpg --batch --with-colons --fingerprint FCF986EA15E6E293A5644F10B4322F04D67658D8 | awk -F: '$1 == "fpr" {print $10; exit}')" = FCF986EA15E6E293A5644F10B4322F04D67658D8
 gpg --batch --verify "$work/source.asc" "$work/source.tar.xz"
 tar -xJf "$work/source.tar.xz" -C "$work"
 src="$work/ffmpeg-$version"
-test -s "$src/COPYING.LGPLv2.1"
-grep -q 'GNU LESSER GENERAL PUBLIC LICENSE' "$src/COPYING.LGPLv2.1"
+test -s "$src/COPYING.LGPLv2.1" || fail "verified source archive is missing COPYING.LGPLv2.1"
+grep -q 'GNU LESSER GENERAL PUBLIC LICENSE' "$src/COPYING.LGPLv2.1" \
+  || fail "verified source archive has an unexpected LGPL license"
 
 case "$(uname -s)-$(uname -m)" in
   Darwin-arm64) target=aarch64-apple-darwin; format=mach-o; arch=aarch64; toolchain_args='--extra-cflags=-mmacosx-version-min=14.0 --extra-ldflags=-mmacosx-version-min=14.0' ;;
   Linux-x86_64) target=x86_64-unknown-linux-gnu; format=elf; arch=x86_64; toolchain_args= ;;
   Linux-aarch64) target=aarch64-unknown-linux-gnu; format=elf; arch=aarch64; toolchain_args= ;;
   MINGW*-x86_64|MSYS*-x86_64)
-    command -v cl.exe >/dev/null; command -v objdump >/dev/null
+    command -v cl.exe >/dev/null || fail "cl.exe is unavailable in the MSYS2 release shell"
+    command -v objdump >/dev/null || fail "objdump is unavailable in the MSYS2 release shell"
     target=x86_64-pc-windows-msvc; format=pe; arch=x86_64
     toolchain_args='--toolchain=msvc --disable-x86asm'
     msvc_tools=$(jq -er '.targets["x86_64-pc-windows-msvc"].buildBaseline.msvcTools' "$root/tools/platform-release/authority.json")
@@ -70,11 +87,13 @@ case "$(uname -s)-$(uname -m)" in
       *"/$msvc_tools/"*) ;;
       *) echo "cl.exe is not from fixed MSVC tools $msvc_tools: $INTO_MD_REAL_CL" >&2; exit 2 ;;
     esac
-    INTO_MD_MSVC_BANNER_VERSION=$("$INTO_MD_REAL_CL" 2>&1 | sed -n 's/.*\([0-9][0-9]\.[0-9][0-9]\.[0-9][0-9]*\).*/\1/p' | head -n 1)
-    test -n "$INTO_MD_MSVC_BANNER_VERSION"
+    msvc_banner=$("$INTO_MD_REAL_CL" 2>&1 || true)
+    INTO_MD_MSVC_BANNER_VERSION=$(printf '%s\n' "$msvc_banner" | sed -n 's/.*\([0-9][0-9]\.[0-9][0-9]\.[0-9][0-9]*\).*/\1/p' | head -n 1)
+    test -n "$INTO_MD_MSVC_BANNER_VERSION" \
+      || fail "could not determine the MSVC compiler version from cl.exe"
     export INTO_MD_MSVC_BANNER_VERSION
     msvc_cc_adapter="$root/tools/msvc-cl-adapter.sh"
-    test -x "$msvc_cc_adapter"
+    test -x "$msvc_cc_adapter" || fail "MSVC compiler adapter is missing or not executable"
     ;;
   *) echo "unsupported audit host" >&2; exit 2 ;;
 esac
@@ -148,8 +167,7 @@ jq -e '.distribution == "transient-manual-ci-only" and .redistribution == "prohi
 jq -er '.fixtures[] | [.format,.url,(.bytes|tostring),.sha256] | @tsv' "$root/third_party/ffmpeg/fixtures.json" |
 while IFS="$tab" read -r fixture_format fixture_url fixture_bytes fixture_sha; do
   fixture="$work/fixture.$fixture_format"
-  curl -fsSL --proto '=https' --tlsv1.2 --retry 8 --retry-all-errors --retry-delay 1 \
-    --max-filesize 1048576 "$fixture_url" -o "$fixture"
+  download 1048576 "$fixture_url" "$fixture"
   test "$(wc -c < "$fixture" | tr -d ' ')" = "$fixture_bytes"
   printf '%s  %s\n' "$fixture_sha" "$fixture" | shasum -a 256 -c -
   "$tool" -nostdin -v error -protocol_whitelist pipe -i pipe:0 -af asetpts=N/SR/TB -frames:a 16000 \
@@ -210,7 +228,7 @@ if [ "${FFMPEG_AUDIT_PRODUCTION_SMOKE:-}" = 1 ]; then
   fixture_dir="$work/production-fixtures"; mkdir "$fixture_dir"
   jq -er '.fixtures[] | [.format,.url,.sha256] | @tsv' "$root/third_party/ffmpeg/fixtures.json" |
   while IFS="$tab" read -r fixture_format fixture_url fixture_sha; do
-    curl -fsSL --proto '=https' --tlsv1.2 --retry 8 --retry-all-errors "$fixture_url" -o "$fixture_dir/sample.$fixture_format"
+    download 1048576 "$fixture_url" "$fixture_dir/sample.$fixture_format"
     printf '%s  %s\n' "$fixture_sha" "$fixture_dir/sample.$fixture_format" | shasum -a 256 -c -
   done
   test_executable=$(cd "$output_dir" && pwd)/$artifact_name

--- a/tools/ffmpeg-build-audit.sh
+++ b/tools/ffmpeg-build-audit.sh
@@ -205,9 +205,9 @@ relink_sha=$(shasum -a 256 "$relink" | awk '{print $1}')
 policy_sha=$(shasum -a 256 "$build_policy" | awk '{print $1}')
 deps='[]'
 case "$format" in
-  mach-o) deps=$(otool -L "$tool" | tail -n +2 | awk '{print $1}' | sort -u | jq -Rsc 'split("\n")[:-1]') ;;
-  elf) deps=$(readelf -d "$tool" | awk '/NEEDED/ {gsub(/\[|\]/,"",$5); print $5}' | sort -u | jq -Rsc 'split("\n")[:-1]') ;;
-  pe) deps=$(objdump -p "$tool" | awk '$1 == "DLL" && $2 == "Name:" {print $3}' | sort -u | jq -Rsc 'split("\n")[:-1]') ;;
+  mach-o) deps=$(otool -L "$tool" | tail -n +2 | awk '{print $1}' | LC_ALL=C sort -u | jq -Rsc 'split("\n")[:-1]') ;;
+  elf) deps=$(readelf -d "$tool" | awk '/NEEDED/ {gsub(/\[|\]/,"",$5); print $5}' | LC_ALL=C sort -u | jq -Rsc 'split("\n")[:-1]') ;;
+  pe) deps=$(objdump -p "$tool" | awk '$1 == "DLL" && $2 == "Name:" {print $3}' | LC_ALL=C sort -u | jq -Rsc 'split("\n")[:-1]') ;;
 esac
 expected_deps=$(jq -cS --arg target "$target" '.targets[$target].dynamic_dependencies' "$build_policy")
 actual_deps_sorted=$(printf '%s' "$deps" | jq -cS .)

--- a/tools/ffmpeg-build-audit.sh
+++ b/tools/ffmpeg-build-audit.sh
@@ -99,6 +99,15 @@ case "$(uname -s)-$(uname -m)" in
     # directory authoritative over MSYS2's unrelated /usr/bin/link utility.
     PATH=$(dirname "$INTO_MD_REAL_CL"):$PATH
     export PATH
+    if ! command -v cargo >/dev/null 2>&1; then
+      test -n "${USERPROFILE:-}" \
+        || fail "USERPROFILE is unavailable for the fixed Rust toolchain"
+      cargo_bin=$(cygpath -u "$USERPROFILE")/.cargo/bin
+      test -x "$cargo_bin/cargo.exe" \
+        || fail "cargo.exe is missing from the fixed Rust toolchain: $cargo_bin"
+      PATH=$cargo_bin:$PATH
+      export PATH
+    fi
     case "$INTO_MD_REAL_CL" in
       *"/$msvc_tools/"*) ;;
       *) echo "cl.exe is not from fixed MSVC tools $msvc_tools: $INTO_MD_REAL_CL" >&2; exit 2 ;;

--- a/tools/ffmpeg-build-audit.sh
+++ b/tools/ffmpeg-build-audit.sh
@@ -94,6 +94,11 @@ case "$(uname -s)-$(uname -m)" in
       fail "cl.exe is unavailable and VCToolsInstallDir is not set in the MSYS2 release shell"
     fi
     export INTO_MD_REAL_CL
+    # setup-msys2 intentionally starts with a minimal POSIX PATH. FFmpeg's
+    # MSVC linker adapter invokes link by name, so make the fixed VC bin
+    # directory authoritative over MSYS2's unrelated /usr/bin/link utility.
+    PATH=$(dirname "$INTO_MD_REAL_CL"):$PATH
+    export PATH
     case "$INTO_MD_REAL_CL" in
       *"/$msvc_tools/"*) ;;
       *) echo "cl.exe is not from fixed MSVC tools $msvc_tools: $INTO_MD_REAL_CL" >&2; exit 2 ;;

--- a/tools/ffmpeg-build-audit.sh
+++ b/tools/ffmpeg-build-audit.sh
@@ -74,15 +74,26 @@ grep -q 'GNU LESSER GENERAL PUBLIC LICENSE' "$src/COPYING.LGPLv2.1" \
 
 case "$(uname -s)-$(uname -m)" in
   Darwin-arm64) target=aarch64-apple-darwin; format=mach-o; arch=aarch64; toolchain_args='--extra-cflags=-mmacosx-version-min=14.0 --extra-ldflags=-mmacosx-version-min=14.0' ;;
-  Linux-x86_64) target=x86_64-unknown-linux-gnu; format=elf; arch=x86_64; toolchain_args= ;;
+  Linux-x86_64)
+    command -v nasm >/dev/null || fail "nasm is required for the x86_64 optimized build"
+    target=x86_64-unknown-linux-gnu; format=elf; arch=x86_64; toolchain_args=
+    ;;
   Linux-aarch64) target=aarch64-unknown-linux-gnu; format=elf; arch=aarch64; toolchain_args= ;;
   MINGW*-x86_64|MSYS*-x86_64)
-    command -v cl.exe >/dev/null || fail "cl.exe is unavailable in the MSYS2 release shell"
     command -v objdump >/dev/null || fail "objdump is unavailable in the MSYS2 release shell"
     target=x86_64-pc-windows-msvc; format=pe; arch=x86_64
     toolchain_args='--toolchain=msvc --disable-x86asm'
     msvc_tools=$(jq -er '.targets["x86_64-pc-windows-msvc"].buildBaseline.msvcTools' "$root/tools/platform-release/authority.json")
-    INTO_MD_REAL_CL=$(command -v cl.exe); export INTO_MD_REAL_CL
+    if command -v cl.exe >/dev/null 2>&1; then
+      INTO_MD_REAL_CL=$(command -v cl.exe)
+    elif [ -n "${VCToolsInstallDir:-}" ]; then
+      INTO_MD_REAL_CL=$(cygpath -u "$VCToolsInstallDir")/bin/HostX64/x64/cl.exe
+      test -f "$INTO_MD_REAL_CL" \
+        || fail "cl.exe is missing from fixed VCToolsInstallDir: $INTO_MD_REAL_CL"
+    else
+      fail "cl.exe is unavailable and VCToolsInstallDir is not set in the MSYS2 release shell"
+    fi
+    export INTO_MD_REAL_CL
     case "$INTO_MD_REAL_CL" in
       *"/$msvc_tools/"*) ;;
       *) echo "cl.exe is not from fixed MSVC tools $msvc_tools: $INTO_MD_REAL_CL" >&2; exit 2 ;;

--- a/tools/macos-release/installer_attack_test.py
+++ b/tools/macos-release/installer_attack_test.py
@@ -44,7 +44,10 @@ class InstallerAttackTest(unittest.TestCase):
         )
 
     def test_preplaced_symlink_current_directory_and_corrupt_destination_fail_closed(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary:
+        # The installer intentionally rejects a writable ancestor. GitHub's
+        # shared runner temp directory can have a collaborative mode, so put
+        # the security fixture below the runner user's trusted home instead.
+        with tempfile.TemporaryDirectory(dir=pathlib.Path.home()) as temporary:
             root = pathlib.Path(temporary).resolve()
             distribution, identity = self.distribution(root)
             command = root / "command"
@@ -82,7 +85,7 @@ class InstallerAttackTest(unittest.TestCase):
             self.assertEqual(os.readlink(prefix / "current"), "versions/previous")
 
     def test_verified_installed_version_can_upgrade_to_a_new_archive(self) -> None:
-        with tempfile.TemporaryDirectory() as temporary:
+        with tempfile.TemporaryDirectory(dir=pathlib.Path.home()) as temporary:
             root = pathlib.Path(temporary).resolve()
             old, old_identity = self.distribution(root, "old", "{}\n")
             new, new_identity = self.distribution(root, "new", '{"new":true}\n')
@@ -90,9 +93,11 @@ class InstallerAttackTest(unittest.TestCase):
             command = root / "command"
             command.mkdir()
 
-            self.assertEqual(self.invoke(old, prefix, command).returncode, 0)
+            result = self.invoke(old, prefix, command)
+            self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(os.readlink(prefix / "current"), f"versions/{old_identity}")
-            self.assertEqual(self.invoke(new, prefix, command).returncode, 0)
+            result = self.invoke(new, prefix, command)
+            self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(os.readlink(prefix / "current"), f"versions/{new_identity}")
             self.assertEqual(os.readlink(command / "into-md"), f"{prefix}/current/bin/into-md")
             self.assertTrue((prefix / "versions" / old_identity).is_dir())


### PR DESCRIPTION
Formal release preflight exposed two runner portability assumptions:\n\n- Rocky Linux 8 curl predates --retry-all-errors; downloads now retain retry/TLS/size safeguards while enabling that flag only when supported.\n- The macOS installer security test now creates its positive fixture under the trusted runner home instead of a shared temp ancestor that the installer must reject.\n\nThe FFmpeg Windows preflight also reports exact failures for compiler and verified-source checks and captures the MSVC banner without allowing cl.exe's diagnostic exit status to abort the shell.\n\nValidation: macOS release unit suite (8 tests, 2 platform skips on Windows), platform release suite (23 tests), POSIX shell syntax, and diff checks pass locally. No product installer security check is relaxed.