### PR TITLE
ci(release): print installed smoke failure reports

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -293,7 +293,7 @@ jobs:
           "$installed/bin/into-md" capabilities list --json | jq -e '[.capabilities[] | select(.status == "ready")] | length == 3'
           mkdir "${{ runner.temp }}/smoke-core"
           archive_sha=$(sha256sum "${{ runner.temp }}/${{ matrix.archive }}" | awk '{print $1}')
-          "$installed/bin/installed-smoke" \
+          if ! "$installed/bin/installed-smoke" \
             --install-root "$installed" \
             --into-md "$installed/bin/into-md" \
             --rust-library "$installed/lib/into-markdown-rust" \
@@ -306,7 +306,10 @@ jobs:
             --cargo "$(rustup which cargo)" \
             --rustc "$(rustup which rustc)" \
             --pdfium-library "$installed/lib/pdfium/libpdfium.so" \
-            --timeout-seconds 90
+            --timeout-seconds 90; then
+            cat "${{ runner.temp }}/into-md-${{ matrix.target }}-core-smoke.json"
+            exit 1
+          fi
           "${{ runner.temp }}/distribution/uninstall" "${{ runner.temp }}/install" "${{ runner.temp }}/bin"
           diff -ru "${{ runner.temp }}/agent-skills-before" "$HOME/.agents/skills"
       - name: Clean-install and verify all capabilities
@@ -369,6 +372,10 @@ jobs:
             --rustc "$(rustup which rustc)" `
             --pdfium-library "$installed\bin\pdfium.dll" `
             --timeout-seconds 90
+          if ($LASTEXITCODE -ne 0) {
+            Get-Content "${{ runner.temp }}\into-md-${{ matrix.target }}-core-smoke.json" -Raw
+            throw "installed Core smoke failed"
+          }
           & "${{ runner.temp }}\distribution\Uninstall.ps1" -Prefix "${{ runner.temp }}\install" -CommandDirectory "${{ runner.temp }}\bin"
           if (Compare-Object $agentSkillsBefore @(Get-AgentSkillTree $agentSkills)) { throw "Core uninstaller modified the Agent Skills directory" }
       - name: Run installed Core smoke and platform acceptance
@@ -379,7 +386,7 @@ jobs:
           installed=$("$distribution/install" "${{ runner.temp }}/accept-install" "${{ runner.temp }}/accept-bin" | tail -1)
           mkdir "${{ runner.temp }}/installed-smoke-state"
           archive_sha=$(sha256sum "${{ runner.temp }}/${{ matrix.archive }}" | awk '{print $1}')
-          "$installed/bin/installed-smoke" --install-root "$installed" --into-md "$installed/bin/into-md" --rust-library "$installed/lib/into-markdown-rust" --manifest "$installed/archive-manifest.json" --fixtures "$installed/share/into-markdown/smoke/fixtures" --audio-fixture "$GITHUB_WORKSPACE/fixtures/asr-quality/source/en-clear.wav" --temp-root "${{ runner.temp }}/installed-smoke-state" --report "${{ runner.temp }}/installed-smoke.json" --archive-sha256 "$archive_sha" --cargo "$(rustup which cargo)" --rustc "$(rustup which rustc)" --pdfium-library "$installed/lib/pdfium/libpdfium.so" --timeout-seconds 90
+          if ! "$installed/bin/installed-smoke" --install-root "$installed" --into-md "$installed/bin/into-md" --rust-library "$installed/lib/into-markdown-rust" --manifest "$installed/archive-manifest.json" --fixtures "$installed/share/into-markdown/smoke/fixtures" --audio-fixture "$GITHUB_WORKSPACE/fixtures/asr-quality/source/en-clear.wav" --temp-root "${{ runner.temp }}/installed-smoke-state" --report "${{ runner.temp }}/installed-smoke.json" --archive-sha256 "$archive_sha" --cargo "$(rustup which cargo)" --rustc "$(rustup which rustc)" --pdfium-library "$installed/lib/pdfium/libpdfium.so" --timeout-seconds 90; then cat "${{ runner.temp }}/installed-smoke.json"; exit 1; fi
           python tools/platform-release/platform_acceptance.py --target "${{ matrix.target }}" --install-root "$installed" --into-md "$installed/bin/into-md" --plugins "${{ runner.temp }}/plugins-a" --publisher "$installed/share/into-markdown/plugins/official-publisher.json" --fixtures "$installed/share/into-markdown/smoke/fixtures" --audio-fixture "$GITHUB_WORKSPACE/fixtures/asr-quality/source/en-clear.wav" --work-root "${{ runner.temp }}/platform-acceptance-state" --archive-sha256 "$archive_sha" --platform-audit "${{ runner.temp }}/platform-audit.json" --report "${{ runner.temp }}/platform-acceptance.json" --timeout-seconds 900
           "$distribution/uninstall" "${{ runner.temp }}/accept-install" "${{ runner.temp }}/accept-bin"
       - name: Run installed Core smoke and platform acceptance on Windows
@@ -393,7 +400,10 @@ jobs:
           New-Item -ItemType Directory "${{ runner.temp }}\installed-smoke-state" | Out-Null
           $archiveSha = (Get-FileHash -Algorithm SHA256 "${{ runner.temp }}\${{ matrix.archive }}").Hash.ToLowerInvariant()
           & "$installed\bin\installed-smoke.exe" --install-root $installed --into-md "$installed\bin\into-md.exe" --rust-library "$installed\lib\into-markdown-rust" --manifest "$installed\archive-manifest.json" --fixtures "$installed\share\into-markdown\smoke\fixtures" --audio-fixture "$env:GITHUB_WORKSPACE\fixtures\asr-quality\source\en-clear.wav" --temp-root "${{ runner.temp }}\installed-smoke-state" --report "${{ runner.temp }}\installed-smoke.json" --archive-sha256 $archiveSha --cargo (rustup which cargo) --rustc (rustup which rustc) --pdfium-library "$installed\lib\pdfium\pdfium.dll" --timeout-seconds 90
-          if ($LASTEXITCODE -ne 0) { throw "installed Core smoke failed" }
+          if ($LASTEXITCODE -ne 0) {
+            Get-Content "${{ runner.temp }}\installed-smoke.json" -Raw
+            throw "installed Core smoke failed"
+          }
           python tools/platform-release/platform_acceptance.py --target "${{ matrix.target }}" --install-root $installed --into-md "$installed\bin\into-md.exe" --plugins "${{ runner.temp }}\plugins-a" --publisher "$installed\share\into-markdown\plugins\official-publisher.json" --fixtures "$installed\share\into-markdown\smoke\fixtures" --audio-fixture "$env:GITHUB_WORKSPACE\fixtures\asr-quality\source\en-clear.wav" --work-root "${{ runner.temp }}\platform-acceptance-state" --archive-sha256 $archiveSha --platform-audit "${{ runner.temp }}\platform-audit.json" --report "${{ runner.temp }}\platform-acceptance.json" --timeout-seconds 900
           if ($LASTEXITCODE -ne 0) { throw "installed platform acceptance failed" }
           & "$distribution\Uninstall.ps1" -Prefix "${{ runner.temp }}\accept-install" -CommandDirectory "${{ runner.temp }}\accept-bin"

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -80,6 +80,24 @@ class PlatformReleaseTests(unittest.TestCase):
         self.assertNotIn("${{ github.workspace }}/fixtures/asr-quality", workflow)
         self.assertNotIn(r"${{ github.workspace }}\fixtures\asr-quality", workflow)
 
+    def test_installed_smoke_failures_print_the_machine_report(self) -> None:
+        workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(workflow.count('cat "${{ runner.temp }}/installed-smoke.json"'), 1)
+        self.assertEqual(
+            workflow.count('Get-Content "${{ runner.temp }}\\installed-smoke.json" -Raw'),
+            1,
+        )
+        self.assertIn(
+            'cat "${{ runner.temp }}/into-md-${{ matrix.target }}-core-smoke.json"',
+            workflow,
+        )
+        self.assertIn(
+            'Get-Content "${{ runner.temp }}\\into-md-${{ matrix.target }}-core-smoke.json" -Raw',
+            workflow,
+        )
+
     def test_windows_cmake_uses_the_activated_pinned_msvc_toolchain(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
Prints the existing machine-readable installed-smoke report immediately beside each failing Linux or Windows smoke invocation, before the job exits. Pass/fail semantics and report contracts are unchanged. Adds workflow contract coverage. Validation: platform release tests passed; git diff --check passed.