### PR TITLE
fix(release): pass real 0.0.3 Windows and Linux E2E

### DIFF
--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -4118,6 +4118,7 @@ fn invocation_capabilities(
     plans: &[WorkPlan],
     explicit_format: Option<InputFormat>,
     extension_hint: Option<&str>,
+    options: &ConversionOptions,
 ) -> crate::services::InvocationCapabilities {
     let hinted = explicit_format.or_else(|| extension_hint.and_then(InputFormat::from_extension));
     let mut formats = Vec::new();
@@ -4163,13 +4164,22 @@ fn invocation_capabilities(
     };
     let media =
         |format| matches!(format, InputFormat::Audio | InputFormat::Video | InputFormat::YouTube);
+    let legacy_office =
+        |format| matches!(format, InputFormat::Doc | InputFormat::Ppt | InputFormat::Xls);
+    let effective_ocr_policy = match options.ai.vision_ocr {
+        AiMode::Only => OcrPolicy::Always,
+        AiMode::Fallback | AiMode::Prefer if options.ocr.policy == OcrPolicy::Off => {
+            OcrPolicy::Auto
+        }
+        _ => options.ocr.policy,
+    };
     crate::services::InvocationCapabilities {
-        ocr: formats.iter().copied().any(visual),
+        ocr: formats.iter().copied().any(|format| {
+            visual(format) && !(effective_ocr_policy == OcrPolicy::Auto && legacy_office(format))
+        }),
         transcription: formats.iter().copied().any(media),
         diarization: formats.iter().copied().any(media),
-        legacy_office: formats
-            .iter()
-            .any(|format| matches!(format, InputFormat::Doc | InputFormat::Ppt | InputFormat::Xls)),
+        legacy_office: formats.iter().copied().any(legacy_office),
     }
 }
 
@@ -4225,8 +4235,12 @@ fn run_conversion(
         ..into_markdown::ExecutionOptions::default()
     };
     let explicit_format = arguments.format.as_deref().map(parse_format).transpose()?;
-    let capability_needs =
-        invocation_capabilities(&plans, explicit_format, arguments.extension.as_deref());
+    let capability_needs = invocation_capabilities(
+        &plans,
+        explicit_format,
+        arguments.extension.as_deref(),
+        &loaded.options,
+    );
     let services = crate::services::assemble(&loaded, &execution, &context.cwd, capability_needs)?;
     let output_context =
         into_markdown::ExecutionContext::new(execution.clone(), loaded.options.limits.clone());
@@ -6883,19 +6897,30 @@ mod tests {
             output: None,
             output_root: None,
         };
-        let office = invocation_capabilities(&[plan("report.xls")], None, None);
+        let mut options = ConversionOptions::default();
+        let office = invocation_capabilities(&[plan("report.xls")], None, None, &options);
         assert!(office.legacy_office);
-        assert!(office.ocr);
+        assert!(!office.ocr);
         assert!(!office.transcription);
         assert!(!office.diarization);
 
-        let media = invocation_capabilities(&[plan("meeting.webm")], None, None);
+        options.ocr.policy = OcrPolicy::Always;
+        let office_with_explicit_ocr =
+            invocation_capabilities(&[plan("slides.ppt")], None, None, &options);
+        assert!(office_with_explicit_ocr.legacy_office);
+        assert!(office_with_explicit_ocr.ocr);
+
+        options = ConversionOptions::default();
+        let image = invocation_capabilities(&[plan("scan.png")], None, None, &options);
+        assert!(image.ocr);
+
+        let media = invocation_capabilities(&[plan("meeting.webm")], None, None, &options);
         assert!(media.transcription);
         assert!(media.diarization);
         assert!(!media.legacy_office);
         assert!(!media.ocr);
 
-        let unknown = invocation_capabilities(&[plan("opaque")], None, None);
+        let unknown = invocation_capabilities(&[plan("opaque")], None, None, &options);
         assert!(unknown.ocr && unknown.transcription && unknown.diarization);
         assert!(unknown.legacy_office);
     }

--- a/crates/api/src/diarization_service.rs
+++ b/crates/api/src/diarization_service.rs
@@ -5,6 +5,14 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+fn select_snapshot_operation<T, E>(
+    read_only_sandbox: bool,
+    authenticated: impl FnOnce() -> Result<T, E>,
+    ordinary: impl FnOnce() -> Result<T, E>,
+) -> Result<T, E> {
+    if read_only_sandbox { authenticated() } else { ordinary() }
+}
+
 /// Explicit verified paths required for speaker diarization.
 #[derive(Debug, Clone)]
 pub struct InstalledDiarizationConfig {
@@ -110,23 +118,9 @@ fn installed_diarization_service_inner(
         "{}@vad-sha256:{}+speaker-sha256:{}",
         config.model_bundle, vad.sha256, embedding.sha256
     );
-    let library = into_markdown_onnxruntime::RuntimeLibrary::load(
-        &config.runtime_trusted_root,
-        &config.runtime_library,
-    )
-    .map_err(|error| ConversionError::ComponentUnavailable {
-        component: "onnxruntime".into(),
-        detail: format!("installed ONNX Runtime is unavailable: {error}"),
-    })?;
+    let library = load_diarization_runtime(config, read_only_sandbox)?;
     let runtime_version = library.version().to_owned();
-    let factory = into_markdown_onnxruntime::OrtSessionFactory::new(
-        Arc::new(library),
-        config.worker_executable.clone(),
-    )
-    .map_err(|error| ConversionError::ComponentUnavailable {
-        component: "onnxruntime-worker".into(),
-        detail: format!("installed ONNX worker is unavailable: {error}"),
-    })?;
+    let factory = diarization_session_factory(config, library, read_only_sandbox)?;
     let resolver = into_markdown_asr::DiarizationModelResolver::new(Arc::clone(&manager), context)?;
     let runtime = into_markdown_ocr::OnnxRuntime::new(
         Arc::new(resolver),
@@ -166,10 +160,74 @@ fn installed_diarization_service_inner(
     )))
 }
 
+fn load_diarization_runtime(
+    config: &InstalledDiarizationConfig,
+    read_only_sandbox: bool,
+) -> Result<into_markdown_onnxruntime::RuntimeLibrary, ConversionError> {
+    select_snapshot_operation(
+        read_only_sandbox,
+        || {
+            into_markdown_onnxruntime::RuntimeLibrary::load_authenticated_read_only_snapshot(
+                &config.runtime_trusted_root,
+                &config.runtime_library,
+            )
+        },
+        || {
+            into_markdown_onnxruntime::RuntimeLibrary::load(
+                &config.runtime_trusted_root,
+                &config.runtime_library,
+            )
+        },
+    )
+    .map_err(|error| ConversionError::ComponentUnavailable {
+        component: "onnxruntime".into(),
+        detail: format!("installed ONNX Runtime is unavailable: {error}"),
+    })
+}
+
+fn diarization_session_factory(
+    config: &InstalledDiarizationConfig,
+    library: into_markdown_onnxruntime::RuntimeLibrary,
+    read_only_sandbox: bool,
+) -> Result<into_markdown_onnxruntime::OrtSessionFactory, ConversionError> {
+    let library = Arc::new(library);
+    select_snapshot_operation(
+        read_only_sandbox,
+        || {
+            into_markdown_onnxruntime::OrtSessionFactory::new_authenticated_read_only_snapshot(
+                Arc::clone(&library),
+                config.worker_executable.clone(),
+            )
+        },
+        || {
+            into_markdown_onnxruntime::OrtSessionFactory::new(
+                Arc::clone(&library),
+                config.worker_executable.clone(),
+            )
+        },
+    )
+    .map_err(|error| ConversionError::ComponentUnavailable {
+        component: "onnxruntime-worker".into(),
+        detail: format!("installed ONNX worker is unavailable: {error}"),
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{ErrorCode, ExecutionOptions, ResourceLimits};
+
+    #[test]
+    fn read_only_sandbox_selects_authenticated_native_snapshot_operations() {
+        assert_eq!(
+            select_snapshot_operation(true, || Ok::<_, ()>("authenticated"), || Ok("ordinary")),
+            Ok("authenticated")
+        );
+        assert_eq!(
+            select_snapshot_operation(false, || Ok::<_, ()>("authenticated"), || Ok("ordinary")),
+            Ok("ordinary")
+        );
+    }
 
     #[test]
     fn missing_bundle_fails_before_native_runtime_lookup() {

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -198,7 +198,7 @@ fn plan_enrichment(
     services: &Services,
     context: &ExecutionContext,
 ) -> Result<EnrichmentPlan, ConversionError> {
-    if !ocr_enabled(options)
+    if !embedded_visual_ocr_enabled(input_format, options)
         || input_format == InputFormat::Image
         || !eligible_container(input_format)
     {
@@ -738,7 +738,7 @@ async fn enrich(
     services: &Services,
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
-    if !ocr_enabled(options)
+    if !embedded_visual_ocr_enabled(input_format, options)
         || input_format == InputFormat::Image
         || !eligible_container(input_format)
     {
@@ -964,6 +964,12 @@ async fn enrich(
 
 fn ocr_enabled(options: &ConversionOptions) -> bool {
     effective_ocr_policy(options) != OcrPolicy::Off
+}
+
+fn embedded_visual_ocr_enabled(input_format: InputFormat, options: &ConversionOptions) -> bool {
+    ocr_enabled(options)
+        && !(effective_ocr_policy(options) == OcrPolicy::Auto
+            && matches!(input_format, InputFormat::Doc | InputFormat::Ppt | InputFormat::Xls))
 }
 
 fn effective_ocr_policy(options: &ConversionOptions) -> OcrPolicy {
@@ -2400,6 +2406,36 @@ mod tests {
             assert_eq!(after.assets, expected_assets);
             assert_eq!(after.diagnostics, expected_diagnostics);
         }
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[test]
+    fn legacy_office_auto_does_not_plan_or_run_embedded_visual_ocr() {
+        let ocr = source_bound_ocr(false);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+
+        for format in [InputFormat::Doc, InputFormat::Ppt, InputFormat::Xls] {
+            let before = output();
+            let expected_document = before.document.clone();
+            let expected_assets = before.assets.clone();
+            let expected_diagnostics = before.diagnostics.clone();
+            let context =
+                ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+            assert_eq!(
+                plan_enrichment(&before, format, &options, &services, &context).unwrap(),
+                EnrichmentPlan::Skip,
+                "{format:?}"
+            );
+            let after = block_on(enrich(before, format, &options, &services, &context))
+                .unwrap_or_else(|error| panic!("{format:?}: {error}"));
+            assert_eq!(after.document, expected_document, "{format:?}");
+            assert_eq!(after.assets, expected_assets, "{format:?}");
+            assert_eq!(after.diagnostics, expected_diagnostics, "{format:?}");
+        }
+
+        assert_eq!(ocr.plans.load(Ordering::SeqCst), 0);
         assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
     }
 

--- a/crates/onnxruntime/src/lib.rs
+++ b/crates/onnxruntime/src/lib.rs
@@ -1482,6 +1482,23 @@ mod tests {
         }
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn authenticated_snapshot_accepts_canonical_verbatim_windows_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        let root = directory.path().join("runtime");
+        fs::create_dir(&root).unwrap();
+        let library = root.join("onnxruntime.dll");
+        fs::write(&library, b"fixture").unwrap();
+        let canonical_root = root.canonicalize().unwrap();
+        let canonical_library = library.canonicalize().unwrap();
+        assert!(canonical_root.to_string_lossy().starts_with(r"\\?\"));
+        let (opened, identity) =
+            open_explicit_authenticated_snapshot(&canonical_root, &canonical_library).unwrap();
+        assert_eq!(opened.metadata().unwrap().len(), 7);
+        assert_eq!(identity, canonical_library);
+    }
+
     #[test]
     fn dependency_authority_accepts_only_platform_system_names() {
         assert!(dependencies_are_system_only(

--- a/tools/platform-release/audit.py
+++ b/tools/platform-release/audit.py
@@ -227,6 +227,14 @@ def clr_il_only(output: str) -> bool:
     )
 
 
+def requires_x86_64_extension_level(notes: str) -> bool:
+    """Return true when ELF declares an ISA requirement above x86-64 baseline."""
+    needed = "\n".join(
+        line for line in notes.splitlines() if "x86 ISA needed:" in line
+    )
+    return re.search(r"\bx86-64-v[234]\b", needed, re.IGNORECASE) is not None
+
+
 def audit_tree(root: pathlib.Path, audit: Audit, linux: bool) -> None:
     audit.require(root, "regular-root", root.is_dir() and not root.is_symlink(), "root must be a real directory")
     for path in sorted(root.rglob("*")):
@@ -319,6 +327,14 @@ def audit_linux(root: pathlib.Path, expected_machine: str, audit: Audit) -> None
         if paths:
             allowed = {"/lib64/ld-linux-x86-64.so.2", "/lib/ld-linux-aarch64.so.1"}
             audit.require(relative, "elf-interpreter", paths[0] in allowed, paths[0])
+        if expected_machine == "Advanced Micro Devices X86-64":
+            notes = command([readelf, "-nW", str(binary)])
+            audit.require(
+                relative,
+                "x86-64-isa-baseline",
+                not requires_x86_64_extension_level(notes),
+                "ELF must not require x86-64-v2/v3/v4",
+            )
 
 
 def audit_windows(

--- a/tools/platform-release/release.py
+++ b/tools/platform-release/release.py
@@ -163,7 +163,16 @@ def refresh_ffmpeg_authority(authority_path: pathlib.Path, executable: pathlib.P
 
 def build(target: str, output: pathlib.Path) -> pathlib.Path:
     environment = os.environ.copy()
-    environment.update({"CARGO_INCREMENTAL": "0", "CARGO_TARGET_DIR": str(output)})
+    environment.update(
+        {
+            "CARGO_INCREMENTAL": "0",
+            "CARGO_TARGET_DIR": str(output),
+            # whisper.cpp otherwise enables GGML_NATIVE and bakes the release
+            # runner's optional ISA extensions into the provider.  The Rust
+            # target-cpu baseline below does not apply to this CMake subtree.
+            "GGML_NATIVE": "OFF",
+        }
+    )
     rustflags = ["-C", "strip=debuginfo"]
     target_cpu = {
         "x86_64-unknown-linux-gnu": "x86-64",
@@ -224,6 +233,9 @@ def build_embedded_core(
             "CARGO_TARGET_DIR": str(output),
             "INTO_MD_EMBEDDED_PDFIUM_ROOT": str(pdfium_root.resolve()),
             "INTO_MD_EMBEDDED_OCR_ROOT": str(ocr_root.resolve()),
+            # Keep every Cargo/CMake invocation in the release authority on
+            # the same portable CPU policy, including clean rebuilds.
+            "GGML_NATIVE": "OFF",
         }
     )
     target_cpu = {

--- a/tools/platform-release/test_platform_tools.py
+++ b/tools/platform-release/test_platform_tools.py
@@ -20,6 +20,7 @@ from audit import (
     Audit,
     AuditFailure,
     clr_il_only,
+    requires_x86_64_extension_level,
     resolve_release_packages,
     run,
     safe_zip_extract,
@@ -202,6 +203,23 @@ class PlatformToolTests(unittest.TestCase):
         self.assertTrue(clr_il_only(header))
         self.assertFalse(clr_il_only(header.replace("0 [       0]", "2000 [      80]")))
         self.assertFalse(clr_il_only("native PE"))
+
+    def test_linux_native_audit_rejects_raised_x86_64_isa_levels(self) -> None:
+        self.assertFalse(
+            requires_x86_64_extension_level(
+                "Properties: x86 ISA needed: x86-64-baseline\n"
+            )
+        )
+        self.assertTrue(
+            requires_x86_64_extension_level(
+                "Properties: x86 ISA needed: x86-64-baseline, x86-64-v4\n"
+            )
+        )
+        self.assertFalse(
+            requires_x86_64_extension_level(
+                "Properties: x86 ISA used: x86-64-v4\n"
+            )
+        )
 
     def test_zip_extractor_rejects_parent_traversal(self) -> None:
         with tempfile.TemporaryDirectory() as name:

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -203,6 +203,27 @@ class PlatformReleaseTests(unittest.TestCase):
                 ],
             )
 
+    def test_release_build_disables_native_ggml_cpu_tuning(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            output = pathlib.Path(name)
+            environments = []
+
+            def fake_run(arguments, **kwargs):
+                command = [str(value) for value in arguments]
+                if command[:2] == ["cargo", "build"]:
+                    environments.append(kwargs["env"])
+                    release_bin = output / "release"
+                    release_bin.mkdir()
+                    for _, binary in RELEASE_BUILD_PRODUCTS:
+                        (release_bin / binary).touch()
+                return ""
+
+            with mock.patch.object(release_module, "run", side_effect=fake_run):
+                release_module.build("x86_64-unknown-linux-gnu", output)
+            self.assertEqual(len(environments), 1)
+            self.assertEqual(environments[0]["GGML_NATIVE"], "OFF")
+            self.assertIn("target-cpu=x86-64", environments[0]["RUSTFLAGS"])
+
     def test_release_build_rejects_a_missing_helper_product(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             output = pathlib.Path(name)
@@ -225,8 +246,11 @@ class PlatformReleaseTests(unittest.TestCase):
             root = pathlib.Path(name)
             commands = []
 
-            def fake_run(arguments, **_kwargs):
+            environments = []
+
+            def fake_run(arguments, **kwargs):
                 commands.append([str(value) for value in arguments])
+                environments.append(kwargs["env"])
                 return ""
 
             with mock.patch.object(release_module, "run", side_effect=fake_run):
@@ -245,6 +269,8 @@ class PlatformReleaseTests(unittest.TestCase):
             self.assertIn("into-md", commands[0])
             feature = commands[0].index("--features")
             self.assertEqual(commands[0][feature + 1], "embedded-runtime")
+            self.assertEqual(environments[0]["GGML_NATIVE"], "OFF")
+            self.assertIn("target-cpu=x86-64", environments[0]["RUSTFLAGS"])
 
     def test_release_build_prefetches_complete_locked_cargo_closure(self) -> None:
         source = (ROOT / "tools/platform-release/release.py").read_text(

--- a/tools/portable-release/native_acceptance.py
+++ b/tools/portable-release/native_acceptance.py
@@ -24,6 +24,9 @@ CORE_ARCHIVES = {
     "aarch64-apple-darwin": ("into-md-macos-arm64.zip", "into-md", "Mach-O", "arm64"),
 }
 MAX_OUTPUT_BYTES = 64 * 1024
+LEGACY_OFFICE_FIXTURES = (
+    pathlib.Path(__file__).resolve().parents[1] / "macos-release" / "fixtures"
+)
 
 
 class AcceptanceError(RuntimeError):
@@ -141,6 +144,22 @@ def run_case(
     )
 
 
+def assert_runtime_absent(
+    cache: pathlib.Path,
+    home: pathlib.Path,
+    temporary: pathlib.Path,
+    detail: str,
+) -> None:
+    runtime_roots = [
+        cache / "into-markdown" / "runtime",
+        home / ".cache" / "into-markdown" / "runtime",
+        home / "Library" / "Caches" / "into-markdown" / "runtime",
+    ]
+    fallback = list(temporary.glob("into-markdown-runtime-*"))
+    if any(path.exists() for path in runtime_roots) or fallback:
+        raise AcceptanceError(f"{detail} materialized native runtime")
+
+
 def run_e2e(
     target: str, data: bytes, member: str, artifact_sha: str, expected_version: str
 ) -> dict:
@@ -190,16 +209,43 @@ def run_e2e(
             environment,
         )
         cases = [help_case, version_case, text_case]
-        if not result.is_file() or "portable release acceptance" not in result.read_text(encoding="utf-8"):
+        if not result.is_file() or "portable release acceptance" not in result.read_text(
+            encoding="utf-8"
+        ):
             raise AcceptanceError("plain-text conversion output is missing or invalid")
-        runtime_roots = [
-            cache / "into-markdown" / "runtime",
-            home / ".cache" / "into-markdown" / "runtime",
-            home / "Library" / "Caches" / "into-markdown" / "runtime",
-        ]
-        fallback = list(temporary.glob("into-markdown-runtime-*"))
-        if any(path.exists() for path in runtime_roots) or fallback:
-            raise AcceptanceError("help, version, or plain text conversion materialized native runtime")
+        assert_runtime_absent(cache, home, temporary, "help, version, or plain text conversion")
+        for extension in ("doc", "ppt", "xls"):
+            fixture = LEGACY_OFFICE_FIXTURES / f"normal.{extension}"
+            if not fixture.is_file():
+                raise AcceptanceError(f"legacy Office fixture is unavailable: {fixture.name}")
+            legacy_result = work / f"normal-{extension}.md"
+            legacy_case, _ = run_case(
+                f"legacy-office-{extension}",
+                binary,
+                [
+                    str(fixture),
+                    "-o",
+                    str(legacy_result),
+                    "--conflict",
+                    "error",
+                    "--no-config",
+                    "--progress",
+                    "never",
+                ],
+                work,
+                environment,
+            )
+            cases.append(legacy_case)
+            if not legacy_result.is_file() or not legacy_result.read_bytes():
+                raise AcceptanceError(
+                    f"legacy Office {extension.upper()} output is missing or empty"
+                )
+            assert_runtime_absent(
+                cache,
+                home,
+                temporary,
+                f"default legacy Office {extension.upper()} conversion",
+            )
         return {
             "schemaVersion": 1,
             "target": target,


### PR DESCRIPTION
## Summary

- keep default legacy DOC/PPT/XLS conversions runtime-free while preserving explicit OCR
- compile whisper.cpp for the portable x86-64 baseline instead of the CI runner CPU
- use authenticated read-only ONNX snapshots for sandboxed Windows diarization
- reject ELF executables that declare x86-64-v2/v3/v4 requirements

## Real draft E2E findings addressed

The current 0.0.3 draft was downloaded and tested on native Windows and WSL Linux x86_64. This PR fixes all three blockers found: legacy PPT materialized OCR under the default policy, Linux speech crashed with SIGILL, and Windows diarization rejected its authenticated snapshot path.

## Verification

- 45 combined release/native Python tests
- 436 converter tests (435 passed, 1 ignored)
- focused API diarization and Windows verbatim-path tests
- fixed Windows embedded Core: help/version/text/DOC/PPT/XLS create no runtime; explicit image OCR succeeds
- release jobs remain exactly four platform checks