### PR TITLE
test(ocr): stabilize cooperative timeout coverage

### DIFF
--- a/.github/workflows/semantic-layout-quality.yml
+++ b/.github/workflows/semantic-layout-quality.yml
@@ -97,6 +97,11 @@ jobs:
           //crates/converters:pdf_layout_quality
           //crates/api:ppocrv6_image_quality
           --jobs=1 --local_resources=memory=4096 --test_output=errors
+      - name: Run the OCR merge and runtime regressions
+        run: >-
+          bazel --output_user_root="${{ runner.temp }}/bazel" test --config=${{ matrix.config }} --lockfile_mode=error
+          //crates/ocr:ocr_test
+          --jobs=1 --local_resources=memory=4096 --test_output=errors
 
   repository-boundary:
     runs-on: ubuntu-24.04

--- a/crates/ocr/src/merge/tests/resources.rs
+++ b/crates/ocr/src/merge/tests/resources.rs
@@ -210,20 +210,19 @@ fn large_text_checkpoint_observes_timeout_after_work_begins() {
     text::set_test_hook(Some(Box::new(move |stage, bytes| {
         if stage == text::TextStage::Associate {
             hook_reached.store(bytes, Ordering::SeqCst);
-            std::thread::sleep(Duration::from_millis(30));
+            std::thread::sleep(Duration::from_millis(1_100));
         }
     })));
     let _reset = ResetTextHook;
     let detected = detection(&[(polygon(20.0, 20.0, 100.0, 16.0), 0.99)]);
     let large = "a".repeat(16 * 1024);
     let recognized = recognition(&[(0, &large, 0.99)]);
-    // Fixture allocation is outside the request deadline. The test measures
-    // timeout observation during merge work, not runner scheduling or setup.
+    // Fixture allocation is outside the request deadline. Keep enough time for
+    // loaded CI runners to enter the checkpoint, then make the hook itself
+    // cross the deadline so this measures timeout observation during merge
+    // work rather than scheduler latency.
     let context = ExecutionContext::new(
-        ExecutionOptions {
-            timeout: Some(Duration::from_millis(10)),
-            ..ExecutionOptions::default()
-        },
+        ExecutionOptions { timeout: Some(Duration::from_secs(1)), ..ExecutionOptions::default() },
         ResourceLimits::default(),
     );
     let error = merge_document(


### PR DESCRIPTION
## What changed
- give loaded runners enough time to enter the text checkpoint, then cross the deadline inside the checkpoint hook
- run the complete OCR Bazel regression suite in the four-platform semantic-quality PR gate

## Why
Formal Linux x86_64 run 33029374704 timed out before entering the intended checkpoint because the test used a 10 ms total request deadline. Product timeout behavior was correct; the scheduling-sensitive assertion was not.

## Validation
- targeted Cargo regression: 1 passed in 1.10s
- local Windows Bazel //crates/ocr:ocr_test: all 133 tests passed
- cargo fmt --check and git diff --check