### PR TITLE
fix(release): use Python 3.11 in EL8 builders

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -53,13 +53,15 @@ jobs:
       - name: Bootstrap fixed Linux build container
         if: runner.os == 'Linux'
         run: |
-          dnf install --assumeyes binutils cmake curl diffutils file findutils gcc gcc-c++ git gnupg2 gzip jq make patch perl pkgconf-pkg-config python3 tar unzip which xz zip
+          dnf install --assumeyes binutils cmake curl diffutils file findutils gcc gcc-c++ git gnupg2 gzip jq make patch perl pkgconf-pkg-config python3.11 python3.11-pip tar unzip which xz zip
           if [ "$(uname -m)" = x86_64 ]; then
             dnf --enablerepo=powertools install --assumeyes nasm
             nasm -v
           fi
-          test -x /usr/bin/python || ln -s /usr/bin/python3 /usr/local/bin/python
+          ln -sf /usr/bin/python3.11 /usr/local/bin/python
+          ln -sf /usr/bin/python3.11 /usr/local/bin/python3
           python --version
+          python -c 'import sys; assert sys.version_info[:2] == (3, 11)'
           test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.28"
           python -c 'import os; assert tuple(map(int, os.uname().release.split("-")[0].split(".")[:2])) >= (5, 15)'
       - uses: actions/checkout@v4

--- a/docs/platform-modular-release.md
+++ b/docs/platform-modular-release.md
@@ -26,6 +26,7 @@ DOC/PPT/XLS 真实文件转换并卸载。
 
 Linux 两个架构都在 `authority.json` 固定摘要的 Rocky Linux 8.10 原生容器中构建。发布契约是
 glibc 不高于 2.28、运行内核 5.15 以上；x86_64 使用通用 `x86-64`，ARM64 使用通用 ARMv8-A，
+容器内固定使用 Rocky AppStream Python 3.11 执行发布工具，不能回退到 EL8 默认 Python 3.6。
 组装器显式传递 `target-cpu`，不接受宿主 `native` 特性。Windows 固定 MSVC 14.44.35207 与
 Windows SDK 10.0.26100.0。`audit.py` 在最终真实成员上检查 ELF/PE 架构、GLIBC symbol
 ceiling、解释器、DT_NEEDED、RPATH/RUNPATH、文件模式、PE import 与项目二进制 Authenticode；


### PR DESCRIPTION
Rocky Linux 8 defaults to Python 3.6, which cannot parse the release tooling. Install and pin AppStream Python 3.11 for both Linux release architectures while retaining Rocky 8/glibc 2.28. This fixes the ARM64 formal release failure in run 32933030805; x86_64 shares the same container bootstrap.