### PR TITLE
fix(release): align native sandbox authorities

### DIFF
--- a/crates/process-plugin/src/sandbox/windows.rs
+++ b/crates/process-plugin/src/sandbox/windows.rs
@@ -668,19 +668,19 @@ fn validate_acl_aces(
         }
         let sid = (&raw const ace.SidStart).cast_mut().cast();
         let identity = allowed.iter().position(|allowed| unsafe { EqualSid(sid, *allowed) } != 0);
-        let (identity_name, expected_mask) = if let Some(identity) = identity {
+        let (identity_name, expected_mask, os_administrator) = if let Some(identity) = identity {
             if seen[identity] {
                 return Err(format!("ACE {index} duplicates an allowed SID"));
             }
             seen[identity] = true;
-            ("user", masks[identity])
+            ("user", masks[identity], false)
         } else if allow_os_administrators && unsafe { IsWellKnownSid(sid, WinLocalSystemSid) } != 0
         {
             if seen_system {
                 return Err(format!("ACE {index} duplicates LocalSystem"));
             }
             seen_system = true;
-            ("LocalSystem", FILE_ALL_ACCESS)
+            ("LocalSystem", FILE_ALL_ACCESS, true)
         } else if allow_os_administrators
             && unsafe { IsWellKnownSid(sid, WinBuiltinAdministratorsSid) } != 0
         {
@@ -688,13 +688,13 @@ fn validate_acl_aces(
                 return Err(format!("ACE {index} duplicates Builtin Administrators"));
             }
             seen_administrators = true;
-            ("Builtin Administrators", FILE_ALL_ACCESS)
+            ("Builtin Administrators", FILE_ALL_ACCESS, true)
         } else {
             return Err(format!("ACE {index} has an unauthorized SID"));
         };
-        let expected_inheritance = if is_directory { 3 } else { 0 };
+        let inheritance = ace.Header.AceFlags & !INHERITED_ACE_FLAG;
         if ace.Mask != expected_mask
-            || ace.Header.AceFlags & !INHERITED_ACE_FLAG != expected_inheritance
+            || !valid_ace_inheritance(is_directory, os_administrator, inheritance)
         {
             return Err(format!(
                 "ACE {index} for {identity_name} has mask 0x{:08x} and flags 0x{:02x}",
@@ -706,6 +706,17 @@ fn validate_acl_aces(
         return Err("an expected allowed SID is absent".to_owned());
     }
     Ok(())
+}
+
+const fn valid_ace_inheritance(
+    is_directory: bool,
+    os_administrator: bool,
+    inheritance: u8,
+) -> bool {
+    if !is_directory {
+        return inheritance == 0;
+    }
+    inheritance == 3 || os_administrator && inheritance == 0
 }
 
 struct CurrentUser {
@@ -1494,5 +1505,16 @@ mod tests {
         let process_unc = wide_process_path(Path::new(r"\\?\UNC\server\share\working")).unwrap();
         let process_unc = String::from_utf16(&process_unc[..process_unc.len() - 1]).unwrap();
         assert_eq!(process_unc, r"\\server\share\working");
+    }
+
+    #[test]
+    fn os_administrator_directory_ace_may_be_narrower_than_user_inheritance() {
+        assert!(valid_ace_inheritance(true, true, 0));
+        assert!(valid_ace_inheritance(true, true, 3));
+        assert!(!valid_ace_inheritance(true, true, 1));
+        assert!(!valid_ace_inheritance(true, false, 0));
+        assert!(valid_ace_inheritance(true, false, 3));
+        assert!(valid_ace_inheritance(false, true, 0));
+        assert!(!valid_ace_inheritance(false, true, 3));
     }
 }

--- a/crates/provider-plugin/src/process.rs
+++ b/crates/provider-plugin/src/process.rs
@@ -16,7 +16,25 @@ use std::time::Duration;
 const PROTOCOL_VERSION: u32 = 1;
 const FRAME_OVERHEAD: u64 = 1024 * 1024;
 const MAX_FRAME_BYTES: u64 = 64 * 1024 * 1024;
+// RLIMIT_AS accounts every mapping in the provider coordinator, not only
+// resident capability data. A provider that is authorized to launch an
+// authenticated helper therefore needs fixed virtual-address headroom while
+// the helper installs its own model-derived hard limit before loading ORT.
+const LINUX_CHILD_COORDINATOR_ADDRESS_SPACE_BYTES: u64 = 512 * 1024 * 1024;
 static REQUEST_SEQUENCE: AtomicU64 = AtomicU64::new(1);
+
+fn process_address_space_limit(
+    declared_memory: u64,
+    allow_child_processes: bool,
+) -> Result<u64, ConversionError> {
+    if cfg!(target_os = "linux") && allow_child_processes {
+        declared_memory
+            .checked_add(LINUX_CHILD_COORDINATOR_ADDRESS_SPACE_BYTES)
+            .ok_or_else(|| unavailable("process-v1", "provider address-space limit overflowed"))
+    } else {
+        Ok(declared_memory)
+    }
+}
 
 /// Authenticated process runtime bound to one self-contained installed capability.
 pub struct ProcessCapability {
@@ -74,7 +92,10 @@ impl ProcessCapability {
                 unavailable(&binding.provider_id, "capability frame limit is invalid")
             })?,
             max_output_bytes: capability.resources.max_output_bytes,
-            max_memory_bytes: capability.resources.max_memory_bytes,
+            max_memory_bytes: process_address_space_limit(
+                capability.resources.max_memory_bytes,
+                manifest.permissions.child_processes,
+            )?,
             max_file_bytes: capability
                 .resources
                 .max_input_bytes
@@ -757,6 +778,21 @@ mod tests {
                 locator: SourceLocator { time: Some(range), ..SourceLocator::default() },
                 confidence: Some(0.9),
             },
+        }
+    }
+
+    #[test]
+    fn child_provider_address_space_keeps_declared_memory_separate() {
+        let declared = 768 * 1024 * 1024;
+        let expected = if cfg!(target_os = "linux") {
+            declared + LINUX_CHILD_COORDINATOR_ADDRESS_SPACE_BYTES
+        } else {
+            declared
+        };
+        assert_eq!(process_address_space_limit(declared, true).unwrap(), expected);
+        assert_eq!(process_address_space_limit(declared, false).unwrap(), declared);
+        if cfg!(target_os = "linux") {
+            assert!(process_address_space_limit(u64::MAX, true).is_err());
         }
     }
 

--- a/docs/process-plugins.md
+++ b/docs/process-plugins.md
@@ -40,7 +40,9 @@ HOME 和 loader 变量不会继承。原生 provider 也必须把该协议变量
 
 - Linux：`RLIMIT_AS/FSIZE/NOFILE/CORE`，Landlock 只读 runtime/动态加载器目录且只允许
   私有临时目录写入，seccomp 拒绝 socket、跨进程信号、fork、namespace、mount、ptrace
-  等调用；只允许同进程线程 clone。
+  等调用；只允许同进程线程 clone。签名 manifest 明确允许认证 helper 时，协调进程的
+  `RLIMIT_AS` 额外包含固定 512 MiB 虚拟地址开销；能力声明的实际内存预算保持不变，
+  helper 仍在加载 runtime/model 前安装由其合同计算的独立硬上限。
 - macOS：固定虚拟地址上限、父进程物理内存监控和 deny-default Seatbelt；拒绝网络，
   只读 runtime/模型/系统 dyld 支持目录，只写私有临时目录。只有签名 manifest 显式声明
   时才允许从已认证 runtime 启动 helper。

--- a/docs/process-plugins.md
+++ b/docs/process-plugins.md
@@ -48,7 +48,9 @@ HOME 和 loader 变量不会继承。原生 provider 也必须把该协议变量
   时才允许从已认证 runtime 启动 helper。
 - Windows：安装层预创建并 ACL 授权的 AppContainer SID；启动时 capability 数量为零，
   仅继承三根协议 handle。主线程在 Job 的单进程、内存和 close-kill 限制安装并复核 token
-  SID 后才恢复。cwd 必须与该 SID 的 storage identity 精确一致。
+  SID 后才恢复。cwd 必须与该 SID 的 storage identity 精确一致。私有根只额外接受
+  LocalSystem/Builtin Administrators 的精确完全控制 ACE；目录本身的非继承管理 ACE 与
+  子项继承 ACE 均可接受，其他 SID、mask 或 inheritance 组合仍拒绝。
 
 某个平台不能建立这些边界时，运行时返回 `pluginSandboxUnavailable`，不会降级为普通
 子进程。文件大小、句柄、内存、握手时间、不可关闭的硬请求期限和 frame/output 上限均由宿主策略限制。


### PR DESCRIPTION
## Summary
- keep the signed capability memory budget unchanged while adding fixed Linux `RLIMIT_AS` headroom to child-authorized provider coordinators; the ONNX helper retains its own model-derived hard limit
- accept a directory-only full-control ACE only for LocalSystem/Builtin Administrators on protected Windows private roots, while preserving exact user/AppContainer SID, mask, and inheritance checks
- document and test both native authority calculations

## Formal release evidence
Run 33064956691 collected both failures before this patch:
- Linux x86_64 and ARM64 real OCR reached ONNX but the 768 MiB coordinator `RLIMIT_AS` could not launch its independently bounded worker (`workerLimitUnavailable`)
- Windows rejected the GitHub-hosted runner's narrower directory-only Builtin Administrators ACE (`mask 0x001f01ff`, `flags 0x00`)
- both Linux native gates passed; the unchanged macOS ARM64 formal release passed

## Local verification
- `cargo fmt --all -- --check`
- `cargo test -p into-markdown-provider-plugin --locked` (11 passed)
- `cargo clippy -p into-markdown-provider-plugin --all-targets --locked -- -D warnings`
- `cargo test -p into-markdown-process-plugin --locked` (6 unit + 8 real sandbox integration passed)
- `cargo clippy -p into-markdown-process-plugin --all-targets --locked -- -D warnings`