### PR TITLE
fix(release): create authoritative container temp root

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -155,6 +155,7 @@ jobs:
         run: |
           umask 077
           test -n "$PLUGIN_SIGNING_KEY_BASE64"
+          install -d -m 700 "${{ runner.temp }}"
           printf '%s' "$PLUGIN_SIGNING_KEY_BASE64" | base64 --decode > "${{ runner.temp }}/plugin-key.pk8"
       - name: Decode protected plugin signing key on Windows
         if: runner.os == 'Windows'

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -61,6 +61,7 @@ class PlatformReleaseTests(unittest.TestCase):
         )
         key_path = "${{ runner.temp }}/plugin-key.pk8"
         windows_key_path = r"${{ runner.temp }}\plugin-key.pk8"
+        self.assertIn('install -d -m 700 "${{ runner.temp }}"', workflow)
         self.assertGreaterEqual(workflow.count(key_path), 3)
         self.assertIn(windows_key_path, workflow)
         self.assertNotIn("$RUNNER_TEMP/plugin-key.pk8", workflow)


### PR DESCRIPTION
Creates the authoritative runner.temp directory with mode 0700 before decoding the internal plugin-integrity key in Linux container jobs. This follows the path-unification fix from PR 221 and addresses the early No such file error observed in both Linux architectures. Validation: 33 platform release/metadata/signing-policy tests passed; git diff --check passed.