### PR TITLE
fix(release): keep plugin key on authoritative temp path

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           umask 077
           test -n "$PLUGIN_SIGNING_KEY_BASE64"
-          printf '%s' "$PLUGIN_SIGNING_KEY_BASE64" | base64 --decode > "$RUNNER_TEMP/plugin-key.pk8"
+          printf '%s' "$PLUGIN_SIGNING_KEY_BASE64" | base64 --decode > "${{ runner.temp }}/plugin-key.pk8"
       - name: Decode protected plugin signing key on Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -163,7 +163,7 @@ jobs:
           PLUGIN_SIGNING_KEY_BASE64: ${{ secrets.PLUGIN_SIGNING_KEY_BASE64 }}
         run: |
           if (-not $env:PLUGIN_SIGNING_KEY_BASE64) { throw "plugin signing key is absent" }
-          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\plugin-key.pk8", [Convert]::FromBase64String($env:PLUGIN_SIGNING_KEY_BASE64))
+          [IO.File]::WriteAllBytes("${{ runner.temp }}\plugin-key.pk8", [Convert]::FromBase64String($env:PLUGIN_SIGNING_KEY_BASE64))
       - name: Import protected Windows signing material
         if: runner.os == 'Windows' && inputs.signing_mode == 'signed'
         shell: pwsh
@@ -459,7 +459,7 @@ jobs:
             Remove-Item "Cert:\CurrentUser\My\$env:WINDOWS_SIGNING_THUMBPRINT" -Force -ErrorAction SilentlyContinue
           }
           Remove-Item "$env:RUNNER_TEMP\release-signing.pfx" -Force -ErrorAction SilentlyContinue
-          Remove-Item "$env:RUNNER_TEMP\plugin-key.pk8" -Force -ErrorAction SilentlyContinue
+          Remove-Item "${{ runner.temp }}\plugin-key.pk8" -Force -ErrorAction SilentlyContinue
 
   publish-draft:
     needs: native-release

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -55,6 +55,17 @@ class PlatformReleaseTests(unittest.TestCase):
         self.assertIn("sha256sum --check", workflow)
         self.assertIn("ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel", workflow)
 
+    def test_plugin_key_uses_the_same_authoritative_temp_path_as_packaging(self) -> None:
+        workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
+            encoding="utf-8"
+        )
+        key_path = "${{ runner.temp }}/plugin-key.pk8"
+        windows_key_path = r"${{ runner.temp }}\plugin-key.pk8"
+        self.assertGreaterEqual(workflow.count(key_path), 3)
+        self.assertIn(windows_key_path, workflow)
+        self.assertNotIn("$RUNNER_TEMP/plugin-key.pk8", workflow)
+        self.assertNotIn(r"$env:RUNNER_TEMP\plugin-key.pk8", workflow)
+
     def test_windows_cmake_uses_the_activated_pinned_msvc_toolchain(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
Uses the same runner.temp authority when decoding, consuming, and cleaning up the internal plugin-integrity key. Adds a workflow contract regression test. Validation: 33 platform release/metadata/signing-policy unit tests passed; git diff --check passed.