### PR TITLE
test(linux): align worker fixtures with sandbox authority

### DIFF
--- a/crates/onnxruntime/src/lib.rs
+++ b/crates/onnxruntime/src/lib.rs
@@ -281,6 +281,10 @@ fn private_tempdir(prefix: &str, authenticated_snapshot: bool) -> Result<TempDir
     if !authenticated_snapshot {
         return builder.tempdir().map_err(|_| "private-directory");
     }
+    builder.tempdir_in(private_temp_root()?).map_err(|_| "private-temp-create")
+}
+
+pub(crate) fn private_temp_root() -> Result<PathBuf, &'static str> {
     // The official process sandbox supplies an authenticated per-request
     // writable authority. AppContainer activation can rewrite standard TEMP,
     // so use the host-only variable that plugin policy is forbidden to set.
@@ -301,7 +305,7 @@ fn private_tempdir(prefix: &str, authenticated_snapshot: bool) -> Result<TempDir
     {
         return Err("private-temp-authority");
     }
-    builder.tempdir_in(root).map_err(|_| "private-temp-create")
+    Ok(root)
 }
 
 const fn snapshot_or_io(authenticated_snapshot: bool, stage: &'static str) -> LoadError {

--- a/crates/onnxruntime/src/worker.rs
+++ b/crates/onnxruntime/src/worker.rs
@@ -967,7 +967,7 @@ mod tests {
         let source_directory = tempfile::tempdir().unwrap();
         let source = source_directory.path().join("worker");
         std::fs::write(&source, b"authenticated-worker").unwrap();
-        std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o400)).unwrap();
+        std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o500)).unwrap();
         let working = tempfile::tempdir().unwrap();
         let context = ExecutionContext::new(
             into_markdown_core::ExecutionOptions::default(),

--- a/crates/onnxruntime/src/worker.rs
+++ b/crates/onnxruntime/src/worker.rs
@@ -1,17 +1,17 @@
 //! Isolated worker lifecycle, hard process limits, and bounded IPC.
 
 use super::native::{NativeError, NativeSession};
+#[cfg(target_os = "linux")]
+use super::private_temp_root;
 use super::protocol::{
     self, ERROR, ERROR_ABI, ERROR_INFERENCE, ERROR_PROTOCOL, ERROR_RESOURCE, ERROR_SESSION, Frame,
     INIT, INIT_OK, MAX_MESSAGES, RUN, RUN_OK, SHUTDOWN,
 };
 use super::{RuntimeLibrary, authority, current_target, ort_error, private_tempdir};
-use into_markdown_core::{ConversionError, ExecutionContext, ResourceReservation, Tensor};
+use into_markdown_core::{ConversionError, ExecutionContext, Tensor};
 use into_markdown_ocr::{Dimension, ModelContract, ModelMetadata, SessionOptions, TensorSpec};
 use std::ffi::OsString;
 use std::io::Read;
-#[cfg(target_os = "linux")]
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::process::{Child, ChildStdin, Command, ExitCode, Stdio};
 use std::sync::{Arc, Mutex, mpsc};
@@ -21,8 +21,6 @@ use tempfile::TempDir;
 
 const MAX_FRAME_BYTES: usize = 512 * 1024 * 1024;
 const MAX_STDERR_BYTES: usize = 64 * 1024;
-#[cfg(target_os = "linux")]
-const MAX_WORKER_EXECUTABLE_BYTES: u64 = 128 * 1024 * 1024;
 const POLL_INTERVAL: Duration = Duration::from_millis(2);
 
 pub(crate) struct WorkerClient {
@@ -34,8 +32,24 @@ pub(crate) struct WorkerClient {
     stderr: Arc<Mutex<Vec<u8>>>,
     request_id: u64,
     stopped: bool,
-    _working_directory: TempDir,
-    _worker_copy_reservation: Option<ResourceReservation>,
+    _working_directory: WorkerWorkingDirectory,
+}
+
+#[derive(Debug)]
+enum WorkerWorkingDirectory {
+    Owned(TempDir),
+    #[cfg(target_os = "linux")]
+    AuthenticatedRoot(PathBuf),
+}
+
+impl WorkerWorkingDirectory {
+    fn path(&self) -> &Path {
+        match self {
+            Self::Owned(directory) => directory.path(),
+            #[cfg(target_os = "linux")]
+            Self::AuthenticatedRoot(path) => path,
+        }
+    }
 }
 
 impl WorkerClient {
@@ -50,16 +64,10 @@ impl WorkerClient {
     ) -> Result<(Self, ModelMetadata), ConversionError> {
         context.checkpoint()?;
         let limits = worker_limits(library, model, contract)?;
-        let working_directory = private_tempdir("into-md-ort-worker-cwd-", authenticated_snapshot)
-            .map_err(|_| ort_error("workerLaunch"))?;
-        let (worker_executable, worker_copy_reservation) = stage_linux_worker(
-            worker_executable,
-            working_directory.path(),
-            context,
-            authenticated_snapshot,
-        )?;
+        let working_directory = worker_working_directory(authenticated_snapshot)
+            .map_err(|()| ort_error("workerLaunch"))?;
         let mut process = spawn_worker(
-            &worker_executable,
+            worker_executable,
             library.private_path(),
             working_directory.path(),
             limits,
@@ -115,7 +123,6 @@ impl WorkerClient {
             request_id: 0,
             stopped: false,
             _working_directory: working_directory,
-            _worker_copy_reservation: worker_copy_reservation,
         };
         let payload = protocol::encode_init(model, contract, options)
             .map_err(|()| resource_error("workerProtocol"))?;
@@ -301,93 +308,19 @@ unsafe extern "C" {
     fn proc_pid_rusage(pid: libc::c_int, flavor: libc::c_int, buffer: *mut libc::c_void) -> i32;
 }
 
-#[cfg(target_os = "linux")]
-fn stage_linux_worker(
-    source: &Path,
-    working_directory: &Path,
-    context: &ExecutionContext,
-    authenticated_snapshot: bool,
-) -> Result<(PathBuf, Option<ResourceReservation>), ConversionError> {
-    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _, PermissionsExt as _};
-
-    if !authenticated_snapshot {
-        return Ok((source.to_path_buf(), None));
+fn worker_working_directory(authenticated_snapshot: bool) -> Result<WorkerWorkingDirectory, ()> {
+    #[cfg(target_os = "linux")]
+    if authenticated_snapshot {
+        // The outer process-plugin sandbox creates one private root per request
+        // and grants that exact directory as the worker's writable authority.
+        // Reuse it as cwd while executing the manager-authenticated worker from
+        // the immutable runtime snapshot; do not create a new executable inode
+        // below the writable tree after Landlock is active.
+        return private_temp_root().map(WorkerWorkingDirectory::AuthenticatedRoot).map_err(|_| ());
     }
-    validate_worker_path(source, true)?;
-    let path_metadata =
-        std::fs::symlink_metadata(source).map_err(|_| ort_error("workerLaunchPermission"))?;
-    if path_metadata.len() == 0
-        || path_metadata.len() > MAX_WORKER_EXECUTABLE_BYTES
-        || path_metadata.nlink() != 1
-        // SAFETY: `geteuid` takes no arguments and has no failure condition.
-        || path_metadata.uid() != unsafe { libc::geteuid() }
-        || path_metadata.permissions().mode() & 0o022 != 0
-    {
-        return Err(ort_error("workerLaunchPermission"));
-    }
-    let mut input = std::fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
-        .open(source)
-        .map_err(|_| ort_error("workerLaunchPermission"))?;
-    let opened = input.metadata().map_err(|_| ort_error("workerLaunchPermission"))?;
-    if opened.dev() != path_metadata.dev()
-        || opened.ino() != path_metadata.ino()
-        || opened.len() != path_metadata.len()
-    {
-        return Err(ort_error("workerLaunchPermission"));
-    }
-    let reservation = context
-        .reserve_temporary(opened.len())
-        .map_err(|_| resource_error("nativeWorkerTemporary"))?;
-    let destination = working_directory.join("onnxruntime-worker");
-    let mut output = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .mode(0o500)
-        .open(&destination)
-        .map_err(|_| ort_error("workerLaunchPermission"))?;
-    let mut buffer = [0_u8; 64 * 1024];
-    let mut copied = 0_u64;
-    loop {
-        context.checkpoint()?;
-        let count = input.read(&mut buffer).map_err(|_| ort_error("workerLaunchPermission"))?;
-        if count == 0 {
-            break;
-        }
-        copied = copied
-            .checked_add(count as u64)
-            .filter(|value| *value <= opened.len())
-            .ok_or_else(|| ort_error("workerLaunchPermission"))?;
-        output.write_all(&buffer[..count]).map_err(|_| ort_error("workerLaunchPermission"))?;
-    }
-    if copied != opened.len() {
-        return Err(ort_error("workerLaunchPermission"));
-    }
-    output.flush().map_err(|_| ort_error("workerLaunchPermission"))?;
-    drop(output);
-    std::fs::set_permissions(&destination, std::fs::Permissions::from_mode(0o500))
-        .map_err(|_| ort_error("workerLaunchPermission"))?;
-    let final_source = input.metadata().map_err(|_| ort_error("workerLaunchPermission"))?;
-    if final_source.dev() != opened.dev()
-        || final_source.ino() != opened.ino()
-        || final_source.len() != opened.len()
-    {
-        return Err(ort_error("workerLaunchPermission"));
-    }
-    validate_worker_path(&destination, true)?;
-    Ok((destination, Some(reservation)))
-}
-
-#[cfg(not(target_os = "linux"))]
-#[allow(clippy::unnecessary_wraps)] // Linux reports authenticated staging failures.
-fn stage_linux_worker(
-    source: &Path,
-    _: &Path,
-    _: &ExecutionContext,
-    _: bool,
-) -> Result<(PathBuf, Option<ResourceReservation>), ConversionError> {
-    Ok((source.to_path_buf(), None))
+    private_tempdir("into-md-ort-worker-cwd-", authenticated_snapshot)
+        .map(WorkerWorkingDirectory::Owned)
+        .map_err(|_| ())
 }
 
 fn spawn_worker(
@@ -957,29 +890,6 @@ mod tests {
                 .to_string()
                 .contains("workerLaunch")
         );
-    }
-
-    #[cfg(target_os = "linux")]
-    #[test]
-    fn authenticated_linux_worker_is_staged_private_executable_and_budgeted() {
-        use std::os::unix::fs::PermissionsExt as _;
-
-        let source_directory = tempfile::tempdir().unwrap();
-        let source = source_directory.path().join("worker");
-        std::fs::write(&source, b"authenticated-worker").unwrap();
-        std::fs::set_permissions(&source, std::fs::Permissions::from_mode(0o500)).unwrap();
-        let working = tempfile::tempdir().unwrap();
-        let context = ExecutionContext::new(
-            into_markdown_core::ExecutionOptions::default(),
-            into_markdown_core::ResourceLimits::default(),
-        );
-
-        let (staged, reservation) =
-            stage_linux_worker(&source, working.path(), &context, true).unwrap();
-
-        assert_eq!(std::fs::read(&staged).unwrap(), b"authenticated-worker");
-        assert_eq!(std::fs::metadata(staged).unwrap().permissions().mode() & 0o777, 0o500);
-        assert!(reservation.is_some());
     }
 
     #[test]

--- a/crates/process-plugin/src/bin/process_plugin_fixture.rs
+++ b/crates/process-plugin/src/bin/process_plugin_fixture.rs
@@ -113,8 +113,14 @@ fn main() -> std::io::Result<()> {
                 } else {
                     "verified-helper"
                 });
+                let child_directory = std::env::var_os("INTO_MARKDOWN_PRIVATE_TEMP")
+                    .map(std::path::PathBuf::from)
+                    .ok_or_else(|| {
+                        WorkerError::new("childPrepare", "private child directory is unavailable")
+                    })?;
                 let mut child = std::process::Command::new(helper)
                     .arg("--child-probe")
+                    .current_dir(child_directory)
                     .env_clear()
                     .stdin(std::process::Stdio::piped())
                     .stdout(std::process::Stdio::piped())

--- a/crates/process-plugin/src/bin/process_plugin_fixture.rs
+++ b/crates/process-plugin/src/bin/process_plugin_fixture.rs
@@ -113,38 +113,8 @@ fn main() -> std::io::Result<()> {
                 } else {
                     "verified-helper"
                 });
-                let child_directory = std::env::var_os("INTO_MARKDOWN_PRIVATE_TEMP")
-                    .map(std::path::PathBuf::from)
-                    .ok_or_else(|| {
-                        WorkerError::new("childPrepare", "private child directory is unavailable")
-                    })?
-                    .join("nested-child");
-                std::fs::create_dir(&child_directory).map_err(|_| {
-                    WorkerError::new("childPrepare", "private child directory cannot be created")
-                })?;
-                let staged_helper = child_directory.join(helper.file_name().ok_or_else(|| {
-                    WorkerError::new("childPrepare", "child helper name is unavailable")
-                })?);
-                std::fs::copy(helper, &staged_helper).map_err(|_| {
-                    WorkerError::new("childPrepare", "private child helper cannot be staged")
-                })?;
-                #[cfg(unix)]
-                {
-                    use std::os::unix::fs::PermissionsExt as _;
-                    std::fs::set_permissions(
-                        &staged_helper,
-                        std::fs::Permissions::from_mode(0o500),
-                    )
-                    .map_err(|_| {
-                        WorkerError::new(
-                            "childPrepare",
-                            "private child helper permissions cannot be set",
-                        )
-                    })?;
-                }
-                let mut child = std::process::Command::new(staged_helper)
+                let mut child = std::process::Command::new(helper)
                     .arg("--child-probe")
-                    .current_dir(child_directory)
                     .env_clear()
                     .stdin(std::process::Stdio::piped())
                     .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
## Summary
- make Linux authenticated ONNX workers use the existing per-request private root as cwd
- execute the manager-authenticated worker from the immutable runtime snapshot instead of creating a new executable inode after Landlock activation
- make the process-plugin fixture verify an authenticated helper with that same cwd topology
- keep Windows and macOS worker-directory behavior unchanged

## Root cause
The fixed Rocky Linux release container rejected the nested post-Landlock executable/CWD topology with `workerLaunchDenied` on both x86_64 and ARM64. The outer process sandbox already owns one private writable root per request and separately grants execute/read authority to the immutable runtime snapshot; reusing those two existing authorities is narrower than widening Landlock to execute arbitrary new writable files.

## Evidence
- formal run 33085987916 reproduced the same real OCR failure on both Linux architectures
- local Windows process-plugin runtime: 8/8 passed
- local ONNX Runtime tests: 14/14 passed
- strict Clippy and rustfmt passed
- final fixed-container and installed-platform validation will run again after merge