### PR TITLE
fix(release): pin Linux GGML shared library directory

### DIFF
--- a/third_party/whisper-rs-0.16.0/PATCH-AUTHORITY.json
+++ b/third_party/whisper-rs-0.16.0/PATCH-AUTHORITY.json
@@ -6,7 +6,7 @@
   "upstream_commit": "7558e1b72f54f2f22a53589afb77e65681834c36",
   "crates_io_sha256": "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6",
   "whisper_rs_sys_crates_io_sha256": "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f",
-  "patch_scope": "Own abort/progress callback allocations in FullParams and release them on every drop path; bind Bazel to whisper.cpp 1.8.3; vendor whisper-rs-sys 0.15.0, enable authenticated x86 CPU runtime dispatch, and report dynamic-mode SystemInfo through OS-aware x86 feature detection",
+  "patch_scope": "Own abort/progress callback allocations in FullParams and release them on every drop path; bind Bazel to whisper.cpp 1.8.3; vendor whisper-rs-sys 0.15.0, enable authenticated x86 CPU runtime dispatch with a deterministic shared-library install directory, and report dynamic-mode SystemInfo through OS-aware x86 feature detection",
   "tree_digest_algorithm": "sha256(sorted(relative_path NUL sha256(LF-normalized_bytes) LF), excluding PATCH-AUTHORITY.json)",
-  "tree_sha256": "e4ecfd6e940aac27d4f2f5d2cff2b436b6429d3a8d3d98ac8ae000b233232a47"
+  "tree_sha256": "4a836ad69e36ca9061cf14887294bf44ec8037cb29e28a60cfa24bee1b0f95a0"
 }

--- a/third_party/whisper-rs-0.16.0/sys/build.rs
+++ b/third_party/whisper-rs-0.16.0/sys/build.rs
@@ -295,6 +295,15 @@ fn main() {
         }
     }
 
+    if runtime_dispatch {
+        // GNUInstallDirs selects lib64 on some x86_64 distributions (including
+        // the EL8 release authority), while Cargo's native link search and the
+        // portable runtime staging contract use <prefix>/lib. Apply this after
+        // forwarded CMake variables so the reviewed layout cannot be changed by
+        // an ambient CMAKE_INSTALL_LIBDIR.
+        config.define("CMAKE_INSTALL_LIBDIR", "lib");
+    }
+
     if cfg!(not(feature = "openmp")) {
         config.define("GGML_OPENMP", "OFF");
     }

--- a/tools/license-check/src/lib.rs
+++ b/tools/license-check/src/lib.rs
@@ -1809,8 +1809,8 @@ fn validate_asr_quality(root: &Path, authority: &AsrQualityAuthority, errors: &m
 
 fn validate_whisper_rs_patch(root: &Path, errors: &mut Vec<String>) {
     const AUTHORITY_SHA256: &str =
-        "b43df56b404ad1456b7ed33b223083a14d3072a9ca04fe2dcb90db4bb01cf2d7";
-    const TREE_SHA256: &str = "e4ecfd6e940aac27d4f2f5d2cff2b436b6429d3a8d3d98ac8ae000b233232a47";
+        "b1394e767280cfd68605e11353d76a6bd2b0134c192f80d7d7dbe4fb582a4e10";
+    const TREE_SHA256: &str = "4a836ad69e36ca9061cf14887294bf44ec8037cb29e28a60cfa24bee1b0f95a0";
     let directory = root.join("third_party/whisper-rs-0.16.0");
     let authority_path = directory.join("PATCH-AUTHORITY.json");
     let bytes = match fs::read(&authority_path) {
@@ -1842,7 +1842,7 @@ fn validate_whisper_rs_patch(root: &Path, errors: &mut Vec<String>) {
         || authority.whisper_rs_sys_crates_io_sha256
             != "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
         || authority.patch_scope
-            != "Own abort/progress callback allocations in FullParams and release them on every drop path; bind Bazel to whisper.cpp 1.8.3; vendor whisper-rs-sys 0.15.0, enable authenticated x86 CPU runtime dispatch, and report dynamic-mode SystemInfo through OS-aware x86 feature detection"
+            != "Own abort/progress callback allocations in FullParams and release them on every drop path; bind Bazel to whisper.cpp 1.8.3; vendor whisper-rs-sys 0.15.0, enable authenticated x86 CPU runtime dispatch with a deterministic shared-library install directory, and report dynamic-mode SystemInfo through OS-aware x86 feature detection"
         || authority.tree_digest_algorithm
             != "sha256(sorted(relative_path NUL sha256(LF-normalized_bytes) LF), excluding PATCH-AUTHORITY.json)"
         || authority.tree_sha256 != TREE_SHA256

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -323,6 +323,21 @@ class PlatformReleaseTests(unittest.TestCase):
         for backend in ("rpc", "cuda", "vulkan", "blas"):
             self.assertNotIn(f'ggml_backend_load_best("{backend}"', cpu_loader)
 
+    def test_runtime_dispatch_pins_shared_library_install_directory(self) -> None:
+        source = (
+            ROOT / "third_party/whisper-rs-0.16.0/sys/build.rs"
+        ).read_text(encoding="utf-8")
+        install_dir = 'config.define("CMAKE_INSTALL_LIBDIR", "lib")'
+        self.assertEqual(source.count(install_dir), 1)
+        self.assertGreater(
+            source.index(install_dir),
+            source.index("for (key, value) in env::vars()"),
+        )
+        self.assertLess(
+            source.index(install_dir),
+            source.index('if cfg!(not(feature = "openmp"))'),
+        )
+
     def test_stage_ggml_runtime_requires_and_copies_exact_windows_closure(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             root = pathlib.Path(name)


### PR DESCRIPTION
Fixes the Linux x86_64 0.0.3 release link failure from run 33219152130. Rocky EL8 GNUInstallDirs selected lib64 while whisper-rs-sys advertised out/lib to rust-lld. Runtime-dispatch builds now pin CMAKE_INSTALL_LIBDIR=lib after ambient CMake forwarding. Validated with a hostile lib64 environment in WSL, 36 release tests, license audit, fmt, and diff checks.