### PR TITLE
Complete offline release inputs and reap Linux process trees

### DIFF
--- a/tools/installed-smoke/src/process.rs
+++ b/tools/installed-smoke/src/process.rs
@@ -64,7 +64,7 @@ impl Executor for RealExecutor {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
-        process_tree::configure(&mut command);
+        process_tree::configure(&mut command)?;
         let mut child =
             command.spawn().map_err(|error| format!("cannot start process: {error}"))?;
         let mut tree = match process_tree::own(&child) {
@@ -78,18 +78,15 @@ impl Executor for RealExecutor {
         if let Some(mut input) = child.stdin.take()
             && let Err(error) = input.write_all(spec.stdin)
         {
-            tree.terminate();
-            let _ = child.wait();
+            tree.terminate_and_reap(&mut child);
             return Err(format!("cannot write process input: {error}"));
         }
         let Some(stdout) = child.stdout.take() else {
-            tree.terminate();
-            let _ = child.wait();
+            tree.terminate_and_reap(&mut child);
             return Err("process stdout is unavailable".into());
         };
         let Some(stderr) = child.stderr.take() else {
-            tree.terminate();
-            let _ = child.wait();
+            tree.terminate_and_reap(&mut child);
             return Err("process stderr is unavailable".into());
         };
         let stdout_thread = read_bounded(stdout);
@@ -97,8 +94,7 @@ impl Executor for RealExecutor {
         let deadline = Instant::now() + spec.timeout;
         let status = loop {
             if spec.cancel_file.is_some_and(Path::exists) {
-                tree.terminate();
-                let _ = child.wait();
+                tree.terminate_and_reap(&mut child);
                 let _ = stdout_thread.join();
                 let _ = stderr_thread.join();
                 return Err("process cancelled".into());
@@ -107,16 +103,14 @@ impl Executor for RealExecutor {
                 Ok(Some(status)) => break status,
                 Ok(None) => {}
                 Err(error) => {
-                    tree.terminate();
-                    let _ = child.wait();
+                    tree.terminate_and_reap(&mut child);
                     let _ = stdout_thread.join();
                     let _ = stderr_thread.join();
                     return Err(format!("cannot poll process: {error}"));
                 }
             }
             if Instant::now() >= deadline {
-                tree.terminate();
-                let _ = child.wait();
+                tree.terminate_and_reap(&mut child);
                 let _ = stdout_thread.join();
                 let _ = stderr_thread.join();
                 return Err("process deadline exceeded".into());
@@ -125,7 +119,7 @@ impl Executor for RealExecutor {
         };
         // A command that exits while leaving a grandchild holding an inherited
         // pipe must not hang the reader joins or escape the smoke run.
-        tree.terminate();
+        tree.terminate_and_reap(&mut child);
         let stdout = stdout_thread.join().map_err(|_| "stdout reader panicked".to_owned())??;
         let stderr = stderr_thread.join().map_err(|_| "stderr reader panicked".to_owned())??;
         Ok(CommandOutput { exit_code: status.code(), stdout, stderr })

--- a/tools/installed-smoke/src/process_tree.rs
+++ b/tools/installed-smoke/src/process_tree.rs
@@ -10,8 +10,20 @@ pub(crate) struct ProcessTree {
 }
 
 #[cfg(unix)]
-pub(crate) fn configure(command: &mut Command) {
+#[allow(clippy::unnecessary_wraps)] // Linux can fail while enabling subreaping.
+pub(crate) fn configure(command: &mut Command) -> Result<(), String> {
     use std::os::unix::process::CommandExt;
+    #[cfg(target_os = "linux")]
+    // Make killed grandchildren reparent to the smoke runner, not to a
+    // container PID 1 that may never reap them.
+    // SAFETY: PR_SET_CHILD_SUBREAPER changes only the calling process's child
+    // reparenting policy and is idempotent.
+    if unsafe { libc::prctl(libc::PR_SET_CHILD_SUBREAPER, 1) } != 0 {
+        return Err(format!(
+            "cannot establish subprocess reaper: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
     // SAFETY: `setpgid` is async-signal-safe and only assigns the child to a
     // fresh process group before exec.
     unsafe {
@@ -19,6 +31,7 @@ pub(crate) fn configure(command: &mut Command) {
             if libc::setpgid(0, 0) == 0 { Ok(()) } else { Err(std::io::Error::last_os_error()) }
         });
     }
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -29,11 +42,27 @@ pub(crate) fn own(child: &Child) -> Result<ProcessTree, String> {
 
 #[cfg(unix)]
 impl ProcessTree {
-    pub(crate) fn terminate(&mut self) {
+    pub(crate) fn terminate_and_reap(&mut self, child: &mut Child) {
         // SAFETY: a negative PID addresses only the fresh group created for
         // this smoke subprocess. ESRCH is an already-terminated success case.
         unsafe {
             libc::kill(-self.group, libc::SIGKILL);
+        }
+        let _ = child.wait();
+        #[cfg(target_os = "linux")]
+        loop {
+            // Grandchildren killed with the group are now direct children due
+            // to PR_SET_CHILD_SUBREAPER. Reap only this owned process group.
+            // SAFETY: a negative first argument selects children in this fresh
+            // process group; the status is intentionally discarded.
+            let result = unsafe { libc::waitpid(-self.group, std::ptr::null_mut(), 0) };
+            if result > 0 {
+                continue;
+            }
+            if result == -1 && std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            break;
         }
     }
 }
@@ -42,12 +71,14 @@ impl ProcessTree {
 pub(crate) struct ProcessTree(std::os::windows::io::OwnedHandle);
 
 #[cfg(windows)]
-pub(crate) fn configure(command: &mut Command) {
+#[allow(clippy::unnecessary_wraps)] // Shared fallible cross-platform boundary.
+pub(crate) fn configure(command: &mut Command) -> Result<(), String> {
     use std::os::windows::process::CommandExt;
     use windows_sys::Win32::System::Threading::{
         CREATE_NEW_PROCESS_GROUP, CREATE_NO_WINDOW, CREATE_SUSPENDED,
     };
     command.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW | CREATE_SUSPENDED);
+    Ok(())
 }
 
 #[cfg(windows)]
@@ -100,13 +131,14 @@ pub(crate) fn own(child: &Child) -> Result<ProcessTree, String> {
 
 #[cfg(windows)]
 impl ProcessTree {
-    pub(crate) fn terminate(&mut self) {
+    pub(crate) fn terminate_and_reap(&mut self, child: &mut Child) {
         use std::os::windows::io::AsRawHandle;
         use windows_sys::Win32::System::JobObjects::TerminateJobObject;
         // SAFETY: the owned job handle remains live for this call.
         unsafe {
             TerminateJobObject(self.0.as_raw_handle(), 1);
         }
+        let _ = child.wait();
     }
 }
 
@@ -114,7 +146,9 @@ impl ProcessTree {
 pub(crate) struct ProcessTree;
 
 #[cfg(not(any(unix, windows)))]
-pub(crate) fn configure(_: &mut Command) {}
+pub(crate) fn configure(_: &mut Command) -> Result<(), String> {
+    Err("process-tree ownership is unsupported on this platform".into())
+}
 
 #[cfg(not(any(unix, windows)))]
 pub(crate) fn own(_: &Child) -> Result<ProcessTree, String> {
@@ -123,5 +157,5 @@ pub(crate) fn own(_: &Child) -> Result<ProcessTree, String> {
 
 #[cfg(not(any(unix, windows)))]
 impl ProcessTree {
-    pub(crate) fn terminate(&mut self) {}
+    pub(crate) fn terminate_and_reap(&mut self, _: &mut Child) {}
 }

--- a/tools/macos-release/common_test.py
+++ b/tools/macos-release/common_test.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pathlib
 import sys
 import unittest
 
@@ -7,6 +8,12 @@ from common import ReleaseError, run
 
 
 class CommonTests(unittest.TestCase):
+    def test_release_build_prefetches_complete_locked_cargo_closure(self) -> None:
+        source = pathlib.Path(__file__).with_name("release.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('run(["cargo", "fetch", "--locked"]', source)
+
     def test_command_failure_preserves_bounded_diagnostic_tail(self) -> None:
         script = (
             "import sys; "

--- a/tools/macos-release/release.py
+++ b/tools/macos-release/release.py
@@ -73,6 +73,9 @@ def build(target: pathlib.Path) -> None:
         "RUSTFLAGS": " ".join(f"--remap-path-prefix={source}={destination}" for source, destination in remaps) + " -C strip=debuginfo " + f"-C link-arg=-mmacosx-version-min={authority()['minimumMacos']}",
         "CARGO_TARGET_DIR": str(target),
     })
+    # release-projection verifies the complete lockfile with offline Cargo
+    # metadata, including packages that are conditional on other platforms.
+    run(["cargo", "fetch", "--locked"], cwd=ROOT, env=environment)
     run(["cargo", "build", "-j2", "--release", "--locked", "-p", "into-markdown-cli", "--bin", "into-md", "-p", "into-markdown-onnxruntime", "--bin", "onnxruntime-worker", "-p", "into-markdown-plugin-manager", "--bin", "package_plugin", "-p", "installed-smoke", "--bin", "installed-smoke", "-p", "installed-smoke", "--bin", "archive-check", "-p", "license-check", "--bin", "release-projection"], cwd=ROOT, env=environment)
     run(["cargo", "build", "-j2", "--release", "--locked", "--features", "metal", "-p", "into-markdown-official-provider", "--bin", "into-md-ocr-provider", "--bin", "into-md-media-provider"], cwd=ROOT, env=environment)
 

--- a/tools/platform-release/release.py
+++ b/tools/platform-release/release.py
@@ -163,6 +163,10 @@ def build(target: str, output: pathlib.Path) -> pathlib.Path:
             ]
         )
     environment["RUSTFLAGS"] = " ".join(rustflags)
+    # release-projection intentionally runs Cargo metadata offline across the
+    # complete lockfile, including dependencies for non-host targets. Seed that
+    # immutable closure before compiling only the host release products.
+    run(["cargo", "fetch", "--locked"], cwd=ROOT, env=environment)
     run(
         [
             "cargo",

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -24,6 +24,12 @@ from release import (
 
 
 class PlatformReleaseTests(unittest.TestCase):
+    def test_release_build_prefetches_complete_locked_cargo_closure(self) -> None:
+        source = (ROOT / "tools/platform-release/release.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn('run(["cargo", "fetch", "--locked"]', source)
+
     def test_linux_release_bootstrap_provides_bindgen_libclang(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Root causes
- macOS built only host crates, then the fail-closed offline release projection needed an uncached non-host conditional crate from the complete lockfile
- Linux ARM64 exposed that killing a process group inside a container can leave a dead grandchild reparented to a non-reaping PID 1, making the no-orphan acceptance fail

## Fix
- cargo fetch --locked before platform compilation on macOS, Linux, and Windows; assembly remains offline
- establish the installed-smoke runner as a Linux child subreaper before launch
- on cancellation/deadline/completion, kill the owned process group, wait for its leader, then reap only descendants in that fresh group
- keep Windows kill-on-close Job Object semantics and macOS process-group behavior unchanged

## Verification
- platform discovery: 23 passed
- formal platform test selection: 26 passed
- macOS discovery: 11 passed (2 host-only skips)
- Windows installed-smoke unit suite: 23 passed
- Windows installed-smoke strict Clippy: passed with -D warnings`n- local cargo fetch --locked followed by offline Cargo metadata: passed
- git diff --check`n
The existing Linux grandchild cancellation test exercises the new subreaper path on native Linux CI. No lockfiles or package contents change.