### PR TITLE
fix(ci): isolate formal release gates

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -194,7 +194,7 @@ jobs:
           python -m unittest tools.platform-release.test_release tools.platform-release.test_platform_tools tools.publish_release_assets_test tools.release_metadata_test tools.release_signing_policy_test
           cargo test --workspace --all-targets --locked -- --test-threads=1
           cargo clippy --workspace --exclude whisper-rs --all-targets --no-deps --locked -- -D clippy::correctness -D clippy::suspicious -D clippy::perf
-          bazel --output_user_root="${{ runner.temp }}/bazel" test --config=${{ matrix.bazel_config }} --lockfile_mode=error //...
+          bazel --output_user_root="${{ runner.temp }}/bazel" test --config=${{ matrix.bazel_config }} --lockfile_mode=error --local_test_jobs=1 --test_env=RUST_TEST_THREADS=1 //...
       - name: Authenticode-sign project executables
         if: runner.os == 'Windows' && inputs.signing_mode == 'signed'
         shell: pwsh

--- a/crates/ocr/src/merge/tests/resources.rs
+++ b/crates/ocr/src/merge/tests/resources.rs
@@ -214,6 +214,11 @@ fn large_text_checkpoint_observes_timeout_after_work_begins() {
         }
     })));
     let _reset = ResetTextHook;
+    let detected = detection(&[(polygon(20.0, 20.0, 100.0, 16.0), 0.99)]);
+    let large = "a".repeat(16 * 1024);
+    let recognized = recognition(&[(0, &large, 0.99)]);
+    // Fixture allocation is outside the request deadline. The test measures
+    // timeout observation during merge work, not runner scheduling or setup.
     let context = ExecutionContext::new(
         ExecutionOptions {
             timeout: Some(Duration::from_millis(10)),
@@ -221,9 +226,6 @@ fn large_text_checkpoint_observes_timeout_after_work_begins() {
         },
         ResourceLimits::default(),
     );
-    let detected = detection(&[(polygon(20.0, 20.0, 100.0, 16.0), 0.99)]);
-    let large = "a".repeat(16 * 1024);
-    let recognized = recognition(&[(0, &large, 0.99)]);
     let error = merge_document(
         Document::default(),
         &[input(&detected, &recognized)],

--- a/web/console/tests/determinism.py
+++ b/web/console/tests/determinism.py
@@ -22,7 +22,10 @@ def inventory(root: pathlib.Path) -> dict[str, bytes]:
         raise AssertionError(f"generated Web bundle is not a directory: {root}")
     result: dict[str, bytes] = {}
     for path in sorted(root.rglob("*"), key=lambda candidate: candidate.as_posix()):
-        metadata = path.lstat()
+        # Individual generated files can also be runfiles symlinks. Follow the
+        # Bazel-owned link for classification and content while retaining the
+        # stable runfiles-relative name in the inventory.
+        metadata = path.stat()
         if stat.S_ISDIR(metadata.st_mode):
             continue
         if not stat.S_ISREG(metadata.st_mode):


### PR DESCRIPTION
## Summary
- follow Bazel-owned file symlinks when inventorying generated Web assets
- exclude OCR fixture allocation from the request timeout under test
- isolate formal Bazel test processes and Rust test threads from concurrent build noise

## Local evidence
- cargo test -p into-markdown-ocr large_text_checkpoint_observes_timeout_after_work_begins
- bazelisk test //web/console:determinism_test //crates/ocr:ocr_test //crates/converters:converters_test (3/3 passed)
- 32 platform release/metadata/signing-policy unit tests passed