### PR TITLE
fix(release): protect macOS acceptance user data

### DIFF
--- a/.github/workflows/macos-arm64-release.yml
+++ b/.github/workflows/macos-arm64-release.yml
@@ -255,7 +255,8 @@ jobs:
           diff -ru ".agents/skills/into-markdown" \
             "$installed/share/into-markdown/skills/into-markdown"
           export INTO_MARKDOWN_USER_DATA_HOME="$RUNNER_TEMP/clean-user-data"
-          mkdir -p "$INTO_MARKDOWN_USER_DATA_HOME" "$RUNNER_TEMP/smoke-core"
+          mkdir -m 700 "$INTO_MARKDOWN_USER_DATA_HOME"
+          mkdir -p "$RUNNER_TEMP/smoke-core"
           signer_id=$(jq -r '.signingKeyId' "$installed/share/into-markdown/plugins/official-publisher.json")
           signer_sha=$(jq -r '.signingKeySha256' "$installed/share/into-markdown/plugins/official-publisher.json")
           for package in official.ocr.ppocrv6 official.media.whisper; do


### PR DESCRIPTION
## Summary
- create the macOS release acceptance user-data anchor with owner-private permissions
- preserve the existing macOS package assembly and unsigned artifact behavior

## Evidence
- formal release run 33004813066 completed reproducible builds, unsigned assembly, and SBOM validation
- final lifecycle gate rejected the prior 0755 test directory as designed
- this matches the existing Linux release gate's 0700 setup