### PR TITLE
fix(release): preserve the 0.0.3 build window

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -45,22 +45,22 @@ jobs:
             runner: ubuntu-24.04
             container: docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
             target: x86_64-unknown-linux-gnu
-            timeout_minutes: 10
+            timeout_minutes: 30
           - label: Linux ARM64
             runner: ubuntu-24.04-arm
             container: docker.io/rockylinux/rockylinux:8.10@sha256:e8a49c5403b687db05d4d67333fa45808fbe74f36e683cec7abb1f7d0f2338c6
             target: aarch64-unknown-linux-gnu
-            timeout_minutes: 10
+            timeout_minutes: 30
           - label: Windows x86_64
             runner: windows-2025
             container: ''
             target: x86_64-pc-windows-msvc
-            timeout_minutes: 10
+            timeout_minutes: 30
           - label: macOS Apple Silicon
             runner: macos-14
             container: ''
             target: aarch64-apple-darwin
-            timeout_minutes: 10
+            timeout_minutes: 30
     steps:
       - name: Bootstrap fixed Linux container
         if: runner.os == 'Linux'
@@ -275,6 +275,7 @@ jobs:
           if-no-files-found: error
           retention-days: 7
       - name: Record artifact upload timing
+        shell: bash
         run: |
           python tools/release_timing.py finish \
             --report "$RUNNER_TEMP/release-timings.json" \
@@ -292,17 +293,13 @@ jobs:
             ~/.cargo/git/db
           key: release-cargo-registry-v1-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}
       - uses: actions/cache/save@v4
-        if: inputs.signing_mode == 'unsigned' && steps.build-cache.outputs.cache-hit != 'true'
-        with:
-          path: ${{ runner.temp }}/release-work/build
-          key: release-cargo-only-v2-${{ matrix.target }}-${{ hashFiles('Cargo.lock') }}-${{ hashFiles('tools/platform-release/authority.json', 'tools/platform-release/cpu-policy.json') }}-${{ hashFiles('apps/**/*.rs', 'crates/**/*.rs', 'third_party/whisper-rs-sys/**', 'tools/**/*.rs', 'Cargo.toml') }}
-      - uses: actions/cache/save@v4
         if: steps.native-cache.outputs.cache-hit != 'true'
         with:
           path: ${{ runner.temp }}/release-work/cache
           key: release-native-inputs-v1-${{ matrix.target }}-${{ hashFiles('tools/platform-release/authority.json', 'tools/macos-release/authority.json') }}
       - name: Record cache upload timing and publish summary
         if: always()
+        shell: bash
         run: |
           python tools/release_timing.py finish \
             --report "$RUNNER_TEMP/release-timings.json" \

--- a/tools/platform-release/release.py
+++ b/tools/platform-release/release.py
@@ -263,20 +263,19 @@ def build(target: str, output: pathlib.Path) -> pathlib.Path:
     products = list(RELEASE_BUILD_PRODUCTS)
     if target == "x86_64-pc-windows-msvc":
         products.append(WINDOWS_CORE_PREWARM_PRODUCT)
+    # Compile every helper and both provider entrypoints in one Cargo feature
+    # graph.  Building the OCR and media provider in separate invocations made
+    # Cargo rebuild their shared API/engine closure once per feature set (more
+    # than six minutes on the Windows release runner).  The provider package's
+    # default feature set intentionally contains both runtimes, matching the
+    # single-invocation macOS authority.
     command = ["cargo", "build", "--release", "--locked"]
     for package, binary in products:
         command.extend(["-p", package, "--bin", binary])
+    command.extend(["-p", "into-markdown-official-provider"])
+    for binary, _feature in PROVIDER_BUILD_PRODUCTS:
+        command.extend(["--bin", binary])
     run(command, cwd=ROOT, env=environment)
-    for binary, feature in PROVIDER_BUILD_PRODUCTS:
-        run(
-            [
-                "cargo", "build", "--release", "--locked", "-p",
-                "into-markdown-official-provider", "--bin", binary,
-                "--no-default-features", "--features", feature,
-            ],
-            cwd=ROOT,
-            env=environment,
-        )
     release_bin = output / "release"
     missing = [
         executable_name(binary, target)

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -165,12 +165,21 @@ class PlatformReleaseTests(unittest.TestCase):
         for forbidden in ["installed-smoke", "platform_acceptance.py", "into-md-installer"]:
             self.assertNotIn(forbidden, workflow)
         self.assertIn("timeout-minutes: ${{ matrix.timeout_minutes }}", workflow)
-        self.assertEqual(workflow.count("timeout_minutes: 10"), 4)
-        self.assertNotIn("timeout_minutes: 30", workflow)
+        self.assertEqual(workflow.count("timeout_minutes: 30"), 4)
         self.assertEqual(workflow.count("    timeout-minutes: 5"), 1)
         windows = workflow.index("target: x86_64-pc-windows-msvc")
-        self.assertIn("timeout_minutes: 10", workflow[windows : windows + 100])
+        self.assertIn("timeout_minutes: 30", workflow[windows : windows + 100])
         self.assertIn("INTO_MD_RELEASE_STREAM_LOGS: '1'", workflow)
+        self.assertEqual(workflow.count("uses: actions/cache/save@v4"), 2)
+        self.assertEqual(
+            workflow.count("path: ${{ runner.temp }}/release-work/build"), 1
+        )
+        for step in [
+            "Record artifact upload timing",
+            "Record cache upload timing and publish summary",
+        ]:
+            position = workflow.index(f"- name: {step}")
+            self.assertIn("shell: bash", workflow[position : position + 180])
 
     def test_release_build_only_validates_without_mutating_github_release(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(
@@ -357,7 +366,7 @@ class PlatformReleaseTests(unittest.TestCase):
                     output / "release",
                 )
             builds = [command for command in commands if command[:2] == ["cargo", "build"]]
-            self.assertEqual(len(builds), 3)
+            self.assertEqual(len(builds), 1)
             selections = [
                 builds[0][index : index + 4]
                 for index, value in enumerate(builds[0])
@@ -371,11 +380,22 @@ class PlatformReleaseTests(unittest.TestCase):
                         *RELEASE_BUILD_PRODUCTS,
                         WINDOWS_CORE_PREWARM_PRODUCT,
                     ]
+                    + [
+                        (
+                            "into-markdown-official-provider",
+                            release_module.PROVIDER_BUILD_PRODUCTS[0][0],
+                        )
+                    ]
                 ],
             )
+            provider_position = builds[0].index("into-markdown-official-provider")
             self.assertEqual(
-                [(build[build.index("--bin") + 1], build[build.index("--features") + 1]) for build in builds[1:]],
-                list(release_module.PROVIDER_BUILD_PRODUCTS),
+                builds[0][provider_position + 1 :],
+                [
+                    value
+                    for binary, _feature in release_module.PROVIDER_BUILD_PRODUCTS
+                    for value in ("--bin", binary)
+                ],
             )
 
     def test_release_build_disables_native_ggml_cpu_tuning(self) -> None:
@@ -397,7 +417,7 @@ class PlatformReleaseTests(unittest.TestCase):
 
             with mock.patch.object(release_module, "run", side_effect=fake_run):
                 release_module.build("x86_64-unknown-linux-gnu", output)
-            self.assertEqual(len(environments), 3)
+            self.assertEqual(len(environments), 1)
             self.assertEqual(environments[0]["GGML_NATIVE"], "OFF")
             self.assertEqual(environments[0]["GGML_CPU_ALL_VARIANTS"], "ON")
             for key in (


### PR DESCRIPTION
Batches the complete findings from release run 33226006864: sets platform release jobs to the requested 30-minute safety limit, compiles both official providers in one Cargo invocation instead of rebuilding their shared dependency graph twice, removes the large Cargo target cache upload from the critical release path, and forces Bash for cross-platform timing summaries. PR gates remain exactly four and bounded to five minutes. Verified with the exact combined Cargo selection on Windows, 95 release contract tests, formatting, and diff checks.