### PR TITLE
Fix Linux bindgen and resilient OCR release inputs

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -53,13 +53,16 @@ jobs:
       - name: Bootstrap fixed Linux build container
         if: runner.os == 'Linux'
         run: |
-          dnf install --assumeyes binutils cmake curl diffutils file findutils gcc gcc-c++ git gnupg2 gzip jq make patch perl pkgconf-pkg-config python3.11 python3.11-pip tar unzip which xz zip
+          dnf install --assumeyes binutils clang-libs cmake curl diffutils file findutils gcc gcc-c++ git gnupg2 gzip jq make patch perl pkgconf-pkg-config python3.11 python3.11-pip tar unzip which xz zip
           if [ "$(uname -m)" = x86_64 ]; then
             dnf --enablerepo=powertools install --assumeyes nasm
             nasm -v
           fi
           ln -sf /usr/bin/python3.11 /usr/local/bin/python
           ln -sf /usr/bin/python3.11 /usr/local/bin/python3
+          libclang_path="$(rpm -ql clang-libs | grep -E '/libclang\.so(\.[0-9]+)*$' | head -n 1)"
+          test -f "$libclang_path"
+          echo "LIBCLANG_PATH=$(dirname "$libclang_path")" >> "$GITHUB_ENV"
           python --version
           python -c 'import sys; assert sys.version_info[:2] == (3, 11)'
           test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.28"

--- a/tools/macos-release/acquire.py
+++ b/tools/macos-release/acquire.py
@@ -36,11 +36,13 @@ def acquire(cache: pathlib.Path, selected: set[str] | None = None) -> None:
         if destination.is_file() and validate(destination, item):
             continue
         temporary = destination.with_suffix(".download")
+        urls = [item["url"], *item.get("mirror_urls", [])]
         for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
             temporary.unlink(missing_ok=True)
             try:
                 request = urllib.request.Request(
-                    item["url"], headers={"User-Agent": "into-markdown-release/1"}
+                    urls[(attempt - 1) % len(urls)],
+                    headers={"User-Agent": "into-markdown-release/1"},
                 )
                 with urllib.request.urlopen(request, timeout=180) as response, temporary.open(
                     "xb"

--- a/tools/macos-release/acquire_test.py
+++ b/tools/macos-release/acquire_test.py
@@ -21,7 +21,10 @@ class AcquireTests(unittest.TestCase):
         payload = b"verified-runtime"
         item = {
             "id": "runtime",
-            "url": "https://github.com/owner/repository/download/runtime",
+            "url": "https://paddle-model-ecology.bj.bcebos.com/runtime",
+            "mirror_urls": [
+                "https://github.com/owner/repository/download/runtime"
+            ],
             "bytes": len(payload),
             "sha256": hashlib.sha256(payload).hexdigest(),
         }
@@ -33,6 +36,10 @@ class AcquireTests(unittest.TestCase):
             ) as opened:
                 acquire.acquire(cache)
             self.assertEqual(opened.call_count, 2)
+            self.assertEqual(
+                opened.call_args_list[1].args[0].full_url,
+                item["mirror_urls"][0],
+            )
             self.assertEqual((cache / "runtime").read_bytes(), payload)
 
 

--- a/tools/macos-release/authority.json
+++ b/tools/macos-release/authority.json
@@ -21,12 +21,18 @@
     {
       "id": "ocr-detector",
       "url": "https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_tiny_det_onnx_infer.tar",
+      "mirror_urls": [
+        "https://huggingface.co/LunarOilRig/paddleocr-onnx/resolve/e6fe11fd12923086bb6f7e7742891920ff77a208/PP-OCRv6_tiny_det_onnx_infer.tar"
+      ],
       "bytes": 1792000,
       "sha256": "ff6ab415b0a6e0c488550f2fb5d5046f1719848df220b2dc21b56402a65bc05d"
     },
     {
       "id": "ocr-recognizer",
       "url": "https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_tiny_rec_onnx_infer.tar",
+      "mirror_urls": [
+        "https://huggingface.co/LunarOilRig/paddleocr-onnx/resolve/e6fe11fd12923086bb6f7e7742891920ff77a208/PP-OCRv6_tiny_rec_onnx_infer.tar"
+      ],
       "bytes": 4526080,
       "sha256": "1e13b22717b1edd89d4cde4fda272b6c17d5b505c97c2baea99da1a3a2d54b29"
     },

--- a/tools/platform-release/acquire.py
+++ b/tools/platform-release/acquire.py
@@ -37,9 +37,10 @@ def acquire(cache: pathlib.Path, downloads: dict[str, dict]) -> None:
             continue
         temporary = destination.with_suffix(".download")
         temporary.unlink(missing_ok=True)
+        urls = [item["url"], *item.get("mirror_urls", [])]
         for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
             try:
-                download_once(identity, item, temporary)
+                download_once(identity, item, temporary, urls[(attempt - 1) % len(urls)])
             except (IncompleteDownload, TimeoutError, urllib.error.URLError, OSError) as error:
                 if attempt == DOWNLOAD_ATTEMPTS:
                     temporary.unlink(missing_ok=True)
@@ -54,13 +55,15 @@ def acquire(cache: pathlib.Path, downloads: dict[str, dict]) -> None:
             break
 
 
-def download_once(identity: str, item: dict, temporary: pathlib.Path) -> None:
+def download_once(
+    identity: str, item: dict, temporary: pathlib.Path, url: str
+) -> None:
     expected = item.get("bytes")
     offset = temporary.stat().st_size if temporary.exists() else 0
     headers = {"User-Agent": "into-markdown-release/1"}
     if offset:
         headers["Range"] = f"bytes={offset}-"
-    request = urllib.request.Request(item["url"], headers=headers)
+    request = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(request, timeout=180) as response:
         parsed = urllib.parse.urlparse(response.geturl())
         if parsed.scheme != "https" or parsed.hostname not in ALLOWED_HOSTS:

--- a/tools/platform-release/authority.json
+++ b/tools/platform-release/authority.json
@@ -78,11 +78,17 @@
   "sharedDownloads": {
     "ocr-detector": {
       "url": "https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_tiny_det_onnx_infer.tar",
+      "mirror_urls": [
+        "https://huggingface.co/LunarOilRig/paddleocr-onnx/resolve/e6fe11fd12923086bb6f7e7742891920ff77a208/PP-OCRv6_tiny_det_onnx_infer.tar"
+      ],
       "bytes": 1792000,
       "sha256": "ff6ab415b0a6e0c488550f2fb5d5046f1719848df220b2dc21b56402a65bc05d"
     },
     "ocr-recognizer": {
       "url": "https://paddle-model-ecology.bj.bcebos.com/paddlex/official_inference_model/paddle3.0.0/PP-OCRv6_tiny_rec_onnx_infer.tar",
+      "mirror_urls": [
+        "https://huggingface.co/LunarOilRig/paddleocr-onnx/resolve/e6fe11fd12923086bb6f7e7742891920ff77a208/PP-OCRv6_tiny_rec_onnx_infer.tar"
+      ],
       "bytes": 4526080,
       "sha256": "1e13b22717b1edd89d4cde4fda272b6c17d5b505c97c2baea99da1a3a2d54b29"
     },

--- a/tools/platform-release/test_acquire.py
+++ b/tools/platform-release/test_acquire.py
@@ -3,6 +3,7 @@ import io
 import pathlib
 import tempfile
 import unittest
+import urllib.error
 from unittest import mock
 
 from acquire import acquire
@@ -19,6 +20,28 @@ class Response(io.BytesIO):
 
 
 class AcquireTests(unittest.TestCase):
+    def test_http_failure_falls_back_to_hash_equivalent_mirror(self):
+        expected = b"mirrored artifact"
+        item = {
+            "url": "https://paddle-model-ecology.bj.bcebos.com/artifact",
+            "mirror_urls": ["https://github.com/example/artifact"],
+            "bytes": len(expected),
+            "sha256": hashlib.sha256(expected).hexdigest(),
+        }
+        denied = urllib.error.HTTPError(item["url"], 403, "Forbidden", {}, None)
+        with tempfile.TemporaryDirectory() as name:
+            root = pathlib.Path(name)
+            with mock.patch(
+                "urllib.request.urlopen", side_effect=[denied, Response(expected)]
+            ) as opened:
+                acquire(root, {"runtime": item})
+            self.assertEqual(opened.call_count, 2)
+            self.assertEqual(
+                opened.call_args_list[1].args[0].full_url,
+                item["mirror_urls"][0],
+            )
+            self.assertEqual((root / "runtime").read_bytes(), expected)
+
     def test_retries_truncated_response_and_publishes_only_verified_bytes(self):
         expected = b"complete artifact"
         item = {

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -12,7 +12,7 @@ import zipfile
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
-from common import ReleaseError, authority, run, sha256
+from common import ROOT, ReleaseError, authority, run, sha256
 from release import (
     CORE_COMPONENTS,
     OCR_COMPONENTS,
@@ -24,6 +24,13 @@ from release import (
 
 
 class PlatformReleaseTests(unittest.TestCase):
+    def test_linux_release_bootstrap_provides_bindgen_libclang(self) -> None:
+        workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("dnf install --assumeyes binutils clang-libs", workflow)
+        self.assertIn('echo "LIBCLANG_PATH=$(dirname "$libclang_path")"', workflow)
+
     def test_command_failure_preserves_bounded_diagnostic_tail(self) -> None:
         script = (
             "import sys; "


### PR DESCRIPTION
## Root causes
- both formal EL8 releases failed while compiling whisper-rs-sys because bindgen could not find libclang.so`n- the macOS runner was consistently denied by the Paddle object endpoint for ocr-detector, including all four retries

## Fix
- install Rocky clang-libs, verify its packaged library, and export explicit LIBCLANG_PATH for both Linux architectures
- add already-reviewed, commit-pinned Hugging Face mirrors for both PP-OCRv6 ONNX archives
- alternate authorized origins on retry while preserving HTTPS host allowlists, exact byte counts, and SHA-256 authority checks on Linux, Windows, and macOS
- add workflow and mirror fallback contract tests

## Verification
- platform-release discovery: 22 passed
- formal platform suite: 25 passed
- macOS release discovery: 10 passed (2 host-only skips)
- both mirror archives downloaded locally with exact authority sizes and hashes
- git diff --check`n
The macOS build/sign/notarization workflow and product package structure remain unchanged.