### PR TITLE
fix(release): accept identical GGML build closures

### DIFF
--- a/tools/platform-release/release.py
+++ b/tools/platform-release/release.py
@@ -297,27 +297,34 @@ def stage_ggml_runtime(
     variants = GGML_CPU_VARIANTS.get(target)
     if variants is None:
         return []
-    candidates = [
-        path
-        for path in sorted((build_root / "release/build").glob("whisper-rs-sys-*/out"))
-        if (path / "bin" / variants[0]).is_file()
-    ]
-    if len(candidates) != 1:
-        raise ReleaseError(
-            f"GGML runtime output is absent or ambiguous for {target}: {candidates}"
-        )
-    root = candidates[0]
-    mapping = {name: root / "bin" / name for name in variants}
+    roots = sorted((build_root / "release/build").glob("whisper-rs-sys-*/out"))
+    names = list(variants)
     if target == "x86_64-pc-windows-msvc":
-        mapping.update({name: root / "bin" / name for name in ("whisper.dll", "ggml.dll", "ggml-base.dll")})
+        names.extend(("whisper.dll", "ggml.dll", "ggml-base.dll"))
+        relative = {name: pathlib.PurePosixPath("bin") / name for name in names}
     else:
-        mapping.update(
-            {
-                "libwhisper.so.1": root / "lib/libwhisper.so.1.8.3",
-                "libggml.so.0": root / "lib/libggml.so.0.9.5",
-                "libggml-base.so.0": root / "lib/libggml-base.so.0.9.5",
-            }
+        relative = {
+            **{name: pathlib.PurePosixPath("bin") / name for name in names},
+            "libwhisper.so.1": pathlib.PurePosixPath("lib/libwhisper.so.1.8.3"),
+            "libggml.so.0": pathlib.PurePosixPath("lib/libggml.so.0.9.5"),
+            "libggml-base.so.0": pathlib.PurePosixPath("lib/libggml-base.so.0.9.5"),
+        }
+    candidates = []
+    for root in roots:
+        mapping = {name: root / path for name, path in relative.items()}
+        if all(path.is_file() and not path.is_symlink() for path in mapping.values()):
+            candidates.append(mapping)
+    if not candidates:
+        raise ReleaseError(
+            f"GGML runtime output is absent for {target}: {roots}"
         )
+    fingerprints = {
+        tuple((name, sha256(path)) for name, path in sorted(mapping.items()))
+        for mapping in candidates
+    }
+    if len(fingerprints) != 1:
+        raise ReleaseError(f"GGML runtime outputs disagree for {target}: {roots}")
+    mapping = candidates[0]
     staged = []
     for name, source in sorted(mapping.items()):
         output = destination / name

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -504,23 +504,47 @@ class PlatformReleaseTests(unittest.TestCase):
     def test_stage_ggml_runtime_requires_and_copies_exact_windows_closure(self) -> None:
         with tempfile.TemporaryDirectory() as name:
             root = pathlib.Path(name)
-            output = root / "release/build/whisper-rs-sys-fixture/out"
             expected = {
                 *release_module.GGML_CPU_VARIANTS["x86_64-pc-windows-msvc"],
                 "whisper.dll",
                 "ggml.dll",
                 "ggml-base.dll",
             }
-            for filename in expected:
-                path = output / "bin" / filename
-                path.parent.mkdir(parents=True, exist_ok=True)
-                path.write_bytes(filename.encode())
+            for identity in ("fixture-a", "fixture-b"):
+                output = root / f"release/build/whisper-rs-sys-{identity}/out"
+                for filename in expected:
+                    path = output / "bin" / filename
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(filename.encode())
             destination = root / "speech/bin"
             staged = release_module.stage_ggml_runtime(
                 root, "x86_64-pc-windows-msvc", destination
             )
             self.assertEqual({path.name for path in staged}, expected)
             self.assertEqual({path.name for path in destination.iterdir()}, expected)
+
+    def test_stage_ggml_runtime_rejects_nonidentical_duplicate_closures(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = pathlib.Path(name)
+            expected = {
+                *release_module.GGML_CPU_VARIANTS["x86_64-pc-windows-msvc"],
+                "whisper.dll",
+                "ggml.dll",
+                "ggml-base.dll",
+            }
+            for identity in ("fixture-a", "fixture-b"):
+                output = root / f"release/build/whisper-rs-sys-{identity}/out"
+                for filename in expected:
+                    path = output / "bin" / filename
+                    path.parent.mkdir(parents=True, exist_ok=True)
+                    path.write_bytes(filename.encode())
+            changed = root / "release/build/whisper-rs-sys-fixture-b/out/bin/ggml.dll"
+            changed.write_bytes(b"different")
+
+            with self.assertRaisesRegex(ReleaseError, "outputs disagree"):
+                release_module.stage_ggml_runtime(
+                    root, "x86_64-pc-windows-msvc", root / "speech/bin"
+                )
 
     def test_release_build_rejects_a_missing_helper_product(self) -> None:
         with tempfile.TemporaryDirectory() as name:


### PR DESCRIPTION
## Summary
- accept duplicate Cargo GGML output directories only when the complete runtime closures are byte-identical by SHA-256
- retain fail-closed behavior for missing, symlinked, incomplete, or disagreeing outputs
- cover identical and mismatched duplicate Windows closures

## Validation
- platform-release tests: 69 pass
- portable-release tests: 19 pass
- cargo fmt, Python compile, and git diff check: pass

All platform release timeouts remain at 30 minutes.