### PR TITLE
ci(release): prefetch the complete Cargo gate closure

### DIFF
--- a/.github/workflows/native-release-gates.yml
+++ b/.github/workflows/native-release-gates.yml
@@ -69,6 +69,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git/db
+          key: release-gates-cargo-registry-v1-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
       - uses: actions/setup-node@v4
         with:
           node-version: 24.13.0
@@ -95,6 +101,8 @@ jobs:
         shell: pwsh
         run: |
           "CMAKE_GENERATOR=NMake Makefiles" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Prefetch complete locked Cargo closure
+        run: cargo fetch --locked
       - name: Prepare Cargo plugin lifecycle fixture on Linux
         if: runner.os == 'Linux'
         shell: bash

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -36,6 +36,8 @@ class PlatformReleaseTests(unittest.TestCase):
         self.assertNotIn("cargo test --workspace --all-targets", workflow)
         self.assertIn("cargo test --workspace --all-targets", gates)
         self.assertIn("cargo clippy --workspace", gates)
+        self.assertIn("run: cargo fetch --locked", gates)
+        self.assertIn("~/.cargo/registry", gates)
         self.assertIn("repository-cache: true", gates)
         self.assertIn("disk-cache: release-gates-${{ inputs.bazel_config }}", gates)
 


### PR DESCRIPTION
## Summary
- restore the explicit cargo fetch --locked prerequisite that the monolithic release build previously provided
- keep license/release authority tests offline after the complete locked closure is present
- cache only the Cargo registry/git download data by fixed lockfile and runner OS
- preserve target build isolation, strict Clippy, Bazel gates, and installed acceptance

## Verification
- 16 platform release workflow contract tests passed
- actionlint 1.7.7 passed
- git diff --check

This fixes the early x86_64 gate failure in run 33052386852 where offline cargo metadata lacked android_system_properties 0.1.6.