### PR TITLE
Fix final 0.0.2 acceptance and bound native gates

### DIFF
--- a/.github/workflows/native-release-gates.yml
+++ b/.github/workflows/native-release-gates.yml
@@ -23,7 +23,7 @@ jobs:
   native-gates:
     runs-on: ${{ inputs.runner }}
     container: ${{ inputs.container }}
-    timeout-minutes: 180
+    timeout-minutes: 20
     steps:
       - name: Bootstrap fixed Linux gate container
         if: runner.os == 'Linux'
@@ -103,20 +103,8 @@ jobs:
           "CMAKE_GENERATOR=NMake Makefiles" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Prefetch complete locked Cargo closure
         run: cargo fetch --locked
-      - name: Prepare Cargo plugin lifecycle fixture on Linux
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          cargo build --locked -p into-markdown-plugin-manager --bin plugin_manager_process_fixture --target "${{ inputs.target }}"
-          echo "INTO_MD_PLUGIN_PROCESS_FIXTURE=$PWD/target/${{ inputs.target }}/debug/plugin_manager_process_fixture" >> "$GITHUB_ENV"
-      - name: Prepare Cargo plugin lifecycle fixture on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          cargo build --locked -p into-markdown-plugin-manager --bin plugin_manager_process_fixture --target "${{ inputs.target }}"
-          "INTO_MD_PLUGIN_PROCESS_FIXTURE=$PWD\target\${{ inputs.target }}\debug\plugin_manager_process_fixture.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Run target-native Clippy and Bazel gates
         run: |
           python -m unittest tools.platform-release.test_release tools.platform-release.test_platform_tools tools.publish_release_assets_test tools.release_metadata_test tools.release_signing_policy_test
           cargo clippy --workspace --exclude whisper-rs --all-targets --no-deps --locked -- -D clippy::correctness -D clippy::suspicious -D clippy::perf
-          bazel --output_user_root="${{ runner.temp }}/bazel" test --config=${{ inputs.bazel_config }} --lockfile_mode=error --local_test_jobs=1 --test_env=RUST_TEST_THREADS=1 //...
+          bazel --output_user_root="${{ runner.temp }}/bazel" test --config=${{ inputs.bazel_config }} --lockfile_mode=error --local_test_jobs=1 --test_env=RUST_TEST_THREADS=1 //tools/platform-release:release_test //tools/platform-release:platform_tools_test //tools/platform-release:installer_test //tools/installed-smoke:installed_smoke_test

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,7 @@ platform(
 )
 
 exports_files([
+    ".github/workflows/macos-arm64-release.yml",
     ".github/workflows/native-release-gates.yml",
     ".github/workflows/platform-modular-release.yml",
     ".bazelversion",

--- a/tools/platform-release/BUILD.bazel
+++ b/tools/platform-release/BUILD.bazel
@@ -43,8 +43,13 @@ py_test(
     data = [
         "//:Cargo.toml",
         "//:MODULE.bazel",
+        "//:.github/workflows/macos-arm64-release.yml",
         "//:.github/workflows/native-release-gates.yml",
         "//:.github/workflows/platform-modular-release.yml",
+        "Install.cmd",
+        "Install.ps1",
+        "Uninstall.cmd",
+        "Uninstall.ps1",
         "//tools/installed-smoke:rust_consumer_source",
     ],
     main = "test_release.py",

--- a/tools/platform-release/platform_acceptance.py
+++ b/tools/platform-release/platform_acceptance.py
@@ -73,6 +73,23 @@ class Result:
     detail: str
 
 
+def fixture_conversion_arguments(
+    source: pathlib.Path,
+    output: pathlib.Path,
+    capability_arguments: list[str],
+) -> list[str]:
+    """Build a deterministic fixture command with an isolated output authority."""
+    if source == output:
+        raise ValueError("fixture input and output must be different paths")
+    return [
+        str(source),
+        "--output", str(output),
+        "--conflict", "error",
+        *capability_arguments,
+        "--emit", "result-json",
+    ]
+
+
 class ProcessOwner:
     """Own a process group on Unix or a kill-on-close Job Object on Windows."""
 
@@ -258,8 +275,16 @@ class Runner:
             if os.name == "nt"
             else 0
         )
+        output_root = private_directory(state / "running-media-outputs")
         process = subprocess.Popen(
-            [str(self.executable), str(audio), "--ai", "audio-transcription=only", "--emit", "result-json"],
+            [
+                str(self.executable),
+                *fixture_conversion_arguments(
+                    audio,
+                    output_root / "immutable-snapshot.md",
+                    ["--ai", "audio-transcription=only"],
+                ),
+            ],
             cwd=self.work,
             env=self.environment(state),
             stdin=subprocess.DEVNULL,
@@ -290,7 +315,11 @@ class Runner:
         self.call(
             "running-media-new-task-disabled",
             state,
-            [str(audio), "--ai", "audio-transcription=only", "--emit", "result-json"],
+            fixture_conversion_arguments(
+                audio,
+                output_root / "disabled-new-task.md",
+                ["--ai", "audio-transcription=only"],
+            ),
             succeed=False,
         )
         self.call("running-media-enable", state, ["plugins", "enable", plugin, "--scope", "global"])
@@ -727,10 +756,15 @@ def main() -> int:
         initialize_core_state(runner, core_ocr_state, "core-only")
         core_ocr_fixture = core_ocr_state / "ocr-english-clear-1.png"
         shutil.copyfile(fixtures / "ocr" / "ocr-english-clear-1.png", core_ocr_fixture)
+        core_ocr_outputs = private_directory(core_ocr_state / "outputs")
         runner.call(
             "real-ocr-core-only",
             core_ocr_state,
-            [str(core_ocr_fixture), "--ocr", "always", "--emit", "result-json"],
+            fixture_conversion_arguments(
+                core_ocr_fixture,
+                core_ocr_outputs / "ocr-core-only.md",
+                ["--ocr", "always"],
+            ),
         )
         plugin_names = list(PLUGINS)
         for mask in range(1 << len(plugin_names)):
@@ -774,15 +808,24 @@ def main() -> int:
         speech_fixture = fixture_state / audio.name
         shutil.copyfile(fixtures / "ocr" / "ocr-english-clear-1.png", ocr_fixture)
         shutil.copyfile(audio, speech_fixture)
+        fixture_outputs = private_directory(fixture_state / "outputs")
         runner.call(
             "real-ocr-fixture",
             lifecycle,
-            [str(ocr_fixture), "--ocr", "always", "--emit", "result-json"],
+            fixture_conversion_arguments(
+                ocr_fixture,
+                fixture_outputs / "ocr-with-speech-installed.md",
+                ["--ocr", "always"],
+            ),
         )
         runner.call(
             "real-speech-fixture",
             lifecycle,
-            [str(speech_fixture), "--ai", "audio-transcription=only", "--emit", "result-json"],
+            fixture_conversion_arguments(
+                speech_fixture,
+                fixture_outputs / "speech-installed.md",
+                ["--ai", "audio-transcription=only"],
+            ),
         )
         runner.running_snapshot(lifecycle, speech_fixture, "official.media.whisper")
 

--- a/tools/platform-release/test_platform_tools.py
+++ b/tools/platform-release/test_platform_tools.py
@@ -29,6 +29,7 @@ from platform_acceptance import (
     PLUGINS,
     assert_states,
     capability_map,
+    fixture_conversion_arguments,
     repairable_payload_files,
     resolve_package,
     tree_hash,
@@ -234,6 +235,18 @@ class PlatformToolTests(unittest.TestCase):
     def test_capability_json_contract_is_indexed_by_id(self) -> None:
         value = capability_map('{"capabilities":[{"id":"ocr","status":"ready"}]}')
         self.assertEqual(value["ocr"]["status"], "ready")
+
+    def test_real_fixture_commands_have_explicit_isolated_outputs(self) -> None:
+        source = pathlib.Path("state/fixture.png")
+        output = pathlib.Path("state/outputs/fixture.md")
+        arguments = fixture_conversion_arguments(
+            source, output, ["--ocr", "always"]
+        )
+        self.assertEqual(arguments[0], str(source))
+        self.assertEqual(arguments[1:5], ["--output", str(output), "--conflict", "error"])
+        self.assertEqual(arguments[-4:], ["--ocr", "always", "--emit", "result-json"])
+        with self.assertRaisesRegex(ValueError, "different paths"):
+            fixture_conversion_arguments(source, source, ["--ocr", "always"])
 
     def test_core_only_acceptance_requires_ready_ocr_and_absent_speech(self) -> None:
         self.assertEqual(BUILTIN_CAPABILITIES, {"ocr": "official.ocr.ppocrv6"})

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -45,6 +45,16 @@ class PlatformReleaseTests(unittest.TestCase):
         self.assertNotIn("cargo test --workspace --all-targets", gates)
         self.assertIn("cargo clippy --workspace", gates)
         self.assertIn("bazel --output_user_root", gates)
+        self.assertNotIn("RUST_TEST_THREADS=1 //...", gates)
+        for target in (
+            "//tools/platform-release:release_test",
+            "//tools/platform-release:platform_tools_test",
+            "//tools/platform-release:installer_test",
+            "//tools/installed-smoke:installed_smoke_test",
+        ):
+            self.assertIn(target, gates)
+        self.assertIn("timeout-minutes: 20", gates)
+        self.assertNotIn("plugin_manager_process_fixture", gates)
         self.assertIn("run: cargo fetch --locked", gates)
         self.assertIn("~/.cargo/registry", gates)
         self.assertIn("repository-cache: true", gates)


### PR DESCRIPTION
## Summary
- give every installed OCR/speech acceptance conversion an explicit isolated output, including running-task snapshots
- declare the Windows Bazel runfiles used by release contract tests
- remove an unused Cargo fixture build and replace full-repository Bazel duplication with four release/installer targets
- cap the shared native gate at 20 minutes

## Root causes from formal release
- Linux ARM acceptance reused the default asset directory and hit assetConflict on the second OCR fixture
- Windows release_test missed the macOS workflow and four installer scripts from its runfiles
- Windows //... ran 56 tests and waited 900 seconds for license_check_unit_test after equivalent release audits had already run

## Local verification
- 51 release/platform/signing/asset tests passed
- Bazel Windows release_test and platform_tools_test passed in runfiles mode
- real installed Core OCR converted the same fixture to two isolated outputs with identical SHA-256 results