### PR TITLE
fix(release): isolate Git objects during secret audit

### DIFF
--- a/.github/workflows/public-release-readiness.yml
+++ b/.github/workflows/public-release-readiness.yml
@@ -22,10 +22,54 @@ jobs:
           curl --fail --location --proto '=https' --tlsv1.2 --output "$RUNNER_TEMP/gitleaks.tar.gz" https://github.com/gitleaks/gitleaks/releases/download/v8.28.0/gitleaks_8.28.0_linux_x64.tar.gz
           echo 'a65b5253807a68ac0cafa4414031fd740aeb55f54fb7e55f386acb52e6a840eb  '"$RUNNER_TEMP/gitleaks.tar.gz" | sha256sum --check
           tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP" gitleaks
-      - name: Scan the current tree and complete Git history
+      - name: Scan the current tree and complete reachable Git history
         run: |
-          set -o pipefail
-          git cat-file --batch-all-objects --batch | "$RUNNER_TEMP/gitleaks" stdin --config .gitleaks.toml --redact --no-banner --report-format json --report-path "$RUNNER_TEMP/history-findings.json"
+          set -euo pipefail
+          history_dir="$RUNNER_TEMP/git-history-objects"
+          mkdir -p "$history_dir"
+          git rev-list --objects --all > "$RUNNER_TEMP/git-object-paths.txt"
+          python - "$RUNNER_TEMP/git-object-paths.txt" "$RUNNER_TEMP/git-object-types.txt" "$history_dir" <<'PY'
+          from pathlib import Path
+          import string
+          import subprocess
+          import sys
+
+          paths_file, types_file, history_dir = map(Path, sys.argv[1:])
+          object_ids = sorted(
+              {line.split(" ", 1)[0] for line in paths_file.read_text().splitlines()}
+          )
+          process = subprocess.Popen(
+              ["git", "cat-file", "--batch"],
+              stdin=subprocess.PIPE,
+              stdout=subprocess.PIPE,
+          )
+          assert process.stdin is not None and process.stdout is not None
+          try:
+              with types_file.open("w", encoding="utf-8", newline="\n") as manifest:
+                  for object_id in object_ids:
+                      if len(object_id) not in (40, 64) or any(
+                          character not in string.hexdigits for character in object_id
+                      ):
+                          raise RuntimeError(f"invalid Git object id: {object_id!r}")
+                      process.stdin.write(f"{object_id}\n".encode())
+                      process.stdin.flush()
+                      header = process.stdout.readline().decode().strip().split()
+                      if len(header) != 3 or header[0] != object_id:
+                          raise RuntimeError(f"invalid git cat-file header for {object_id}")
+                      object_type, size = header[1], int(header[2])
+                      payload = process.stdout.read(size)
+                      if len(payload) != size or process.stdout.read(1) != b"\n":
+                          raise RuntimeError(f"truncated Git object: {object_id}")
+                      (history_dir / object_id).write_bytes(payload)
+                      manifest.write(f"{object_id} {object_type}\n")
+              process.stdin.close()
+              if process.wait() != 0:
+                  raise RuntimeError("git cat-file --batch failed")
+          finally:
+              if process.poll() is None:
+                  process.kill()
+          PY
+          "$RUNNER_TEMP/gitleaks" dir "$history_dir" --config .gitleaks.toml --redact --no-banner --report-format json --report-path "$RUNNER_TEMP/history-findings.json"
       - name: Scan issue and PR metadata, Actions logs, and retained artifacts
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -40,6 +84,8 @@ jobs:
           name: public-release-readiness
           path: |
             ${{ runner.temp }}/history-findings.json
+            ${{ runner.temp }}/git-object-paths.txt
+            ${{ runner.temp }}/git-object-types.txt
             ${{ runner.temp }}/public-audit/*-findings.json
             ${{ runner.temp }}/public-audit/pii-findings.json
             ${{ runner.temp }}/public-audit/public-readiness.json


### PR DESCRIPTION
## Summary
- replace the delimiter-free `git cat-file --batch-all-objects` stream with one file per reachable Git object
- retain object/path and object/type manifests for investigation
- use one persistent `git cat-file --batch` process so the full 7,534-object export remains fast

## Why
The delimiter-free stream can synthesize a Gitleaks match across adjacent Git object boundaries. Such findings have no file or commit and cannot be safely investigated. Scanning each reachable object independently preserves the complete public ref history without cross-object matches.

## Verification
- actionlint `.github/workflows/public-release-readiness.yml`
- full local export: 7,534 objects / 7,534 manifest entries
- Gitleaks v8.28.0 directory scan: 200.27 MB, 0 findings, ~7.5 s scan time
- `git diff --check`