### PR TITLE
Make native release test fixtures portable

### DIFF
--- a/crates/onnxruntime/src/lib.rs
+++ b/crates/onnxruntime/src/lib.rs
@@ -1515,9 +1515,11 @@ mod tests {
             parse_version_pointer(missing_nul.as_ptr()).unwrap_err(),
             LoadError::VersionMismatch
         );
-        let invalid_utf8 = [std::ffi::c_char::MIN, 0];
+        // Keep the invalid byte stable across targets where `c_char` may be
+        // either signed (x86_64) or unsigned (aarch64).
+        let invalid_utf8 = [0xff_u8, 0_u8];
         assert_eq!(
-            parse_version_pointer(invalid_utf8.as_ptr()).unwrap_err(),
+            parse_version_pointer(invalid_utf8.as_ptr().cast()).unwrap_err(),
             LoadError::VersionMismatch
         );
     }

--- a/crates/process-plugin/tests/runtime.rs
+++ b/crates/process-plugin/tests/runtime.rs
@@ -385,7 +385,9 @@ impl Harness {
 
 #[test]
 fn payloads_larger_than_a_protocol_frame_use_the_private_staged_source() {
-    let runtime = Harness::try_new_with_mode_and_file_limit(None, Some(32 * 1024 * 1024)).unwrap();
+    let fixture_bytes = std::fs::metadata(fixture_executable()).unwrap().len();
+    let max_file_bytes = fixture_bytes.max(32 * 1024 * 1024);
+    let runtime = Harness::try_new_with_mode_and_file_limit(None, Some(max_file_bytes)).unwrap();
     let mut source = vec![b'x'; 13 * 1024 * 1024];
     source[..8].copy_from_slice(b"large-ok");
     let result = runtime.execute(&source, ExecutionOptions::default()).unwrap();


### PR DESCRIPTION
## Summary
- use a fixed invalid UTF-8 byte pattern instead of target-dependent c_char::MIN
- size the staged-source file ceiling for the actual debug process fixture while preserving the 32 MiB floor
- leave production parser, runtime policy, and the independent over-limit rejection test unchanged

## Verification
- cargo fmt --all -- --check
- cargo test --locked -p into-markdown-onnxruntime tests::invalid_c_strings_fail_with_a_stable_error -- --exact --nocapture
- cargo test --locked -p into-markdown-process-plugin --test runtime payloads_larger_than_a_protocol_frame_use_the_private_staged_source -- --exact --nocapture
- git diff --check

Fixes the Linux ARM64 and x86_64 formal release blockers from run 32958166992.