### PR TITLE
fix(linux): allow declared local child spawn IPC

### DIFF
--- a/crates/process-plugin/src/sandbox/unix.rs
+++ b/crates/process-plugin/src/sandbox/unix.rs
@@ -318,6 +318,21 @@ mod linux {
                 1,
             ));
             filters.push(stmt(RET_K, ERRNO | libc::ENOSYS as u32));
+            if allow_child_processes {
+                // Rust's child launch path uses a private Unix socketpair to report an exec
+                // error to its parent. AF_UNIX socketpairs are local IPC and confer no network
+                // namespace authority; every socket/connect/bind/listen syscall remains denied.
+                filters.push(jump(
+                    JMP_JEQ_K,
+                    u32::try_from(libc::SYS_socketpair).map_err(std::io::Error::other)?,
+                    0,
+                    4,
+                ));
+                filters.push(stmt(LD_W_ABS, 16));
+                filters.push(jump(JMP_JEQ_K, libc::AF_UNIX as u32, 1, 0));
+                filters.push(stmt(RET_K, ERRNO | libc::EPERM as u32));
+                filters.push(stmt(RET_K, ALLOW));
+            }
             let process_instruction;
             filters.push(jump(
                 JMP_JEQ_K,
@@ -330,7 +345,11 @@ mod linux {
             filters.push(jump(JMP_JEQ_K, 0, 1, 0));
             filters.push(stmt(RET_K, ERRNO | libc::EPERM as u32));
             filters.push(stmt(RET_K, ALLOW));
-            for syscall in denied.into_iter().chain(legacy.iter().copied()) {
+            for syscall in denied
+                .into_iter()
+                .chain(legacy.iter().copied())
+                .filter(|syscall| !allow_child_processes || *syscall != libc::SYS_socketpair)
+            {
                 filters.push(jump(
                     JMP_JEQ_K,
                     u32::try_from(syscall).map_err(std::io::Error::other)?,


### PR DESCRIPTION
## Root cause\n\nRocky 8 / glibc 2.28 uses an AF_UNIX socketpair to report exec failures while launching a declared provider-owned helper. The process sandbox denied every socketpair, so the authenticated ONNX worker failed with EPERM/workerLaunchDenied even though clone and exec were explicitly authorized.\n\n## Fix\n\n- allow only AF_UNIX socketpair when allow_child_processes is declared\n- keep socket, connect, bind, listen, and non-AF_UNIX socketpair denied\n- retain the existing authenticated runtime and private working-directory authority\n\n## Evidence\n\n- focused Rocky 8 x86 diagnostic failed with EPERM, then uniquely identified SYS_socketpair (errno 101)\n- the same Rocky 8 test passes with this exact scoped rule and without any pre_exec workaround\n- local Windows process runtime: 8/8 integration tests and 6/6 unit tests passed\n- strict process-plugin Clippy and rustfmt passed\n\nDiagnostic-only workflow/errno changes are not included in this PR.