### PR TITLE
feat(release): publish installable unsigned platform artifacts

### DIFF
--- a/.github/workflows/macos-arm64-release.yml
+++ b/.github/workflows/macos-arm64-release.yml
@@ -7,6 +7,14 @@ on:
         description: GitHub draft release tag that will contain the Core and two target-qualified .imp files
         required: true
         type: string
+      signing_mode:
+        description: External publisher signing policy; unsigned uses ad-hoc Mach-O signatures and is not notarized
+        required: true
+        default: unsigned
+        type: choice
+        options:
+          - unsigned
+          - signed
 
 permissions:
   contents: read
@@ -50,7 +58,7 @@ jobs:
       - name: Validate release assembly and metadata contracts
         run: |
           python3 -m unittest discover -s tools/macos-release -p '*test.py'
-          python3 -m unittest tools.publish_release_assets_test tools.release_metadata_test
+          python3 -m unittest tools.publish_release_assets_test tools.release_metadata_test tools.release_signing_policy_test
       - name: Build audited LGPL FFmpeg runtime
         env:
           FFMPEG_AUDIT_NETWORK: "1"
@@ -84,6 +92,7 @@ jobs:
             cmp "$RUNNER_TEMP/plugins-a/$package.imp" "$RUNNER_TEMP/plugins-b/$package.imp"
           done
       - name: Import protected Apple signing and notarization credentials
+        if: inputs.signing_mode == 'signed'
         env:
           APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -110,6 +119,7 @@ jobs:
             -k "$RELEASE_KEYCHAIN_PASSWORD" "$RUNNER_TEMP/release.keychain-db"
           security list-keychains -d user -s "$RUNNER_TEMP/release.keychain-db"
       - name: Assemble Developer ID signed release artifacts
+        if: inputs.signing_mode == 'signed'
         env:
           APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
           PLUGIN_BASE_URL: https://github.com/${{ github.repository }}/releases/download/${{ inputs.release_tag }}
@@ -117,25 +127,50 @@ jobs:
           set -eu
           test -n "$APPLE_CODESIGN_IDENTITY"
           PYTHONPATH=tools/macos-release python3 tools/macos-release/release.py \
-            --output "$RUNNER_TEMP/core-stage-signed" \
+            --output "$RUNNER_TEMP/core-stage-final" \
             --cache "$RUNNER_TEMP/release-cache" \
             --build-root "$RUNNER_TEMP/build-a" \
             --skip-build \
             --ffmpeg-artifacts "$RUNNER_TEMP/ffmpeg-audit" \
             --plugin-signing-key "$RUNNER_TEMP/official-plugin-signing-key.pk8" \
             --plugin-base-url "$PLUGIN_BASE_URL" \
-            --plugins-output "$RUNNER_TEMP/plugins-signed" \
+            --plugins-output "$RUNNER_TEMP/plugins-final" \
             --archive "$RUNNER_TEMP/into-md-macos-arm64-core-signed.tar.gz" \
             --codesign-identity "$APPLE_CODESIGN_IDENTITY"
           hdiutil create -quiet -fs HFS+ -format UDZO \
             -volname "into-markdown" \
-            -srcfolder "$RUNNER_TEMP/core-stage-signed" \
+            -srcfolder "$RUNNER_TEMP/core-stage-final" \
             "$RUNNER_TEMP/into-md-macos-arm64-core.dmg"
           /usr/bin/codesign --force --sign "$APPLE_CODESIGN_IDENTITY" \
             --timestamp --options runtime "$RUNNER_TEMP/into-md-macos-arm64-core.dmg"
           /usr/bin/codesign --verify --strict --verbose=2 \
             "$RUNNER_TEMP/into-md-macos-arm64-core.dmg"
+      - name: Assemble installable unsigned release artifacts
+        if: inputs.signing_mode == 'unsigned'
+        env:
+          PLUGIN_BASE_URL: https://github.com/${{ github.repository }}/releases/download/${{ inputs.release_tag }}
+        run: |
+          set -eu
+          PYTHONPATH=tools/macos-release python3 tools/macos-release/release.py \
+            --output "$RUNNER_TEMP/core-stage-final" \
+            --cache "$RUNNER_TEMP/release-cache" \
+            --build-root "$RUNNER_TEMP/build-a" \
+            --skip-build \
+            --ffmpeg-artifacts "$RUNNER_TEMP/ffmpeg-audit" \
+            --plugin-signing-key "$RUNNER_TEMP/official-plugin-signing-key.pk8" \
+            --plugin-base-url "$PLUGIN_BASE_URL" \
+            --plugins-output "$RUNNER_TEMP/plugins-final" \
+            --archive "$RUNNER_TEMP/into-md-macos-arm64-core-unsigned.tar.gz" \
+            --codesign-identity "-"
+          hdiutil create -quiet -fs HFS+ -format UDZO \
+            -volname "into-markdown" \
+            -srcfolder "$RUNNER_TEMP/core-stage-final" \
+            "$RUNNER_TEMP/into-md-macos-arm64-core.dmg"
+          /usr/bin/codesign --force --sign - "$RUNNER_TEMP/into-md-macos-arm64-core.dmg"
+          /usr/bin/codesign --verify --strict --verbose=2 \
+            "$RUNNER_TEMP/into-md-macos-arm64-core.dmg"
       - name: Notarize Core and two capability plugins
+        if: inputs.signing_mode == 'signed'
         env:
           APPLE_NOTARY_KEY_ID: ${{ secrets.APPLE_NOTARY_KEY_ID }}
           APPLE_NOTARY_ISSUER_ID: ${{ secrets.APPLE_NOTARY_ISSUER_ID }}
@@ -149,17 +184,24 @@ jobs:
             --issuer "$APPLE_NOTARY_ISSUER_ID" --wait
           xcrun stapler staple "$RUNNER_TEMP/into-md-macos-arm64-core.dmg"
           xcrun stapler validate "$RUNNER_TEMP/into-md-macos-arm64-core.dmg"
-          core_sha=$(shasum -a 256 "$RUNNER_TEMP/into-md-macos-arm64-core.dmg" | awk '{print $1}')
-          printf '%s  %s\n' "$core_sha" "into-md-macos-arm64-core.dmg" \
-            > "$RUNNER_TEMP/into-md-macos-arm64-core.dmg.sha256"
           for package in official.ocr.ppocrv6 official.media.whisper; do
-            cp "$RUNNER_TEMP/plugins-signed/$package.imp" "$RUNNER_TEMP/$package.zip"
+            cp "$RUNNER_TEMP/plugins-final/$package.imp" "$RUNNER_TEMP/$package.zip"
             xcrun notarytool submit "$RUNNER_TEMP/$package.zip" \
               --key "$RUNNER_TEMP/notary-key.p8" \
               --key-id "$APPLE_NOTARY_KEY_ID" \
               --issuer "$APPLE_NOTARY_ISSUER_ID" --wait
             rm "$RUNNER_TEMP/$package.zip"
           done
+      - name: Record final Core digest and external signing policy
+        run: |
+          core_sha=$(shasum -a 256 "$RUNNER_TEMP/into-md-macos-arm64-core.dmg" | awk '{print $1}')
+          printf '%s  %s\n' "$core_sha" "into-md-macos-arm64-core.dmg" \
+            > "$RUNNER_TEMP/into-md-macos-arm64-core.dmg.sha256"
+          python3 tools/release-signing-policy.py \
+            --target aarch64-apple-darwin \
+            --mode "${{ inputs.signing_mode }}" \
+            --source-revision "${{ github.sha }}" \
+            --output "$RUNNER_TEMP/aarch64-apple-darwin-signing-policy.json"
       - name: Generate and externally validate release SBOMs
         run: |
           set -eu
@@ -167,7 +209,7 @@ jobs:
           mount="$RUNNER_TEMP/core-dmg-readonly"
           mkdir "$mount"
           python3 tools/publish_release_assets.py \
-            --source "$RUNNER_TEMP/plugins-signed" \
+            --source "$RUNNER_TEMP/plugins-final" \
             --output "$RUNNER_TEMP/published-plugins" \
             --target aarch64-apple-darwin
           hdiutil attach -readonly -nobrowse -mountpoint "$mount" \
@@ -191,7 +233,7 @@ jobs:
             638fd9bd8be61901316eb6d063574e16d5403a1870073ec4d9241426a997501a
           python3 -m pip install "$wheel"
           for document in "$metadata"/*.spdx.json; do pyspdxtools -i "$document"; done
-      - name: Verify notarized clean install and plugin lifecycle
+      - name: Verify final clean install and plugin lifecycle
         run: |
           mkdir -p "$HOME/.agents/skills/existing-skill"
           printf '%s\n' 'preserve user-owned skill' > "$HOME/.agents/skills/existing-skill/SENTINEL"
@@ -213,8 +255,8 @@ jobs:
           signer_id=$(jq -r '.signingKeyId' "$installed/share/into-markdown/plugins/official-publisher.json")
           signer_sha=$(jq -r '.signingKeySha256' "$installed/share/into-markdown/plugins/official-publisher.json")
           for package in official.ocr.ppocrv6 official.media.whisper; do
-            sha=$(shasum -a 256 "$RUNNER_TEMP/plugins-signed/$package.imp" | awk '{print $1}')
-            "$installed/bin/into-md" plugins install "$RUNNER_TEMP/plugins-signed/$package.imp" \
+            sha=$(shasum -a 256 "$RUNNER_TEMP/plugins-final/$package.imp" | awk '{print $1}')
+            "$installed/bin/into-md" plugins install "$RUNNER_TEMP/plugins-final/$package.imp" \
               --sha256 "$sha" --signing-key-id "$signer_id" \
               --signing-key-sha256 "$signer_sha" --scope global
             "$installed/bin/into-md" plugins verify "$package" --scope global
@@ -249,11 +291,13 @@ jobs:
             ${{ runner.temp }}/published-plugins/*
             ${{ runner.temp }}/into-md-macos-arm64-core-smoke.json
             ${{ runner.temp }}/release-metadata/*
+            ${{ runner.temp }}/aarch64-apple-darwin-signing-policy.json
           if-no-files-found: error
-      - name: Add notarized macOS assets to the protected draft release
+      - name: Add final macOS assets to the protected draft release
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
+          SIGNING_MODE: ${{ inputs.signing_mode }}
         run: |
           set -eu
           publish="$RUNNER_TEMP/publish"
@@ -263,16 +307,24 @@ jobs:
           cp "$RUNNER_TEMP/published-plugins"/* "$publish"/
           cp "$RUNNER_TEMP/into-md-macos-arm64-core-smoke.json" \
             "$publish/aarch64-apple-darwin-installed-smoke.json"
+          cp "$RUNNER_TEMP/aarch64-apple-darwin-signing-policy.json" "$publish/"
           for document in "$RUNNER_TEMP"/release-metadata/*; do
             cp "$document" "$publish/${document##*/}"
           done
+          if [ "$SIGNING_MODE" = unsigned ]; then
+            title="Into Markdown $RELEASE_TAG [UNSIGNED]"
+            notes="Core plus target-specific OCR and speech plugins. UNSIGNED distribution: verify every SHA-256 sidecar before installing. Windows may show Unknown publisher or SmartScreen warnings; macOS may require Open Anyway or quarantine removal after digest verification. Plugin packages retain internal Ed25519 manifest signatures. Draft until Linux, Windows, and macOS release gates all pass."
+          else
+            title="Into Markdown $RELEASE_TAG"
+            notes="Core plus target-specific OCR and speech plugins. External publisher signatures are enabled. Draft until Linux, Windows, and macOS release gates all pass."
+          fi
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             test "$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)" = true
           else
             gh release create "$RELEASE_TAG" --draft --target "${{ github.sha }}" \
-              --title "Into Markdown $RELEASE_TAG" \
-              --notes "Core plus target-specific OCR and speech plugins. Draft until Linux, Windows, and macOS release gates all pass."
+              --title "$title" --notes "$notes"
           fi
+          gh release edit "$RELEASE_TAG" --title "$title" --notes "$notes"
           gh release upload "$RELEASE_TAG" "$publish"/* --clobber
       - name: Remove release credentials
         if: always()

--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -7,6 +7,14 @@ on:
         description: GitHub draft release tag that will contain every target's Core and two .imp files
         required: true
         type: string
+      signing_mode:
+        description: External publisher signing policy; unsigned remains installable but triggers OS trust warnings
+        required: true
+        default: unsigned
+        type: choice
+        options:
+          - unsigned
+          - signed
 
 permissions:
   contents: read
@@ -112,16 +120,22 @@ jobs:
           umask 077
           test -n "$PLUGIN_SIGNING_KEY_BASE64"
           printf '%s' "$PLUGIN_SIGNING_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/plugin-key.pk8"
-      - name: Decode protected signing material
+      - name: Decode protected plugin signing key on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         env:
           PLUGIN_SIGNING_KEY_BASE64: ${{ secrets.PLUGIN_SIGNING_KEY_BASE64 }}
+        run: |
+          if (-not $env:PLUGIN_SIGNING_KEY_BASE64) { throw "plugin signing key is absent" }
+          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\plugin-key.pk8", [Convert]::FromBase64String($env:PLUGIN_SIGNING_KEY_BASE64))
+      - name: Import protected Windows signing material
+        if: runner.os == 'Windows' && inputs.signing_mode == 'signed'
+        shell: pwsh
+        env:
           WINDOWS_SIGNING_PFX_BASE64: ${{ secrets.WINDOWS_SIGNING_PFX_BASE64 }}
           WINDOWS_SIGNING_PFX_PASSWORD: ${{ secrets.WINDOWS_SIGNING_PFX_PASSWORD }}
         run: |
-          if (-not $env:PLUGIN_SIGNING_KEY_BASE64 -or -not $env:WINDOWS_SIGNING_PFX_BASE64 -or -not $env:WINDOWS_SIGNING_PFX_PASSWORD) { throw "release signing material is absent" }
-          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\plugin-key.pk8", [Convert]::FromBase64String($env:PLUGIN_SIGNING_KEY_BASE64))
+          if (-not $env:WINDOWS_SIGNING_PFX_BASE64 -or -not $env:WINDOWS_SIGNING_PFX_PASSWORD) { throw "Windows signing material is absent" }
           [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\release-signing.pfx", [Convert]::FromBase64String($env:WINDOWS_SIGNING_PFX_BASE64))
           $password = ConvertTo-SecureString $env:WINDOWS_SIGNING_PFX_PASSWORD -AsPlainText -Force
           $certificate = Import-PfxCertificate -FilePath "$env:RUNNER_TEMP\release-signing.pfx" -CertStoreLocation Cert:\CurrentUser\My -Password $password
@@ -147,12 +161,12 @@ jobs:
           "INTO_MD_PLUGIN_PROCESS_FIXTURE=$PWD\target\${{ matrix.target }}\debug\plugin_manager_process_fixture.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Run target-native Cargo, Clippy, and Bazel gates
         run: |
-          python -m unittest tools.platform-release.test_release tools.platform-release.test_platform_tools tools.publish_release_assets_test tools.release_metadata_test
+          python -m unittest tools.platform-release.test_release tools.platform-release.test_platform_tools tools.publish_release_assets_test tools.release_metadata_test tools.release_signing_policy_test
           cargo test --workspace --all-targets --locked -- --test-threads=1
           cargo clippy --workspace --exclude whisper-rs --all-targets --no-deps --locked -- -D clippy::correctness -D clippy::suspicious -D clippy::perf
           bazel --output_user_root="${{ runner.temp }}/bazel" test --config=${{ matrix.bazel_config }} --lockfile_mode=error //...
       - name: Authenticode-sign project executables
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && inputs.signing_mode == 'signed'
         shell: pwsh
         run: |
           $names = @("into-md.exe", "installed-smoke.exe", "archive-check.exe", "into-md-installer.exe", "into-md-ocr-provider.exe", "into-md-media-provider.exe", "onnxruntime-worker.exe")
@@ -184,7 +198,7 @@ jobs:
           Remove-Item "${{ runner.temp }}\core-a", "${{ runner.temp }}\core-b", "${{ runner.temp }}\plugins-a", "${{ runner.temp }}\plugins-b" -Recurse -Force
           Remove-Item "${{ runner.temp }}\${{ matrix.archive }}.a", "${{ runner.temp }}\${{ matrix.archive }}.a.sha256", "${{ runner.temp }}\${{ matrix.archive }}.b", "${{ runner.temp }}\${{ matrix.archive }}.b.sha256" -Force
       - name: Assemble Authenticode release artifacts
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && inputs.signing_mode == 'signed'
         shell: pwsh
         run: >-
           python tools/platform-release/release.py
@@ -199,11 +213,27 @@ jobs:
           --plugins-output "${{ runner.temp }}/plugins-a"
           --archive "${{ runner.temp }}/${{ matrix.archive }}"
           --windows-signing-thumbprint $env:WINDOWS_SIGNING_THUMBPRINT
+      - name: Assemble unsigned Windows release artifacts
+        if: runner.os == 'Windows' && inputs.signing_mode == 'unsigned'
+        shell: pwsh
+        run: >-
+          python tools/platform-release/release.py
+          --target ${{ matrix.target }}
+          --build-root "${{ runner.temp }}/build"
+          --skip-build
+          --cache "${{ runner.temp }}/cache"
+          --ffmpeg-artifacts ffmpeg-audit-output
+          --plugin-signing-key "${{ runner.temp }}/plugin-key.pk8"
+          --plugin-base-url "https://github.com/${{ github.repository }}/releases/download/${{ inputs.release_tag }}"
+          --output "${{ runner.temp }}/core-final"
+          --plugins-output "${{ runner.temp }}/plugins-a"
+          --archive "${{ runner.temp }}/${{ matrix.archive }}"
       - name: Clean-install and verify all capabilities
         if: runner.os == 'Linux'
         env:
           INTO_MARKDOWN_USER_DATA_HOME: ${{ runner.temp }}/clean-user-data
         run: |
+          mkdir -m 700 "$INTO_MARKDOWN_USER_DATA_HOME"
           mkdir -p "$HOME/.agents/skills/existing-skill"
           printf '%s\n' 'preserve user-owned skill' > "$HOME/.agents/skills/existing-skill/SENTINEL"
           cp -R "$HOME/.agents/skills" "${{ runner.temp }}/agent-skills-before"
@@ -248,6 +278,11 @@ jobs:
         env:
           INTO_MARKDOWN_USER_DATA_HOME: ${{ runner.temp }}\clean-user-data
         run: |
+          New-Item -ItemType Directory -Path $env:INTO_MARKDOWN_USER_DATA_HOME | Out-Null
+          $identity = "$env:USERDOMAIN\$env:USERNAME"
+          & "$env:SystemRoot\System32\icacls.exe" $env:INTO_MARKDOWN_USER_DATA_HOME /inheritance:r /grant:r "${identity}:(OI)(CI)F" | Out-Null
+          if ($LASTEXITCODE -ne 0) { throw "cannot protect isolated user-data directory" }
+          $env:INTO_MARKDOWN_USER_DATA_HOME = "\\?\$((Resolve-Path $env:INTO_MARKDOWN_USER_DATA_HOME).Path)"
           $agentSkills = "$HOME\.agents\skills"
           New-Item -ItemType Directory -Force "$agentSkills\existing-skill" | Out-Null
           Set-Content -NoNewline "$agentSkills\existing-skill\SENTINEL" "preserve user-owned skill"
@@ -264,7 +299,7 @@ jobs:
           $agentSkillsBefore = @(Get-AgentSkillTree $agentSkills)
           Expand-Archive -LiteralPath "${{ runner.temp }}\${{ matrix.archive }}" -DestinationPath "${{ runner.temp }}\distribution"
           & "${{ runner.temp }}\distribution\bin\archive-check.exe" "${{ runner.temp }}\distribution"
-          python tools/platform-release/audit.py --target "${{ matrix.target }}" --core-root "${{ runner.temp }}\distribution" --plugins "${{ runner.temp }}\plugins-a" --report "${{ runner.temp }}\platform-audit.json"
+          python tools/platform-release/audit.py --target "${{ matrix.target }}" --core-root "${{ runner.temp }}\distribution" --plugins "${{ runner.temp }}\plugins-a" --report "${{ runner.temp }}\platform-audit.json" --windows-signing-mode "${{ inputs.signing_mode }}"
           & "${{ runner.temp }}\distribution\Install.ps1" -Prefix "${{ runner.temp }}\install" -CommandDirectory "${{ runner.temp }}\bin"
           & "${{ runner.temp }}\distribution\Install.ps1" -Prefix "${{ runner.temp }}\install" -CommandDirectory "${{ runner.temp }}\bin"
           if (Compare-Object $agentSkillsBefore @(Get-AgentSkillTree $agentSkills)) { throw "Core installer modified the Agent Skills directory" }
@@ -326,7 +361,7 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "installed platform acceptance failed" }
           & "$distribution\Uninstall.ps1" -Prefix "${{ runner.temp }}\accept-install" -CommandDirectory "${{ runner.temp }}\accept-bin"
       - name: Sign Linux release artifacts
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && inputs.signing_mode == 'signed'
         env:
           RELEASE_GPG_PRIVATE_KEY_BASE64: ${{ secrets.RELEASE_GPG_PRIVATE_KEY_BASE64 }}
           RELEASE_GPG_KEY_FINGERPRINT: ${{ secrets.RELEASE_GPG_KEY_FINGERPRINT }}
@@ -337,6 +372,13 @@ jobs:
           printf '%s' "$RELEASE_GPG_PRIVATE_KEY_BASE64" | base64 --decode | gpg --batch --import
           test "$(gpg --batch --with-colons --fingerprint "$RELEASE_GPG_KEY_FINGERPRINT" | awk -F: '$1 == "fpr" {print $10; exit}')" = "$RELEASE_GPG_KEY_FINGERPRINT"
           for artifact in "${{ runner.temp }}/${{ matrix.archive }}" "${{ runner.temp }}/plugins-a/"*.imp; do gpg --batch --local-user "$RELEASE_GPG_KEY_FINGERPRINT" --detach-sign --armor "$artifact"; done
+      - name: Record external signing policy
+        run: >-
+          python tools/release-signing-policy.py
+          --target ${{ matrix.target }}
+          --mode ${{ inputs.signing_mode }}
+          --source-revision "${{ github.sha }}"
+          --output "${{ runner.temp }}/${{ matrix.target }}-signing-policy.json"
       - name: Materialize target-qualified public plugin assets
         run: >-
           python tools/publish_release_assets.py
@@ -371,6 +413,7 @@ jobs:
             ${{ runner.temp }}/platform-audit.json
             ${{ runner.temp }}/installed-smoke.json
             ${{ runner.temp }}/platform-acceptance.json
+            ${{ runner.temp }}/${{ matrix.target }}-signing-policy.json
           if-no-files-found: error
       - name: Remove Windows signing credentials
         if: always() && runner.os == 'Windows'
@@ -398,6 +441,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.release_tag }}
+          SIGNING_MODE: ${{ inputs.signing_mode }}
         run: |
           set -eu
           publish="$RUNNER_TEMP/publish"
@@ -409,15 +453,23 @@ jobs:
             for report in platform-audit.json installed-smoke.json platform-acceptance.json; do
               cp "$directory/$report" "$publish/$target-$report"
             done
+            cp "$directory/$target-signing-policy.json" "$publish/"
             for document in "$directory"/release-metadata/*; do
               cp "$document" "$publish/${document##*/}"
             done
           done
+          if [ "$SIGNING_MODE" = unsigned ]; then
+            title="Into Markdown $RELEASE_TAG [UNSIGNED]"
+            notes="Core plus target-specific OCR and speech plugins. UNSIGNED distribution: verify every SHA-256 sidecar before installing. Windows may show Unknown publisher or SmartScreen warnings; macOS may require Open Anyway or quarantine removal after digest verification. Plugin packages retain internal Ed25519 manifest signatures. Draft until Linux, Windows, and macOS release gates all pass."
+          else
+            title="Into Markdown $RELEASE_TAG"
+            notes="Core plus target-specific OCR and speech plugins. External publisher signatures are enabled. Draft until Linux, Windows, and macOS release gates all pass."
+          fi
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             test "$(gh release view "$RELEASE_TAG" --json isDraft --jq .isDraft)" = true
           else
             gh release create "$RELEASE_TAG" --draft --target "${{ github.sha }}" \
-              --title "Into Markdown $RELEASE_TAG" \
-              --notes "Core plus target-specific OCR and speech plugins. Draft until Linux, Windows, and macOS release gates all pass."
+              --title "$title" --notes "$notes"
           fi
+          gh release edit "$RELEASE_TAG" --title "$title" --notes "$notes"
           gh release upload "$RELEASE_TAG" "$publish"/* --clobber

--- a/docs/license-governance.md
+++ b/docs/license-governance.md
@@ -182,12 +182,14 @@ plugins on all four supported targets. Component generation can run before targe
 bytes exist; finalization binds its executable, build authority, source and relink members, while
 strict archive verification remains fail-closed when checked-in FFmpeg approval is required.
 
-`finalize` consumes the signed or notarized artifact hash, exact member hashes and ownership, source
+`finalize` consumes the final installable artifact hash (after external signing/notarization when
+enabled), exact member hashes and ownership, source
 revision, and observed build tools. Member SHA-256 remains the release integrity authority; the
 SPDX sidecar additionally records the required SHA-1 and package verification code. It emits
 `<artifact>.spdx.json`, `<artifact>.sources.json`, and
 `<artifact>.THIRD_PARTY_NOTICES.md`. Core tar/ZIP members come from an `archive-check`-verified
-extraction; macOS members come from a read-only mount of the stapled DMG; `.imp` members must agree
+extraction; macOS members come from a read-only mount of the final DMG (stapled in signed mode);
+`.imp` members must agree
 in both directions with `plugin.json` and `provider.json` inventories.
 
 `aggregate` requires exactly Core plus the OCR and media plugins. Its `core` profile

--- a/docs/licensing.md
+++ b/docs/licensing.md
@@ -141,7 +141,8 @@ FFmpeg 还必须由可复现配置检查证明只启用 LGPL-compatible 组件�
 `npm-release.spdx.json`；SBOM 是发布物的一部分，不是仅供 CI 使用的中间文件。
 统一 `release-projection` 对 Core 与两个能力插件分别生成 SPDX 2.3、`SOURCES.json` 和第三方
 声明，并对 Core 归档清单、最终解包成员以及插件签名/runtime inventory 做双向逐文件检查。
-签名、公证或 stapling 后的最终构件再生成 artifact sidecar；四个平台的聚合 release set
+最终构件（signed 模式在签名、公证或 stapling 后，unsigned 模式在可安装归档完成后）再生成
+artifact sidecar；四个平台的聚合 release set
 明确区分仅 Core 与 Core 加两个插件的完整离线集合。
 
 ## Wasmtime WASI runtime

--- a/docs/macos-arm64-release.md
+++ b/docs/macos-arm64-release.md
@@ -5,7 +5,7 @@
 
 Apple silicon 每个版本固定发布四个独立构件：
 
-- `into-md-macos-arm64-core.dmg`：Developer ID 签名、Apple 公证并 stapling 的 `into-md`、Document IR、管理界面、PDFium、安装器、Core SBOM 与许可材料；
+- `into-md-macos-arm64-core.dmg`：包含 `into-md`、Document IR、管理界面、PDFium、安装器、Core SBOM 与许可材料；外部身份由同目标 signing policy 说明；
 - `official.ocr.ppocrv6-aarch64-apple-darwin.imp`：OCR provider、ONNX Runtime、worker、PP-OCRv6 检测/识别模型与字典；
 - `official.media.whisper-aarch64-apple-darwin.imp`：语音 provider、FFmpeg、ONNX Runtime、worker、Whisper、VAD 与说话人模型；
 - `into-markdown-skill.zip`：平台无关的 Agent Skill，另附 SHA-256，并以相同字节内置于 Core。
@@ -35,16 +35,26 @@ PYTHONPATH=tools/macos-release python3 tools/macos-release/release.py \
 
 本地命令输出用于确定性门禁的 Core tar 与两个包内 ID 不变的 `.imp`；发布到 GitHub Release 时
 文件名增加 `-aarch64-apple-darwin`，与 Core 内官方发布者 URL 完全一致。平台无关的 skill 工作流独立生成两次 ZIP、
-逐字节比较并重新验证内容。正式发布工作流先对两次未注入发布凭据的干净构建逐字节比较，再从已验证的同一构建产物生成 Developer ID 签名版本；Core 装入 DMG 后提交 Apple 公证并 stapling，两个插件分别以 ZIP 载体提交公证。最终发布 DMG、两个 `.imp`、skill ZIP 及各自 SHA-256。
+逐字节比较并重新验证内容。正式发布工作流先对两次未注入外部身份凭据的干净构建逐字节比较，
+再从已验证的同一构建产物生成最终版本。`signing_mode=unsigned` 是默认路径：Mach-O 和 DMG
+使用 ad-hoc 签名以保持 Apple silicon 可执行性，但不提交 Apple 公证；`signed` 路径保持
+Developer ID、可信时间戳、公证与 stapling。两个模式都发布 DMG、两个 `.imp`、skill ZIP、
+各自 SHA-256 和 `aarch64-apple-darwin-signing-policy.json`。
 
-公证和 stapling 完成后，工作流以只读方式重新挂载最终 DMG，先运行其中的 `archive-check`，
+最终 DMG 生成（signed 模式还包括公证和 stapling）后，工作流以只读方式重新挂载，先运行其中的 `archive-check`，
 再从实际挂载成员生成最终 Core sidecar。两个 `.imp` 从最终 ZIP 成员生成 sidecar，并与已签名
 package/runtime inventory 双向核对。每个构件发布 `.spdx.json`、`.sources.json`、
 `.THIRD_PARTY_NOTICES.md`；目标级 release set 分别表达仅 Core 与 Core 加两个插件的完整离线集合，
 不创建额外的完整离线归档。所有 SPDX 2.3 JSON 由固定版本与 wheel 哈希的官方 `spdx-tools`
 执行完整校验。
 
-发布凭据由 GitHub 受保护的 `release` environment 注入：Developer ID Application 证书、临时 keychain 密码、App Store Connect API key 与插件 Ed25519 私钥都必须非空。工作流结束时删除 keychain 和凭据文件；缺少任一凭据会失败关闭。项目 Mach-O、FFmpeg 与 PDFium 的发布副本在 manifest/SBOM 哈希生成前签名；已具备有效上游 Developer ID 签名的 ONNX Runtime 保留其供应商签名。workflow dispatch 使用与 Linux/Windows 相同的 `release_tag`，只向受保护 draft release 补齐已公证 DMG、两个目标限定插件及报告；四个平台复核前不公开 draft。
+插件 Ed25519 私钥由 GitHub 受保护的 `release` environment 注入，两种模式都必须非空，因为
+插件管理器用它验证 `.imp` 清单。只有 `signed` 模式才读取 Developer ID Application 证书、临时
+keychain 密码和 App Store Connect API key；缺少任一对应凭据会失败。unsigned 模式无需 Apple
+开发者账号，工作流结束时仍删除所有临时密钥文件。项目 Mach-O、FFmpeg 与 PDFium 的最终副本
+在 manifest/SBOM 哈希前完成所选模式的 codesign；已具备有效上游 Developer ID 签名的 ONNX
+Runtime 保留供应商签名。workflow dispatch 使用与 Linux/Windows 相同的 `release_tag` 和
+`signing_mode`，向受保护 draft release 补齐 DMG、两个目标限定插件、signing policy 及报告。
 
 ## 安装与能力管理
 
@@ -61,10 +71,10 @@ into-md capabilities list
 
 ## 验证
 
-发布验证必须从只读挂载的已公证 Core DMG 和空用户目录开始，随后通过公开 CLI/Web 流程安装两个插件。门禁检查：
+发布验证必须从只读挂载的最终 Core DMG 和空用户目录开始，随后通过公开 CLI/Web 流程安装两个插件。门禁检查：
 
 - Core 与两个插件分别具有签名/哈希/SBOM/许可证据；
-- Core DMG 的公证票据和 stapling 验证通过，两个插件的独立公证提交均为 Accepted；
+- signing policy 与 dispatch 模式一致；signed 模式验证公证票据、stapling 和两个插件的独立公证，unsigned 模式验证 ad-hoc code signature 且报告明确给出 Gatekeeper 安装提示；
 - Core inventory 不出现 `ffmpeg`、`onnxruntime` 或 `models`，DOC/PPT/XLS 目录状态为 Core `available`；
 - Core 清单包含完整 Agent Skill，且内置副本与独立 skill ZIP 逐文件一致；
 - 插件安装、更新、校验、禁用、修复、卸载和离线重启；

--- a/docs/platform-modular-release.md
+++ b/docs/platform-modular-release.md
@@ -1,6 +1,6 @@
 # Linux 与 Windows 模块化发布
 
-最终用户应按[安装与部署指南](user-guide.md)校验签名与摘要、安装 Core、离线导入能力插件并
+最终用户应按[安装与部署指南](user-guide.md)校验 signing policy 与摘要、安装 Core、离线导入能力插件并
 排障；本文描述跨平台发布装配与验收权威。
 
 Linux x86_64、Linux ARM64 与 Windows x86_64 和 macOS ARM64 使用相同产品边界：一个包含
@@ -9,7 +9,8 @@ Office 97–2003 原生解析的 Core 归档，以及 `official.ocr.ppocrv6`、`
 SBOM、签名清单和目标平台声明。
 
 每个最终 Core/插件构件同时发布以完整文件名为前缀的 `.spdx.json`、`.sources.json` 和
-`.THIRD_PARTY_NOTICES.md` sidecar，并保留既有 SHA-256 与签名。每个目标另有
+`.THIRD_PARTY_NOTICES.md` sidecar，并保留 SHA-256。每个目标另有 `*-signing-policy.json`，明确
+记录外部签名模式、发布者身份是否被操作系统验证及对应安装警告。每个目标另有
 `into-markdown-<target>-release-set.json` 和聚合 SPDX；其中 `core` 只引用 Core，
 `complete-offline` 引用 Core 与两个插件，不产生另一份重复归档。
 
@@ -26,11 +27,12 @@ DOC/PPT/XLS 真实文件转换并卸载。
 Linux 两个架构都在 `authority.json` 固定摘要的 Rocky Linux 8.10 原生容器中构建。发布契约是
 glibc 不高于 2.28、运行内核 5.15 以上；x86_64 使用通用 `x86-64`，ARM64 使用通用 ARMv8-A，
 组装器显式传递 `target-cpu`，不接受宿主 `native` 特性。Windows 固定 MSVC 14.44.35207 与
-Windows SDK 10.0.26100.0。`audit.py` 在签名后的真实成员上检查 ELF/PE 架构、GLIBC symbol
+Windows SDK 10.0.26100.0。`audit.py` 在最终真实成员上检查 ELF/PE 架构、GLIBC symbol
 ceiling、解释器、DT_NEEDED、RPATH/RUNPATH、文件模式、PE import 与项目二进制 Authenticode；
-报告作为 `platform-audit.json` 上传。
+在 unsigned 模式下还要求项目二进制没有意外混入外部 Authenticode 身份。报告作为
+`platform-audit.json` 上传。
 
-最终 sidecar 在 Authenticode 或 Linux detached signature 完成后生成。Core 成员来自最终
+最终 sidecar 从最终归档生成。Core 成员来自最终
 归档的干净解包目录，并先由归档内 `archive-check` 与 `archive-manifest.json` 双向核对；插件
 直接遍历最终 ZIP，并要求每个成员的大小和 SHA-256 同时匹配已签名 `plugin.json` 与
 `provider.json` runtime inventory。SPDX 2.3 JSON 还会由固定版本、固定 wheel SHA-256 的官方
@@ -54,14 +56,13 @@ python tools/platform-release/release.py \
   --archive /absolute/into-md-linux-x86_64-core.tar.gz
 ```
 
-Windows 工作流先对两次组装结果做逐字节比较，再从同一批已签名项目二进制生成最终构件。
-受保护的 PFX 只导入当前 runner 的临时 CurrentUser 证书存储，签名命令仅传递非敏感
-thumbprint；语音插件中的 FFmpeg 发布副本也在插件 manifest 哈希生成前执行 Authenticode
-与可信时间戳，插件内 authority 随签名字节重新绑定。Core 的 PDFium 保留固定上游字节，
-因此运行时仍可直接按仓库 authority 校验；ONNX Runtime 保留供应商签名。
-工作流结束后移除证书和 PFX。Linux 对 Core
-和每个 `.imp` 生成受保护 GPG 密钥的 detached signature。缺少发布凭据时工作流必须失败，
-不能用临时签名冒充公开发布签名。
+workflow dispatch 的 `signing_mode` 明确选择 `unsigned` 或 `signed`，默认是可安装的
+`unsigned`。unsigned 不读取 Windows PFX 或 Linux GPG secret；Windows 可能显示 Unknown
+publisher/SmartScreen，Linux 不生成 `.asc`。signed 模式保留原有路径：Windows 只把 PFX 导入
+runner 的临时 CurrentUser 证书存储，并在插件 manifest 哈希前完成项目二进制和 FFmpeg 的
+Authenticode 与可信时间戳；Linux 为 Core 和每个 `.imp` 生成 GPG detached signature。选择
+signed 却缺少对应凭据时必须失败。两种模式都保留内部 `.imp` Ed25519 签名，该密钥用于包清单
+完整性，不是操作系统发布者证书。Core 的 PDFium 保留固定上游字节，ONNX Runtime 保留供应商签名。
 
 Windows 的 OCR 与语音进程使用稳定的零 capability AppContainer 身份。插件管理器只给当前已
 验证、不可变的 runtime 快照授予读取和执行 ACL，并由 kill-on-close Job Object 持有整个进程树。
@@ -92,9 +93,10 @@ Actions 日志和历史 artifacts。任何发现先吊销/轮换并清理精确�
 转换可见性后立即恢复 main 保护、push ruleset、只读默认 token、fork 审批和受保护 `release`
 environment。当前发布 job 只接受 main 或 tag，并且正式凭据只通过该 environment 提供。
 
-正式 workflow dispatch 接收一个有界 `release_tag`，在 Core 的官方发布者记录中写入该 GitHub
+正式 workflow dispatch 接收有界 `release_tag` 和显式 `signing_mode`，在 Core 的官方发布者记录中写入该 GitHub
 Release 的不可变下载根。公开资产使用 `插件ID-目标.imp`，因此三个目标的同 ID 插件可以安全地
 共存于 GitHub Release 的平面命名空间；包内插件 ID 和本地 `.imp` 文件名保持不变。Linux、Windows
-job 全绿后，工作流只创建或更新受保护的 draft release，并同时上传 Core、签名、摘要、SBOM、
+job 全绿后，工作流只创建或更新受保护的 draft release，并同时上传 Core、可选外部签名、摘要、SBOM、
 来源、NOTICE、平台审计、installed-smoke 与 acceptance 报告。macOS 同提交的签名/公证工作流
-补齐自己的目标资产；只有四个平台全部通过并复核摘要后才把 draft 发布为公开 release。
+按同一 signing mode 补齐目标资产；只有四个平台全部通过并复核摘要后才把 draft 发布为公开 release。
+unsigned draft 的标题和说明必须显著标识 `UNSIGNED`，不能让用户误以为操作系统验证了发布者。

--- a/docs/user-guide.en.md
+++ b/docs/user-guide.en.md
@@ -3,8 +3,10 @@
 [中文](user-guide.md) · [CLI examples](cli-examples.en.md)
 
 A release contains one platform Core, two self-contained capability plugins, and the Agent Skill.
-Every Core/plugin has SHA-256, signature, SPDX, source, and notice sidecars. Combine only artifacts
-from the same version and target.
+Every Core/plugin has SHA-256, SPDX, source, and notice sidecars. Each target's
+`*-signing-policy.json` states whether an external publisher signature is present. The default release
+mode is `unsigned`: it is installable, but the operating system cannot verify the publisher identity.
+Both `.imp` files always retain internal Ed25519 manifest signatures and pinned SHA-256 values.
 
 | Capability | Artifact |
 | --- | --- |
@@ -18,24 +20,26 @@ external office suite.
 
 ## Install Core
 
-On macOS ARM64, verify digest, notarization, and mounted content before running the DMG installer:
+On macOS ARM64, verify the digest, then mount the DMG according to its signing policy:
 
 ```sh
 shasum -a 256 -c into-md-macos-arm64-core.dmg.sha256
-spctl --assess --type open --verbose=2 into-md-macos-arm64-core.dmg
+# For unsigned releases only, remove quarantine after the digest matches.
+xattr -d com.apple.quarantine into-md-macos-arm64-core.dmg 2>/dev/null || true
 hdiutil attach into-md-macos-arm64-core.dmg
-cd "/Volumes/Into Markdown"
+cd "/Volumes/into-markdown" # use the actual path printed by hdiutil
 ./bin/archive-check .
 ./install "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
 ```
 
-Use the volume name printed by `hdiutil`; macOS x86_64 is unsupported.
+Unsigned DMGs use ad-hoc Mach-O signatures for Apple silicon execution, but have no Developer ID or
+Apple notarization. Alternatively, keep quarantine and choose Open Anyway in Privacy & Security.
+Only a `signed` policy should pass `spctl --assess --type open --verbose=2`. macOS x86_64 is unsupported.
 
 On Linux, select the x86_64 or ARM64 archive matching `uname -m`:
 
 ```sh
 sha256sum -c into-md-linux-x86_64-core.tar.gz.sha256
-gpg --verify into-md-linux-x86_64-core.tar.gz.asc into-md-linux-x86_64-core.tar.gz
 mkdir into-md-core
 tar -xzf into-md-linux-x86_64-core.tar.gz -C into-md-core
 cd into-md-core
@@ -43,19 +47,24 @@ cd into-md-core
 ./install "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
 ```
 
-Use `into-md-linux-arm64-core.tar.gz` on ARM64. The installer never edits shell profiles.
+Use `into-md-linux-arm64-core.tar.gz` on ARM64. A `.asc` is present only for a `signed` policy; verify
+it with GPG in that mode. For unsigned releases, the SHA-256 sidecar adjacent to the GitHub Release
+asset is the pre-install authority. The installer never edits shell profiles.
 
-On Windows x86_64, verify the ZIP digest and Authenticode of project executables inside it:
+On Windows x86_64, verify the ZIP digest first. For an unsigned ZIP, remove its download mark only
+after that digest matches:
 
 ```powershell
 (Get-FileHash -Algorithm SHA256 .\into-md-windows-x86_64-core.zip).Hash
+Unblock-File .\into-md-windows-x86_64-core.zip
 Expand-Archive .\into-md-windows-x86_64-core.zip .\into-md-core
-Get-AuthenticodeSignature .\into-md-core\bin\into-md.exe | Format-List
 & .\into-md-core\bin\archive-check.exe .\into-md-core
-& .\into-md-core\Install.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\into-md-core\Install.ps1
 ```
 
-The digest must match the release sidecar and Authenticode `Status` must be `Valid`.
+The digest must match the release sidecar. Unknown publisher and SmartScreen warnings are expected
+for unsigned releases; never bypass them if the digest differs. Only a `signed` policy should be
+checked with `Get-AuthenticodeSignature`, whose `Status` must then be `Valid`.
 
 Repeating the same Linux or Windows install verifies and repairs that version instead of returning
 a conflict. An upgrade keeps the immutable old version and switches authority only after the new

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -3,7 +3,9 @@
 [English](user-guide.en.md) · [CLI 示例](cli-examples.md)
 
 正式发布由一个平台 Core、两个自包含能力插件和 Agent Skill 组成。每个 Core/插件同时发布
-SHA-256、签名、SPDX、来源与第三方声明 sidecar。只组合相同版本和目标平台的构件。
+SHA-256、SPDX、来源与第三方声明 sidecar；每个目标的 `*-signing-policy.json` 明确说明是否具有
+外部发布者签名。只组合相同版本和目标平台的构件。当前默认发布模式是 `unsigned`：可以安装，
+但操作系统不能验证发布者身份。两个 `.imp` 始终保留内部 Ed25519 清单签名和 SHA-256 固定。
 
 | 能力 | 构件 |
 | --- | --- |
@@ -16,24 +18,27 @@ Office 97–2003 的 `.doc/.ppt/.xls` 由 Core 原生解析，不调用 LibreOff
 
 ## 安装 Core
 
-macOS ARM64 校验摘要、公证与挂载内容后运行 DMG 根目录安装器：
+macOS ARM64 先校验摘要，再根据 signing policy 挂载 DMG 并运行根目录安装器：
 
 ```sh
 shasum -a 256 -c into-md-macos-arm64-core.dmg.sha256
-spctl --assess --type open --verbose=2 into-md-macos-arm64-core.dmg
+# unsigned 发布在摘要匹配后可移除下载隔离；signed 发布改用 spctl 验证
+xattr -d com.apple.quarantine into-md-macos-arm64-core.dmg 2>/dev/null || true
 hdiutil attach into-md-macos-arm64-core.dmg
-cd "/Volumes/Into Markdown"
+# 使用 hdiutil 输出的实际卷路径
+cd "/Volumes/into-markdown"
 ./bin/archive-check .
 ./install "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
 ```
 
-卷名以 `hdiutil` 输出为准；不支持 macOS x86_64。
+unsigned DMG 使用 ad-hoc Mach-O 签名保证 Apple silicon 可执行性，但没有 Developer ID 或 Apple
+公证；也可以保留 quarantine，并在“系统设置 → 隐私与安全”中选择“仍要打开”。只有 policy 为
+`signed` 时才应执行 `spctl --assess --type open --verbose=2` 并要求通过。不支持 macOS x86_64。
 
 Linux 选择与 `uname -m` 匹配的 x86_64 或 ARM64 归档：
 
 ```sh
 sha256sum -c into-md-linux-x86_64-core.tar.gz.sha256
-gpg --verify into-md-linux-x86_64-core.tar.gz.asc into-md-linux-x86_64-core.tar.gz
 mkdir into-md-core
 tar -xzf into-md-linux-x86_64-core.tar.gz -C into-md-core
 cd into-md-core
@@ -41,19 +46,23 @@ cd into-md-core
 ./install "$HOME/.local/share/into-markdown" "$HOME/.local/bin"
 ```
 
-ARM64 使用 `into-md-linux-arm64-core.tar.gz`。安装器不修改 shell profile。
+ARM64 使用 `into-md-linux-arm64-core.tar.gz`。只有 signing policy 为 `signed` 时才会发布 `.asc`，
+此时额外运行 `gpg --verify`；unsigned 模式以 GitHub Release 旁的 SHA-256 sidecar 为安装前校验
+权威。安装器不修改 shell profile。
 
-Windows x86_64 在 PowerShell 校验 ZIP 摘要及内部项目可执行文件的 Authenticode：
+Windows x86_64 在 PowerShell 先校验 ZIP 摘要；unsigned ZIP 只有在摘要匹配后才解除下载标记：
 
 ```powershell
 (Get-FileHash -Algorithm SHA256 .\into-md-windows-x86_64-core.zip).Hash
+Unblock-File .\into-md-windows-x86_64-core.zip
 Expand-Archive .\into-md-windows-x86_64-core.zip .\into-md-core
-Get-AuthenticodeSignature .\into-md-core\bin\into-md.exe | Format-List
 & .\into-md-core\bin\archive-check.exe .\into-md-core
-& .\into-md-core\Install.ps1
+powershell -NoProfile -ExecutionPolicy Bypass -File .\into-md-core\Install.ps1
 ```
 
-摘要必须匹配发布 sidecar，Authenticode `Status` 必须为 `Valid`。
+摘要必须匹配发布 sidecar。unsigned 发布会显示 `Unknown publisher` 或 SmartScreen 提示，这是预期
+行为；不要在摘要不匹配时绕过提示。只有 signing policy 为 `signed` 时才运行
+`Get-AuthenticodeSignature` 并要求 `Status` 为 `Valid`。
 
 Linux 和 Windows 重复运行同一安装命令会验证并修复相同版本，而不是返回冲突。升级保留旧的
 不可变版本，只有新归档完整校验后才切换。Windows PATH 中的 `into-md.exe` 是稳定 launcher，

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -17,3 +17,12 @@ py_test(
     ],
     main = "publish_release_assets_test.py",
 )
+
+py_test(
+    name = "release_signing_policy_test",
+    srcs = [
+        "release-signing-policy.py",
+        "release_signing_policy_test.py",
+    ],
+    main = "release_signing_policy_test.py",
+)

--- a/tools/platform-release/BUILD.bazel
+++ b/tools/platform-release/BUILD.bazel
@@ -24,7 +24,6 @@ py_library(
     srcs = [
         "acquire.py",
         "common.py",
-        "legacy_authority.py",
         "release.py",
     ],
     data = ["authority.json"],
@@ -48,7 +47,6 @@ py_library(
     srcs = [
         "audit.py",
         "common.py",
-        "legacy_authority.py",
         "platform_acceptance.py",
     ],
     imports = ["."],

--- a/tools/platform-release/audit.py
+++ b/tools/platform-release/audit.py
@@ -166,7 +166,7 @@ def audit_windows(
     root: pathlib.Path,
     expected_machine: str,
     audit: Audit,
-    allow_unsigned_test_artifacts: bool,
+    signing_mode: str,
 ) -> None:
     dumpbin = resolve_msvc_tool("dumpbin.exe")
     signtool = resolve_windows_sdk_tool("signtool.exe")
@@ -224,12 +224,12 @@ def audit_windows(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
             )
-            if allow_unsigned_test_artifacts and signature.returncode != 0:
-                audit.record(
+            if signing_mode == "unsigned":
+                audit.require(
                     relative,
-                    "authenticode-local-test-exemption",
-                    True,
-                    "unsigned local test artifact; production Authenticode was not evaluated",
+                    "authenticode-unsigned-distribution",
+                    signature.returncode != 0,
+                    "unsigned distribution must not carry an unexpected Authenticode identity",
                 )
             else:
                 audit.require(
@@ -246,7 +246,17 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--core-root", type=pathlib.Path, required=True)
     parser.add_argument("--plugins", type=pathlib.Path, required=True)
     parser.add_argument("--report", type=pathlib.Path, required=True)
-    parser.add_argument("--allow-unsigned-test-artifacts", action="store_true")
+    parser.add_argument(
+        "--windows-signing-mode",
+        choices=("signed", "unsigned"),
+        default="signed",
+        help="Expected Authenticode policy for Windows project binaries.",
+    )
+    parser.add_argument(
+        "--allow-unsigned-test-artifacts",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
     return parser.parse_args()
 
 
@@ -255,8 +265,13 @@ def run(
     core_root: pathlib.Path,
     plugins: pathlib.Path,
     *,
+    windows_signing_mode: str = "signed",
     allow_unsigned_test_artifacts: bool = False,
 ) -> dict[str, object]:
+    if windows_signing_mode not in {"signed", "unsigned"}:
+        raise ValueError(f"unsupported Windows signing mode: {windows_signing_mode}")
+    if allow_unsigned_test_artifacts:
+        windows_signing_mode = "unsigned"
     platform, machine = TARGETS[target]
     audit = Audit(target)
     artifacts: list[dict[str, str]] = []
@@ -277,16 +292,16 @@ def run(
             if platform == "linux":
                 audit_linux(root, machine, audit)
             else:
-                audit_windows(root, machine, audit, allow_unsigned_test_artifacts)
+                audit_windows(root, machine, audit, windows_signing_mode)
             audit.record(label, "platform-audit", True, "passed")
     finally:
         temporary.cleanup()
     return {
         "schemaVersion": 1,
         "target": target,
-        "testMode": {
-            "allowUnsignedArtifacts": allow_unsigned_test_artifacts,
-            "formalReleaseEligible": not allow_unsigned_test_artifacts,
+        "distributionSigning": {
+            "mode": windows_signing_mode if platform == "windows" else "not-audited",
+            "publisherIdentityVerified": windows_signing_mode == "signed" if platform == "windows" else None,
         },
         "artifacts": artifacts,
         "findings": [finding.__dict__ for finding in audit.findings],
@@ -302,6 +317,7 @@ def main() -> int:
             arguments.target,
             arguments.core_root.resolve(strict=True),
             arguments.plugins.resolve(strict=True),
+            windows_signing_mode=arguments.windows_signing_mode,
             allow_unsigned_test_artifacts=arguments.allow_unsigned_test_artifacts,
         )
     except Exception as error:

--- a/tools/platform-release/test_platform_tools.py
+++ b/tools/platform-release/test_platform_tools.py
@@ -20,6 +20,7 @@ from audit import (
     AuditFailure,
     clr_il_only,
     distributed_source_fixture,
+    run,
     safe_zip_extract,
 )
 from platform_acceptance import capability_map, repairable_payload_files, tree_hash
@@ -28,6 +29,15 @@ WINDOW_FLAGS = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
 
 
 class PlatformToolTests(unittest.TestCase):
+    def test_platform_audit_rejects_unknown_signing_mode_before_io(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported Windows signing mode"):
+            run(
+                "x86_64-pc-windows-msvc",
+                pathlib.Path("missing-core"),
+                pathlib.Path("missing-plugins"),
+                windows_signing_mode="surprise",
+            )
+
     def test_repair_fixture_never_corrupts_plugin_manager_authority(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             root = pathlib.Path(name)

--- a/tools/release-signing-policy.py
+++ b/tools/release-signing-policy.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Write a machine-readable statement of the external release signing policy."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+
+
+TARGET_POLICIES = {
+    "x86_64-unknown-linux-gnu": ("GPG detached signatures", "No GPG identity signature is included."),
+    "aarch64-unknown-linux-gnu": ("GPG detached signatures", "No GPG identity signature is included."),
+    "x86_64-pc-windows-msvc": ("Authenticode", "Windows may show Unknown publisher or SmartScreen warnings."),
+    "aarch64-apple-darwin": ("Developer ID and Apple notarization", "macOS may require Open Anyway or removal of quarantine after SHA-256 verification."),
+}
+
+
+def policy(target: str, mode: str, source_revision: str) -> dict[str, object]:
+    if target not in TARGET_POLICIES:
+        raise ValueError(f"unsupported target: {target}")
+    if mode not in {"signed", "unsigned"}:
+        raise ValueError(f"unsupported signing mode: {mode}")
+    mechanism, unsigned_warning = TARGET_POLICIES[target]
+    signed = mode == "signed"
+    return {
+        "schemaVersion": 1,
+        "target": target,
+        "sourceRevision": source_revision,
+        "mode": mode,
+        "installable": True,
+        "externalPublisherIdentityVerified": signed,
+        "externalSigningMechanism": mechanism if signed else None,
+        "warning": None if signed else unsigned_warning,
+        "pluginPackageIntegrity": "Ed25519 manifest signature and pinned SHA-256",
+    }
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--target", choices=sorted(TARGET_POLICIES), required=True)
+    parser.add_argument("--mode", choices=("signed", "unsigned"), required=True)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    result = policy(arguments.target, arguments.mode, arguments.source_revision)
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_signing_policy_test.py
+++ b/tools/release_signing_policy_test.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import unittest
+
+
+SOURCE = pathlib.Path(__file__).with_name("release-signing-policy.py")
+SPEC = importlib.util.spec_from_file_location("release_signing_policy", SOURCE)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ReleaseSigningPolicyTests(unittest.TestCase):
+    def test_unsigned_windows_policy_is_installable_and_explicit(self) -> None:
+        result = MODULE.policy("x86_64-pc-windows-msvc", "unsigned", "abc123")
+        self.assertTrue(result["installable"])
+        self.assertFalse(result["externalPublisherIdentityVerified"])
+        self.assertIn("Unknown publisher", result["warning"])
+        self.assertIn("Ed25519", result["pluginPackageIntegrity"])
+
+    def test_signed_macos_policy_records_external_identity(self) -> None:
+        result = MODULE.policy("aarch64-apple-darwin", "signed", "abc123")
+        self.assertTrue(result["externalPublisherIdentityVerified"])
+        self.assertEqual(result["externalSigningMechanism"], "Developer ID and Apple notarization")
+        self.assertIsNone(result["warning"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add explicit unsigned/signed external publisher modes to Linux, Windows, and macOS release workflows, defaulting to unsigned
- keep internal Ed25519 plugin manifest verification while making Authenticode, GPG, Developer ID, and notarization optional
- record signing policy per target and document safe unsigned installation
- prepare canonical protected Windows acceptance state before plugin installation

## Local verification
- Windows unsigned Core archive audit: 16,110 findings passed
- installed-smoke: 24/24 passed
- platform acceptance: 92/92 cases, 6/6 plugin matrix, 0 residual resources
- true install, repeat install, upgrade, OCR, speech, Web lifecycle, and uninstall exercised
- Python release tests: 23 passed
- docs contract: passed
- workflow YAML parsed successfully

Closes the remaining unsigned-release credential blocker for #134 and #135.