### PR TITLE
Scope release metadata components to each plugin

### DIFF
--- a/tools/release-metadata.py
+++ b/tools/release-metadata.py
@@ -24,6 +24,21 @@ OCR_MODEL_COMPONENTS = {
     "ppocrv6-tiny-recognizer-character-table",
     "ppocrv6-tiny-recognizer-onnx-model",
 }
+PLUGIN_RUNTIME_COMPONENTS = {
+    "ocr-plugin": (
+        "onnxruntime-cpu",
+        "ppocrv6-tiny-detector-onnx-model",
+        "ppocrv6-tiny-recognizer-character-table",
+        "ppocrv6-tiny-recognizer-onnx-model",
+    ),
+    "media-plugin": (
+        "ffmpeg",
+        "onnxruntime-cpu",
+        "whisper-small",
+        "silero-vad-half-onnx-model",
+        "3dspeaker-eres2net-base-onnx-model",
+    ),
+}
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
@@ -152,6 +167,22 @@ def source_components(contents: bytes) -> list[str]:
         for component in value["components"]
         if component["distributed"]
     ]
+
+
+def scoped_plugin_components(
+    source_component_ids: list[str], artifact: str
+) -> list[str]:
+    runtime_components = PLUGIN_RUNTIME_COMPONENTS[artifact]
+    missing_runtime = set(runtime_components) - set(source_component_ids)
+    if missing_runtime:
+        raise RuntimeError(
+            f"plugin source inventory omits runtime components: "
+            f"{sorted(missing_runtime)}"
+        )
+    cargo_components = [
+        item for item in source_component_ids if item.startswith("cargo:")
+    ]
+    return [*cargo_components, *runtime_components]
 
 
 def core_projection(
@@ -327,7 +358,8 @@ def plugin_projection(
             or source_manifest["artifact"] != expected_identity
         ):
             raise RuntimeError(f"plugin source identity differs: {artifact.name}")
-        components = source_components(sources)
+        source_component_ids = source_components(sources)
+        components = scoped_plugin_components(source_component_ids, expected_artifact)
         cargo_components = [item for item in components if item.startswith("cargo:")]
         files = []
         for info in infos:

--- a/tools/release_metadata_test.py
+++ b/tools/release_metadata_test.py
@@ -93,6 +93,18 @@ class ReleaseMetadataTests(unittest.TestCase):
                 "components": [
                     {"id": "cargo:example@1.0.0", "distributed": True},
                     {"id": "onnxruntime-cpu", "distributed": True},
+                    {
+                        "id": "ppocrv6-tiny-detector-onnx-model",
+                        "distributed": True,
+                    },
+                    {
+                        "id": "ppocrv6-tiny-recognizer-character-table",
+                        "distributed": True,
+                    },
+                    {
+                        "id": "ppocrv6-tiny-recognizer-onnx-model",
+                        "distributed": True,
+                    },
                     {"id": "npm:vite@1.0.0", "distributed": False},
                 ]
             }
@@ -150,7 +162,13 @@ class ReleaseMetadataTests(unittest.TestCase):
             )
             self.assertEqual(
                 projection["components"],
-                ["cargo:example@1.0.0", "onnxruntime-cpu"],
+                [
+                    "cargo:example@1.0.0",
+                    "onnxruntime-cpu",
+                    "ppocrv6-tiny-detector-onnx-model",
+                    "ppocrv6-tiny-recognizer-character-table",
+                    "ppocrv6-tiny-recognizer-onnx-model",
+                ],
             )
             provider = next(
                 item
@@ -175,6 +193,28 @@ class ReleaseMetadataTests(unittest.TestCase):
             )
             self.assertEqual(projection["artifact"], "ocr-plugin")
             self.assertEqual(projection["file_name"], published.name)
+
+    def test_plugin_runtime_components_are_scoped_to_the_artifact(self) -> None:
+        global_sources = [
+            "cargo:shared@1.0.0",
+            *release_metadata.PLUGIN_RUNTIME_COMPONENTS["ocr-plugin"],
+            *release_metadata.PLUGIN_RUNTIME_COMPONENTS["media-plugin"],
+        ]
+        for artifact, expected in release_metadata.PLUGIN_RUNTIME_COMPONENTS.items():
+            selected = release_metadata.scoped_plugin_components(
+                global_sources, artifact
+            )
+            self.assertEqual(
+                set(selected) & release_metadata.OCR_MODEL_COMPONENTS,
+                release_metadata.OCR_MODEL_COMPONENTS
+                if artifact == "ocr-plugin"
+                else set(),
+            )
+            self.assertEqual(
+                set(selected)
+                & set(release_metadata.PLUGIN_RUNTIME_COMPONENTS["media-plugin"]),
+                set(expected) if artifact == "media-plugin" else {"onnxruntime-cpu"},
+            )
 
     def test_ocr_model_ownership_is_digest_bound_across_archive_paths(self) -> None:
         detector_digest = (


### PR DESCRIPTION
Fixes formal macOS metadata finalization by separating the artifact runtime component closure from the global SOURCES inventory. OCR keeps ONNX Runtime and its three OCR assets; speech keeps FFmpeg, ONNX Runtime, Whisper, VAD, and speaker recognition assets. Cargo source components remain complete. Validated with 18 unit tests and both real local Windows OCR/speech IMP packages; each ownership closure passes and no cross-plugin model remains.