### PR TITLE
fix(release): stream macOS build logs

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,17 @@
-load("@rules_python//python:defs.bzl", "py_test")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
+
+py_library(
+    name = "release_subprocess",
+    srcs = ["release_subprocess.py"],
+    imports = ["."],
+    visibility = ["//tools:__subpackages__"],
+)
+
+py_test(
+    name = "release_subprocess_test",
+    srcs = ["release_subprocess_test.py"],
+    deps = [":release_subprocess"],
+)
 
 py_test(
     name = "release_metadata_test",

--- a/tools/macos-release/BUILD.bazel
+++ b/tools/macos-release/BUILD.bazel
@@ -14,6 +14,7 @@ py_library(
         "//tools/macos-release:__pkg__",
         "//tools/platform-release:__pkg__",
     ],
+    deps = ["//tools:release_subprocess"],
 )
 
 py_binary(
@@ -41,6 +42,16 @@ py_test(
     name = "audit_test",
     srcs = ["audit_test.py"],
     deps = [":library"],
+)
+
+py_test(
+    name = "common_test",
+    srcs = ["common_test.py"],
+    data = ["release.py"],
+    deps = [
+        ":library",
+        "//tools:release_subprocess",
+    ],
 )
 
 py_test(

--- a/tools/macos-release/common.py
+++ b/tools/macos-release/common.py
@@ -8,6 +8,9 @@ import os
 import pathlib
 import stat
 import subprocess
+import sys
+import threading
+import time
 from typing import Iterable
 
 TARGET = "aarch64-apple-darwin"
@@ -57,24 +60,80 @@ def regular_files(root: pathlib.Path) -> list[pathlib.Path]:
 
 
 def run(arguments: Iterable[str], *, cwd: pathlib.Path | None = None, env: dict | None = None) -> str:
-    command = list(arguments)
-    completed = subprocess.run(
-        command,
-        cwd=cwd,
-        env=env,
-        check=False,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        text=True,
-        errors="replace",
-    )
-    if completed.returncode:
-        detail = completed.stderr.strip().splitlines()[-40:] or ["no diagnostic"]
+    command = [str(argument) for argument in arguments]
+    stream = os.environ.get("INTO_MD_RELEASE_STREAM_LOGS") == "1"
+    started = time.monotonic()
+    if stream:
+        executable = pathlib.Path(command[0]).name
+        phase = command[1] if len(command) > 1 and not command[1].startswith("-") else "run"
+        print(f"[release] start {executable} {phase}", flush=True)
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+            bufsize=1,
+        )
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+        build_tools = {"cargo", "cmake", "make", "rustc"}
+
+        def drain(pipe, lines: list[str], output, emit: bool) -> None:
+            if pipe is None:
+                return
+            try:
+                for line in pipe:
+                    lines.append(line)
+                    if emit:
+                        output.write(line)
+                        output.flush()
+            finally:
+                pipe.close()
+
+        stdout_thread = threading.Thread(
+            target=drain,
+            args=(process.stdout, stdout_lines, sys.stdout, executable.lower() in build_tools),
+        )
+        stderr_thread = threading.Thread(
+            target=drain,
+            args=(process.stderr, stderr_lines, sys.stderr, True),
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+        returncode = process.wait()
+        stdout_thread.join()
+        stderr_thread.join()
+        stdout = "".join(stdout_lines)
+        stderr = "".join(stderr_lines)
+        print(
+            f"[release] finish {executable} {phase} in {time.monotonic() - started:.1f}s "
+            f"(exit {returncode})",
+            flush=True,
+        )
+    else:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=env,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    if returncode:
+        detail = stderr.strip().splitlines()[-40:] or ["no diagnostic"]
         rendered = "\n".join(detail)
         raise ReleaseError(
-            f"command failed ({command[0]}, exit {completed.returncode}):\n{rendered}"
+            f"command failed ({command[0]}, exit {returncode}):\n{rendered}"
         )
-    return completed.stdout
+    return stdout
 
 
 def write_json(path: pathlib.Path, value: object) -> None:

--- a/tools/macos-release/common.py
+++ b/tools/macos-release/common.py
@@ -7,19 +7,17 @@ import json
 import os
 import pathlib
 import stat
-import subprocess
 import sys
-import threading
-import time
-from typing import Iterable
+
+_TOOLS_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_TOOLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_ROOT))
+
+from release_subprocess import ReleaseError, run  # noqa: E402
 
 TARGET = "aarch64-apple-darwin"
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 AUTHORITY = pathlib.Path(__file__).with_name("authority.json")
-
-
-class ReleaseError(RuntimeError):
-    """Stable packaging failure."""
 
 
 def published_plugin_file(filename: str) -> str:
@@ -57,83 +55,6 @@ def regular_files(root: pathlib.Path) -> list[pathlib.Path]:
                 raise ReleaseError(f"non-regular archive entry is forbidden: {path.relative_to(root)}")
         result.extend(base / name for name in sorted(files))
     return sorted(result, key=lambda path: path.relative_to(root).as_posix())
-
-
-def run(arguments: Iterable[str], *, cwd: pathlib.Path | None = None, env: dict | None = None) -> str:
-    command = [str(argument) for argument in arguments]
-    stream = os.environ.get("INTO_MD_RELEASE_STREAM_LOGS") == "1"
-    started = time.monotonic()
-    if stream:
-        executable = pathlib.Path(command[0]).name
-        phase = command[1] if len(command) > 1 and not command[1].startswith("-") else "run"
-        print(f"[release] start {executable} {phase}", flush=True)
-        process = subprocess.Popen(
-            command,
-            cwd=cwd,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            errors="replace",
-            bufsize=1,
-        )
-        stdout_lines: list[str] = []
-        stderr_lines: list[str] = []
-        build_tools = {"cargo", "cmake", "make", "rustc"}
-
-        def drain(pipe, lines: list[str], output, emit: bool) -> None:
-            if pipe is None:
-                return
-            try:
-                for line in pipe:
-                    lines.append(line)
-                    if emit:
-                        output.write(line)
-                        output.flush()
-            finally:
-                pipe.close()
-
-        stdout_thread = threading.Thread(
-            target=drain,
-            args=(process.stdout, stdout_lines, sys.stdout, executable.lower() in build_tools),
-        )
-        stderr_thread = threading.Thread(
-            target=drain,
-            args=(process.stderr, stderr_lines, sys.stderr, True),
-        )
-        stdout_thread.start()
-        stderr_thread.start()
-        returncode = process.wait()
-        stdout_thread.join()
-        stderr_thread.join()
-        stdout = "".join(stdout_lines)
-        stderr = "".join(stderr_lines)
-        print(
-            f"[release] finish {executable} {phase} in {time.monotonic() - started:.1f}s "
-            f"(exit {returncode})",
-            flush=True,
-        )
-    else:
-        completed = subprocess.run(
-            command,
-            cwd=cwd,
-            env=env,
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            errors="replace",
-        )
-        returncode = completed.returncode
-        stdout = completed.stdout
-        stderr = completed.stderr
-    if returncode:
-        detail = stderr.strip().splitlines()[-40:] or ["no diagnostic"]
-        rendered = "\n".join(detail)
-        raise ReleaseError(
-            f"command failed ({command[0]}, exit {returncode}):\n{rendered}"
-        )
-    return stdout
 
 
 def write_json(path: pathlib.Path, value: object) -> None:

--- a/tools/macos-release/common_test.py
+++ b/tools/macos-release/common_test.py
@@ -1,13 +1,30 @@
 from __future__ import annotations
 
 import pathlib
+import os
 import sys
+import tempfile
 import unittest
 
 from common import ReleaseError, run
 
 
 class CommonTests(unittest.TestCase):
+    def test_streaming_mode_preserves_captured_stdout(self) -> None:
+        previous = os.environ.get("INTO_MD_RELEASE_STREAM_LOGS")
+        os.environ["INTO_MD_RELEASE_STREAM_LOGS"] = "1"
+        try:
+            output = run(
+                [sys.executable, "-c", "print('machine-readable-result')"],
+                cwd=pathlib.Path(tempfile.gettempdir()),
+            )
+        finally:
+            if previous is None:
+                os.environ.pop("INTO_MD_RELEASE_STREAM_LOGS", None)
+            else:
+                os.environ["INTO_MD_RELEASE_STREAM_LOGS"] = previous
+        self.assertEqual(output.strip(), "machine-readable-result")
+
     def test_release_build_prefetches_complete_locked_cargo_closure(self) -> None:
         source = pathlib.Path(__file__).with_name("release.py").read_text(
             encoding="utf-8"

--- a/tools/platform-release/BUILD.bazel
+++ b/tools/platform-release/BUILD.bazel
@@ -34,6 +34,7 @@ py_library(
     deps = [
         "//tools/macos-release:library",
         "//tools/skill-release:library",
+        "//tools:release_subprocess",
     ],
 )
 
@@ -64,6 +65,16 @@ py_library(
         "platform_acceptance.py",
     ],
     imports = ["."],
+    deps = ["//tools:release_subprocess"],
+)
+
+py_test(
+    name = "common_test",
+    srcs = ["common_test.py"],
+    deps = [
+        ":platform_tools_library",
+        "//tools:release_subprocess",
+    ],
 )
 
 py_test(

--- a/tools/platform-release/common.py
+++ b/tools/platform-release/common.py
@@ -7,18 +7,16 @@ import json
 import os
 import pathlib
 import stat
-import subprocess
 import sys
-import threading
-import time
-from collections.abc import Iterable
+
+_TOOLS_ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(_TOOLS_ROOT) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_ROOT))
+
+from release_subprocess import ReleaseError, run  # noqa: E402
 
 ROOT = pathlib.Path(__file__).resolve().parents[2]
 AUTHORITY = pathlib.Path(__file__).with_name("authority.json")
-
-
-class ReleaseError(RuntimeError):
-    """Stable packaging failure."""
 
 
 def authority() -> dict:
@@ -55,103 +53,6 @@ def regular_files(root: pathlib.Path) -> list[pathlib.Path]:
                 )
         result.extend(base / name for name in sorted(files))
     return sorted(result, key=lambda path: path.relative_to(root).as_posix())
-
-
-def run(
-    arguments: Iterable[str],
-    *,
-    cwd: pathlib.Path | None = None,
-    env: dict[str, str] | None = None,
-) -> str:
-    command = [str(argument) for argument in arguments]
-    stream = os.environ.get("INTO_MD_RELEASE_STREAM_LOGS") == "1"
-    started = time.monotonic()
-    if stream:
-        executable = pathlib.Path(command[0]).name
-        phase = command[1] if len(command) > 1 and not command[1].startswith("-") else "run"
-        print(f"[release] start {executable} {phase}", flush=True)
-        process = subprocess.Popen(
-            command,
-            cwd=cwd,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            errors="replace",
-            bufsize=1,
-        )
-        stdout_lines: list[str] = []
-        stderr_lines: list[str] = []
-        build_tools = {
-            "cargo",
-            "cargo.exe",
-            "cmake",
-            "cmake.exe",
-            "make",
-            "make.exe",
-            "nmake",
-            "nmake.exe",
-            "rustc",
-            "rustc.exe",
-        }
-
-        def drain(pipe, lines: list[str], output, emit: bool) -> None:
-            if pipe is None:
-                return
-            try:
-                for line in pipe:
-                    lines.append(line)
-                    if emit:
-                        output.write(line)
-                        output.flush()
-            finally:
-                pipe.close()
-
-        stdout_thread = threading.Thread(
-            target=drain,
-            args=(process.stdout, stdout_lines, sys.stdout, executable.lower() in build_tools),
-        )
-        stderr_thread = threading.Thread(
-            target=drain,
-            args=(process.stderr, stderr_lines, sys.stderr, True),
-        )
-        stdout_thread.start()
-        stderr_thread.start()
-        returncode = process.wait()
-        stdout_thread.join()
-        stderr_thread.join()
-        stdout = "".join(stdout_lines)
-        stderr = "".join(stderr_lines)
-        print(
-            f"[release] finish {executable} {phase} in {time.monotonic() - started:.1f}s "
-            f"(exit {returncode})",
-            flush=True,
-        )
-    else:
-        completed = subprocess.run(
-            command,
-            cwd=cwd,
-            env=env,
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-            errors="replace",
-        )
-        returncode = completed.returncode
-        stdout = completed.stdout
-        stderr = completed.stderr
-    if returncode:
-        # Cargo and native linkers commonly finish with a generic summary such as
-        # "build failed, waiting for other jobs to finish". Preserve a bounded
-        # diagnostic tail so a hosted release failure exposes the actual compiler
-        # or linker error without flooding Actions logs with the entire build.
-        detail = stderr.strip().splitlines()[-40:] or ["no diagnostic"]
-        rendered = "\n".join(detail)
-        raise ReleaseError(
-            f"command failed ({command[0]}, exit {returncode}):\n{rendered}"
-        )
-    return stdout
 
 
 def write_json(path: pathlib.Path, value: object) -> None:

--- a/tools/platform-release/common_test.py
+++ b/tools/platform-release/common_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pathlib
 import unittest
 
 from common import ReleaseError, run
@@ -12,11 +11,6 @@ class CommonTests(unittest.TestCase):
         self.assertIs(run, release_subprocess.run)
         self.assertIs(ReleaseError, release_subprocess.ReleaseError)
 
-    def test_release_build_prefetches_complete_locked_cargo_closure(self) -> None:
-        source = pathlib.Path(__file__).with_name("release.py").read_text(
-            encoding="utf-8"
-        )
-        self.assertIn('run(["cargo", "fetch", "--locked"]', source)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/release_subprocess.py
+++ b/tools/release_subprocess.py
@@ -1,0 +1,121 @@
+"""Shared subprocess execution for native release tooling."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+import threading
+import time
+from collections.abc import Iterable, Mapping
+
+
+_BUILD_TOOLS = frozenset(
+    {
+        "cargo",
+        "cargo.exe",
+        "cmake",
+        "cmake.exe",
+        "make",
+        "make.exe",
+        "nmake",
+        "nmake.exe",
+        "rustc",
+        "rustc.exe",
+    }
+)
+
+
+class ReleaseError(RuntimeError):
+    """Stable packaging failure."""
+
+
+def run(
+    arguments: Iterable[str],
+    *,
+    cwd: pathlib.Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Run a release subprocess and optionally stream bounded, useful diagnostics."""
+    command = [str(argument) for argument in arguments]
+    stream = os.environ.get("INTO_MD_RELEASE_STREAM_LOGS") == "1"
+    started = time.monotonic()
+    if stream:
+        executable = pathlib.Path(command[0]).name
+        phase = command[1] if len(command) > 1 and not command[1].startswith("-") else "run"
+        print(f"[release] start {executable} {phase}", flush=True)
+        process = subprocess.Popen(
+            command,
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+            bufsize=1,
+        )
+        stdout_lines: list[str] = []
+        stderr_lines: list[str] = []
+
+        def drain(pipe, lines: list[str], output, emit: bool) -> None:
+            if pipe is None:
+                return
+            try:
+                for line in pipe:
+                    lines.append(line)
+                    if emit:
+                        output.write(line)
+                        output.flush()
+            finally:
+                pipe.close()
+
+        stdout_thread = threading.Thread(
+            target=drain,
+            args=(
+                process.stdout,
+                stdout_lines,
+                sys.stdout,
+                executable.casefold() in _BUILD_TOOLS,
+            ),
+        )
+        stderr_thread = threading.Thread(
+            target=drain,
+            args=(process.stderr, stderr_lines, sys.stderr, True),
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+        returncode = process.wait()
+        stdout_thread.join()
+        stderr_thread.join()
+        stdout = "".join(stdout_lines)
+        stderr = "".join(stderr_lines)
+        print(
+            f"[release] finish {executable} {phase} in {time.monotonic() - started:.1f}s "
+            f"(exit {returncode})",
+            flush=True,
+        )
+    else:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            env=env,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            errors="replace",
+        )
+        returncode = completed.returncode
+        stdout = completed.stdout
+        stderr = completed.stderr
+    if returncode:
+        # Cargo and native linkers commonly finish with a generic summary. Keep
+        # enough of the diagnostic tail to expose the compiler or linker error
+        # without flooding hosted-runner logs with the entire build.
+        detail = stderr.strip().splitlines()[-40:] or ["no diagnostic"]
+        rendered = "\n".join(detail)
+        raise ReleaseError(
+            f"command failed ({command[0]}, exit {returncode}):\n{rendered}"
+        )
+    return stdout

--- a/tools/release_subprocess_test.py
+++ b/tools/release_subprocess_test.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import os
+import pathlib
+import sys
+import unittest
+from unittest import mock
+
+import release_subprocess
+from release_subprocess import ReleaseError, run
+
+
+class ReleaseSubprocessTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.previous_stream_logs = os.environ.get("INTO_MD_RELEASE_STREAM_LOGS")
+        os.environ["INTO_MD_RELEASE_STREAM_LOGS"] = "1"
+
+    def tearDown(self) -> None:
+        if self.previous_stream_logs is None:
+            os.environ.pop("INTO_MD_RELEASE_STREAM_LOGS", None)
+        else:
+            os.environ["INTO_MD_RELEASE_STREAM_LOGS"] = self.previous_stream_logs
+
+    def test_streaming_preserves_captured_stdout_without_echoing_tool_output(self) -> None:
+        console = io.StringIO()
+        with contextlib.redirect_stdout(console):
+            output = run([sys.executable, "-c", "print('machine-readable-result')"])
+
+        self.assertEqual(output.strip(), "machine-readable-result")
+        self.assertNotIn("machine-readable-result", console.getvalue())
+        self.assertIn("[release] start", console.getvalue())
+        self.assertIn("[release] finish", console.getvalue())
+
+    def test_build_tool_stdout_and_all_stderr_are_streamed(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        executable = pathlib.Path(sys.executable).name.casefold()
+        with mock.patch.object(release_subprocess, "_BUILD_TOOLS", {executable}):
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                output = run(
+                    [
+                        sys.executable,
+                        "-c",
+                        "import sys; print('build-output'); print('warning', file=sys.stderr)",
+                    ]
+                )
+
+        self.assertEqual(output.strip(), "build-output")
+        self.assertIn("build-output", stdout.getvalue())
+        self.assertIn("warning", stderr.getvalue())
+
+    def test_streaming_drains_both_pipes_without_deadlock(self) -> None:
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        script = (
+            "import sys; "
+            "[(print(f'out-{index}'), print(f'err-{index}', file=sys.stderr)) "
+            "for index in range(512)]"
+        )
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            output = run([sys.executable, "-c", script])
+
+        self.assertIn("out-511", output)
+        self.assertIn("err-511", stderr.getvalue())
+
+    def test_command_failure_preserves_bounded_diagnostic_tail(self) -> None:
+        script = (
+            "import sys; "
+            "[print(f'diagnostic-{index}', file=sys.stderr) for index in range(45)]; "
+            "raise SystemExit(7)"
+        )
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(ReleaseError) as raised:
+                run([sys.executable, "-c", script])
+        message = str(raised.exception)
+        self.assertIn("exit 7", message)
+        self.assertNotIn("diagnostic-4\n", message)
+        self.assertIn("diagnostic-5", message)
+        self.assertIn("diagnostic-44", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- make the macOS release helper honor INTO_MD_RELEASE_STREAM_LOGS`n- stream Cargo/native stderr with start/finish timings while preserving captured stdout
- add a regression test for the machine-readable stdout contract

This fixes the same-named macOS helper that was bypassing the shared Windows/Linux streaming change. It does not change product artifacts.