### PR TITLE
fix(release): normalize Linux C++ metadata identity

### DIFF
--- a/tools/release-metadata.py
+++ b/tools/release-metadata.py
@@ -74,6 +74,13 @@ def sha1(path: pathlib.Path) -> str:
     return digest.hexdigest()
 
 
+def build_tool_execution_name(command: str) -> str:
+    # Release projection identities deliberately use a conservative portable
+    # alphabet. Keep the observed executable command exact while recording the
+    # conventional, safe C++ compiler identity used by release metadata.
+    return "cxx" if command == "c++" else command
+
+
 def run_projection(tool: pathlib.Path, operation: str, value: dict) -> dict:
     with tempfile.TemporaryDirectory(prefix="into-md-release-metadata-") as name:
         request = pathlib.Path(name) / "request.json"
@@ -151,7 +158,7 @@ def build_tool_executions(target: str) -> list[dict]:
         result.append(
             {
                 "authority_id": authority_id,
-                "name": command,
+                "name": build_tool_execution_name(command),
                 "version": version,
                 "bytes": executable.stat().st_size,
                 "sha256": sha256(executable),

--- a/tools/release_metadata_test.py
+++ b/tools/release_metadata_test.py
@@ -20,6 +20,10 @@ SPEC.loader.exec_module(release_metadata)
 
 
 class ReleaseMetadataTests(unittest.TestCase):
+    def test_linux_cxx_execution_uses_a_portable_projection_identity(self) -> None:
+        self.assertEqual(release_metadata.build_tool_execution_name("c++"), "cxx")
+        self.assertEqual(release_metadata.build_tool_execution_name("cc"), "cc")
+
     def test_generated_metadata_preserves_declared_utf8_bytes(self) -> None:
         contents = "line one\nline two\n"
         encoded = contents.encode("utf-8")


### PR DESCRIPTION
Fixes the Linux release SBOM failure reached after installed-smoke and platform acceptance succeeded. The observed command remains c++ --version, while the release-projection identity uses the portable name cxx. Adds a regression test. Evidence from run 33134806557: both Linux architectures failed only at Generate release SBOMs with ubuntu-build-toolchain:c++ has incomplete identity; both native gates and installed acceptance had already passed.