### PR TITLE
fix(bazel): declare packager tempfile dependency

### DIFF
--- a/.github/workflows/bazel-platform-toolchains.yml
+++ b/.github/workflows/bazel-platform-toolchains.yml
@@ -50,6 +50,7 @@ jobs:
           bazel build --config=${{ matrix.config }} --lockfile_mode=error
           //toolchains:native_toolchain_contract
           //crates/core:core
+          //crates/plugin-manager:package_plugin
           //tests/contracts:public_api_consumer
       - name: Run the platform-independent core test
         run: >-

--- a/crates/plugin-manager/BUILD.bazel
+++ b/crates/plugin-manager/BUILD.bazel
@@ -45,6 +45,7 @@ rust_binary(
         "@crates//:serde",
         "@crates//:serde_json",
         "@crates//:sha2",
+        "@crates//:tempfile",
         "@crates//:zip",
     ],
 )


### PR DESCRIPTION
## What changed
- declare the packager's direct tempfile dependency in its Bazel target
- build the package_plugin binary explicitly in every native PR gate

## Why
Formal Linux x86_64 run 33024967671 passed Cargo tests and Clippy, then the full Bazel gate correctly found that the packaging target's BUILD.bazel had not been updated with the already-existing Cargo dependency.

## Validation
- local Windows Bazel build: //crates/plugin-manager:package_plugin (992 actions, success)
- no Cargo.lock or MODULE.bazel.lock changes