### PR TITLE
Stabilize native Bazel release gates

### DIFF
--- a/apps/cli/BUILD.bazel
+++ b/apps/cli/BUILD.bazel
@@ -59,6 +59,7 @@ rust_test(
         "//fixtures:corpus",
         "//fixtures:manifest.json",
     ],
+    tags = ["exclusive"],
     deps = [
         "//crates/api:into_markdown",
         "//crates/process-plugin:process_plugin",
@@ -67,7 +68,10 @@ rust_test(
         "@crates//:zip",
     ],
     edition = "2024",
-    env = {"INTO_MD_BIN": "$(location :into-md)"},
+    env = {
+        "INTO_MD_BIN": "$(location :into-md)",
+        "RUST_TEST_THREADS": "1",
+    },
 )
 
 rust_test(

--- a/crates/process-plugin/BUILD.bazel
+++ b/crates/process-plugin/BUILD.bazel
@@ -58,5 +58,9 @@ rust_test(
     # This target validates the plugin's own OS sandbox. Bazel's macOS
     # sandbox cannot be nested with sandbox_init(3), so run the test process
     # locally and let the runtime under test install the restrictive profile.
-    tags = ["no-sandbox"],
+    env = {"RUST_TEST_THREADS": "1"},
+    tags = [
+        "exclusive",
+        "no-sandbox",
+    ],
 )

--- a/web/console/tests/determinism.py
+++ b/web/console/tests/determinism.py
@@ -12,6 +12,12 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 
 def inventory(root: pathlib.Path) -> dict[str, bytes]:
+    # Bazel exposes tree artifacts as directory symlinks on Linux. pathlib does
+    # not descend when the rglob root itself is a symlink, so bind
+    # the comparison to the resolved tree artifact before walking it.
+    root = root.resolve(strict=True)
+    if not root.is_dir():
+        raise AssertionError(f"generated Web bundle is not a directory: {root}")
     result: dict[str, bytes] = {}
     for path in sorted(root.rglob("*"), key=lambda candidate: candidate.as_posix()):
         metadata = path.lstat()


### PR DESCRIPTION
## Summary
- resolve Linux Bazel tree-artifact symlinks before Web bundle inventory
- serialize the real CLI and process-plugin test binaries
- run both process-heavy Bazel targets exclusively so OS sandbox lifecycle assertions are not starved by the full repository test fan-out

The tests remain enabled and retain all assertions; this removes host-load and Python 3.6 runfiles nondeterminism found by the formal Linux release jobs.

## Validation
- Bazel 9.2.0: //web/console:determinism_test
- Bazel 9.2.0: //apps/cli:exit_contract_test (15/15)
- Bazel 9.2.0: //crates/process-plugin:process_plugin_integration_test (9/9)
- combined targeted Bazel run: 3/3 targets passed
- git diff --check