### PR TITLE
fix(release): protect artifact redirect credentials

### DIFF
--- a/tools/platform-release/BUILD.bazel
+++ b/tools/platform-release/BUILD.bazel
@@ -68,3 +68,16 @@ py_test(
     main = "test_platform_tools.py",
     deps = [":platform_tools_library"],
 )
+
+py_library(
+    name = "public_audit_library",
+    srcs = ["public_audit.py"],
+    imports = ["."],
+)
+
+py_test(
+    name = "public_audit_test",
+    srcs = ["test_public_audit.py"],
+    main = "test_public_audit.py",
+    deps = [":public_audit_library"],
+)

--- a/tools/platform-release/public_audit.py
+++ b/tools/platform-release/public_audit.py
@@ -12,8 +12,34 @@ import re
 import subprocess
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import zipfile
+
+
+def origin(url: str) -> tuple[str, str, int | None]:
+    parsed = urllib.parse.urlsplit(url)
+    return parsed.scheme.lower(), (parsed.hostname or "").lower(), parsed.port
+
+
+class SafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Never forward the GitHub bearer token to cross-origin download hosts."""
+
+    def redirect_request(
+        self,
+        request: urllib.request.Request,
+        file_pointer: object,
+        code: int,
+        message: str,
+        headers: object,
+        new_url: str,
+    ) -> urllib.request.Request | None:
+        redirected = super().redirect_request(
+            request, file_pointer, code, message, headers, new_url
+        )
+        if redirected is not None and origin(request.full_url) != origin(new_url):
+            redirected.remove_header("Authorization")
+        return redirected
 
 
 def request(url: str, token: str) -> bytes:
@@ -28,7 +54,8 @@ def request(url: str, token: str) -> bytes:
     last: Exception | None = None
     for attempt in range(4):
         try:
-            with urllib.request.urlopen(value, timeout=120) as response:
+            opener = urllib.request.build_opener(SafeRedirectHandler())
+            with opener.open(value, timeout=120) as response:
                 return response.read()
         except urllib.error.HTTPError as error:
             if error.code < 500 or attempt == 3:

--- a/tools/platform-release/test_public_audit.py
+++ b/tools/platform-release/test_public_audit.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import urllib.request
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+from public_audit import SafeRedirectHandler
+
+
+class SafeRedirectHandlerTests(unittest.TestCase):
+    def redirect(self, destination: str) -> urllib.request.Request:
+        source = urllib.request.Request(
+            "https://api.github.com/repos/example/project/actions/artifacts/1/zip",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": "Bearer official-release-token",
+            },
+        )
+        redirected = SafeRedirectHandler().redirect_request(
+            source, None, 302, "Found", {}, destination
+        )
+        assert redirected is not None
+        return redirected
+
+    def test_cross_origin_artifact_redirect_drops_authorization(self) -> None:
+        redirected = self.redirect(
+            "https://productionresultssa.blob.core.windows.net/actions-results/"
+            "artifact.zip?sig=pre-signed"
+        )
+        self.assertIsNone(redirected.get_header("Authorization"))
+        self.assertEqual(
+            redirected.get_header("Accept"), "application/vnd.github+json"
+        )
+
+    def test_same_origin_redirect_keeps_authorization(self) -> None:
+        redirected = self.redirect(
+            "https://api.github.com/repositories/1/actions/artifacts/1/zip"
+        )
+        self.assertEqual(
+            redirected.get_header("Authorization"),
+            "Bearer official-release-token",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- strip the GitHub bearer token from cross-origin Actions log/artifact redirects
- retain authentication for same-origin GitHub API redirects
- add a Bazel regression test for both redirect paths

## Validation
- `python tools/platform-release/test_public_audit.py`
- `bazelisk.exe test //tools/platform-release:public_audit_test --test_output=errors`

This unblocks the public release-readiness audit, which previously failed with Azure HTTP 401 after the GitHub artifact endpoint redirected to a pre-signed blob URL. The full Git history scan in that failed run completed with zero findings.