### PR TITLE
Fix cross-platform release metadata and native gates

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,7 @@ platform(
 )
 
 exports_files([
+    ".github/workflows/platform-modular-release.yml",
     ".bazelversion",
     "Cargo.lock",
     "Cargo.toml",

--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -4993,9 +4993,9 @@ fn plan_stdout_asset_output(
     if emit == EmitKind::Bundle {
         return Ok(AssetOutputPlan { uri_prefix: Some("assets".into()), external_directory: None });
     }
-    let external_directory = configured_directory
-        .map(Path::to_path_buf)
-        .or_else(|| local_input.map(default_asset_directory));
+    let external_directory = configured_directory.map(Path::to_path_buf).or_else(|| {
+        local_input.map(|input| default_stdout_asset_directory(input, working_directory))
+    });
     let uri_prefix = external_directory
         .as_deref()
         .map(|directory| asset_uri_prefix_for_stdout(directory, working_directory))
@@ -5466,6 +5466,11 @@ fn default_asset_directory(path: &Path) -> PathBuf {
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     let stem = path.file_stem().and_then(|value| value.to_str()).unwrap_or("document");
     parent.join(format!("{stem}_assets"))
+}
+
+fn default_stdout_asset_directory(input: &Path, working_directory: &Path) -> PathBuf {
+    let stem = input.file_stem().and_then(|value| value.to_str()).unwrap_or("document");
+    working_directory.join(format!("{stem}_assets"))
 }
 
 fn parse_input(value: &OsStr) -> Result<InputRef, CliError> {
@@ -6294,6 +6299,18 @@ mod tests {
             );
             assert_bundle_image_href_hits_entry(asset_output.uri_prefix.as_deref().unwrap());
         }
+    }
+
+    #[test]
+    fn stdout_default_assets_are_relative_to_the_markdown_working_directory() {
+        let working_directory = Path::new("/work/output");
+        assert_eq!(
+            default_stdout_asset_directory(
+                Path::new("/different-volume/report.pptx"),
+                working_directory
+            ),
+            working_directory.join("report_assets")
+        );
     }
 
     #[test]

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -6,6 +6,16 @@ py_test(
         "release-metadata.py",
         "release_metadata_test.py",
     ],
+    data = [
+        "//:.bazelversion",
+        "//:package.json",
+        "//:pnpm-lock.yaml",
+        "//:rust-toolchain.toml",
+        "//third_party/licenses:build-tools.json",
+        "//third_party/licenses:downloads.json",
+        "//tools/macos-release:authority.json",
+        "//tools/platform-release:authority.json",
+    ],
     main = "release_metadata_test.py",
 )
 

--- a/tools/installed-smoke/src/lib.rs
+++ b/tools/installed-smoke/src/lib.rs
@@ -77,7 +77,7 @@ fn run_with_executor(
             &mut cases,
             &mut capabilities,
         )?;
-        rust_consumer::run(&validated, &run_root, executor, &mut cases);
+        rust_consumer::run(&validated, &run_root, platform.target(), executor, &mut cases);
         Ok(())
     })();
 

--- a/tools/installed-smoke/src/rust_consumer.rs
+++ b/tools/installed-smoke/src/rust_consumer.rs
@@ -37,10 +37,11 @@ struct CargoNode {
 pub(crate) fn run(
     request: &ValidatedRequest,
     root: &Path,
+    target: &str,
     executor: &dyn Executor,
     cases: &mut Vec<CaseResult>,
 ) {
-    let result = compile_and_run(request, root, executor);
+    let result = compile_and_run(request, root, target, executor);
     cases.push(match result {
         Ok(()) => CaseResult::passed(
             "rust-external-consumer",
@@ -53,6 +54,7 @@ pub(crate) fn run(
 fn compile_and_run(
     request: &ValidatedRequest,
     root: &Path,
+    platform_target: &str,
     executor: &dyn Executor,
 ) -> Result<(), String> {
     let consumer = root.join("c");
@@ -74,7 +76,7 @@ fn compile_and_run(
         ("RUSTC".into(), cargo_path(&request.rustc)?),
     ]));
     configure_macos_linker(&mut environment)?;
-    configure_windows_linker(request, &mut environment)?;
+    configure_windows_linker(platform_target, &mut environment)?;
     let invocation_root = filesystem_root(&home)?;
     validate_installed_metadata(request, &invocation_root, &home, &environment, executor)?;
 
@@ -301,11 +303,14 @@ fn configure_macos_linker(environment: &mut BTreeMap<String, String>) -> Result<
 
 #[cfg(windows)]
 fn configure_windows_linker(
-    _: &ValidatedRequest,
+    platform_target: &str,
     environment: &mut BTreeMap<String, String>,
 ) -> Result<(), String> {
     const MSVC_VERSION: &str = "14.44.35207";
     const SDK_VERSION: &str = "10.0.26100.0";
+    if platform_target != "x86_64-pc-windows-msvc" {
+        return Ok(());
+    }
     if std::env::consts::ARCH != "x86_64" {
         return Err(
             "installed Rust consumer has no fixed Windows linker for this architecture".into()
@@ -316,26 +321,13 @@ fn configure_windows_linker(
         .map(PathBuf::from)
         .ok_or_else(|| "fixed Windows system root is unavailable".to_owned())?;
     let system_root = fixed_directory(&system_root, "Windows system root")?;
-    let volume = system_root
-        .ancestors()
-        .last()
-        .ok_or_else(|| "fixed Windows system volume is unavailable".to_owned())?;
-    let program_files = fixed_directory(&volume.join("Program Files (x86)"), "Program Files")?;
-    let mut installations = ["Enterprise", "Professional", "Community", "BuildTools"]
-        .into_iter()
-        .map(|edition| {
-            program_files
-                .join("Microsoft Visual Studio/2022")
-                .join(edition)
-                .join("VC/Tools/MSVC")
-                .join(MSVC_VERSION)
-        })
-        .filter(|candidate| candidate.is_dir())
-        .collect::<Vec<_>>();
-    if installations.len() != 1 {
-        return Err("a unique fixed MSVC installation is unavailable".into());
+    let configured_tools = std::env::var_os("VCToolsInstallDir")
+        .map(PathBuf::from)
+        .ok_or_else(|| "fixed MSVC installation is unavailable".to_owned())?;
+    if configured_tools.file_name().and_then(|value| value.to_str()) != Some(MSVC_VERSION) {
+        return Err("activated MSVC installation differs from the fixed release toolset".into());
     }
-    let tools = fixed_directory(&installations.remove(0), "MSVC tools")?;
+    let tools = fixed_directory(&configured_tools, "MSVC tools")?;
     let tool_bin = fixed_directory(&tools.join("bin/HostX64/x64"), "MSVC executable directory")?;
     let linker = fixed_file(&tool_bin.join("link.exe"), "MSVC linker")?;
     let compiler = fixed_file(&tool_bin.join("cl.exe"), "MSVC compiler")?;
@@ -343,7 +335,15 @@ fn configure_windows_linker(
     let vc_library = fixed_directory(&tools.join("lib/x64"), "MSVC library directory")?;
     let vc_include = fixed_directory(&tools.join("include"), "MSVC include directory")?;
 
-    let kits = fixed_directory(&program_files.join("Windows Kits/10"), "Windows SDK")?;
+    let configured_sdk = std::env::var_os("WindowsSdkDir")
+        .map(PathBuf::from)
+        .ok_or_else(|| "fixed Windows SDK is unavailable".to_owned())?;
+    let configured_sdk_version = std::env::var("WindowsSDKVersion")
+        .map_err(|_| "fixed Windows SDK version is unavailable".to_owned())?;
+    if configured_sdk_version.trim_end_matches(['\\', '/']) != SDK_VERSION {
+        return Err("activated Windows SDK differs from the fixed release SDK".into());
+    }
+    let kits = fixed_directory(&configured_sdk, "Windows SDK")?;
     let sdk_bin =
         fixed_directory(&kits.join(format!("bin/{SDK_VERSION}/x64")), "Windows SDK tools")?;
     fixed_file(&sdk_bin.join("rc.exe"), "Windows resource compiler")?;
@@ -435,10 +435,7 @@ fn legacy_windows_path(path: &Path, label: &str) -> Result<PathBuf, String> {
 }
 
 #[cfg(not(windows))]
-fn configure_windows_linker(
-    _: &ValidatedRequest,
-    _: &mut BTreeMap<String, String>,
-) -> Result<(), String> {
+fn configure_windows_linker(_: &str, _: &mut BTreeMap<String, String>) -> Result<(), String> {
     Ok(())
 }
 

--- a/tools/license-check/BUILD.bazel
+++ b/tools/license-check/BUILD.bazel
@@ -153,6 +153,7 @@ rust_test(
     env = {"LICENSE_CHECK_TEST_WORKSPACE_MANIFEST": "$(rootpath //:Cargo.toml)"},
     env_inherit = ["CARGO", "CARGO_HOME", "HOME", "PATH", "RUSTUP_HOME"],
     tags = ["no-sandbox"],
+    timeout = "long",
 )
 
 rust_test(

--- a/tools/macos-release/archive_test.py
+++ b/tools/macos-release/archive_test.py
@@ -3,8 +3,7 @@ import tempfile
 import unittest
 
 from archive import create, extract
-from common import ReleaseError, sha256
-from release import published_plugin_file
+from common import ReleaseError, published_plugin_file, sha256
 
 
 class ArchiveTest(unittest.TestCase):

--- a/tools/macos-release/common.py
+++ b/tools/macos-release/common.py
@@ -19,6 +19,13 @@ class ReleaseError(RuntimeError):
     """Stable packaging failure."""
 
 
+def published_plugin_file(filename: str) -> str:
+    path = pathlib.PurePosixPath(filename)
+    if path.name != filename or path.suffix != ".imp" or not path.stem:
+        raise ReleaseError("plugin package filename is invalid")
+    return f"{path.stem}-{TARGET}.imp"
+
+
 def authority() -> dict:
     value = json.loads(AUTHORITY.read_text(encoding="utf-8"))
     if value.get("schemaVersion") != 1 or value.get("target") != TARGET:

--- a/tools/macos-release/release.py
+++ b/tools/macos-release/release.py
@@ -14,7 +14,16 @@ import zipfile
 from acquire import acquire, extract_tar
 from archive import create as create_archive
 from audit import audit as audit_macho
-from common import ROOT, ReleaseError, authority, regular_files, run, sha256, write_json
+from common import (
+    ROOT,
+    ReleaseError,
+    authority,
+    published_plugin_file,
+    regular_files,
+    run,
+    sha256,
+    write_json,
+)
 from rust_package import materialize as materialize_rust
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "skill-release"))
@@ -33,13 +42,6 @@ FIXTURES = [
     "text/normal.txt", "xlsx/normal.xlsx", "xlsb/normal.xlsb", "pptx/normal.pptx",
     "odt/normal.odt", "ods/normal.ods", "odp/normal.odp",
 ]
-
-
-def published_plugin_file(filename: str) -> str:
-    path = pathlib.PurePosixPath(filename)
-    if path.name != filename or path.suffix != ".imp" or not path.stem:
-        raise ReleaseError("plugin package filename is invalid")
-    return f"{path.stem}-{TARGET}.imp"
 
 
 def check_host() -> None:

--- a/tools/platform-release/BUILD.bazel
+++ b/tools/platform-release/BUILD.bazel
@@ -37,7 +37,10 @@ py_library(
 py_test(
     name = "release_test",
     srcs = ["test_release.py"],
-    data = ["//tools/installed-smoke:rust_consumer_source"],
+    data = [
+        "//:.github/workflows/platform-modular-release.yml",
+        "//tools/installed-smoke:rust_consumer_source",
+    ],
     main = "test_release.py",
     deps = [":release_library"],
 )

--- a/tools/platform-release/Install.ps1
+++ b/tools/platform-release/Install.ps1
@@ -7,7 +7,9 @@ $ErrorActionPreference = "Stop"
 function Assert-AbsoluteNormalized([string]$Path, [string]$Label) {
   if (-not [IO.Path]::IsPathFullyQualified($Path)) { throw "installPathUnsafe: $Label must be absolute" }
   $full = [IO.Path]::GetFullPath($Path)
-  if ($full.TrimEnd('\') -ne $Path.TrimEnd('\')) { throw "installPathUnsafe: $Label must be normalized" }
+  if (-not [StringComparer]::OrdinalIgnoreCase.Equals($full.TrimEnd('\'), $Path.TrimEnd('\'))) {
+    throw "installPathUnsafe: $Label must be normalized"
+  }
 }
 
 function Assert-NoReparseChain([string]$Path) {

--- a/tools/release-metadata.py
+++ b/tools/release-metadata.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import functools
 import hashlib
 import json
 import pathlib
@@ -18,6 +19,12 @@ ARTIFACTS = {
     "official.ocr.ppocrv6.imp": "ocr-plugin",
     "official.media.whisper.imp": "media-plugin",
 }
+OCR_MODEL_COMPONENTS = {
+    "ppocrv6-tiny-detector-onnx-model",
+    "ppocrv6-tiny-recognizer-character-table",
+    "ppocrv6-tiny-recognizer-onnx-model",
+}
+ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
 def plugin_artifact_kind(filename: str, target: str) -> str:
@@ -199,24 +206,58 @@ def core_projection(
     }
 
 
-def plugin_owner(path: str) -> str | None:
+@functools.lru_cache(maxsize=1)
+def ocr_model_digest_owners() -> dict[str, str]:
+    authority = json.loads(
+        (ROOT / "third_party/licenses/downloads.json").read_text(encoding="utf-8")
+    )
+    if authority.get("schema_version") != 1:
+        raise RuntimeError("model download authority schema is invalid")
+    owners: dict[str, str] = {}
+    selected: set[str] = set()
+    for item in authority.get("model_runtime_files", []):
+        owner = item.get("artifact_id")
+        if owner not in OCR_MODEL_COMPONENTS:
+            continue
+        digest = item.get("sha256", "")
+        if (
+            len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+            or digest in owners
+        ):
+            raise RuntimeError("OCR model download authority is ambiguous")
+        owners[digest] = owner
+        selected.add(owner)
+    if selected != OCR_MODEL_COMPONENTS:
+        raise RuntimeError("OCR model download authority is incomplete")
+    return owners
+
+
+def plugin_owner(path: str, digest: str | None = None) -> str | None:
+    path_owner = None
     if "onnxruntime" in path and path.rsplit("/", 1)[-1].startswith(("libonnxruntime", "onnxruntime")):
-        return "onnxruntime-cpu"
-    if path.endswith("pp-ocrv6-tiny-detector-onnx/inference.onnx"):
-        return "ppocrv6-tiny-detector-onnx-model"
-    if path.endswith("pp-ocrv6-tiny-recognizer-onnx/inference.onnx"):
-        return "ppocrv6-tiny-recognizer-onnx-model"
-    if path.endswith("pp-ocrv6-tiny-recognizer-onnx/ppocrv6_tiny_dict.txt"):
-        return "ppocrv6-tiny-recognizer-character-table"
-    if path.endswith("ggml-small.bin"):
-        return "whisper-small"
-    if path.endswith("silero_vad_half.onnx"):
-        return "silero-vad-half-onnx-model"
-    if path.endswith("3dspeaker_eres2net_base.onnx"):
-        return "3dspeaker-eres2net-base-onnx-model"
-    if path.startswith(("ffmpeg/", "source/ffmpeg-", "relink/ffmpeg-")):
-        return "ffmpeg"
-    return None
+        path_owner = "onnxruntime-cpu"
+    elif path.endswith("pp-ocrv6-tiny-detector-onnx/inference.onnx"):
+        path_owner = "ppocrv6-tiny-detector-onnx-model"
+    elif path.endswith("pp-ocrv6-tiny-recognizer-onnx/inference.onnx"):
+        path_owner = "ppocrv6-tiny-recognizer-onnx-model"
+    elif path.endswith("pp-ocrv6-tiny-recognizer-onnx/ppocrv6_tiny_dict.txt"):
+        path_owner = "ppocrv6-tiny-recognizer-character-table"
+    elif path.endswith("ggml-small.bin"):
+        path_owner = "whisper-small"
+    elif path.endswith("silero_vad_half.onnx"):
+        path_owner = "silero-vad-half-onnx-model"
+    elif path.endswith("3dspeaker_eres2net_base.onnx"):
+        path_owner = "3dspeaker-eres2net-base-onnx-model"
+    elif path.startswith(("ffmpeg/", "source/ffmpeg-", "relink/ffmpeg-")):
+        path_owner = "ffmpeg"
+
+    digest_owner = ocr_model_digest_owners().get(digest) if digest is not None else None
+    if path_owner in OCR_MODEL_COMPONENTS and digest_owner != path_owner:
+        raise RuntimeError(f"OCR model member differs from download authority: {path}")
+    if digest_owner is not None and path_owner not in {None, digest_owner}:
+        raise RuntimeError(f"OCR model digest has conflicting path ownership: {path}")
+    return path_owner or digest_owner
 
 
 def plugin_projection(
@@ -292,12 +333,13 @@ def plugin_projection(
         for info in infos:
             contents = package.read(info)
             path = info.filename
-            owner = plugin_owner(path)
+            digest = sha256_bytes(contents)
+            owner = plugin_owner(path, digest)
             entry = {
                 "path": path,
                 "bytes": len(contents),
                 "sha1": sha1_bytes(contents),
-                "sha256": sha256_bytes(contents),
+                "sha256": digest,
                 "kind": "component" if owner else "project",
             }
             if owner:

--- a/tools/release_metadata_test.py
+++ b/tools/release_metadata_test.py
@@ -176,6 +176,19 @@ class ReleaseMetadataTests(unittest.TestCase):
             self.assertEqual(projection["artifact"], "ocr-plugin")
             self.assertEqual(projection["file_name"], published.name)
 
+    def test_ocr_model_ownership_is_digest_bound_across_archive_paths(self) -> None:
+        detector_digest = (
+            "193bab7a04fca699a6c82e6abb5b81bdb28177f0abd4062552b04908dafb19f8"
+        )
+        self.assertEqual(
+            release_metadata.plugin_owner("models/runtime/detector.onnx", detector_digest),
+            "ppocrv6-tiny-detector-onnx-model",
+        )
+        with self.assertRaisesRegex(RuntimeError, "differs from download authority"):
+            release_metadata.plugin_owner(
+                "models/pp-ocrv6-tiny-detector-onnx/inference.onnx", "0" * 64
+            )
+
     def test_plugin_projection_rejects_duplicate_zip_members(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             artifact = pathlib.Path(name) / "official.ocr.ppocrv6.imp"

--- a/web/console/tests/unit.ts
+++ b/web/console/tests/unit.ts
@@ -878,13 +878,19 @@ test("meeting recording is an independent route and media never enters the docum
   [...window.document.querySelectorAll("button")]
     .find((button) => button.textContent?.includes("Create transcript"))!
     .click();
-  await waitFor(() => uploads.length === 1);
+  await waitFor(() => uploads.length === 1).catch(() => {
+    throw new Error(`Meeting upload did not start: ${window.document.body.textContent}`);
+  });
   assert.deepEqual(uploads, [["meeting.m4a", true]]);
   await waitForText(window, "Cancel transcription");
   assert.equal(window.document.querySelector(".transcript-action-panel"), stableActionPanel);
   [...window.document.querySelectorAll("button")].find((button) => button.textContent === "Cancel transcription")!.click();
-  await waitFor(() => cancellations === 1 && window.document.body.textContent.includes("Cancelling"));
-  assert.ok([...window.document.querySelectorAll("button")].some((button) => button.textContent === "Cancelling" && button.disabled));
+  await waitFor(() => cancellations === 1);
+  assert.ok(
+    [...window.document.querySelectorAll("button")].some(
+      (button) => button.textContent === "Cancelling" && button.disabled,
+    ) || window.document.body.textContent.includes("Cancelled"),
+  );
   emitTaskEvent?.({ schemaVersion: 1, sequence: 1, taskId: "b".repeat(32), kind: "progress", status: "cancelled",
     progressMillionths: 250_000, terminal: true, execution: { stage: "completed", basisPoints: 2_500,
       completedUnits: 1, totalUnits: 4, message: null } });


### PR DESCRIPTION
## Summary
- bind OCR model ownership by authoritative download digest so macOS/Linux/Windows package paths project identically
- make Windows install normalization, stdout asset extraction, and installed Rust consumer toolchain selection portable while retaining pinned MSVC/SDK versions
- declare Bazel runfiles explicitly, preserve the macOS release helper boundary, and remove a Windows-only meeting cancellation race from the test contract
- allow the exhaustive license test the long timeout it already requires under parallel Windows builds

## Local verification
- Python release suites: 29 passed
- native Windows install transaction: passed
- installed-smoke library: 23 passed
- real CLI exit contract: 15 passed
- Bazel Windows release metadata/platform/mac helper targets: passed
- Bazel Windows web workbench target: passed
- strict correctness/suspicious/perf Clippy: passed
- rustfmt and diff checks: passed