### PR TITLE
fix(release): pass Linux default-user E2E

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -106,8 +106,12 @@ jobs:
         if: inputs.signing_mode == 'unsigned'
         with:
           path: ${{ runner.temp }}/release-work/build
-          key: release-cargo-only-v1-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('apps/**/*.rs', 'crates/**/*.rs', 'tools/**/*.rs', 'Cargo.toml') }}
-          restore-keys: release-cargo-only-v1-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-
+          # whisper-rs-sys forwards GGML_* variables dynamically and does not
+          # declare them as Cargo rerun inputs. Put the explicit CPU policy
+          # ahead of the source hash so no target cache built under a different
+          # native-ISA policy can be restored.
+          key: release-cargo-only-v2-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('tools/platform-release/authority.json', 'tools/platform-release/cpu-policy.json') }}-${{ hashFiles('apps/**/*.rs', 'crates/**/*.rs', 'tools/**/*.rs', 'Cargo.toml') }}
+          restore-keys: release-cargo-only-v2-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('tools/platform-release/authority.json', 'tools/platform-release/cpu-policy.json') }}-
       - uses: actions/cache@v4
         with:
           path: ${{ runner.temp }}/release-work/cache

--- a/apps/cli/src/embedded_runtime.rs
+++ b/apps/cli/src/embedded_runtime.rs
@@ -675,13 +675,52 @@ fn create_private_directory(path: &Path) -> Result<(), String> {
 
 #[cfg(not(windows))]
 fn create_private_directory(path: &Path) -> Result<(), String> {
+    use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _};
+
     reject_existing_ancestor_links(path)?;
-    fs::create_dir_all(path)
-        .map_err(|error| format!("create private runtime directory: {error}"))?;
-    reject_link(path)?;
-    use std::os::unix::fs::PermissionsExt as _;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o700))
-        .map_err(|error| format!("protect runtime directory: {error}"))?;
+    let mut missing = Vec::new();
+    let mut cursor = path;
+    loop {
+        match fs::symlink_metadata(cursor) {
+            Ok(metadata) => {
+                if !metadata.is_dir() || is_reparse_or_link(&metadata) {
+                    return Err("private runtime path is a link or non-directory".into());
+                }
+                if cursor == path
+                    && (metadata.uid() != rustix::process::geteuid().as_raw()
+                        || metadata.mode() & 0o7777 != 0o700)
+                {
+                    return Err("private runtime directory owner or permissions are unsafe".into());
+                }
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                missing.push(cursor.to_owned());
+                cursor = cursor
+                    .parent()
+                    .ok_or_else(|| "private runtime directory has no trusted parent".to_owned())?;
+            }
+            Err(error) => return Err(format!("inspect private runtime directory: {error}")),
+        }
+    }
+    for directory in missing.into_iter().rev() {
+        match fs::DirBuilder::new().mode(0o700).create(&directory) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(error) => {
+                return Err(format!("create private runtime directory: {error}"));
+            }
+        }
+        let metadata = fs::symlink_metadata(&directory)
+            .map_err(|error| format!("inspect created runtime directory: {error}"))?;
+        if !metadata.is_dir()
+            || is_reparse_or_link(&metadata)
+            || metadata.uid() != rustix::process::geteuid().as_raw()
+            || metadata.mode() & 0o7777 != 0o700
+        {
+            return Err("created runtime directory owner or permissions are unsafe".into());
+        }
+    }
     Ok(())
 }
 
@@ -894,6 +933,70 @@ mod tests {
         let published = materialize_at(&base, payload).unwrap();
         assert!(!stale.exists());
         verify_tree(&published, payload).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn first_ocr_materialization_under_default_umask_makes_every_directory_private() {
+        use std::os::unix::fs::MetadataExt as _;
+
+        const CHILD: &str = "INTO_MD_TEST_UMASK_022_MATERIALIZATION_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            let current_test = std::thread::current().name().unwrap().to_owned();
+            let status = std::process::Command::new(std::env::current_exe().unwrap())
+                .arg("--exact")
+                .arg(current_test)
+                .arg("--nocapture")
+                .env(CHILD, "1")
+                .status()
+                .unwrap();
+            assert!(status.success(), "umask regression subprocess failed");
+            return;
+        }
+
+        let previous = rustix::process::umask(rustix::fs::Mode::from_raw_mode(0o022));
+        let temporary = tempfile::tempdir().unwrap();
+        let (archive, files) = test_archive(&[
+            ("bin/helpers/tool", b"tool", true),
+            ("models/detection/model", b"model", false),
+        ]);
+        let archive = Box::leak(archive.into_boxed_slice());
+        let files = Box::leak(files.into_boxed_slice());
+        let archive_sha256 = Box::leak(format!("{:x}", Sha256::digest(&*archive)).into_boxed_str());
+        let payload = Payload { label: "ocr", archive, archive_sha256, files };
+        let base = temporary.path().join("cache/into-markdown/runtime");
+        let published = materialize_at(&base, payload).unwrap();
+        for directory in [
+            temporary.path().join("cache"),
+            temporary.path().join("cache/into-markdown"),
+            base,
+            published.clone(),
+            published.join("bin"),
+            published.join("bin/helpers"),
+            published.join("models"),
+            published.join("models/detection"),
+        ] {
+            let metadata = fs::symlink_metadata(&directory).unwrap();
+            assert_eq!(metadata.mode() & 0o7777, 0o700, "{}", directory.display());
+        }
+        verify_tree(&published, payload).unwrap();
+        let _ = rustix::process::umask(previous);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn existing_non_private_managed_directory_is_rejected() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temporary = tempfile::tempdir().unwrap();
+        let managed = temporary.path().join("runtime");
+        fs::create_dir(&managed).unwrap();
+        fs::set_permissions(&managed, fs::Permissions::from_mode(0o755)).unwrap();
+        assert_eq!(
+            create_private_directory(&managed).unwrap_err(),
+            "private runtime directory owner or permissions are unsafe"
+        );
+        assert_eq!(fs::symlink_metadata(&managed).unwrap().permissions().mode() & 0o7777, 0o755);
     }
 
     #[cfg(unix)]

--- a/tools/platform-release/audit.py
+++ b/tools/platform-release/audit.py
@@ -235,6 +235,31 @@ def requires_x86_64_extension_level(notes: str) -> bool:
     return re.search(r"\bx86-64-v[234]\b", needed, re.IGNORECASE) is not None
 
 
+def ggml_cpu_init_uses_nonbaseline_x86(disassembly: str) -> bool:
+    """Detect optional x86 ISA in GGML's unconditional CPU initializer.
+
+    GNU property notes are only emitted when every linked object declares an
+    ISA requirement. A statically linked `-march=native` GGML object can contain
+    EVEX/VEX instructions without raising that note and then SIGILL before its
+    runtime feature dispatch is usable. The release provider keeps this symbol,
+    so audit the initializer itself in addition to the ELF notes.
+    """
+    instruction = re.compile(r"^\s*[0-9a-f]+:\s+(?:[0-9a-f]{2}\s+)+\s*([^\s]+)(?:\s|$)")
+    extended_register = re.compile(
+        r"\b(?:[yz]mm\d+|xmm(?:1[6-9]|2\d|3[01])|k[0-7])\b",
+        re.IGNORECASE,
+    )
+    for line in disassembly.splitlines():
+        matched = instruction.match(line)
+        if not matched:
+            continue
+        mnemonic = matched.group(1).lower()
+        operands = line[matched.end() :]
+        if mnemonic.startswith("v") or extended_register.search(operands):
+            return True
+    return False
+
+
 def audit_tree(root: pathlib.Path, audit: Audit, linux: bool) -> None:
     audit.require(root, "regular-root", root.is_dir() and not root.is_symlink(), "root must be a real directory")
     for path in sorted(root.rglob("*")):
@@ -303,7 +328,9 @@ def audit_rust_facade(root: pathlib.Path, audit: Audit) -> None:
 
 def audit_linux(root: pathlib.Path, expected_machine: str, audit: Audit) -> None:
     readelf = shutil.which("readelf")
+    objdump = shutil.which("objdump")
     audit.require("readelf", "tool-present", readelf is not None, "GNU readelf is required")
+    audit.require("objdump", "tool-present", objdump is not None, "GNU objdump is required")
     binaries = candidates(root, b"\x7fELF")
     audit.require(root, "elf-present", bool(binaries), "no ELF binary found")
     for binary in binaries:
@@ -335,6 +362,17 @@ def audit_linux(root: pathlib.Path, expected_machine: str, audit: Audit) -> None
                 not requires_x86_64_extension_level(notes),
                 "ELF must not require x86-64-v2/v3/v4",
             )
+            if binary.name == "into-md-media-provider":
+                ggml_init = command(
+                    [objdump, "-d", "-M", "intel", "--disassemble=ggml_cpu_init", str(binary)]
+                )
+                audit.require(
+                    relative,
+                    "ggml-x86-64-isa-baseline",
+                    "<ggml_cpu_init>" in ggml_init
+                    and not ggml_cpu_init_uses_nonbaseline_x86(ggml_init),
+                    "GGML CPU initialization must contain only x86-64 baseline instructions",
+                )
 
 
 def audit_windows(

--- a/tools/platform-release/cpu-policy.json
+++ b/tools/platform-release/cpu-policy.json
@@ -1,0 +1,48 @@
+{
+  "schemaVersion": 1,
+  "targets": {
+    "x86_64-unknown-linux-gnu": {
+      "cmakeEnvironment": {
+        "GGML_NATIVE": "OFF",
+        "GGML_SSE42": "OFF",
+        "GGML_AVX": "OFF",
+        "GGML_AVX2": "OFF",
+        "GGML_AVX_VNNI": "OFF",
+        "GGML_FMA": "OFF",
+        "GGML_F16C": "OFF",
+        "GGML_BMI2": "OFF",
+        "GGML_AVX512": "OFF",
+        "GGML_AVX512_VBMI": "OFF",
+        "GGML_AVX512_VNNI": "OFF",
+        "GGML_AVX512_BF16": "OFF",
+        "GGML_AMX_TILE": "OFF",
+        "GGML_AMX_INT8": "OFF",
+        "GGML_AMX_BF16": "OFF"
+      }
+    },
+    "aarch64-unknown-linux-gnu": {
+      "cmakeEnvironment": {
+        "GGML_NATIVE": "OFF"
+      }
+    },
+    "x86_64-pc-windows-msvc": {
+      "cmakeEnvironment": {
+        "GGML_NATIVE": "OFF",
+        "GGML_SSE42": "OFF",
+        "GGML_AVX": "OFF",
+        "GGML_AVX2": "OFF",
+        "GGML_AVX_VNNI": "OFF",
+        "GGML_FMA": "OFF",
+        "GGML_F16C": "OFF",
+        "GGML_BMI2": "OFF",
+        "GGML_AVX512": "OFF",
+        "GGML_AVX512_VBMI": "OFF",
+        "GGML_AVX512_VNNI": "OFF",
+        "GGML_AVX512_BF16": "OFF",
+        "GGML_AMX_TILE": "OFF",
+        "GGML_AMX_INT8": "OFF",
+        "GGML_AMX_BF16": "OFF"
+      }
+    }
+  }
+}

--- a/tools/platform-release/release.py
+++ b/tools/platform-release/release.py
@@ -60,6 +60,9 @@ RELEASE_BUILD_PRODUCTS = (
     ("into-markdown-official-provider", "into-md-media-provider"),
 )
 WINDOWS_CORE_PREWARM_PRODUCT = ("into-markdown-cli", "into-md")
+CPU_POLICY = json.loads(
+    (ROOT / "tools/platform-release/cpu-policy.json").read_text(encoding="utf-8")
+)
 FIXTURES = [
     "docx/normal.docx",
     "docx/corrupt.docx",
@@ -161,18 +164,38 @@ def refresh_ffmpeg_authority(authority_path: pathlib.Path, executable: pathlib.P
     write_json(authority_path, value)
 
 
+def portable_cpu_environment(target: str) -> dict[str, str]:
+    """Return CMake flags that make native release helpers match the CPU authority.
+
+    whisper-rs-sys forwards GGML_* environment variables to CMake, but Cargo does
+    not include those dynamically enumerated variables in the build-script
+    fingerprint. The release workflow therefore binds cpu-policy.json and the
+    platform authority into the Cargo target-cache key. Keep the optional x86
+    instruction sets explicit here: GGML's defaults change when
+    SOURCE_DATE_EPOCH or cross compilation changes GGML_NATIVE_DEFAULT.
+    """
+    try:
+        environment = CPU_POLICY["targets"][target]["cmakeEnvironment"]
+    except (KeyError, TypeError) as error:
+        raise ReleaseError(f"native CPU policy is missing for {target}") from error
+    if (
+        not isinstance(environment, dict)
+        or environment.get("GGML_NATIVE") != "OFF"
+        or any(not isinstance(key, str) or value != "OFF" for key, value in environment.items())
+    ):
+        raise ReleaseError(f"native CPU policy is invalid for {target}")
+    return dict(environment)
+
+
 def build(target: str, output: pathlib.Path) -> pathlib.Path:
     environment = os.environ.copy()
     environment.update(
         {
             "CARGO_INCREMENTAL": "0",
             "CARGO_TARGET_DIR": str(output),
-            # whisper.cpp otherwise enables GGML_NATIVE and bakes the release
-            # runner's optional ISA extensions into the provider.  The Rust
-            # target-cpu baseline below does not apply to this CMake subtree.
-            "GGML_NATIVE": "OFF",
         }
     )
+    environment.update(portable_cpu_environment(target))
     rustflags = ["-C", "strip=debuginfo"]
     target_cpu = {
         "x86_64-unknown-linux-gnu": "x86-64",
@@ -233,11 +256,11 @@ def build_embedded_core(
             "CARGO_TARGET_DIR": str(output),
             "INTO_MD_EMBEDDED_PDFIUM_ROOT": str(pdfium_root.resolve()),
             "INTO_MD_EMBEDDED_OCR_ROOT": str(ocr_root.resolve()),
-            # Keep every Cargo/CMake invocation in the release authority on
-            # the same portable CPU policy, including clean rebuilds.
-            "GGML_NATIVE": "OFF",
         }
     )
+    # Keep every Cargo/CMake invocation in the release authority on the same
+    # portable CPU policy, including clean rebuilds.
+    environment.update(portable_cpu_environment(target))
     target_cpu = {
         "x86_64-unknown-linux-gnu": "x86-64",
         "aarch64-unknown-linux-gnu": "generic",

--- a/tools/platform-release/test_platform_tools.py
+++ b/tools/platform-release/test_platform_tools.py
@@ -20,6 +20,7 @@ from audit import (
     Audit,
     AuditFailure,
     clr_il_only,
+    ggml_cpu_init_uses_nonbaseline_x86,
     requires_x86_64_extension_level,
     resolve_release_packages,
     run,
@@ -220,6 +221,24 @@ class PlatformToolTests(unittest.TestCase):
                 "Properties: x86 ISA used: x86-64-v4\n"
             )
         )
+
+    def test_linux_native_audit_rejects_unnoted_ggml_native_instructions(self) -> None:
+        baseline = """
+0000000000001000 <ggml_cpu_init>:
+    1000: 0f 10 00              movups xmm0,XMMWORD PTR [rax]
+    1003: 66 0f ef c0           pxor   xmm0,xmm0
+"""
+        avx = """
+0000000000001000 <ggml_cpu_init>:
+    1000: c5 f8 57 c0           vxorps xmm0,xmm0,xmm0
+"""
+        evex = """
+0000000000001000 <ggml_cpu_init>:
+    1000: 62 e1 6e 08 58 44 24 03 vaddss xmm16,xmm2,DWORD PTR [rsp+0xc]
+"""
+        self.assertFalse(ggml_cpu_init_uses_nonbaseline_x86(baseline))
+        self.assertTrue(ggml_cpu_init_uses_nonbaseline_x86(avx))
+        self.assertTrue(ggml_cpu_init_uses_nonbaseline_x86(evex))
 
     def test_zip_extractor_rejects_parent_traversal(self) -> None:
         with tempfile.TemporaryDirectory() as name:

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -27,6 +27,7 @@ from release import (
     WINDOWS_CORE_PREWARM_PRODUCT,
     create_archive,
     distributed_source_ids,
+    portable_cpu_environment,
     published_plugin_file,
 )
 
@@ -150,7 +151,7 @@ class PlatformReleaseTests(unittest.TestCase):
         )
         self.assertIn("${{ runner.temp }}/release-work/build", workflow)
         self.assertIn(
-            "key: release-cargo-only-v1-${{ matrix.target }}-"
+            "key: release-cargo-only-v2-${{ matrix.target }}-"
             "${{ hashFiles('Cargo.lock') }}",
             workflow,
         )
@@ -222,7 +223,23 @@ class PlatformReleaseTests(unittest.TestCase):
                 release_module.build("x86_64-unknown-linux-gnu", output)
             self.assertEqual(len(environments), 1)
             self.assertEqual(environments[0]["GGML_NATIVE"], "OFF")
+            for key in (
+                "GGML_SSE42",
+                "GGML_AVX",
+                "GGML_AVX2",
+                "GGML_FMA",
+                "GGML_F16C",
+                "GGML_BMI2",
+                "GGML_AVX512",
+            ):
+                self.assertEqual(environments[0][key], "OFF")
             self.assertIn("target-cpu=x86-64", environments[0]["RUSTFLAGS"])
+
+    def test_release_cpu_policy_is_explicit_for_every_x86_64_extension(self) -> None:
+        policy = portable_cpu_environment("x86_64-unknown-linux-gnu")
+        self.assertEqual(policy["GGML_NATIVE"], "OFF")
+        self.assertTrue(all(value == "OFF" for value in policy.values()))
+        self.assertNotIn("GGML_AVX", portable_cpu_environment("aarch64-unknown-linux-gnu"))
 
     def test_release_build_rejects_a_missing_helper_product(self) -> None:
         with tempfile.TemporaryDirectory() as name:
@@ -284,6 +301,17 @@ class PlatformReleaseTests(unittest.TestCase):
         )
         self.assertIn("dnf install --assumeyes binutils clang-libs", workflow)
         self.assertIn('echo "LIBCLANG_PATH=$(dirname "$libclang_path")"', workflow)
+
+    def test_release_cargo_cache_is_bound_to_native_cpu_policy(self) -> None:
+        workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("release-cargo-only-v2-", workflow)
+        self.assertIn(
+            "hashFiles('tools/platform-release/authority.json', 'tools/platform-release/cpu-policy.json')",
+            workflow,
+        )
+        self.assertNotIn("release-cargo-only-v1-", workflow)
 
     def test_linux_release_does_not_bootstrap_a_second_build_system(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(


### PR DESCRIPTION
## Summary

- create embedded runtime cache directories recursively with owner-only permissions under a normal umask
- bind Cargo target caching to an explicit portable CPU policy
- force the speech provider to the declared x86-64 baseline and audit ggml_cpu_init for VEX/EVEX instructions

## Real-machine evidence

- Windows fixed draft: Core, OCR, speech transcription and diarization all pass
- WSL exposed and reproduced both blockers before this patch
- clean Linux provider: 55 release tests pass, bad draft provider is rejected, rebuilt provider passes disassembly audit
- WSL real transcription (43.55s) and diarization (44.07s) pass with no SIGILL
- default-umask runtime directory regression passes on WSL; Windows embedded-runtime tests remain green

After merge, the 0.0.3 draft will be rebuilt and revalidated before publication.