### PR TITLE
fix(release): keep MSVC linker authority after FFmpeg

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -181,6 +181,15 @@ jobs:
         if: runner.os == 'Windows'
         shell: msys2 {0}
         run: openssl genpkey -algorithm ED25519 -outform DER -out "$RUNNER_TEMP/plugin-integrity-key.pk8"
+      - name: Bind Cargo to the pinned MSVC linker
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $linker = Join-Path $env:VCToolsInstallDir 'bin\Hostx64\x64\link.exe'
+          if (-not (Test-Path -LiteralPath $linker -PathType Leaf)) {
+            throw "Pinned MSVC linker is unavailable: $linker"
+          }
+          "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$linker" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
       - name: Build and verify compact Core and speech once
         shell: bash
         env:

--- a/third_party/licenses/cargo-normal-runtime.json
+++ b/third_party/licenses/cargo-normal-runtime.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 1,
   "root": "into-markdown-cli",
-  "cargo_lock_sha256": "91b36212fef6e23398ef31d6ddf409d974ed5548ce8aaef912b93a378ed2ff79",
+  "cargo_lock_sha256": "019644bb44dca7e3318616db49be2fb807f8f115861dffe95e3e3c80a9ea9dd9",
   "workspace_manifest_sha256": {
-    "Cargo.toml": "f1a8babfaf1243d9f70f9df34c1bc3b9cfa9f0fceae764716520fcf2b92389ca",
-    "apps/cli/Cargo.toml": "aaa68a1458ec9bb63b3abde07db79174dc3e0ac578c1c82767f7b0d322efff88",
+    "Cargo.toml": "79c1092e56886ca4c29effb70941e2c36d485c46c17bae1868c0196ec735ba49",
+    "apps/cli/Cargo.toml": "7a356bec81a668f1b23cb0d409154ebd7104663a862b83e40293b2202875c634",
     "apps/official-provider/Cargo.toml": "6a0e9e72741846674c6d94790186427a0234a640483deb6400b930b8150ef6a7",
     "crates/ai/Cargo.toml": "adffc09c06b695fe830fe58647a2cd1f18df627b1932331b372c690843781eeb",
     "crates/api/Cargo.toml": "fe0a95f3c11da60ec76b75ec5f17e94bd10be2eed365100def297010f493cc9d",

--- a/third_party/licenses/npm-release.spdx.json
+++ b/third_party/licenses/npm-release.spdx.json
@@ -2,8 +2,8 @@
   "spdxVersion": "SPDX-2.3",
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
-  "name": "into-markdown-web-console-eabe5704040d0a16",
-  "documentNamespace": "https://github.com/coolplayagent/into-markdown/spdx/web-console/sha256-eabe5704040d0a16a6fe51f7a2c3456003c35b3d2671256d938ab9e356dcdd58",
+  "name": "into-markdown-web-console-ea8cefa6ae409012",
+  "documentNamespace": "https://github.com/coolplayagent/into-markdown/spdx/web-console/sha256-ea8cefa6ae4090123644ed1e752db076f8f3ebc2969aec7928fc976862f48bd5",
   "creationInfo": {
     "created": "2026-08-13T00:00:00Z",
     "creators": ["Organization: into-markdown contributors"]
@@ -57,8 +57,8 @@
   "files": [
     {
       "SPDXID": "SPDXRef-File-console-app",
-      "fileName": "./web/console/dist/assets/app.eabe5704040d0a16.js",
-      "checksums": [{"algorithm":"SHA256","checksumValue":"eabe5704040d0a16a6fe51f7a2c3456003c35b3d2671256d938ab9e356dcdd58"}],
+      "fileName": "./web/console/dist/assets/app.ea8cefa6ae409012.js",
+      "checksums": [{"algorithm":"SHA256","checksumValue":"ea8cefa6ae4090123644ed1e752db076f8f3ebc2969aec7928fc976862f48bd5"}],
       "licenseConcluded": "NOASSERTION",
       "licenseInfoInFiles": ["ISC", "MIT"],
       "copyrightText": "NOASSERTION"

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -41,6 +41,24 @@ class PlatformReleaseTests(unittest.TestCase):
         for relative, expected in value["workspace_manifest_sha256"].items():
             self.assertEqual(expected, canonical_digest(ROOT / relative), relative)
 
+    def test_web_release_spdx_binds_the_production_app(self) -> None:
+        value = json.loads(
+            (ROOT / "third_party/licenses/npm-release.spdx.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        self.assertEqual(len(value["files"]), 1)
+        entry = value["files"][0]
+        relative = entry["fileName"].removeprefix("./")
+        app = ROOT / relative
+        self.assertTrue(app.is_file(), relative)
+        expected = next(
+            item["checksumValue"]
+            for item in entry["checksums"]
+            if item["algorithm"] == "SHA256"
+        )
+        self.assertEqual(expected, hashlib.sha256(app.read_bytes()).hexdigest())
+
     def test_release_version_matches_workspace_and_bazel_module(self) -> None:
         workspace = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
         self.assertEqual(VERSION, workspace["workspace"]["package"]["version"])

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import pathlib
 import re
 import sys
@@ -26,6 +28,19 @@ from release import (
 
 
 class PlatformReleaseTests(unittest.TestCase):
+    def test_cargo_runtime_authority_binds_current_workspace_manifests(self) -> None:
+        authority_path = ROOT / "third_party/licenses/cargo-normal-runtime.json"
+        value = json.loads(authority_path.read_text(encoding="utf-8"))
+
+        def canonical_digest(path: pathlib.Path) -> str:
+            contents = path.read_bytes().replace(b"\r\n", b"\n")
+            self.assertNotIn(b"\r", contents)
+            return hashlib.sha256(contents).hexdigest()
+
+        self.assertEqual(value["cargo_lock_sha256"], canonical_digest(ROOT / "Cargo.lock"))
+        for relative, expected in value["workspace_manifest_sha256"].items():
+            self.assertEqual(expected, canonical_digest(ROOT / relative), relative)
+
     def test_release_version_matches_workspace_and_bazel_module(self) -> None:
         workspace = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
         self.assertEqual(VERSION, workspace["workspace"]["package"]["version"])

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -167,6 +167,8 @@ class PlatformReleaseTests(unittest.TestCase):
         self.assertIn("toolset: 14.44.35207", workflow)
         self.assertIn("sdk: 10.0.26100.0", workflow)
         self.assertIn("CMAKE_GENERATOR=NMake Makefiles", workflow)
+        self.assertIn("CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER", workflow)
+        self.assertIn("$env:VCToolsInstallDir", workflow)
 
     def test_command_failure_preserves_bounded_diagnostic_tail(self) -> None:
         script = (


### PR DESCRIPTION
The Windows FFmpeg build requires MSYS2, whose PATH exposes Git's GNU link.exe ahead of the pinned Visual Studio linker. Bind Cargo explicitly to the active fixed MSVC toolchain before assembling Core and speech.\n\nValidation: 22 release contract tests pass locally.\n\nFollow-up to #246.