### PR TITLE
fix(release): close vendored Whisper source authority

### DIFF
--- a/third_party/licenses/cargo-normal-runtime.json
+++ b/third_party/licenses/cargo-normal-runtime.json
@@ -27,7 +27,7 @@
     "crates/task-store/Cargo.toml": "546dd1855e8f1b73b5099c8b06ff7cc87f67775a772d0a74c1c64c927bb5c027",
     "tests/contracts/Cargo.toml": "2b0bc6bf495f298b497d6d8177bc2a9f67f78f1d24e1e5946d53dfc75e9c8e5f",
     "third_party/whisper-rs-0.16.0/Cargo.toml": "c8ef220097ed0878191082d402fcc218527d580fec079b2842c74ce80b51a5eb",
-    "third_party/whisper-rs-0.16.0/sys/Cargo.toml": "aea7de32e8941a8521e96d3a663051ce24444760cdeb626ce0d78b56b3fbca29",
+    "third_party/whisper-rs-0.16.0/sys/Cargo.toml": "096ffc71c00c9e8aeb7d94f38797696d03a0b333c6ae04e0f9eccdb5403a3d07",
     "tools/asset-update/Cargo.toml": "eec86c662bc803e10c1fcf177702620137acd6a383c89339164889b8ffb927e7",
     "tools/installed-smoke/Cargo.toml": "57704e4d306df0137ba0e802c228a74ce0ec8f6946c1b295f0b2e6ef6065faf2",
     "tools/license-check/Cargo.toml": "6fab86ccb7bbea089f51a32175a01ef9c963f8e3c0a37c54a1ab72fd9ecd472d"

--- a/third_party/whisper-rs-0.16.0/PATCH-AUTHORITY.json
+++ b/third_party/whisper-rs-0.16.0/PATCH-AUTHORITY.json
@@ -8,5 +8,5 @@
   "whisper_rs_sys_crates_io_sha256": "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f",
   "patch_scope": "Own abort/progress callback allocations in FullParams and release them on every drop path; bind Bazel to whisper.cpp 1.8.3; vendor whisper-rs-sys 0.15.0 and enable authenticated x86 CPU runtime dispatch",
   "tree_digest_algorithm": "sha256(sorted(relative_path NUL sha256(LF-normalized_bytes) LF), excluding PATCH-AUTHORITY.json)",
-  "tree_sha256": "e094daf91520d5712d80acb19627683d62b59bec389b85ff026c98966d152815"
+  "tree_sha256": "9f955d9b7e2e5788c3a476ba5c8116c53aba1f0107c6c564200ab27707f77141"
 }

--- a/third_party/whisper-rs-0.16.0/sys/Cargo.toml
+++ b/third_party/whisper-rs-0.16.0/sys/Cargo.toml
@@ -41,6 +41,7 @@ description = "Rust bindings for whisper.cpp (FFI bindings)"
 documentation = "https://docs.rs/whisper-rs-sys"
 readme = false
 license = "Unlicense"
+publish = false
 repository = "https://codeberg.org/tazz4843/whisper-rs"
 
 [features]

--- a/tools/license-check/src/lib.rs
+++ b/tools/license-check/src/lib.rs
@@ -1809,8 +1809,8 @@ fn validate_asr_quality(root: &Path, authority: &AsrQualityAuthority, errors: &m
 
 fn validate_whisper_rs_patch(root: &Path, errors: &mut Vec<String>) {
     const AUTHORITY_SHA256: &str =
-        "affa9144146fc0462c3c7c06ebda9310e86153d66d74e8db0a7608400987ec28";
-    const TREE_SHA256: &str = "e094daf91520d5712d80acb19627683d62b59bec389b85ff026c98966d152815";
+        "448e39039682dbfaffc2905e8442172b3cf4c421f73dbed5566a5fec46ab6702";
+    const TREE_SHA256: &str = "9f955d9b7e2e5788c3a476ba5c8116c53aba1f0107c6c564200ab27707f77141";
     let directory = root.join("third_party/whisper-rs-0.16.0");
     let authority_path = directory.join("PATCH-AUTHORITY.json");
     let bytes = match fs::read(&authority_path) {

--- a/tools/macos-release/release.py
+++ b/tools/macos-release/release.py
@@ -421,6 +421,49 @@ def write_core_license_materials(output: pathlib.Path, cache: pathlib.Path) -> l
                 )
             )
             continue
+        if component["id"] == "cargo:whisper-rs-sys@0.15.0":
+            source = destination / "cargo/whisper-rs-sys-0.15.0-vendored.zip"
+            source.parent.mkdir(parents=True, exist_ok=True)
+            create_archive(
+                ROOT / "third_party/whisper-rs-0.16.0/sys",
+                source,
+                {"archive": "zip"},
+                0,
+            )
+            result.append(
+                material(
+                    source,
+                    output,
+                    "upstream-source-archive",
+                    [component["id"]],
+                    [],
+                )
+            )
+            for name, license_source, spdx in (
+                (
+                    "whisper-rs-sys-Unlicense.txt",
+                    "third_party/whisper-rs-0.16.0/LICENSE",
+                    "Unlicense",
+                ),
+                (
+                    "whisper.cpp-MIT.txt",
+                    "third_party/whisper-rs-0.16.0/sys/whisper.cpp/LICENSE",
+                    "MIT",
+                ),
+            ):
+                path = destination / name
+                copy_file(ROOT / license_source, path, 0o644)
+                result.append(
+                    material(
+                        path,
+                        output,
+                        "license-text",
+                        [component["id"]],
+                        [spdx],
+                        contents=True,
+                    )
+                )
+            continue
         checksum = next(evidence["digest"] for evidence in component["integrity"] if evidence["subject"].startswith("crates.io archive"))
         name_version = component["id"].removeprefix("cargo:").replace("@", "-") + ".crate"
         candidates = list(pathlib.Path.home().glob(f".cargo/registry/cache/*/{name_version}"))

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -46,6 +46,29 @@ class PlatformReleaseTests(unittest.TestCase):
         for relative, expected in value["workspace_manifest_sha256"].items():
             self.assertEqual(expected, canonical_digest(ROOT / relative), relative)
 
+        whisper_sys = tomllib.loads(
+            (ROOT / "third_party/whisper-rs-0.16.0/sys/Cargo.toml").read_text(
+                encoding="utf-8"
+            )
+        )["package"]
+        self.assertEqual(whisper_sys["license"], "Unlicense")
+        self.assertFalse(whisper_sys["publish"])
+
+    def test_all_platforms_preserve_vendored_whisper_sys_source_and_licenses(self) -> None:
+        required = [
+            'component["id"] == "cargo:whisper-rs-sys@0.15.0"',
+            '"cargo/whisper-rs-sys-0.15.0-vendored.zip"',
+            '"whisper-rs-sys-Unlicense.txt"',
+            '"whisper.cpp-MIT.txt"',
+        ]
+        for relative in [
+            "tools/platform-release/release.py",
+            "tools/macos-release/release.py",
+        ]:
+            source = (ROOT / relative).read_text(encoding="utf-8")
+            for marker in required:
+                self.assertIn(marker, source, f"{relative} lacks {marker}")
+
     def test_web_release_spdx_binds_the_production_app(self) -> None:
         value = json.loads(
             (ROOT / "third_party/licenses/npm-release.spdx.json").read_text(


### PR DESCRIPTION
Fixes the release-projection failure from run 33211077222 by declaring the vendored whisper-rs-sys package non-publishable, refreshing the reviewed Cargo/tree authorities, and making macOS project the same vendored source/license materials as Linux and Windows.\n\nValidation: 33 platform-release tests; Cargo runtime authority; four-platform license projection; repository license audit; formatting and diff checks.