### PR TITLE
ci(release): parallelize native gates and cache builds

### DIFF
--- a/.github/workflows/native-release-gates.yml
+++ b/.github/workflows/native-release-gates.yml
@@ -1,0 +1,115 @@
+name: Native release gates
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      target:
+        required: true
+        type: string
+      container:
+        required: true
+        type: string
+      bazel_config:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  native-gates:
+    runs-on: ${{ inputs.runner }}
+    container: ${{ inputs.container }}
+    timeout-minutes: 180
+    steps:
+      - name: Bootstrap fixed Linux gate container
+        if: runner.os == 'Linux'
+        run: |
+          dnf install --assumeyes binutils clang-libs cmake curl diffutils file findutils gcc gcc-c++ git gzip jq make patch perl pkgconf-pkg-config python3.11 python3.11-pip tar unzip which xz zip
+          if [ "$(uname -m)" = x86_64 ]; then
+            dnf --enablerepo=powertools install --assumeyes nasm
+            nasm -v
+          fi
+          case "$(uname -m)" in
+            x86_64)
+              bazelisk_asset=bazelisk-linux-amd64
+              bazelisk_sha256=e1508323f347ad1465a887bc5d2bfb91cffc232d11e8e997b623227c6b32fb76
+              ;;
+            aarch64)
+              bazelisk_asset=bazelisk-linux-arm64
+              bazelisk_sha256=bb608519a440d45d10304eb684a73a2b6bb7699c5b0e5434361661b25f113a5d
+              ;;
+            *)
+              echo "unsupported Linux gate architecture: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+          curl --fail --location --proto '=https' --tlsv1.2 \
+            --output /usr/local/bin/bazelisk \
+            "https://github.com/bazelbuild/bazelisk/releases/download/v1.27.0/$bazelisk_asset"
+          echo "$bazelisk_sha256  /usr/local/bin/bazelisk" | sha256sum --check
+          chmod 0755 /usr/local/bin/bazelisk
+          ln -sf /usr/local/bin/bazelisk /usr/local/bin/bazel
+          ln -sf /usr/bin/python3.11 /usr/local/bin/python
+          ln -sf /usr/bin/python3.11 /usr/local/bin/python3
+          libclang_path="$(rpm -ql clang-libs | grep -E '/libclang\.so(\.[0-9]+)*$' | head -n 1)"
+          test -f "$libclang_path"
+          echo "LIBCLANG_PATH=$(dirname "$libclang_path")" >> "$GITHUB_ENV"
+          test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.28"
+      - uses: actions/checkout@v4
+      - name: Bind fixed Linux checkout ownership
+        if: runner.os == 'Linux'
+        run: |
+          git config --global --unset-all safe.directory || true
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          test "$(git rev-parse --show-toplevel)" = "$GITHUB_WORKSPACE"
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.97.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.13.0
+      - uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: release-gates-${{ inputs.bazel_config }}
+          repository-cache: true
+      - name: Activate fixed pnpm toolchain
+        run: |
+          corepack enable
+          corepack pnpm --version
+      - uses: msys2/setup-msys2@v2
+        if: runner.os == 'Windows'
+        with:
+          install: make diffutils xz curl gnupg jq file binutils python coreutils perl
+      - uses: ilammy/msvc-dev-cmd@v1
+        if: runner.os == 'Windows'
+        with:
+          toolset: 14.44.35207
+          sdk: 10.0.26100.0
+      - name: Bind CMake to the activated Windows toolchain
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          "CMAKE_GENERATOR=NMake Makefiles" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Prepare Cargo plugin lifecycle fixture on Linux
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          cargo build --locked -p into-markdown-plugin-manager --bin plugin_manager_process_fixture --target "${{ inputs.target }}"
+          echo "INTO_MD_PLUGIN_PROCESS_FIXTURE=$PWD/target/${{ inputs.target }}/debug/plugin_manager_process_fixture" >> "$GITHUB_ENV"
+      - name: Prepare Cargo plugin lifecycle fixture on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cargo build --locked -p into-markdown-plugin-manager --bin plugin_manager_process_fixture --target "${{ inputs.target }}"
+          "INTO_MD_PLUGIN_PROCESS_FIXTURE=$PWD\target\${{ inputs.target }}\debug\plugin_manager_process_fixture.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Run target-native Cargo, Clippy, and Bazel gates
+        run: |
+          python -m unittest tools.platform-release.test_release tools.platform-release.test_platform_tools tools.publish_release_assets_test tools.release_metadata_test tools.release_signing_policy_test
+          cargo test --workspace --all-targets --locked -- --test-threads=1
+          cargo clippy --workspace --exclude whisper-rs --all-targets --no-deps --locked -- -D clippy::correctness -D clippy::suspicious -D clippy::perf
+          bazel --output_user_root="${{ runner.temp }}/bazel" test --config=${{ inputs.bazel_config }} --lockfile_mode=error --local_test_jobs=1 --test_env=RUST_TEST_THREADS=1 //...

--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -23,6 +23,32 @@ jobs:
   agent-skill:
     uses: ./.github/workflows/agent-skill-release.yml
 
+  native-gates:
+    needs: agent-skill
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            container: docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
+            bazel_config: linux_x86_64
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            container: docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
+            bazel_config: linux_arm64
+          - runner: windows-2025
+            target: x86_64-pc-windows-msvc
+            container: ''
+            bazel_config: windows_x86_64
+    uses: ./.github/workflows/native-release-gates.yml
+    with:
+      runner: ${{ matrix.runner }}
+      target: ${{ matrix.target }}
+      container: ${{ matrix.container }}
+      bazel_config: ${{ matrix.bazel_config }}
+
   native-release:
     needs: agent-skill
     environment: release
@@ -108,12 +134,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
+      - uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/build
+          key: native-release-rust-1.97.1-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
       - uses: actions/setup-node@v4
         with:
           node-version: 24.13.0
       - uses: bazel-contrib/setup-bazel@0.15.0
         with:
           bazelisk-cache: true
+          disk-cache: platform-release-${{ matrix.bazel_config }}
+          repository-cache: true
       - name: Activate fixed pnpm toolchain
         run: |
           corepack enable
@@ -196,12 +228,6 @@ jobs:
         run: |
           cargo build --locked -p into-markdown-plugin-manager --bin plugin_manager_process_fixture --target "${{ matrix.target }}"
           "INTO_MD_PLUGIN_PROCESS_FIXTURE=$PWD\target\${{ matrix.target }}\debug\plugin_manager_process_fixture.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-      - name: Run target-native Cargo, Clippy, and Bazel gates
-        run: |
-          python -m unittest tools.platform-release.test_release tools.platform-release.test_platform_tools tools.publish_release_assets_test tools.release_metadata_test tools.release_signing_policy_test
-          cargo test --workspace --all-targets --locked -- --test-threads=1
-          cargo clippy --workspace --exclude whisper-rs --all-targets --no-deps --locked -- -D clippy::correctness -D clippy::suspicious -D clippy::perf
-          bazel --output_user_root="${{ runner.temp }}/bazel" test --config=${{ matrix.bazel_config }} --lockfile_mode=error --local_test_jobs=1 --test_env=RUST_TEST_THREADS=1 //...
       - name: Authenticode-sign project executables
         if: runner.os == 'Windows' && inputs.signing_mode == 'signed'
         shell: pwsh
@@ -473,7 +499,7 @@ jobs:
           Remove-Item "${{ runner.temp }}\plugin-key.pk8" -Force -ErrorAction SilentlyContinue
 
   publish-draft:
-    needs: native-release
+    needs: [native-gates, native-release]
     runs-on: ubuntu-24.04
     environment: release
     permissions:

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -24,6 +24,32 @@ from release import (
 
 
 class PlatformReleaseTests(unittest.TestCase):
+    def test_expensive_native_gates_run_in_parallel_with_release_acceptance(self) -> None:
+        workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
+            encoding="utf-8"
+        )
+        gates = (ROOT / ".github/workflows/native-release-gates.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("native-gates:", workflow)
+        self.assertIn("needs: [native-gates, native-release]", workflow)
+        self.assertNotIn("cargo test --workspace --all-targets", workflow)
+        self.assertIn("cargo test --workspace --all-targets", gates)
+        self.assertIn("cargo clippy --workspace", gates)
+        self.assertIn("repository-cache: true", gates)
+        self.assertIn("disk-cache: release-gates-${{ inputs.bazel_config }}", gates)
+
+    def test_native_release_reuses_fixed_toolchain_cargo_dependencies(self) -> None:
+        workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("path: ${{ runner.temp }}/build", workflow)
+        self.assertIn(
+            "key: native-release-rust-1.97.1-${{ runner.os }}-"
+            "${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}",
+            workflow,
+        )
+
     def test_release_build_prefetches_complete_locked_cargo_closure(self) -> None:
         source = (ROOT / "tools/platform-release/release.py").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Outcome
- run the expensive target-native Cargo/Clippy/Bazel gates in parallel with package assembly and installed-platform acceptance
- require both branches before publishing the protected draft
- add per-platform Bazel action/repository caches and a fixed-toolchain Cargo release cache
- preserve every existing release, deterministic assembly, native audit, installed-smoke, platform acceptance, and macOS step

## Expected impact
- installed package failures surface after the release build (roughly 15-20 minutes instead of roughly 55 minutes in run 33043977455)
- uncached end-to-end wall time becomes the maximum of gates and acceptance, not their sum
- retries and later releases reuse fixed-version, target-isolated caches

## Verification
- 37 release contract tests passed
- actionlint 1.7.7 passed for every workflow
- cargo fmt --all -- --check
- git diff --check