### PR TITLE
Harden native release failure recovery and diagnostics

### DIFF
--- a/tools/macos-release/acquire.py
+++ b/tools/macos-release/acquire.py
@@ -7,6 +7,7 @@ import os
 import pathlib
 import shutil
 import tarfile
+import urllib.error
 import urllib.parse
 import urllib.request
 
@@ -23,6 +24,7 @@ ALLOWED_HOSTS = {
     "release-assets.githubusercontent.com",
     "us.aws.cdn.hf.co",
 }
+DOWNLOAD_ATTEMPTS = 4
 
 
 def acquire(cache: pathlib.Path, selected: set[str] | None = None) -> None:
@@ -34,24 +36,41 @@ def acquire(cache: pathlib.Path, selected: set[str] | None = None) -> None:
         if destination.is_file() and validate(destination, item):
             continue
         temporary = destination.with_suffix(".download")
-        temporary.unlink(missing_ok=True)
-        request = urllib.request.Request(item["url"], headers={"User-Agent": "into-markdown-release/1"})
-        with urllib.request.urlopen(request, timeout=120) as response, temporary.open("xb") as output:
-            host = urllib.parse.urlparse(response.geturl()).hostname
-            if host not in ALLOWED_HOSTS:
-                raise ReleaseError("download redirected to an unauthorized host")
-            remaining = item["bytes"]
-            while remaining:
-                chunk = response.read(min(1024 * 1024, remaining + 1))
-                if not chunk or len(chunk) > remaining:
-                    raise ReleaseError(f"{item['id']} download size disagrees with authority")
-                output.write(chunk)
-                remaining -= len(chunk)
-            if response.read(1):
-                raise ReleaseError(f"{item['id']} download exceeds authority")
-        if not validate(temporary, item):
-            raise ReleaseError(f"{item['id']} download hash disagrees with authority")
-        os.replace(temporary, destination)
+        for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
+            temporary.unlink(missing_ok=True)
+            try:
+                request = urllib.request.Request(
+                    item["url"], headers={"User-Agent": "into-markdown-release/1"}
+                )
+                with urllib.request.urlopen(request, timeout=180) as response, temporary.open(
+                    "xb"
+                ) as output:
+                    parsed = urllib.parse.urlparse(response.geturl())
+                    if parsed.scheme != "https" or parsed.hostname not in ALLOWED_HOSTS:
+                        raise ReleaseError("download redirected to an unauthorized host")
+                    remaining = item["bytes"]
+                    while remaining:
+                        chunk = response.read(min(1024 * 1024, remaining + 1))
+                        if not chunk or len(chunk) > remaining:
+                            raise ReleaseError(
+                                f"{item['id']} download size disagrees with authority"
+                            )
+                        output.write(chunk)
+                        remaining -= len(chunk)
+                    if response.read(1):
+                        raise ReleaseError(f"{item['id']} download exceeds authority")
+            except (TimeoutError, urllib.error.URLError, OSError) as error:
+                temporary.unlink(missing_ok=True)
+                if attempt == DOWNLOAD_ATTEMPTS:
+                    raise ReleaseError(
+                        f"{item['id']} download failed after {DOWNLOAD_ATTEMPTS} attempts"
+                    ) from error
+                continue
+            if not validate(temporary, item):
+                temporary.unlink(missing_ok=True)
+                raise ReleaseError(f"{item['id']} download hash disagrees with authority")
+            os.replace(temporary, destination)
+            break
 
 
 def validate(path: pathlib.Path, item: dict) -> bool:

--- a/tools/macos-release/acquire_test.py
+++ b/tools/macos-release/acquire_test.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import pathlib
+import tempfile
+import unittest
+import urllib.error
+from unittest import mock
+
+import acquire
+
+
+class Response(io.BytesIO):
+    def geturl(self) -> str:
+        return "https://github.com/owner/repository/download/runtime"
+
+
+class AcquireTests(unittest.TestCase):
+    def test_transient_http_error_is_retried_and_verified(self) -> None:
+        payload = b"verified-runtime"
+        item = {
+            "id": "runtime",
+            "url": "https://github.com/owner/repository/download/runtime",
+            "bytes": len(payload),
+            "sha256": hashlib.sha256(payload).hexdigest(),
+        }
+        denied = urllib.error.HTTPError(item["url"], 403, "Forbidden", {}, None)
+        with tempfile.TemporaryDirectory() as temporary:
+            cache = pathlib.Path(temporary)
+            with mock.patch.object(acquire, "authority", return_value={"downloads": [item]}), mock.patch(
+                "urllib.request.urlopen", side_effect=[denied, Response(payload)]
+            ) as opened:
+                acquire.acquire(cache)
+            self.assertEqual(opened.call_count, 2)
+            self.assertEqual((cache / "runtime").read_bytes(), payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/macos-release/common.py
+++ b/tools/macos-release/common.py
@@ -62,8 +62,11 @@ def run(arguments: Iterable[str], *, cwd: pathlib.Path | None = None, env: dict 
         errors="replace",
     )
     if completed.returncode:
-        detail = completed.stderr.strip().splitlines()[-1:] or ["no diagnostic"]
-        raise ReleaseError(f"command failed ({command[0]}): {detail[0]}")
+        detail = completed.stderr.strip().splitlines()[-40:] or ["no diagnostic"]
+        rendered = "\n".join(detail)
+        raise ReleaseError(
+            f"command failed ({command[0]}, exit {completed.returncode}):\n{rendered}"
+        )
     return completed.stdout
 
 

--- a/tools/macos-release/common_test.py
+++ b/tools/macos-release/common_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import sys
+import unittest
+
+from common import ReleaseError, run
+
+
+class CommonTests(unittest.TestCase):
+    def test_command_failure_preserves_bounded_diagnostic_tail(self) -> None:
+        script = (
+            "import sys; "
+            "[print(f'diagnostic-{index}', file=sys.stderr) for index in range(45)]; "
+            "raise SystemExit(7)"
+        )
+        with self.assertRaises(ReleaseError) as raised:
+            run([sys.executable, "-c", script])
+        message = str(raised.exception)
+        self.assertIn("exit 7", message)
+        self.assertNotIn("diagnostic-4\n", message)
+        self.assertIn("diagnostic-5", message)
+        self.assertIn("diagnostic-44", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/platform-release/common.py
+++ b/tools/platform-release/common.py
@@ -72,8 +72,15 @@ def run(
         errors="replace",
     )
     if completed.returncode:
-        detail = completed.stderr.strip().splitlines()[-1:] or ["no diagnostic"]
-        raise ReleaseError(f"command failed ({command[0]}): {detail[0]}")
+        # Cargo and native linkers commonly finish with a generic summary such as
+        # "build failed, waiting for other jobs to finish". Preserve a bounded
+        # diagnostic tail so a hosted release failure exposes the actual compiler
+        # or linker error without flooding Actions logs with the entire build.
+        detail = completed.stderr.strip().splitlines()[-40:] or ["no diagnostic"]
+        rendered = "\n".join(detail)
+        raise ReleaseError(
+            f"command failed ({command[0]}, exit {completed.returncode}):\n{rendered}"
+        )
     return completed.stdout
 
 

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -12,7 +12,7 @@ import zipfile
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
-from common import authority, sha256
+from common import ReleaseError, authority, run, sha256
 from release import (
     CORE_COMPONENTS,
     OCR_COMPONENTS,
@@ -24,6 +24,20 @@ from release import (
 
 
 class PlatformReleaseTests(unittest.TestCase):
+    def test_command_failure_preserves_bounded_diagnostic_tail(self) -> None:
+        script = (
+            "import sys; "
+            "[print(f'diagnostic-{index}', file=sys.stderr) for index in range(45)]; "
+            "raise SystemExit(7)"
+        )
+        with self.assertRaises(ReleaseError) as raised:
+            run([sys.executable, "-c", script])
+        message = str(raised.exception)
+        self.assertIn("exit 7", message)
+        self.assertNotIn("diagnostic-4\n", message)
+        self.assertIn("diagnostic-5", message)
+        self.assertIn("diagnostic-44", message)
+
     def test_published_plugin_names_are_flat_and_target_unique(self) -> None:
         self.assertEqual(
             published_plugin_file("official.ocr.ppocrv6.imp", "x86_64-pc-windows-msvc"),


### PR DESCRIPTION
## Summary
- preserve the final 40 stderr lines and exit code from failed Linux, Windows, and macOS release commands
- retry transient macOS release input download failures four times while retaining HTTPS allowlist, exact-size, and SHA-256 verification
- identify exhausted downloads by authority ID without exposing arbitrary URLs
- cover both diagnostic contracts and the observed HTTP 403 recovery path

## Verification
- macOS release unit discovery: 10 passed (2 host-only skips)
- platform release suite: 24 passed
- git diff --check`n
The final unsigned release exposed two independent problems: Cargo's real Linux error was hidden behind its generic final warning, and the macOS runner received a transient HTTP 403 while acquiring a hash-pinned release input.