### PR TITLE
fix(release): stream build logs and allow cold runners

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -29,7 +29,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container }}
     environment: release
-    timeout-minutes: 15
+    timeout-minutes: 30
+    env:
+      INTO_MD_RELEASE_STREAM_LOGS: '1'
     strategy:
       fail-fast: false
       matrix:

--- a/tools/platform-release/common.py
+++ b/tools/platform-release/common.py
@@ -8,6 +8,9 @@ import os
 import pathlib
 import stat
 import subprocess
+import sys
+import threading
+import time
 from collections.abc import Iterable
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
@@ -61,27 +64,94 @@ def run(
     env: dict[str, str] | None = None,
 ) -> str:
     command = [str(argument) for argument in arguments]
-    completed = subprocess.run(
-        command,
-        cwd=cwd,
-        env=env,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        errors="replace",
-    )
-    if completed.returncode:
+    stream = os.environ.get("INTO_MD_RELEASE_STREAM_LOGS") == "1"
+    started = time.monotonic()
+    if stream:
+        executable = pathlib.Path(command[0]).name
+        phase = command[1] if len(command) > 1 and not command[1].startswith("-") else "run"
+        print(f"[release] start {executable} {phase}", flush=True)
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+            bufsize=1,
+        )
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+        build_tools = {
+            "cargo",
+            "cargo.exe",
+            "cmake",
+            "cmake.exe",
+            "make",
+            "make.exe",
+            "nmake",
+            "nmake.exe",
+            "rustc",
+            "rustc.exe",
+        }
+
+        def drain(pipe, lines: list[str], output, emit: bool) -> None:
+            if pipe is None:
+                return
+            try:
+                for line in pipe:
+                    lines.append(line)
+                    if emit:
+                        output.write(line)
+                        output.flush()
+            finally:
+                pipe.close()
+
+        stdout_thread = threading.Thread(
+            target=drain,
+            args=(process.stdout, stdout_lines, sys.stdout, executable.lower() in build_tools),
+        )
+        stderr_thread = threading.Thread(
+            target=drain,
+            args=(process.stderr, stderr_lines, sys.stderr, True),
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+        returncode = process.wait()
+        stdout_thread.join()
+        stderr_thread.join()
+        stdout = "".join(stdout_lines)
+        stderr = "".join(stderr_lines)
+        print(
+            f"[release] finish {executable} {phase} in {time.monotonic() - started:.1f}s "
+            f"(exit {returncode})",
+            flush=True,
+        )
+    else:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=env,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    if returncode:
         # Cargo and native linkers commonly finish with a generic summary such as
         # "build failed, waiting for other jobs to finish". Preserve a bounded
         # diagnostic tail so a hosted release failure exposes the actual compiler
         # or linker error without flooding Actions logs with the entire build.
-        detail = completed.stderr.strip().splitlines()[-40:] or ["no diagnostic"]
+        detail = stderr.strip().splitlines()[-40:] or ["no diagnostic"]
         rendered = "\n".join(detail)
         raise ReleaseError(
-            f"command failed ({command[0]}, exit {completed.returncode}):\n{rendered}"
+            f"command failed ({command[0]}, exit {returncode}):\n{rendered}"
         )
-    return completed.stdout
+    return stdout
 
 
 def write_json(path: pathlib.Path, value: object) -> None:

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -92,6 +92,8 @@ class PlatformReleaseTests(unittest.TestCase):
         self.assertNotIn("tools/platform-release/release.py", workflow)
         for forbidden in ["installed-smoke", "platform_acceptance.py", "into-md-installer"]:
             self.assertNotIn(forbidden, workflow)
+        self.assertIn("timeout-minutes: 30", workflow)
+        self.assertIn("INTO_MD_RELEASE_STREAM_LOGS: '1'", workflow)
 
     def test_embedded_core_is_verified_without_an_installer_or_launcher(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(


### PR DESCRIPTION
## Summary
- stream Cargo/native release subprocess logs with start/finish timings
- preserve bounded failure tails and captured stdout contracts
- raise release build timeout to 30 minutes so cold EL8/Windows runners are not killed at 15 minutes
- keep the PR gate at exactly four checks

## Validation
- platform release contract tests (24/24), including streaming mode
- license audit
- git diff check