### PR TITLE
fix(release): bind Linux linker tool path

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -333,6 +333,7 @@ jobs:
             --rustc "$(rustup which rustc)" \
             --pdfium-library "$installed/lib/pdfium/libpdfium.so" \
             --timeout-seconds 90; then
+            jq -r '.cases[] | select(.status == "failed") | .detail' "${{ runner.temp }}/into-md-${{ matrix.target }}-core-smoke.json"
             cat "${{ runner.temp }}/into-md-${{ matrix.target }}-core-smoke.json"
             exit 1
           fi
@@ -412,7 +413,11 @@ jobs:
           installed=$("$distribution/install" "${{ runner.temp }}/accept-install" "${{ runner.temp }}/accept-bin" | tail -1)
           mkdir "${{ runner.temp }}/installed-smoke-state"
           archive_sha=$(sha256sum "${{ runner.temp }}/${{ matrix.archive }}" | awk '{print $1}')
-          if ! "$installed/bin/installed-smoke" --install-root "$installed" --into-md "$installed/bin/into-md" --rust-library "$installed/lib/into-markdown-rust" --manifest "$installed/archive-manifest.json" --fixtures "$installed/share/into-markdown/smoke/fixtures" --audio-fixture "$GITHUB_WORKSPACE/fixtures/asr-quality/source/en-clear.wav" --temp-root "${{ runner.temp }}/installed-smoke-state" --report "${{ runner.temp }}/installed-smoke.json" --archive-sha256 "$archive_sha" --cargo "$(rustup which cargo)" --rustc "$(rustup which rustc)" --pdfium-library "$installed/lib/pdfium/libpdfium.so" --timeout-seconds 90; then cat "${{ runner.temp }}/installed-smoke.json"; exit 1; fi
+          if ! "$installed/bin/installed-smoke" --install-root "$installed" --into-md "$installed/bin/into-md" --rust-library "$installed/lib/into-markdown-rust" --manifest "$installed/archive-manifest.json" --fixtures "$installed/share/into-markdown/smoke/fixtures" --audio-fixture "$GITHUB_WORKSPACE/fixtures/asr-quality/source/en-clear.wav" --temp-root "${{ runner.temp }}/installed-smoke-state" --report "${{ runner.temp }}/installed-smoke.json" --archive-sha256 "$archive_sha" --cargo "$(rustup which cargo)" --rustc "$(rustup which rustc)" --pdfium-library "$installed/lib/pdfium/libpdfium.so" --timeout-seconds 90; then
+            jq -r '.cases[] | select(.status == "failed") | .detail' "${{ runner.temp }}/installed-smoke.json"
+            cat "${{ runner.temp }}/installed-smoke.json"
+            exit 1
+          fi
           python tools/platform-release/platform_acceptance.py --target "${{ matrix.target }}" --install-root "$installed" --into-md "$installed/bin/into-md" --plugins "${{ runner.temp }}/plugins-a" --publisher "$installed/share/into-markdown/plugins/official-publisher.json" --fixtures "$installed/share/into-markdown/smoke/fixtures" --audio-fixture "$GITHUB_WORKSPACE/fixtures/asr-quality/source/en-clear.wav" --work-root "${{ runner.temp }}/platform-acceptance-state" --archive-sha256 "$archive_sha" --platform-audit "${{ runner.temp }}/platform-audit.json" --report "${{ runner.temp }}/platform-acceptance.json" --timeout-seconds 900
           "$distribution/uninstall" "${{ runner.temp }}/accept-install" "${{ runner.temp }}/accept-bin"
       - name: Run installed Core smoke and platform acceptance on Windows

--- a/tools/installed-smoke/src/rust_consumer.rs
+++ b/tools/installed-smoke/src/rust_consumer.rs
@@ -329,6 +329,10 @@ fn configure_linux_linker(
         ("AR".into(), librarian),
         ("CC".into(), compiler),
         ("CXX".into(), cxx),
+        // GCC invokes its assembler and linker as child tools. Keep those
+        // lookups inside fixed system directories without restoring the
+        // caller's mutable development PATH.
+        ("PATH".into(), "/usr/bin:/bin".into()),
     ]));
     Ok(())
 }
@@ -692,6 +696,22 @@ mod tests {
         let mut environment = BTreeMap::new();
         configure_linux_linker("test-target", &mut environment).unwrap();
         assert!(environment.is_empty());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_linker_configuration_uses_only_fixed_system_tool_directories() {
+        let native_target = match std::env::consts::ARCH {
+            "x86_64" => "x86_64-unknown-linux-gnu",
+            "aarch64" => "aarch64-unknown-linux-gnu",
+            architecture => panic!("unsupported Linux test architecture: {architecture}"),
+        };
+        let mut environment = BTreeMap::new();
+        configure_linux_linker(native_target, &mut environment).unwrap();
+        assert_eq!(environment.get("PATH").map(String::as_str), Some("/usr/bin:/bin"));
+        assert!(environment.get("CC").is_some_and(|value| Path::new(value).is_file()));
+        assert!(environment.get("CXX").is_some_and(|value| Path::new(value).is_file()));
+        assert!(environment.get("AR").is_some_and(|value| Path::new(value).is_file()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- give the isolated Linux Cargo consumer a fixed `/usr/bin:/bin` PATH so GCC can invoke its assembler/linker children
- keep the caller/development PATH excluded
- print failed installed-smoke details as decoded multiline diagnostics before the JSON report

## Failure evidence
Both Linux x86_64 and ARM64 formal release jobs passed all 23 format/runtime cases, including native `.doc/.ppt/.xls`, OCR, and speech, then failed only at `rust-external-consumer` during the final GCC link. Cargo already had fixed absolute CC/CXX/AR/linker paths, but its environment was otherwise cleared; GCC child-tool lookup therefore had no PATH.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p installed-smoke rust_consumer --locked`
- actionlint `.github/workflows/platform-modular-release.yml`
- `git diff --check`