### PR TITLE
fix(plugin): bind Unix provider private temp

### DIFF
--- a/crates/process-plugin/src/bin/process_plugin_fixture.rs
+++ b/crates/process-plugin/src/bin/process_plugin_fixture.rs
@@ -87,6 +87,24 @@ fn main() -> std::io::Result<()> {
                     "secret-leaked"
                 },
             )),
+            "private-temp" => {
+                let private =
+                    std::env::var_os("INTO_MARKDOWN_PRIVATE_TEMP").map(std::path::PathBuf::from);
+                let standard = std::env::var_os(if cfg!(windows) { "TEMP" } else { "TMPDIR" })
+                    .map(std::path::PathBuf::from);
+                let usable = private.as_ref().is_some_and(|root| {
+                    root.is_absolute()
+                        && (cfg!(windows) || standard.as_ref() == Some(root))
+                        && root.is_dir()
+                        && std::fs::OpenOptions::new()
+                            .write(true)
+                            .create_new(true)
+                            .open(root.join("private-temp-probe"))
+                            .and_then(|_| std::fs::remove_file(root.join("private-temp-probe")))
+                            .is_ok()
+                });
+                Ok(result(if usable { "private-temp-ready" } else { "private-temp-invalid" }))
+            }
             "child" => {
                 let executable = std::env::current_exe()
                     .map_err(|_| WorkerError::new("childPrepare", "child helper is unavailable"))?;

--- a/crates/process-plugin/src/lib.rs
+++ b/crates/process-plugin/src/lib.rs
@@ -1600,6 +1600,7 @@ fn reserved_environment_name(value: &str) -> bool {
         value,
         "INTO_MARKDOWN_PLUGIN_PROTOCOL"
             | "INTO_MARKDOWN_INHERITED_SANDBOX"
+            | "INTO_MARKDOWN_PRIVATE_TEMP"
             | "SYSTEMROOT"
             | "WINDIR"
             | "SYSTEMDRIVE"
@@ -1638,6 +1639,7 @@ mod tests {
         for name in [
             "INTO_MARKDOWN_PLUGIN_PROTOCOL",
             "INTO_MARKDOWN_INHERITED_SANDBOX",
+            "INTO_MARKDOWN_PRIVATE_TEMP",
             "SYSTEMROOT",
             "WINDIR",
             "SYSTEMDRIVE",

--- a/crates/process-plugin/src/sandbox/mod.rs
+++ b/crates/process-plugin/src/sandbox/mod.rs
@@ -54,7 +54,7 @@ pub(crate) fn spawn(
         command.env(name, value);
     }
     #[cfg(unix)]
-    command.env("TMPDIR", directory);
+    command.env("TMPDIR", directory).env("INTO_MARKDOWN_PRIVATE_TEMP", directory);
     command.env("INTO_MARKDOWN_PLUGIN_PROTOCOL", "process-v1");
     #[cfg(target_os = "macos")]
     if policy.macos_compatibility_child {

--- a/crates/process-plugin/tests/runtime.rs
+++ b/crates/process-plugin/tests/runtime.rs
@@ -24,6 +24,9 @@ fn real_process_fixture_enforces_protocol_lifecycle_and_capabilities() {
     let secret = harness.execute(b"secret", ExecutionOptions::default()).unwrap();
     assert_eq!(secret.result.markdown, "secret-denied");
 
+    let private_temp = harness.execute(b"private-temp", ExecutionOptions::default()).unwrap();
+    assert_eq!(private_temp.result.markdown, "private-temp-ready");
+
     let outside = tempfile::NamedTempFile::new().unwrap();
     std::fs::write(outside.path(), b"host-secret").unwrap();
     let file = harness


### PR DESCRIPTION
## Summary
- inject the host-owned request-private directory as `INTO_MARKDOWN_PRIVATE_TEMP` for Unix process sandboxes, alongside `TMPDIR`
- reserve that environment name so plugin manifests cannot override the authority
- extend the real OS sandbox fixture to verify the private directory exists and is writable

## Failure evidence
The final Linux x86_64 and ARM64 packages passed installed-smoke, including the external Rust consumer and all Core/plugin cases. Both then failed the real OCR acceptance with `ONNX Runtime library I/O failed during private-temp-environment`. Windows already injects this host-only variable; Unix only injected `TMPDIR` even though ONNX authenticated snapshots require the explicit authority.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p into-markdown-process-plugin --locked` (5 unit + 8 real sandbox integration tests)
- `git diff --check`