### PR TITLE
fix(release): bind EL8 CPU variants and macOS archive

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -62,7 +62,20 @@ jobs:
         run: |
           dnf install --assumeyes binutils clang-libs cmake curl file gcc gcc-c++ git gnupg2 gzip jq make openssl patch perl pkgconf-pkg-config python3.11 tar which xz
           if [ "$(uname -m)" = x86_64 ]; then
-            dnf --enablerepo=powertools install --assumeyes nasm
+            dnf --enablerepo=powertools install --assumeyes gcc-toolset-15-gcc gcc-toolset-15-gcc-c++ nasm
+            toolset_bin=/opt/rh/gcc-toolset-15/root/usr/bin
+            test -x "$toolset_bin/gcc"
+            test -x "$toolset_bin/g++"
+            test "$("$toolset_bin/gcc" -dumpversion | cut -d. -f1)" = 15
+            c_probe="$(mktemp)"
+            cxx_probe="$(mktemp)"
+            trap 'rm -f "$c_probe" "$cxx_probe"' EXIT
+            printf 'int into_md_cpu_variant_probe(void) { return 0; }\n' |
+              "$toolset_bin/gcc" -x c -c -o "$c_probe" -mavxvnni -mavx512vnni -mavx512bf16 -mamx-tile -mamx-int8 -
+            printf 'int into_md_cpu_variant_probe() { return 0; }\n' |
+              "$toolset_bin/g++" -x c++ -c -o "$cxx_probe" -mavxvnni -mavx512vnni -mavx512bf16 -mamx-tile -mamx-int8 -
+            echo "CC=$toolset_bin/gcc" >> "$GITHUB_ENV"
+            echo "CXX=$toolset_bin/g++" >> "$GITHUB_ENV"
           fi
           ln -sf /usr/bin/python3.11 /usr/local/bin/python
           ln -sf /usr/bin/python3.11 /usr/local/bin/python3

--- a/.github/workflows/pr-fast-gate.yml
+++ b/.github/workflows/pr-fast-gate.yml
@@ -102,7 +102,7 @@ jobs:
   macos-arm64:
     name: macOS ARM64 Core
     runs-on: macos-14
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/apps/cli/src/web_tasks.rs
+++ b/apps/cli/src/web_tasks.rs
@@ -421,6 +421,8 @@ struct Shared {
     #[cfg(test)]
     pre_acquire_gate: Mutex<Option<Arc<std::sync::Barrier>>>,
     #[cfg(test)]
+    dequeue_transition_gate: Mutex<Option<Arc<std::sync::Barrier>>>,
+    #[cfg(test)]
     pre_acquire_panic: AtomicUsize,
     #[cfg(test)]
     snapshot_failure: AtomicUsize,
@@ -1196,6 +1198,8 @@ impl WebTaskBackend {
             conversion_entries: AtomicUsize::new(0),
             #[cfg(test)]
             pre_acquire_gate: Mutex::new(None),
+            #[cfg(test)]
+            dequeue_transition_gate: Mutex::new(None),
             #[cfg(test)]
             pre_acquire_panic: AtomicUsize::new(0),
             #[cfg(test)]
@@ -2638,6 +2642,11 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
         return;
     };
     if record.status == TaskStatus::Pending {
+        #[cfg(test)]
+        if let Some(gate) = { lock(&shared.dequeue_transition_gate).clone() } {
+            gate.wait();
+            gate.wait();
+        }
         let transition = TaskTransition {
             expected: TaskStatus::Pending,
             next: TaskStatus::Running,
@@ -2646,7 +2655,18 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
             artifacts: Vec::new(),
         };
         if !retry_dequeued_transition(shared, &job.id, &transition) {
-            stop_unhealthy(shared);
+            // Cancellation may win the Pending -> Running compare-and-swap
+            // after the worker read the Pending record. That is a valid
+            // terminal outcome, not evidence that persistence is unhealthy.
+            let cancellation_won = job.cancellation.is_cancelled()
+                && lock(&shared.task_store)
+                    .get(&job.id)
+                    .ok()
+                    .flatten()
+                    .is_some_and(|record| record.status == TaskStatus::Cancelled);
+            if !cancellation_won {
+                stop_unhealthy(shared);
+            }
             return;
         }
     }
@@ -6988,6 +7008,35 @@ mod tests {
                 other => panic!("invalid cancellation race outcome: {other:?}"),
             }
         }
+    }
+
+    #[test]
+    fn cancellation_winning_dequeue_transition_does_not_stop_the_queue() {
+        let temporary = tempfile::tempdir().unwrap();
+        let backend = WebTaskBackend::open(temporary.path().join("backend")).unwrap();
+        let gate = Arc::new(std::sync::Barrier::new(2));
+        *lock(&backend.owner.shared.dequeue_transition_gate) = Some(Arc::clone(&gate));
+
+        let mut upload = backend.begin_upload("cancel-at-dequeue.txt", None).unwrap();
+        upload.write_chunk(b"cancel after the worker reads Pending").unwrap();
+        let task = upload.finish().unwrap();
+
+        gate.wait();
+        assert_eq!(backend.cancel(&task.id).unwrap().status, TaskStatus::Cancelled);
+        *lock(&backend.owner.shared.dequeue_transition_gate) = None;
+        gate.wait();
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while lock(&backend.owner.shared.queue).cancellations.contains_key(&task.id) {
+            assert!(Instant::now() < deadline, "cancelled worker did not settle");
+            std::thread::yield_now();
+        }
+        assert!(!lock(&backend.owner.shared.queue).stopped);
+
+        let mut successor = backend.begin_upload("successor.txt", None).unwrap();
+        successor.write_chunk(b"the queue remains usable").unwrap();
+        let successor = successor.finish().unwrap();
+        assert_eq!(wait_terminal(&backend, &successor.id).status, TaskStatus::Succeeded);
     }
 
     #[test]

--- a/apps/cli/src/web_tasks.rs
+++ b/apps/cli/src/web_tasks.rs
@@ -2601,7 +2601,7 @@ impl Drop for ActiveWorker<'_> {
 fn run_job(shared: &Arc<Shared>, job: &Job) {
     let mut registered_waiter = RegisteredDiskWaiter { shared, ticket: job.admission_ticket };
     #[cfg(test)]
-    if let Some(gate) = { lock(&shared.pre_acquire_gate).clone() } {
+    if let Some(gate) = { lock(&shared.pre_acquire_gate).take() } {
         gate.wait();
     }
     #[cfg(test)]

--- a/third_party/licenses/build-tools.json
+++ b/third_party/licenses/build-tools.json
@@ -53,7 +53,7 @@
       "scope": "release-assembly",
       "distributed": false,
       "targets": ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "x86_64-pc-windows-msvc"],
-      "integrity": [{"algorithm":"SHA-256","digest":"9bcc6327529f42e82221622473d136a8434c33547f47734435790cd99c0ca79a","subject":"tools/platform-release/authority.json"}],
+      "integrity": [{"algorithm":"SHA-256","digest":"82a98dc6bc49b4dbaef89a31b2be003d42d8538eeb880a48c2e66a185d3ad246","subject":"tools/platform-release/authority.json"}],
       "executables": []
     },
     {
@@ -75,7 +75,7 @@
       "scope": "compile-sign-package",
       "distributed": false,
       "targets": ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"],
-      "integrity": [{"algorithm":"SHA-256","digest":"9bcc6327529f42e82221622473d136a8434c33547f47734435790cd99c0ca79a","subject":"tools/platform-release/authority.json"}],
+      "integrity": [{"algorithm":"SHA-256","digest":"82a98dc6bc49b4dbaef89a31b2be003d42d8538eeb880a48c2e66a185d3ad246","subject":"tools/platform-release/authority.json"}],
       "executables": []
     },
     {
@@ -86,7 +86,7 @@
       "scope": "compile-sign-package",
       "distributed": false,
       "targets": ["x86_64-pc-windows-msvc"],
-      "integrity": [{"algorithm":"SHA-256","digest":"9bcc6327529f42e82221622473d136a8434c33547f47734435790cd99c0ca79a","subject":"tools/platform-release/authority.json"}],
+      "integrity": [{"algorithm":"SHA-256","digest":"82a98dc6bc49b4dbaef89a31b2be003d42d8538eeb880a48c2e66a185d3ad246","subject":"tools/platform-release/authority.json"}],
       "executables": []
     }
   ]

--- a/third_party/whisper-rs-0.16.0/PATCH-AUTHORITY.json
+++ b/third_party/whisper-rs-0.16.0/PATCH-AUTHORITY.json
@@ -6,7 +6,7 @@
   "upstream_commit": "7558e1b72f54f2f22a53589afb77e65681834c36",
   "crates_io_sha256": "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6",
   "whisper_rs_sys_crates_io_sha256": "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f",
-  "patch_scope": "Own abort/progress callback allocations in FullParams and release them on every drop path; bind Bazel to whisper.cpp 1.8.3; vendor whisper-rs-sys 0.15.0 and enable authenticated x86 CPU runtime dispatch",
+  "patch_scope": "Own abort/progress callback allocations in FullParams and release them on every drop path; bind Bazel to whisper.cpp 1.8.3; vendor whisper-rs-sys 0.15.0, enable authenticated x86 CPU runtime dispatch, and report dynamic-mode SystemInfo through OS-aware x86 feature detection",
   "tree_digest_algorithm": "sha256(sorted(relative_path NUL sha256(LF-normalized_bytes) LF), excluding PATCH-AUTHORITY.json)",
-  "tree_sha256": "9f955d9b7e2e5788c3a476ba5c8116c53aba1f0107c6c564200ab27707f77141"
+  "tree_sha256": "e4ecfd6e940aac27d4f2f5d2cff2b436b6429d3a8d3d98ac8ae000b233232a47"
 }

--- a/third_party/whisper-rs-0.16.0/src/standalone.rs
+++ b/third_party/whisper-rs-0.16.0/src/standalone.rs
@@ -115,6 +115,25 @@ pub struct SystemInfo {
     pub f16c: bool,
 }
 
+// `GGML_BACKEND_DL` deliberately keeps the CPU implementation in a runtime-
+// selected shared library.  Its `ggml_cpu_has_*` exports therefore are not
+// available to the provider's link step.  Query the same architectural CPU
+// capabilities through Rust's OS-aware CPUID detection on x86 instead of
+// introducing a static dependency on the baseline CPU backend.  GGML still
+// performs its own compatibility scoring before loading an optimized backend.
+#[cfg(all(feature = "runtime-dispatch", any(target_arch = "x86", target_arch = "x86_64")))]
+impl Default for SystemInfo {
+    fn default() -> Self {
+        Self {
+            avx: std::arch::is_x86_feature_detected!("avx"),
+            avx2: std::arch::is_x86_feature_detected!("avx2"),
+            fma: std::arch::is_x86_feature_detected!("fma"),
+            f16c: std::arch::is_x86_feature_detected!("f16c"),
+        }
+    }
+}
+
+#[cfg(not(all(feature = "runtime-dispatch", any(target_arch = "x86", target_arch = "x86_64"))))]
 impl Default for SystemInfo {
     fn default() -> Self {
         unsafe {

--- a/tools/license-check/src/lib.rs
+++ b/tools/license-check/src/lib.rs
@@ -1809,8 +1809,8 @@ fn validate_asr_quality(root: &Path, authority: &AsrQualityAuthority, errors: &m
 
 fn validate_whisper_rs_patch(root: &Path, errors: &mut Vec<String>) {
     const AUTHORITY_SHA256: &str =
-        "448e39039682dbfaffc2905e8442172b3cf4c421f73dbed5566a5fec46ab6702";
-    const TREE_SHA256: &str = "9f955d9b7e2e5788c3a476ba5c8116c53aba1f0107c6c564200ab27707f77141";
+        "b43df56b404ad1456b7ed33b223083a14d3072a9ca04fe2dcb90db4bb01cf2d7";
+    const TREE_SHA256: &str = "e4ecfd6e940aac27d4f2f5d2cff2b436b6429d3a8d3d98ac8ae000b233232a47";
     let directory = root.join("third_party/whisper-rs-0.16.0");
     let authority_path = directory.join("PATCH-AUTHORITY.json");
     let bytes = match fs::read(&authority_path) {
@@ -1842,7 +1842,7 @@ fn validate_whisper_rs_patch(root: &Path, errors: &mut Vec<String>) {
         || authority.whisper_rs_sys_crates_io_sha256
             != "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
         || authority.patch_scope
-            != "Own abort/progress callback allocations in FullParams and release them on every drop path; bind Bazel to whisper.cpp 1.8.3; vendor whisper-rs-sys 0.15.0 and enable authenticated x86 CPU runtime dispatch"
+            != "Own abort/progress callback allocations in FullParams and release them on every drop path; bind Bazel to whisper.cpp 1.8.3; vendor whisper-rs-sys 0.15.0, enable authenticated x86 CPU runtime dispatch, and report dynamic-mode SystemInfo through OS-aware x86 feature detection"
         || authority.tree_digest_algorithm
             != "sha256(sorted(relative_path NUL sha256(LF-normalized_bytes) LF), excluding PATCH-AUTHORITY.json)"
         || authority.tree_sha256 != TREE_SHA256

--- a/tools/macos-release/release.py
+++ b/tools/macos-release/release.py
@@ -427,7 +427,6 @@ def write_core_license_materials(output: pathlib.Path, cache: pathlib.Path) -> l
             create_archive(
                 ROOT / "third_party/whisper-rs-0.16.0/sys",
                 source,
-                {"archive": "zip"},
                 0,
             )
             result.append(

--- a/tools/platform-release/authority.json
+++ b/tools/platform-release/authority.json
@@ -10,6 +10,7 @@
       "buildBaseline": {
         "container": "docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6",
         "cpu": "x86-64",
+        "nativeCompiler": "gcc-toolset-15",
         "glibcMaximum": "2.28",
         "kernelMinimum": "5.15"
       },

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -407,6 +407,22 @@ class PlatformReleaseTests(unittest.TestCase):
         self.assertIn("dnf install --assumeyes binutils clang-libs", workflow)
         self.assertIn('echo "LIBCLANG_PATH=$(dirname "$libclang_path")"', workflow)
 
+    def test_linux_x86_release_binds_a_compiler_for_every_ggml_variant(self) -> None:
+        workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
+            encoding="utf-8"
+        )
+        baseline = authority()["targets"]["x86_64-unknown-linux-gnu"][
+            "buildBaseline"
+        ]
+        self.assertEqual(baseline["nativeCompiler"], "gcc-toolset-15")
+        self.assertIn("gcc-toolset-15-gcc gcc-toolset-15-gcc-c++", workflow)
+        self.assertIn("/opt/rh/gcc-toolset-15/root/usr/bin", workflow)
+        self.assertIn('echo "CC=$toolset_bin/gcc"', workflow)
+        self.assertIn('echo "CXX=$toolset_bin/g++"', workflow)
+        self.assertIn("-mavxvnni", workflow)
+        self.assertIn("-mamx-int8", workflow)
+        self.assertNotIn("GGML_CPU_ALL_VARIANTS=OFF", workflow)
+
     def test_release_cargo_cache_is_bound_to_native_cpu_policy(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
             encoding="utf-8"

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
+import importlib.util
+import inspect
 import json
 import pathlib
 import re
@@ -68,6 +71,30 @@ class PlatformReleaseTests(unittest.TestCase):
             source = (ROOT / relative).read_text(encoding="utf-8")
             for marker in required:
                 self.assertIn(marker, source, f"{relative} lacks {marker}")
+
+    def test_macos_archive_calls_match_the_real_writer_signature(self) -> None:
+        archive_path = ROOT / "tools/macos-release/archive.py"
+        spec = importlib.util.spec_from_file_location("macos_release_archive", archive_path)
+        self.assertIsNotNone(spec)
+        self.assertIsNotNone(spec.loader)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        self.assertEqual(
+            tuple(inspect.signature(module.create).parameters),
+            ("source", "destination", "epoch"),
+        )
+
+        release_path = ROOT / "tools/macos-release/release.py"
+        tree = ast.parse(release_path.read_text(encoding="utf-8"), release_path.as_posix())
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "create_archive"
+        ]
+        self.assertGreaterEqual(len(calls), 2)
+        self.assertTrue(all(len(call.args) == 3 and not call.keywords for call in calls))
 
     def test_web_release_spdx_binds_the_production_app(self) -> None:
         value = json.loads(


### PR DESCRIPTION
Closes the two target-specific failures from release run 33213543827.\n\n- Bind the pinned Rocky 8 x86 release to GCC Toolset 15 and probe every required GGML CPU ISA before the expensive build, preserving dynamic dispatch and glibc 2.28.\n- Call the deterministic macOS archive writer with its real three-argument signature, with a signature/AST regression contract.\n\nValidation: 35 combined release contracts; exact Rocky 8.10 digest reports GCC 15.2.1 and compiles AVX-VNNI, AVX512-VNNI, BF16 and AMX probes; formatting/diff checks.