### PR TITLE
Fix release authority integrity drift and root-safe rollback test

### DIFF
--- a/apps/cli/src/transaction.rs
+++ b/apps/cli/src/transaction.rs
@@ -1860,6 +1860,8 @@ pub enum HookDecision {
     Continue,
     #[cfg(test)]
     SimulateCrash,
+    #[cfg(test)]
+    SimulateRollbackFailure,
 }
 
 /// A fully staged transaction. Dropping it preserves the journal for recovery.
@@ -1870,6 +1872,8 @@ pub struct PreparedTransaction {
     context: ExecutionContext,
     active: bool,
     temporary_reservations: Vec<ResourceReservation>,
+    #[cfg(test)]
+    simulate_rollback_failure: bool,
     lock: Option<File>,
     handles: TransactionHandles,
 }
@@ -2592,6 +2596,17 @@ impl PreparedTransaction {
         #[cfg(any(unix, windows))]
         {
             self.temporary_reservations.clear();
+            #[cfg(test)]
+            let rollback = if self.simulate_rollback_failure {
+                Err(CliError::new(
+                    ExitClass::Io,
+                    "injectedRollbackFailure",
+                    "deterministic rollback failure injected by the test hook",
+                ))
+            } else {
+                rollback_transaction_with_handles(&self.handles.directory, targets, &self.journal)
+            };
+            #[cfg(not(test))]
             let rollback =
                 rollback_transaction_with_handles(&self.handles.directory, targets, &self.journal);
             if let Err(recovery) = rollback {
@@ -2933,6 +2948,8 @@ pub(crate) fn prepare_with_hook(
             context: context.clone(),
             active: true,
             temporary_reservations: Vec::with_capacity(targets.len()),
+            #[cfg(test)]
+            simulate_rollback_failure: false,
             lock: Some(lock),
             handles: TransactionHandles { root: root_handle, directory: directory_handle },
         };
@@ -3038,6 +3055,15 @@ fn call_hook(
             transaction.preserve_staged_files();
             transaction.deactivate();
             Err(CliError::new(ExitClass::Io, "simulatedCrash", format!("{phase}:{index}")))
+        }
+        #[cfg(test)]
+        HookDecision::SimulateRollbackFailure => {
+            transaction.simulate_rollback_failure = true;
+            Err(CliError::new(
+                ExitClass::Io,
+                "injectedPermissionFailure",
+                format!("deterministic rollback failure requested at {phase}:{index}"),
+            ))
         }
     }
 }
@@ -5711,9 +5737,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn rollback_permission_failure_keeps_the_backup_recoverable() {
-        use std::os::unix::fs::PermissionsExt as _;
-
+    fn rollback_failure_keeps_the_backup_recoverable() {
         let temporary = tempfile::tempdir().unwrap();
         let root = temporary.path().canonicalize().unwrap();
         let output_parent = root.join("locked");
@@ -5726,14 +5750,12 @@ mod tests {
         let error = transaction
             .commit_with_hook(|phase, index| {
                 if phase == "targetInstalled" && index == 0 {
-                    fs::set_permissions(&output_parent, fs::Permissions::from_mode(0o500))?;
-                    Err(CliError::new(ExitClass::Io, "injectedPermissionFailure", "injected"))
+                    Ok(HookDecision::SimulateRollbackFailure)
                 } else {
                     Ok(HookDecision::Continue)
                 }
             })
             .unwrap_err();
-        fs::set_permissions(&output_parent, fs::Permissions::from_mode(0o700)).unwrap();
         assert_eq!(error.code(), "rollbackFailed");
         assert!(error.message().contains("injectedPermissionFailure"));
         assert_eq!(fs::read(directory.join("backup-0")).unwrap(), b"old");

--- a/third_party/licenses/build-tools.json
+++ b/third_party/licenses/build-tools.json
@@ -53,7 +53,7 @@
       "scope": "release-assembly",
       "distributed": false,
       "targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-pc-windows-msvc"],
-      "integrity": [{"algorithm":"SHA-256","digest":"dab2799484b51310b82520c60ec202ca762dc9529872bf1f116c376695d73752","subject":"tools/platform-release/authority.json"}],
+      "integrity": [{"algorithm":"SHA-256","digest":"5b40f688a7f47d493688af6482a4ced0951bc1251cb4e9c0bdb6747c14dc8738","subject":"tools/platform-release/authority.json"}],
       "executables": []
     },
     {
@@ -64,7 +64,7 @@
       "scope": "compile-sign-package",
       "distributed": false,
       "targets": ["aarch64-apple-darwin"],
-      "integrity": [{"algorithm":"SHA-256","digest":"249c6673c3f56ac54d3c587122d59a0f851524172c0719b4698816bbea975ab9","subject":"tools/macos-release/authority.json"}],
+      "integrity": [{"algorithm":"SHA-256","digest":"7586b042c86e5513ea68df54407f0d936e75b87d07041cfd07573887f2fc1f01","subject":"tools/macos-release/authority.json"}],
       "executables": []
     },
     {
@@ -75,7 +75,7 @@
       "scope": "compile-sign-package",
       "distributed": false,
       "targets": ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"],
-      "integrity": [{"algorithm":"SHA-256","digest":"dab2799484b51310b82520c60ec202ca762dc9529872bf1f116c376695d73752","subject":"tools/platform-release/authority.json"}],
+      "integrity": [{"algorithm":"SHA-256","digest":"5b40f688a7f47d493688af6482a4ced0951bc1251cb4e9c0bdb6747c14dc8738","subject":"tools/platform-release/authority.json"}],
       "executables": []
     },
     {
@@ -86,7 +86,7 @@
       "scope": "compile-sign-package",
       "distributed": false,
       "targets": ["x86_64-pc-windows-msvc"],
-      "integrity": [{"algorithm":"SHA-256","digest":"dab2799484b51310b82520c60ec202ca762dc9529872bf1f116c376695d73752","subject":"tools/platform-release/authority.json"}],
+      "integrity": [{"algorithm":"SHA-256","digest":"5b40f688a7f47d493688af6482a4ced0951bc1251cb4e9c0bdb6747c14dc8738","subject":"tools/platform-release/authority.json"}],
       "executables": []
     }
   ]

--- a/tools/release_metadata_test.py
+++ b/tools/release_metadata_test.py
@@ -20,6 +20,23 @@ SPEC.loader.exec_module(release_metadata)
 
 
 class ReleaseMetadataTests(unittest.TestCase):
+    def test_build_tool_integrity_digests_match_every_authority_subject(self) -> None:
+        repository = SCRIPT.parent.parent
+        inventory = json.loads(
+            (repository / "third_party/licenses/build-tools.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        for tool in inventory["tools"]:
+            for integrity in tool["integrity"]:
+                self.assertEqual(integrity["algorithm"], "SHA-256")
+                subject = repository / integrity["subject"]
+                self.assertEqual(
+                    integrity["digest"],
+                    release_metadata.sha256(subject),
+                    f"{tool['id']} integrity drifted for {integrity['subject']}",
+                )
+
     def test_core_projection_requires_exact_archive_manifest_members(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             temporary = pathlib.Path(name)


### PR DESCRIPTION
## Summary
- synchronize the release build-tool inventory with the current platform and macOS authority manifests
- add a regression test that hashes every declared authority subject
- make rollback-failure coverage deterministic when Linux release containers run as root

## Validation
- python -m unittest tools.release_metadata_test tools.platform-release.test_release tools.release_signing_policy_test (15 passed)
- cargo test --locked -p into-markdown-cli --bin into-md transaction::tests::rollback_failure (passed)
- cargo fmt --all -- --check

The rollback injection exists only under cfg(test); production transaction behavior is unchanged.