### PR TITLE
fix(onnx): classify Unix worker launch failures

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -397,7 +397,7 @@ jobs:
             --archive-sha256 "$archiveSha" `
             --cargo "$(rustup which cargo)" `
             --rustc "$(rustup which rustc)" `
-            --pdfium-library "$installed\bin\pdfium.dll" `
+            --pdfium-library "$installed\lib\pdfium\pdfium.dll" `
             --timeout-seconds 90
           if ($LASTEXITCODE -ne 0) {
             Get-Content "${{ runner.temp }}\into-md-${{ matrix.target }}-core-smoke.json" -Raw

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,7 @@ platform(
 )
 
 exports_files([
+    ".github/workflows/native-release-gates.yml",
     ".github/workflows/platform-modular-release.yml",
     ".bazelversion",
     "Cargo.lock",

--- a/crates/onnxruntime/src/worker.rs
+++ b/crates/onnxruntime/src/worker.rs
@@ -318,7 +318,7 @@ fn spawn_worker(
         // The worker installs the platform-native limit before authority parsing,
         // ORT loading, model receipt, or additional threads. On macOS the parent
         // enforces the fixed physical-footprint ceiling instead of RLIMIT_AS.
-        let child = command.spawn().map_err(|_| ort_error("workerLimitUnavailable"))?;
+        let child = command.spawn().map_err(classify_unix_spawn_error)?;
         return Ok(WorkerProcess {
             child,
             #[cfg(target_os = "macos")]
@@ -334,6 +334,16 @@ fn spawn_worker(
         component: "onnxruntime-cpu".into(),
         detail: "workerLimitUnavailable".into(),
     })
+}
+
+#[cfg(unix)]
+fn classify_unix_spawn_error(error: std::io::Error) -> ConversionError {
+    let detail = match error.raw_os_error() {
+        Some(code) if code == libc::EACCES || code == libc::EPERM => "workerLaunchDenied",
+        Some(code) if code == libc::ENOMEM || code == libc::EAGAIN => "workerLimitUnavailable",
+        _ => "workerLaunch",
+    };
+    ort_error(detail)
 }
 
 #[cfg(windows)]
@@ -821,6 +831,30 @@ mod tests {
                 .checked_add(contract.session_memory_bytes)
                 .and_then(|value| value.checked_add(contract.run_memory_bytes))
                 .is_none()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_worker_spawn_errors_keep_authority_and_resource_failures_distinct() {
+        for code in [libc::EACCES, libc::EPERM] {
+            assert!(
+                classify_unix_spawn_error(std::io::Error::from_raw_os_error(code))
+                    .to_string()
+                    .contains("workerLaunchDenied")
+            );
+        }
+        for code in [libc::ENOMEM, libc::EAGAIN] {
+            assert!(
+                classify_unix_spawn_error(std::io::Error::from_raw_os_error(code))
+                    .to_string()
+                    .contains("workerLimitUnavailable")
+            );
+        }
+        assert!(
+            classify_unix_spawn_error(std::io::Error::from_raw_os_error(libc::ENOENT))
+                .to_string()
+                .contains("workerLaunch")
         );
     }
 

--- a/tools/platform-release/BUILD.bazel
+++ b/tools/platform-release/BUILD.bazel
@@ -38,6 +38,7 @@ py_test(
     name = "release_test",
     srcs = ["test_release.py"],
     data = [
+        "//:.github/workflows/native-release-gates.yml",
         "//:.github/workflows/platform-modular-release.yml",
         "//tools/installed-smoke:rust_consumer_source",
     ],

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -41,6 +41,16 @@ class PlatformReleaseTests(unittest.TestCase):
         self.assertIn("repository-cache: true", gates)
         self.assertIn("disk-cache: release-gates-${{ inputs.bazel_config }}", gates)
 
+    def test_windows_core_smoke_uses_installed_pdfium_destination(self) -> None:
+        workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn(r'--pdfium-library "$installed\bin\pdfium.dll"', workflow)
+        self.assertGreaterEqual(
+            workflow.count(r'--pdfium-library "$installed\lib\pdfium\pdfium.dll"'),
+            2,
+        )
+
     def test_native_release_reuses_fixed_toolchain_cargo_dependencies(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- classify Unix ONNX worker spawn failures into stable authority (`workerLaunchDenied`), resource (`workerLimitUnavailable`), and launch (`workerLaunch`) categories
- preserve the existing external component/status shape while removing the misleading all-errors-are-memory mapping
- add Unix unit coverage for EACCES/EPERM, ENOMEM/EAGAIN, and other launch failures

## Evidence
Both Linux targets in formal run 33070651102 still report `workerLimitUnavailable` after adding 512 MiB coordinator `RLIMIT_AS` headroom, proving the old catch-all mapping is blocking root-cause diagnosis.

## Local verification
- `cargo fmt --all -- --check`
- `cargo test -p into-markdown-onnxruntime --locked` (14 passed; explicit pinned quality targets ignored as designed)
- `git diff --check`