### PR TITLE
fix(macos): preserve atomic immutable installer publish

### DIFF
--- a/.github/workflows/bazel-platform-toolchains.yml
+++ b/.github/workflows/bazel-platform-toolchains.yml
@@ -56,6 +56,11 @@ jobs:
           bazel test --config=${{ matrix.config }} --lockfile_mode=error
           //crates/core:core_test
           //toolchains:allocator_bridge_test
+      - name: Run macOS installer transaction security tests
+        if: matrix.config == 'macos_arm64'
+        run: >-
+          bazel test --config=macos_arm64 --lockfile_mode=error
+          //tools/macos-release:installer_attack_test
       - name: Prove the Rust-library allocator bridge is required
         if: matrix.config == 'macos_arm64'
         shell: bash

--- a/tools/macos-release/install
+++ b/tools/macos-release/install
@@ -78,7 +78,20 @@ else
   find "$temporary" -type l -o ! -type d ! -type f | grep . >/dev/null && fail "distribution contains an unsafe file type"
   "$temporary/bin/archive-check" "$temporary" || fail "installed copy integrity check failed"
   chmod -R a-w "$temporary"
-  mv "$temporary" "$destination"
+  # macOS denies renaming a directory whose own owner-write bit is clear,
+  # even when its parent is installer-owned and writable. Keep every child
+  # immutable, restore write only on the staging root for the atomic rename,
+  # then remove it again before publishing `current`.
+  chmod u+w "$temporary"
+  if ! mv "$temporary" "$destination"; then
+    chmod -R u+w "$temporary" 2>/dev/null || true
+    fail "cannot publish verified installed copy"
+  fi
+  if ! chmod u-w "$destination"; then
+    chmod -R u+w "$destination" 2>/dev/null || true
+    rm -rf "$destination" 2>/dev/null || true
+    fail "cannot make installed copy immutable"
+  fi
 fi
 
 check_absent_or_type "$prefix/current" "Symbolic Link"


### PR DESCRIPTION
## Summary
- keep the verified staging tree immutable while restoring owner-write only on its root for macOS atomic rename
- remove owner-write again before publishing `current`
- roll back safely if rename or final immutability fails

## Evidence
The formal macOS runner rejected `mv` after `chmod -R a-w` with `Permission denied` in run https://github.com/coolplayagent/into-markdown/actions/runs/32918213774. This change preserves the existing security boundary and fixes that macOS-specific transaction ordering.

## Validation
- `sh -n tools/macos-release/install`
- `git diff --check`

The protected macOS release workflow will be rerun on the resulting main commit before publishing.