### PR TITLE
fix(release): keep machine metadata out of live logs

### DIFF
--- a/.github/workflows/platform-modular-release.yml
+++ b/.github/workflows/platform-modular-release.yml
@@ -267,6 +267,7 @@ jobs:
               --key-id "$APPLE_NOTARY_KEY_ID" --issuer "$APPLE_NOTARY_ISSUER_ID" --wait
           done
       - name: Start artifact upload timing
+        shell: bash
         run: python tools/release_timing.py mark --marker "$RUNNER_TEMP/artifact-upload.started"
       - uses: actions/upload-artifact@v4
         with:
@@ -275,15 +276,19 @@ jobs:
           if-no-files-found: error
           retention-days: 7
       - name: Record artifact upload timing
+        if: always()
         shell: bash
         run: |
-          python tools/release_timing.py finish \
-            --report "$RUNNER_TEMP/release-timings.json" \
-            --target "${{ matrix.target }}" \
-            --phase artifact-upload \
-            --marker "$RUNNER_TEMP/artifact-upload.started"
+          if test -f "$RUNNER_TEMP/artifact-upload.started"; then
+            python tools/release_timing.py finish \
+              --report "$RUNNER_TEMP/release-timings.json" \
+              --target "${{ matrix.target }}" \
+              --phase artifact-upload \
+              --marker "$RUNNER_TEMP/artifact-upload.started"
+          fi
       - name: Start cache upload timing
-        if: always()
+        if: success()
+        shell: bash
         run: python tools/release_timing.py mark --marker "$RUNNER_TEMP/cache-upload.started"
       - uses: actions/cache/save@v4
         if: steps.cargo-cache.outputs.cache-hit != 'true'
@@ -301,25 +306,29 @@ jobs:
         if: always()
         shell: bash
         run: |
-          python tools/release_timing.py finish \
-            --report "$RUNNER_TEMP/release-timings.json" \
-            --target "${{ matrix.target }}" \
-            --phase cache-upload \
-            --marker "$RUNNER_TEMP/cache-upload.started"
-          python tools/release_timing.py summary \
-            --report "$RUNNER_TEMP/release-timings.json" \
-            --target "${{ matrix.target }}" \
-            --output "$GITHUB_STEP_SUMMARY"
-          mkdir -p "$RUNNER_TEMP/release-output/evidence/${{ matrix.target }}"
-          cp "$RUNNER_TEMP/release-timings.json" \
-            "$RUNNER_TEMP/release-output/evidence/${{ matrix.target }}/release-timings.json"
+          if test -f "$RUNNER_TEMP/cache-upload.started"; then
+            python tools/release_timing.py finish \
+              --report "$RUNNER_TEMP/release-timings.json" \
+              --target "${{ matrix.target }}" \
+              --phase cache-upload \
+              --marker "$RUNNER_TEMP/cache-upload.started"
+          fi
+          if test -f "$RUNNER_TEMP/release-timings.json"; then
+            python tools/release_timing.py summary \
+              --report "$RUNNER_TEMP/release-timings.json" \
+              --target "${{ matrix.target }}" \
+              --output "$GITHUB_STEP_SUMMARY"
+            mkdir -p "$RUNNER_TEMP/release-output/evidence/${{ matrix.target }}"
+            cp "$RUNNER_TEMP/release-timings.json" \
+              "$RUNNER_TEMP/release-output/evidence/${{ matrix.target }}/release-timings.json"
+          fi
       - name: Upload machine-readable release timings
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: timing-${{ matrix.target }}
           path: ${{ runner.temp }}/release-timings.json
-          if-no-files-found: error
+          if-no-files-found: warn
           retention-days: 30
       - name: Remove Windows credentials
         if: always() && runner.os == 'Windows'

--- a/tools/macos-release/release.py
+++ b/tools/macos-release/release.py
@@ -242,7 +242,13 @@ def write_plugin_declarations(
             "components": components,
         },
     )
-    inputs = json.loads(run([str(projection_tool), "generate", str(request)], cwd=ROOT))
+    inputs = json.loads(
+        run(
+            [str(projection_tool), "generate", str(request)],
+            cwd=ROOT,
+            stream_stdout=False,
+        )
+    )
     for key in ["notice", "third_party_notices", "sbom", "sources"]:
         item = inputs[key]
         destination = declaration_root / item["path"]
@@ -363,7 +369,13 @@ def package_official_plugins(packages: pathlib.Path, cache: pathlib.Path, releas
 def write_release_inputs(output: pathlib.Path, projection_tool: pathlib.Path) -> None:
     request = output.parent / "core-release-request.json"
     write_json(request, {"schema_version": 1, "target": TARGET, "artifact": "core", "version": VERSION, "source_revision": source_revision(), "components": CORE_COMPONENTS})
-    inputs = json.loads(run([str(projection_tool), "generate", str(request)], cwd=ROOT))
+    inputs = json.loads(
+        run(
+            [str(projection_tool), "generate", str(request)],
+            cwd=ROOT,
+            stream_stdout=False,
+        )
+    )
     for key in ["notice", "third_party_notices", "sbom", "sources", "core_catalog"]:
         item = inputs[key]
         destination = output / item["path"]

--- a/tools/macos-release/rust_package.py
+++ b/tools/macos-release/rust_package.py
@@ -26,7 +26,13 @@ def materialize(destination: pathlib.Path) -> None:
 
 
 def _materialize_tree(destination: pathlib.Path) -> None:
-    metadata = json.loads(run(["cargo", "metadata", "--locked", "--format-version", "1"], cwd=ROOT))
+    metadata = json.loads(
+        run(
+            ["cargo", "metadata", "--locked", "--format-version", "1"],
+            cwd=ROOT,
+            stream_stdout=False,
+        )
+    )
     packages = {package["id"]: package for package in metadata["packages"]}
     nodes = {node["id"]: node for node in metadata["resolve"]["nodes"]}
     roots = [package["id"] for package in packages.values() if package["name"] == "into-markdown"]

--- a/tools/platform-release/release.py
+++ b/tools/platform-release/release.py
@@ -469,7 +469,13 @@ def write_plugin_declarations(
             "components": components,
         },
     )
-    inputs = json.loads(run([str(projection_tool), "generate", str(request)], cwd=ROOT))
+    inputs = json.loads(
+        run(
+            [str(projection_tool), "generate", str(request)],
+            cwd=ROOT,
+            stream_stdout=False,
+        )
+    )
     for key in ["notice", "third_party_notices", "sbom", "sources"]:
         item = inputs[key]
         destination = declaration_root / item["path"]
@@ -657,7 +663,9 @@ def package_plugins(
 def write_release_inputs(output: pathlib.Path, projection: pathlib.Path, target: str) -> None:
     request = output.parent / "core-release-request.json"
     write_json(request, {"schema_version": 1, "target": target, "artifact": "core", "version": VERSION, "source_revision": source_revision(), "components": CORE_COMPONENTS})
-    inputs = json.loads(run([projection, "generate", request], cwd=ROOT))
+    inputs = json.loads(
+        run([projection, "generate", request], cwd=ROOT, stream_stdout=False)
+    )
     for key in ["notice", "third_party_notices", "sbom", "sources", "core_catalog"]:
         item = inputs[key]
         destination = output / item["path"]

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -170,16 +170,44 @@ class PlatformReleaseTests(unittest.TestCase):
         windows = workflow.index("target: x86_64-pc-windows-msvc")
         self.assertIn("timeout_minutes: 30", workflow[windows : windows + 100])
         self.assertIn("INTO_MD_RELEASE_STREAM_LOGS: '1'", workflow)
+        platform_release = (
+            ROOT / "tools/platform-release/release.py"
+        ).read_text(encoding="utf-8")
+        macos_release = (ROOT / "tools/macos-release/release.py").read_text(
+            encoding="utf-8"
+        )
+        rust_package = (ROOT / "tools/macos-release/rust_package.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(platform_release.count("stream_stdout=False"), 2)
+        self.assertEqual(macos_release.count("stream_stdout=False"), 2)
+        self.assertEqual(rust_package.count("stream_stdout=False"), 1)
         self.assertEqual(workflow.count("uses: actions/cache/save@v4"), 2)
         self.assertEqual(
             workflow.count("path: ${{ runner.temp }}/release-work/build"), 1
         )
         for step in [
+            "Start artifact upload timing",
             "Record artifact upload timing",
+            "Start cache upload timing",
             "Record cache upload timing and publish summary",
         ]:
             position = workflow.index(f"- name: {step}")
             self.assertIn("shell: bash", workflow[position : position + 180])
+        artifact_finish = workflow.index("- name: Record artifact upload timing")
+        cache_finish = workflow.index(
+            "- name: Record cache upload timing and publish summary"
+        )
+        self.assertIn("if: always()", workflow[artifact_finish : artifact_finish + 120])
+        self.assertIn(
+            'test -f "$RUNNER_TEMP/artifact-upload.started"',
+            workflow[artifact_finish : artifact_finish + 700],
+        )
+        self.assertIn(
+            'test -f "$RUNNER_TEMP/cache-upload.started"',
+            workflow[cache_finish : cache_finish + 700],
+        )
+        self.assertIn("if-no-files-found: warn", workflow)
 
     def test_release_build_only_validates_without_mutating_github_release(self) -> None:
         workflow = (ROOT / ".github/workflows/platform-modular-release.yml").read_text(

--- a/tools/release_subprocess.py
+++ b/tools/release_subprocess.py
@@ -20,6 +20,7 @@ def run(
     *,
     cwd: pathlib.Path | None = None,
     env: Mapping[str, str] | None = None,
+    stream_stdout: bool = True,
 ) -> str:
     """Run a release subprocess and optionally stream both output channels live."""
     command = [str(argument) for argument in arguments]
@@ -48,14 +49,15 @@ def run(
             try:
                 for line in pipe:
                     lines.append(line)
-                    output.write(line)
-                    output.flush()
+                    if output is not None:
+                        output.write(line)
+                        output.flush()
             finally:
                 pipe.close()
 
         stdout_thread = threading.Thread(
             target=drain,
-            args=(process.stdout, stdout_lines, sys.stdout),
+            args=(process.stdout, stdout_lines, sys.stdout if stream_stdout else None),
         )
         stderr_thread = threading.Thread(
             target=drain,

--- a/tools/release_subprocess_test.py
+++ b/tools/release_subprocess_test.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import json
 import os
 import sys
 import threading
@@ -30,6 +31,26 @@ class ReleaseSubprocessTests(unittest.TestCase):
         self.assertIn("machine-readable-result", console.getvalue())
         self.assertIn("[release] start", console.getvalue())
         self.assertIn("[release] finish", console.getvalue())
+
+    def test_machine_stdout_is_captured_while_progress_remains_live(self) -> None:
+        console = io.StringIO()
+        diagnostics = io.StringIO()
+        script = (
+            "import json,sys; "
+            "print('projection-progress', file=sys.stderr, flush=True); "
+            "print(json.dumps({'value': 'x' * (128 * 1024)}, separators=(',', ':')))"
+        )
+        with contextlib.redirect_stdout(console), contextlib.redirect_stderr(diagnostics):
+            output = run(
+                [sys.executable, "-c", script],
+                stream_stdout=False,
+            )
+
+        self.assertEqual(len(json.loads(output)["value"]), 128 * 1024)
+        self.assertNotIn('"value"', console.getvalue())
+        self.assertIn("[release] start", console.getvalue())
+        self.assertIn("[release] finish", console.getvalue())
+        self.assertIn("projection-progress", diagnostics.getvalue())
 
     def test_stdout_and_stderr_are_forwarded_before_process_exit(self) -> None:
         class SignalingStream(io.StringIO):


### PR DESCRIPTION
## Summary
- capture large machine-readable release metadata without mirroring it to the Actions log while keeping stderr and phase start/finish live
- use Bash consistently for cross-platform timing markers
- make failure timing finalizers marker-aware so cleanup cannot hide the primary error
- cover >128 KiB machine output and all metadata/timing call sites

## Validation
- real Windows release-projection generation: pass
- portable-release tests: 19 pass
- platform-release tests: 68 pass
- release subprocess/timing tests: 8 pass
- macOS release helper tests: 15 pass
- cargo fmt and git diff check: pass

The platform release safety timeout remains 30 minutes for all four targets.