### PR TITLE
Fix Windows release installer DACL on hosted runners

### DIFF
--- a/.github/workflows/bazel-platform-toolchains.yml
+++ b/.github/workflows/bazel-platform-toolchains.yml
@@ -61,6 +61,11 @@ jobs:
         run: >-
           bazel test --config=macos_arm64 --lockfile_mode=error
           //tools/macos-release:installer_attack_test
+      - name: Run Windows installer transaction security tests outside the Bazel pipe
+        if: matrix.config == 'windows_x86_64'
+        run: >-
+          python tools/platform-release/test_platform_tools.py
+          PlatformToolTests.test_windows_native_install_is_idempotent_and_rolls_back_bad_upgrade
       - name: Prove the Rust-library allocator bridge is required
         if: matrix.config == 'macos_arm64'
         shell: bash

--- a/tools/platform-release/Install.ps1
+++ b/tools/platform-release/Install.ps1
@@ -39,7 +39,10 @@ function Set-OrAssertPrivateDirectory([string]$Path) {
   if ($created) {
     [IO.Directory]::CreateDirectory($Path) | Out-Null
     $identity = [Security.Principal.WindowsIdentity]::GetCurrent().User
-    $acl = Get-Acl -LiteralPath $Path
+    # Start from an empty descriptor instead of editing the inherited one. Some
+    # Windows volumes materialize parent ACEs as explicit entries on creation;
+    # protecting that inherited descriptor would retain those mutation grants.
+    $acl = [Security.AccessControl.DirectorySecurity]::new()
     $acl.SetOwner($identity)
     $acl.SetAccessRuleProtection($true, $false)
     $rule = [Security.AccessControl.FileSystemAccessRule]::new(
@@ -49,7 +52,7 @@ function Set-OrAssertPrivateDirectory([string]$Path) {
       [Security.AccessControl.PropagationFlags]::None,
       [Security.AccessControl.AccessControlType]::Allow
     )
-    $acl.SetAccessRule($rule)
+    $acl.AddAccessRule($rule) | Out-Null
     Set-Acl -LiteralPath $Path -AclObject $acl
   }
   $acl = Get-Acl -LiteralPath $Path
@@ -63,7 +66,7 @@ function Set-OrAssertPrivateDirectory([string]$Path) {
   foreach ($entry in $acl.Access) {
     $sid = $entry.IdentityReference.Translate([Security.Principal.SecurityIdentifier]).Value
     if ($entry.AccessControlType -eq [Security.AccessControl.AccessControlType]::Allow -and ($entry.FileSystemRights -band $mutation) -and $sid -ne $current) {
-      throw "installPathUnsafe: installation prefix grants mutation to another identity"
+      throw "installPathUnsafe: $Path grants mutation to another identity ($sid)"
     }
   }
 }


### PR DESCRIPTION
## Summary

- create new install directories with a fresh, protected current-user DACL instead of retaining explicit ACEs materialized by the parent volume
- keep existing unsafe-path rejection for pre-existing directories and include the offending SID in diagnostics
- run the native Windows install/idempotency/rollback/uninstall test outside Bazel on every Windows platform PR job

## Evidence

The previous formal Windows run passed build, audit, and package assembly, then failed clean install because the GitHub runner volume materialized another identity as an explicit mutation ACE. The new descriptor removes that platform-dependent inheritance ambiguity.

## Local validation

- python tools/platform-release/test_platform_tools.py -v (10/10 passed, including native Windows install transaction)