### PR TITLE
Install pinned Bazelisk in Linux release containers

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -58,6 +58,26 @@ jobs:
             dnf --enablerepo=powertools install --assumeyes nasm
             nasm -v
           fi
+          case "$(uname -m)" in
+            x86_64)
+              bazelisk_asset=bazelisk-linux-amd64
+              bazelisk_sha256=e1508323f347ad1465a887bc5d2bfb91cffc232d11e8e997b623227c6b32fb76
+              ;;
+            aarch64)
+              bazelisk_asset=bazelisk-linux-arm64
+              bazelisk_sha256=bb608519a440d45d10304eb684a73a2b6bb7699c5b0e5434361661b25f113a5d
+              ;;
+            *)
+              echo "unsupported Linux release architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --output /usr/local/bin/bazelisk \
+            "https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/$bazelisk_asset"
+          echo "$bazelisk_sha256  /usr/local/bin/bazelisk" | sha256sum --check
+          chmod 0755 /usr/local/bin/bazelisk
+          ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
           ln -sf /usr/bin/python3.11 /usr/local/bin/python
           ln -sf /usr/bin/python3.11 /usr/local/bin/python3
           libclang_path="$(rpm -ql clang-libs | grep -E '/libclang\.so(\.[0-9]+)*$' | head -n 1)"

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -37,6 +37,24 @@ class PlatformReleaseTests(unittest.TestCase):
         self.assertIn("dnf install --assumeyes binutils clang-libs", workflow)
         self.assertIn('echo "LIBCLANG_PATH=$(dirname "$libclang_path")"', workflow)
 
+    def test_linux_release_bootstrap_installs_hash_pinned_bazelisk(self) -> None:
+        workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("bazelbuild/bazelisk/releases/download/v1.27.0", workflow)
+        self.assertIn("bazelisk-linux-amd64", workflow)
+        self.assertIn("bazelisk-linux-arm64", workflow)
+        self.assertIn(
+            "e1508323f347ad1465a887bc5d2bfb91cffc232d11e8e997b623227c6b32fb76",
+            workflow,
+        )
+        self.assertIn(
+            "bb608519a440d45d10304eb684a73a2b6bb7699c5b0e5434361661b25f113a5d",
+            workflow,
+        )
+        self.assertIn("sha256sum --check", workflow)
+        self.assertIn("ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel", workflow)
+
     def test_windows_cmake_uses_the_activated_pinned_msvc_toolchain(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
             encoding="utf-8"

--- a/tools/release-metadata.py
+++ b/tools/release-metadata.py
@@ -372,6 +372,33 @@ def write_generated(output: pathlib.Path, metadata: dict) -> None:
                 raise RuntimeError(f"generated metadata digest drifted: {path.name}")
 
 
+def validate_projection_ownership(projection: dict) -> None:
+    selected = set(projection["components"])
+    owners: set[str] = set()
+    for item in projection["files"]:
+        owner = item.get("component_id")
+        if owner is not None:
+            owners.add(owner)
+        owners.update(item.get("embedded_components", []))
+    missing = sorted(selected - owners)
+    if not missing:
+        return
+    candidates = [
+        {
+            "path": item["path"],
+            "bytes": item["bytes"],
+            "sha256": item["sha256"],
+            "component_id": item.get("component_id"),
+        }
+        for item in projection["files"]
+        if any(token in item["path"].lower() for token in ("model", "onnx", "dict"))
+    ][:24]
+    raise RuntimeError(
+        f"{projection['artifact']} {projection['file_name']} has unowned components "
+        f"{missing}; bounded model candidates={json.dumps(candidates, sort_keys=True)}"
+    )
+
+
 def generate(
     projection_tool: pathlib.Path,
     target: str,
@@ -398,6 +425,7 @@ def generate(
         projection["build_tools"] = executions
     finalized = []
     for projection in projections:
+        validate_projection_ownership(projection)
         metadata = run_projection(projection_tool, "finalize", projection)
         write_generated(output, metadata)
         finalized.append((projection, metadata))

--- a/tools/release_metadata_test.py
+++ b/tools/release_metadata_test.py
@@ -189,6 +189,26 @@ class ReleaseMetadataTests(unittest.TestCase):
                 "models/pp-ocrv6-tiny-detector-onnx/inference.onnx", "0" * 64
             )
 
+    def test_projection_ownership_failure_identifies_artifact_and_candidates(self) -> None:
+        projection = {
+            "artifact": "ocr-plugin",
+            "file_name": "official.ocr.ppocrv6-aarch64-apple-darwin.imp",
+            "components": ["ppocrv6-tiny-detector-onnx-model"],
+            "files": [
+                {
+                    "path": "models/unexpected/detector.onnx",
+                    "bytes": 7,
+                    "sha256": "a" * 64,
+                    "kind": "project",
+                }
+            ],
+        }
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "ocr-plugin .*unowned components.*models/unexpected/detector.onnx",
+        ):
+            release_metadata.validate_projection_ownership(projection)
+
     def test_plugin_projection_rejects_duplicate_zip_members(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             artifact = pathlib.Path(name) / "official.ocr.ppocrv6.imp"


### PR DESCRIPTION
Installs Bazelisk v1.27.0 inside both pinned Rocky Linux release containers, verifies architecture-specific official SHA-256 digests, and locks the bootstrap behavior with a host-independent test. Root cause: the cache setup action does not expose the host launcher at the container path, so the formal Linux gate reached Bazel and failed with command not found. Validation: platform release unit suite passes 11/11 and git diff check is clean.