### PR TITLE
fix(release): keep Linux Python compatible with glibc 2.28

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -66,6 +66,7 @@ jobs:
           test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.28"
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        if: runner.os != 'Linux'
         with:
           python-version: '3.13'
       - name: Bind Linux checkout ownership


### PR DESCRIPTION
Fixes the 0.0.3 release matrix on Linux ARM64/x86_64 by using the Python 3.11 installed inside the pinned EL8 container. The hosted setup-python ARM64 runtime requires newer glibc symbols and cannot run against the intentional glibc 2.28 baseline.\n\nValidation: platform release contract and tool tests pass locally.\n\nFollow-up to #246.