### PR TITLE
fix(release): bind Linux checkout ownership

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -88,6 +88,12 @@ jobs:
           test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.28"
           python -c 'import os; assert tuple(map(int, os.uname().release.split("-")[0].split(".")[:2])) >= (5, 15)'
       - uses: actions/checkout@v4
+      - name: Bind fixed Linux checkout ownership
+        if: runner.os == 'Linux'
+        run: |
+          git config --global --unset-all safe.directory || true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          test "$(git rev-parse --show-toplevel)" = "$GITHUB_WORKSPACE"
       - name: Validate immutable release URL authority
         shell: bash
         env:


### PR DESCRIPTION
## Summary
- bind only the exact GitHub workspace mount as a safe Git directory inside the pinned EL8 release container
- verify the resulting repository authority immediately with rev-parse
- keep Windows and macOS release paths unchanged

## Evidence
- both Linux architectures passed Cargo, Clippy, and all 55 Bazel targets in formal run 33012075047
- both then failed at deterministic assembly only because Git rejected the container-owned checkout mount as dubious ownership
- 21 platform release/tool unit tests pass locally