### PR TITLE
perf(converters): index embedded visual OCR candidates

### DIFF
--- a/crates/api/src/embedded_visual_ocr_tests.rs
+++ b/crates/api/src/embedded_visual_ocr_tests.rs
@@ -21,6 +21,79 @@ struct PdfGeometryOcr(AtomicUsize);
 
 struct RemoteEmbeddedOcr(AtomicUsize);
 
+struct DanglingDocxConverter;
+
+impl Converter for DanglingDocxConverter {
+    fn id(&self) -> &'static str {
+        "test.api.dangling-docx"
+    }
+
+    fn priority(&self) -> i32 {
+        i32::MAX
+    }
+
+    fn supported_formats(&self) -> &'static [InputFormat] {
+        &[InputFormat::Docx]
+    }
+
+    fn probe<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ProbeOutcome, ConversionError>> {
+        Box::pin(async { Ok(ProbeOutcome::Match { confidence: 1.0 }) })
+    }
+
+    fn planned_output_bytes(
+        &self,
+        _: &ResolvedInput,
+        _: &FormatCandidate,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        Ok(96 * 1024)
+    }
+
+    fn convert<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        _: &'a ConversionOptions,
+        _: &'a Services,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        Box::pin(async {
+            let provenance = || Provenance {
+                kind: ProvenanceKind::NativeParser,
+                provider: "test.api.dangling-docx".into(),
+                locator: SourceLocator::default(),
+                confidence: Some(1.0),
+            };
+            let blocks = vec![
+                BlockNode {
+                    id: NodeId("image-first".into()),
+                    block: Block::Image { asset: AssetId("z-missing".into()), alt: None },
+                    provenance: provenance(),
+                },
+                BlockNode {
+                    id: NodeId("image-second".into()),
+                    block: Block::Image {
+                        asset: AssetId(format!("a-missing-{}", "x".repeat(64 * 1024))),
+                        alt: None,
+                    },
+                    provenance: provenance(),
+                },
+            ];
+            Ok(ConverterOutput::new(
+                Document { blocks, ..Document::default() },
+                Vec::new(),
+                Vec::new(),
+            ))
+        })
+    }
+}
+
 impl OcrEngine for RemoteEmbeddedOcr {
     fn id(&self) -> &'static str {
         "provider.fixture.vision-ocr"
@@ -74,6 +147,30 @@ impl OcrEngine for RemoteEmbeddedOcr {
         self.0.fetch_add(1, Ordering::SeqCst);
         Box::pin(async move { self.recognize(request, context).await.map(OcrRecognition::Remote) })
     }
+}
+
+#[test]
+fn best_effort_auto_keeps_low_memory_dangling_reference_as_a_hard_error() {
+    let mut builder = default_engine_builder();
+    builder.registry_mut().register_converter(Arc::new(DanglingDocxConverter));
+    let engine = builder.build().unwrap();
+    let mut request =
+        ConversionRequest::new(InputRef::bytes(b"fixture".to_vec(), Some("dangling.docx")));
+    request.hint.format = Some(InputFormat::Docx);
+    request.options.error_policy = ErrorPolicy::BestEffort;
+    request.options.ocr.policy = OcrPolicy::Auto;
+    request.options.output.asset_mode = AssetMode::Omit;
+    request.options.limits.max_memory_bytes = 100 * 1024;
+
+    let error = block_on(engine.convert(request)).unwrap_err();
+    assert!(
+        matches!(
+            &error,
+            ConversionError::Internal { detail }
+                if detail == "image node references missing asset z-missing"
+        ),
+        "unexpected engine error: {error:?}"
+    );
 }
 
 impl OcrEngine for PdfGeometryOcr {

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -12,6 +12,12 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Cursor;
 
+mod candidate_index;
+use candidate_index::{
+    CandidateBuffer, OcrCandidate, ReferenceIndex, candidate_index_plan, group_candidates,
+    validate_visual_references_without_index,
+};
+
 const PROVIDER: &str = "builtin.enricher.embedded-visual-ocr";
 const UNSUPPORTED_CODE: &str = "embeddedVisualOcr.unsupportedVisual";
 
@@ -204,24 +210,43 @@ fn plan_enrichment(
     {
         return Ok(EnrichmentPlan::Skip);
     }
-    // Inventory references once. Candidate envelope parsing and hashing below
-    // are then performed once per referenced AssetId, never once per node.
-    let mut reference_counts = BTreeMap::<AssetId, u64>::new();
+    // Measure without allocation, reserve the complete reference inventory,
+    // then build it. Preflight runs before the engine owns the returned plan,
+    // so this temporary index must carry its own request-scoped lease.
+    let mut reference_count = 0_usize;
+    let mut reference_id_bytes = 0_u64;
     for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
-        if find_asset(&output.assets, asset_id, context)?.is_none() {
-            return Err(ConversionError::Internal {
-                detail: format!("image node references missing asset {}", asset_id.0),
-            });
-        }
-        let count = reference_counts.entry(asset_id.clone()).or_default();
-        *count = count.checked_add(1).ok_or_else(|| {
+        reference_count = reference_count.checked_add(1).ok_or_else(|| {
             resource("max_archive_entries", "embedded visual reference count is not representable")
         })?;
+        reference_id_bytes = reference_id_bytes
+            .checked_add(u64::try_from(asset_id.0.len()).map_err(|_| {
+                resource(
+                    "max_memory_bytes",
+                    "embedded visual reference ID length is not representable",
+                )
+            })?)
+            .ok_or_else(|| {
+                resource("max_memory_bytes", "embedded visual reference ID bytes overflow")
+            })?;
         Ok(())
     })?;
-    if reference_counts.is_empty() {
+    if reference_count == 0 {
         return Ok(EnrichmentPlan::Skip);
     }
+    let mut reference_counts =
+        match ReferenceIndex::new(reference_count, reference_id_bytes, context) {
+            Ok(index) => index,
+            Err(error @ ConversionError::ResourceLimit { limit: "max_memory_bytes", .. }) => {
+                validate_visual_references_without_index(output, context)?;
+                return Err(error);
+            }
+            Err(error) => return Err(error),
+        };
+    for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
+        reference_counts.record(asset_id)
+    })?;
+    reference_counts.validate_assets(&output.assets, context)?;
     if effective_ocr_policy(options) == OcrPolicy::Always {
         let mut supported_references = 0_u64;
         for asset in &output.assets {
@@ -229,7 +254,7 @@ fn plan_enrichment(
                 continue;
             }
             supported_references = supported_references
-                .checked_add(reference_counts.get(&asset.id).copied().unwrap_or(0))
+                .checked_add(reference_counts.count(&asset.id).unwrap_or(0))
                 .ok_or_else(|| {
                     resource(
                         "max_archive_entries",
@@ -245,11 +270,15 @@ fn plan_enrichment(
         }
     }
 
-    // (asset index, reference count, dimensions, exact-byte digest)
-    let mut candidates = Vec::<(usize, u64, (u32, u32), [u8; 32])>::new();
+    let mut candidates = CandidateBuffer::new(reference_counts.unique_len(), context)?;
     let mut references = 0_u64;
     let mut candidate_bytes = 0_u64;
-    let mut total = 0_u64;
+    let mut total = reference_counts.planned_bytes();
+    checked_add(
+        &mut total,
+        candidates.planned_bytes(),
+        "OCR candidate buffer retained plan overflow",
+    )?;
     for asset in &output.assets {
         context.checkpoint()?;
         checked_add(
@@ -263,7 +292,7 @@ fn plan_enrichment(
     }
     for (index, asset) in output.assets.iter().enumerate() {
         context.checkpoint()?;
-        let Some(reference_count) = reference_counts.get(&asset.id).copied() else { continue };
+        let Some(reference_count) = reference_counts.count(&asset.id) else { continue };
         if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
             continue;
         }
@@ -306,30 +335,23 @@ fn plan_enrichment(
                 .map_err(|_| resource("max_memory_bytes", "hash/cache plan overflow"))?,
             "hash/cache plan overflow",
         )?;
-        candidates.push((
-            index,
+        candidates.push(OcrCandidate {
+            asset_index: index,
             reference_count,
             dimensions,
-            checkpointed_sha256(&asset.bytes, context)?,
-        ));
+            digest: checkpointed_sha256(&asset.bytes, context)?,
+        })?;
     }
     if references == 0 {
         return Ok(EnrichmentPlan::Skip);
     }
-    let mut unique = Vec::<usize>::new();
-    for candidate_index in 0..candidates.len() {
-        context.checkpoint()?;
-        let candidate = &candidates[candidate_index];
-        if unique.iter().any(|prior_index| {
-            let prior = &candidates[*prior_index];
-            prior.3 == candidate.3
-                && output.assets[prior.0].bytes == output.assets[candidate.0].bytes
-        }) {
-            continue;
-        }
-        unique.push(candidate_index);
-    }
-    let unique_count = u32::try_from(unique.len())
+    let grouping = group_candidates(&candidates, &output.assets, context)?;
+    checked_add(
+        &mut total,
+        candidate_index_plan(candidates.len())?,
+        "OCR candidate index retained plan overflow",
+    )?;
+    let unique_count = u32::try_from(grouping.groups.len())
         .map_err(|_| resource("max_pages", "embedded OCR candidate count overflow"))?;
     if unique_count > options.limits.max_pages {
         return Err(resource(
@@ -346,11 +368,10 @@ fn plan_enrichment(
     // must reject.
     // Account hash/map work once per eligible AssetId, but normalization and
     // provider output once per unique byte identity.
-    for candidate_index in unique {
+    for group in &grouping.groups {
         context.checkpoint()?;
-        let candidate = &candidates[candidate_index];
-        let asset = &output.assets[candidate.0];
-        let (width, height) = candidate.2;
+        let candidate = &candidates[group.representative];
+        let (width, height) = candidate.dimensions;
         let normalized_peak = u64::from(width)
             .checked_mul(u64::from(height))
             .and_then(|pixels| pixels.checked_mul(32))
@@ -380,22 +401,9 @@ fn plan_enrichment(
             }
         };
         provider_working_peak = provider_working_peak.max(provider_working);
-        let (reference_copies, asset_copies) = candidates
-            .iter()
-            .filter(|other| other.3 == candidate.3 && output.assets[other.0].bytes == asset.bytes)
-            .try_fold((0_u64, 0_u64), |values, other| {
-                Ok::<_, ConversionError>((
-                    values.0.checked_add(other.1).ok_or_else(|| {
-                        resource("max_memory_bytes", "OCR reference-copy count overflow")
-                    })?,
-                    values.1.checked_add(1).ok_or_else(|| {
-                        resource("max_memory_bytes", "OCR asset-copy count overflow")
-                    })?,
-                ))
-            })?;
         let added_nodes = usize::try_from(provider_regions)
             .unwrap_or(usize::MAX)
-            .checked_mul(usize::try_from(reference_copies).unwrap_or(usize::MAX))
+            .checked_mul(usize::try_from(group.reference_copies).unwrap_or(usize::MAX))
             .ok_or_else(|| resource("documentNodes", "embedded OCR node preflight overflow"))?;
         planned_added_nodes = planned_added_nodes
             .checked_add(added_nodes)
@@ -410,8 +418,9 @@ fn plan_enrichment(
                 "embedded OCR output can exceed the document node limit",
             ));
         }
-        let retained_copies = reference_copies
-            .checked_add(asset_copies)
+        let retained_copies = group
+            .reference_copies
+            .checked_add(group.asset_copies)
             .and_then(|value| value.checked_add(1))
             .ok_or_else(|| resource("max_memory_bytes", "OCR retained-copy count overflow"))?;
         checked_add(
@@ -662,22 +671,6 @@ fn validated_candidate_dimensions(
     Ok((width, height))
 }
 
-fn find_asset<'a>(
-    assets: &'a [into_markdown_core::Asset],
-    asset_id: &AssetId,
-    context: &ExecutionContext,
-) -> Result<Option<&'a into_markdown_core::Asset>, ConversionError> {
-    for (index, asset) in assets.iter().enumerate() {
-        if index % 256 == 0 {
-            context.checkpoint()?;
-        }
-        if asset.id == *asset_id {
-            return Ok(Some(asset));
-        }
-    }
-    Ok(None)
-}
-
 fn for_each_visual_reference(
     nodes: &[BlockNode],
     context: &ExecutionContext,
@@ -802,8 +795,7 @@ async fn enrich(
             ));
         }
     }
-    let mut hashes_by_asset = BTreeMap::new();
-    let mut unique = BTreeMap::<[u8; 32], AssetId>::new();
+    let mut candidates = CandidateBuffer::new(eligible_assets.len(), context)?;
     let mut referenced_assets = BTreeSet::new();
     let mut compressed_bytes = 0_u64;
     for (index, reference) in references.iter().enumerate() {
@@ -834,36 +826,40 @@ async fn enrich(
             ));
         }
         let digest = checkpointed_sha256(&asset.bytes, context)?;
-        hashes_by_asset.insert(reference.asset.clone(), digest);
-        unique.entry(digest).or_insert_with(|| reference.asset.clone());
+        candidates.push(OcrCandidate {
+            asset_index: *asset_index,
+            reference_count: 1,
+            dimensions: (0, 0),
+            digest,
+        })?;
     }
 
-    let unique_count = u32::try_from(unique.len())
+    let grouping = group_candidates(&candidates, &output.assets, context)?;
+    let unique_count = u32::try_from(grouping.groups.len())
         .map_err(|_| resource("max_pages", "OCR request count is not representable"))?;
     if unique_count > options.limits.max_pages {
         return Err(resource("max_pages", "embedded OCR requests exceed the request limit"));
     }
 
-    let mut cache = BTreeMap::<[u8; 32], CachedContribution>::new();
-    for (ordinal, (digest, asset_id)) in unique.into_iter().enumerate() {
+    let mut cache = Vec::<Option<CachedContribution>>::new();
+    cache.try_reserve_exact(grouping.groups.len()).map_err(|error| {
+        resource("max_memory_bytes", format!("allocate OCR contribution cache: {error}"))
+    })?;
+    cache.resize_with(grouping.groups.len(), || None);
+    for (ordinal, group_index) in grouping.digest_order.iter().copied().enumerate() {
         context.checkpoint()?;
-        let asset_index = assets.get(&asset_id).ok_or_else(|| ConversionError::Internal {
-            detail: "embedded OCR asset inventory changed during enrichment".into(),
-        })?;
-        let asset = &output.assets[*asset_index];
+        let candidate = &candidates[grouping.groups[group_index].representative];
+        let asset = &output.assets[candidate.asset_index];
         let normalized = match normalize(asset, options, context) {
             Ok(value) => value,
             Err(error)
                 if effective_ocr_policy(options) == OcrPolicy::Auto
                     && auto_degradable_normalization(&error) =>
             {
-                cache.insert(
-                    digest,
-                    CachedContribution {
-                        nodes: Vec::new(),
-                        diagnostics: vec![visual_diagnostic(None, error.to_string())],
-                    },
-                );
+                cache[group_index] = Some(CachedContribution {
+                    nodes: Vec::new(),
+                    diagnostics: vec![visual_diagnostic(None, error.to_string())],
+                });
                 continue;
             }
             Err(error) => return Err(error),
@@ -892,13 +888,10 @@ async fn enrich(
                 if effective_ocr_policy(options) == OcrPolicy::Auto
                     && matches!(error, ConversionError::ComponentUnavailable { .. }) =>
             {
-                cache.insert(
-                    digest,
-                    CachedContribution {
-                        nodes: Vec::new(),
-                        diagnostics: vec![visual_diagnostic(None, error.to_string())],
-                    },
-                );
+                cache[group_index] = Some(CachedContribution {
+                    nodes: Vec::new(),
+                    diagnostics: vec![visual_diagnostic(None, error.to_string())],
+                });
                 continue;
             }
             Err(error) => return Err(error),
@@ -918,21 +911,25 @@ async fn enrich(
         if let Some(memory) = contribution.memory.take() {
             output.attach_memory_reservation(context, memory)?;
         }
-        cache.insert(
-            digest,
-            CachedContribution { nodes: contribution.nodes, diagnostics: contribution.diagnostics },
-        );
+        cache[group_index] = Some(CachedContribution {
+            nodes: contribution.nodes,
+            diagnostics: contribution.diagnostics,
+        });
     }
 
     let mut contributions_by_asset = BTreeMap::new();
-    for (index, (asset, digest)) in hashes_by_asset.into_iter().enumerate() {
+    for (index, candidate) in candidates.iter().enumerate() {
         if index % 256 == 0 {
             context.checkpoint()?;
         }
-        if let Some(contribution) = cache.get(&digest) {
-            contributions_by_asset.insert(asset, contribution.clone());
+        let group_index = grouping.membership[index];
+        if let Some(contribution) = &cache[group_index] {
+            contributions_by_asset
+                .insert(output.assets[candidate.asset_index].id.clone(), contribution.clone());
         }
     }
+    drop(grouping);
+    drop(candidates);
     let mut occupied_ids = BTreeSet::new();
     collect_node_ids(&output.document.blocks, &mut occupied_ids, context)?;
     output.document.blocks = rebuild_nodes(

--- a/crates/converters/src/embedded_visual_ocr/candidate_index.rs
+++ b/crates/converters/src/embedded_visual_ocr/candidate_index.rs
@@ -1,0 +1,811 @@
+use super::resource;
+use into_markdown_core::{
+    Asset, AssetId, ConversionError, ConverterOutput, ExecutionContext, ResourceReservation,
+};
+use std::collections::BTreeMap;
+
+const REFERENCE_BASE_BYTES: u64 = 4 * 1024;
+const BYTES_PER_REFERENCE_ENTRY: u64 = 256;
+const CANDIDATE_BUFFER_BASE_BYTES: u64 = 1024;
+const BYTES_PER_CANDIDATE_BUFFER_ENTRY: u64 = 128;
+const GROUPING_BASE_BYTES: u64 = 4 * 1024;
+const BYTES_PER_GROUPING_CANDIDATE: u64 = 1024;
+
+#[cfg(test)]
+thread_local! {
+    static ASSET_LOOKUPS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+    static FULL_BYTE_COMPARISONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Preserve the converter invariant when the indexed validation lease cannot
+/// be acquired. This failure-only path deliberately scans without allocating:
+/// a dangling reference remains a hard error in document order, while a
+/// complete document lets the caller return its original memory limit.
+pub(super) fn validate_visual_references_without_index(
+    output: &ConverterOutput,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    super::for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
+        for (index, asset) in output.assets.iter().enumerate() {
+            if index.is_multiple_of(256) {
+                context.checkpoint()?;
+            }
+            if asset.id == *asset_id {
+                return Ok(());
+            }
+        }
+        Err(ConversionError::Internal {
+            detail: format!("image node references missing asset {}", asset_id.0),
+        })
+    })
+}
+
+pub(super) struct ReferenceIndex {
+    entries: BTreeMap<AssetId, ReferenceEntry>,
+    recorded: usize,
+    recorded_id_bytes: u64,
+    max_references: usize,
+    max_id_bytes: u64,
+    planned_bytes: u64,
+    _memory: ResourceReservation,
+}
+
+struct ReferenceEntry {
+    count: u64,
+    present: bool,
+    first_seen: usize,
+}
+
+impl ReferenceIndex {
+    pub(super) fn new(
+        max_references: usize,
+        max_id_bytes: u64,
+        context: &ExecutionContext,
+    ) -> Result<Self, ConversionError> {
+        let planned_bytes = reference_index_plan(max_references, max_id_bytes)?;
+        let memory = context.reserve_memory(planned_bytes)?;
+        Ok(Self {
+            entries: BTreeMap::new(),
+            recorded: 0,
+            recorded_id_bytes: 0,
+            max_references,
+            max_id_bytes,
+            planned_bytes,
+            _memory: memory,
+        })
+    }
+
+    pub(super) fn record(&mut self, asset_id: &AssetId) -> Result<(), ConversionError> {
+        let id_bytes = u64::try_from(asset_id.0.len()).map_err(|_| {
+            resource("max_memory_bytes", "embedded visual reference ID length is not representable")
+        })?;
+        let next_recorded = self.recorded.checked_add(1).ok_or_else(|| {
+            resource("max_archive_entries", "embedded visual reference count is not representable")
+        })?;
+        let next_id_bytes = self.recorded_id_bytes.checked_add(id_bytes).ok_or_else(|| {
+            resource("max_memory_bytes", "embedded visual reference ID bytes overflow")
+        })?;
+        if next_recorded > self.max_references || next_id_bytes > self.max_id_bytes {
+            return Err(resource(
+                "max_memory_bytes",
+                "embedded visual reference inventory exceeded its preflight plan",
+            ));
+        }
+        if let Some(entry) = self.entries.get_mut(asset_id) {
+            entry.count = entry.count.checked_add(1).ok_or_else(|| {
+                resource(
+                    "max_archive_entries",
+                    "embedded visual reference count is not representable",
+                )
+            })?;
+        } else {
+            self.entries.insert(
+                asset_id.clone(),
+                ReferenceEntry { count: 1, present: false, first_seen: self.recorded },
+            );
+        }
+        self.recorded = next_recorded;
+        self.recorded_id_bytes = next_id_bytes;
+        Ok(())
+    }
+
+    pub(super) fn count(&self, asset_id: &AssetId) -> Option<u64> {
+        self.entries.get(asset_id).map(|entry| entry.count)
+    }
+
+    pub(super) fn unique_len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub(super) fn planned_bytes(&self) -> u64 {
+        self.planned_bytes
+    }
+
+    /// Validate every referenced ID with one ordered-map lookup per asset.
+    /// Repeated asset IDs preserve the existing presence semantics.
+    pub(super) fn validate_assets(
+        &mut self,
+        assets: &[Asset],
+        context: &ExecutionContext,
+    ) -> Result<(), ConversionError> {
+        for (index, asset) in assets.iter().enumerate() {
+            if index.is_multiple_of(256) {
+                context.checkpoint()?;
+            }
+            #[cfg(test)]
+            ASSET_LOOKUPS.set(ASSET_LOOKUPS.get() + 1);
+            if let Some(entry) = self.entries.get_mut(&asset.id) {
+                entry.present = true;
+            }
+        }
+        if let Some((asset_id, _)) = self
+            .entries
+            .iter()
+            .filter(|(_, entry)| !entry.present)
+            .min_by_key(|(_, entry)| entry.first_seen)
+        {
+            return Err(ConversionError::Internal {
+                detail: format!("image node references missing asset {}", asset_id.0),
+            });
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn reference_index_plan(
+    reference_count: usize,
+    reference_id_bytes: u64,
+) -> Result<u64, ConversionError> {
+    u64::try_from(reference_count)
+        .unwrap_or(u64::MAX)
+        .checked_mul(BYTES_PER_REFERENCE_ENTRY)
+        .and_then(|bytes| bytes.checked_add(reference_id_bytes))
+        .and_then(|bytes| bytes.checked_add(REFERENCE_BASE_BYTES))
+        .ok_or_else(|| resource("max_memory_bytes", "embedded visual reference index overflow"))
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct OcrCandidate {
+    pub(super) asset_index: usize,
+    pub(super) reference_count: u64,
+    pub(super) dimensions: (u32, u32),
+    pub(super) digest: [u8; 32],
+}
+
+pub(super) struct CandidateBuffer {
+    items: Vec<OcrCandidate>,
+    capacity: usize,
+    planned_bytes: u64,
+    _memory: ResourceReservation,
+}
+
+impl CandidateBuffer {
+    pub(super) fn new(
+        capacity: usize,
+        context: &ExecutionContext,
+    ) -> Result<Self, ConversionError> {
+        let planned_bytes = candidate_buffer_plan(capacity)?;
+        let memory = context.reserve_memory(planned_bytes)?;
+        let mut items = Vec::new();
+        items.try_reserve_exact(capacity).map_err(|error| {
+            resource("max_memory_bytes", format!("allocate OCR candidate buffer: {error}"))
+        })?;
+        Ok(Self { items, capacity, planned_bytes, _memory: memory })
+    }
+
+    pub(super) fn push(&mut self, candidate: OcrCandidate) -> Result<(), ConversionError> {
+        if self.items.len() == self.capacity {
+            return Err(resource(
+                "max_memory_bytes",
+                "OCR candidate buffer exceeded its preflight plan",
+            ));
+        }
+        self.items.push(candidate);
+        Ok(())
+    }
+
+    pub(super) fn planned_bytes(&self) -> u64 {
+        self.planned_bytes
+    }
+}
+
+impl std::ops::Deref for CandidateBuffer {
+    type Target = [OcrCandidate];
+
+    fn deref(&self) -> &Self::Target {
+        &self.items
+    }
+}
+
+pub(super) fn candidate_buffer_plan(candidate_capacity: usize) -> Result<u64, ConversionError> {
+    u64::try_from(candidate_capacity)
+        .unwrap_or(u64::MAX)
+        .checked_mul(BYTES_PER_CANDIDATE_BUFFER_ENTRY)
+        .and_then(|bytes| bytes.checked_add(CANDIDATE_BUFFER_BASE_BYTES))
+        .ok_or_else(|| resource("max_memory_bytes", "OCR candidate buffer plan overflow"))
+}
+
+pub(super) struct CandidateGroup {
+    pub(super) representative: usize,
+    pub(super) reference_copies: u64,
+    pub(super) asset_copies: u64,
+}
+
+pub(super) struct CandidateGrouping {
+    pub(super) groups: Vec<CandidateGroup>,
+    pub(super) membership: Vec<usize>,
+    pub(super) digest_order: Vec<usize>,
+    _memory: ResourceReservation,
+}
+
+pub(super) fn candidate_index_plan(candidate_count: usize) -> Result<u64, ConversionError> {
+    u64::try_from(candidate_count)
+        .unwrap_or(u64::MAX)
+        .checked_mul(BYTES_PER_GROUPING_CANDIDATE)
+        .and_then(|bytes| bytes.checked_add(GROUPING_BASE_BYTES))
+        .ok_or_else(|| resource("max_memory_bytes", "OCR candidate index plan overflow"))
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+struct BytesKey<'a>(&'a [u8]);
+
+impl Ord for BytesKey<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        #[cfg(test)]
+        FULL_BYTE_COMPARISONS.set(FULL_BYTE_COMPARISONS.get() + 1);
+        self.0.cmp(other.0)
+    }
+}
+
+impl PartialOrd for BytesKey<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Group candidates by digest and then by exact payload. The digest map gives
+/// logarithmic lookup for ordinary unique inputs. A borrowed full-byte index
+/// keeps even a forced-collision bucket logarithmic without copying payloads;
+/// complete byte ordering/equality remains the final identity authority.
+pub(super) fn group_candidates(
+    candidates: &[OcrCandidate],
+    assets: &[Asset],
+    context: &ExecutionContext,
+) -> Result<CandidateGrouping, ConversionError> {
+    let memory = context.reserve_memory(candidate_index_plan(candidates.len())?)?;
+    let mut groups = Vec::<CandidateGroup>::new();
+    groups.try_reserve_exact(candidates.len()).map_err(|error| {
+        resource("max_memory_bytes", format!("allocate OCR candidate groups: {error}"))
+    })?;
+    let mut membership = Vec::<usize>::new();
+    membership.try_reserve_exact(candidates.len()).map_err(|error| {
+        resource("max_memory_bytes", format!("allocate OCR candidate membership: {error}"))
+    })?;
+    let mut buckets = BTreeMap::<[u8; 32], BTreeMap<BytesKey<'_>, usize>>::new();
+    for (candidate_index, candidate) in candidates.iter().enumerate() {
+        context.checkpoint()?;
+        let bucket = buckets.entry(candidate.digest).or_default();
+        let bytes = BytesKey(&assets[candidate.asset_index].bytes);
+        let group_index = match bucket.entry(bytes) {
+            std::collections::btree_map::Entry::Occupied(entry) => {
+                let group_index = *entry.get();
+                let group = &mut groups[group_index];
+                group.reference_copies =
+                    group.reference_copies.checked_add(candidate.reference_count).ok_or_else(
+                        || resource("max_memory_bytes", "OCR reference-copy count overflow"),
+                    )?;
+                group.asset_copies = group
+                    .asset_copies
+                    .checked_add(1)
+                    .ok_or_else(|| resource("max_memory_bytes", "OCR asset-copy count overflow"))?;
+                group_index
+            }
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                let group_index = groups.len();
+                groups.push(CandidateGroup {
+                    representative: candidate_index,
+                    reference_copies: candidate.reference_count,
+                    asset_copies: 1,
+                });
+                entry.insert(group_index);
+                group_index
+            }
+        };
+        membership.push(group_index);
+    }
+    let mut digest_order = Vec::new();
+    digest_order.try_reserve_exact(groups.len()).map_err(|error| {
+        resource("max_memory_bytes", format!("allocate OCR candidate order: {error}"))
+    })?;
+    for bucket in buckets.values() {
+        digest_order.extend(bucket.values().copied());
+    }
+    Ok(CandidateGrouping { groups, membership, digest_order, _memory: memory })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{image_dimensions, plan_enrichment};
+    use super::*;
+    use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
+    use into_markdown_core::{
+        Block, BlockNode, BoxFuture, ConversionOptions, ConverterOutput, Document, EnrichmentPlan,
+        ExecutionOptions, InputFormat, NodeId, OcrEngine, OcrOutputPlan, OcrPolicy, OcrRecognition,
+        OcrRequest, OcrResult, Provenance, ProvenanceKind, ResourceLimits, Services, SourceLocator,
+    };
+    use sha2::{Digest, Sha256};
+    use std::io::Cursor;
+    use std::sync::{Arc, Mutex};
+
+    struct PlanningOrderOcr {
+        dimensions: Mutex<Vec<(u32, u32)>>,
+        fail_at: Option<(u32, u32)>,
+    }
+
+    impl OcrEngine for PlanningOrderOcr {
+        fn id(&self) -> &'static str {
+            "test.ocr.planning-order"
+        }
+
+        fn recognize<'a>(
+            &'a self,
+            _: OcrRequest<'a>,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+            Box::pin(async { unreachable!("planning-order provider never recognizes") })
+        }
+
+        fn planned_bound_output(
+            &self,
+            _: OcrRequest<'_>,
+            _: &ConversionOptions,
+            _: &ExecutionContext,
+        ) -> Result<OcrOutputPlan, ConversionError> {
+            unreachable!("embedded OCR uses the normalized-PNG plan")
+        }
+
+        fn planned_normalized_png_output(
+            &self,
+            width: u32,
+            height: u32,
+            _: &ConversionOptions,
+            _: &ExecutionContext,
+        ) -> Result<OcrOutputPlan, ConversionError> {
+            self.dimensions.lock().unwrap().push((width, height));
+            if self.fail_at == Some((width, height)) {
+                return Err(ConversionError::ResourceLimit {
+                    limit: "max_memory_bytes",
+                    detail: "planning-order sentinel".into(),
+                });
+            }
+            OcrOutputPlan::try_new(1024, 1, 128)
+        }
+
+        fn recognize_bound<'a>(
+            &'a self,
+            _: OcrRequest<'a>,
+            _: &'a ExecutionContext,
+        ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+            Box::pin(async { unreachable!("planning-order provider never recognizes") })
+        }
+    }
+
+    fn asset(index: usize, bytes: Vec<u8>) -> Asset {
+        Asset {
+            id: AssetId(format!("asset-{index}")),
+            filename: None,
+            media_type: "image/png".into(),
+            bytes,
+            external_uri: None,
+        }
+    }
+
+    fn reference_plan(ids: &[AssetId]) -> (usize, u64) {
+        (ids.len(), ids.iter().map(|id| u64::try_from(id.0.len()).unwrap()).sum())
+    }
+
+    fn build_references(
+        ids: &[AssetId],
+        context: &ExecutionContext,
+    ) -> Result<ReferenceIndex, ConversionError> {
+        let (count, bytes) = reference_plan(ids);
+        let mut references = ReferenceIndex::new(count, bytes, context)?;
+        for id in ids {
+            references.record(id)?;
+        }
+        Ok(references)
+    }
+
+    fn png_with_dimensions(width: u32, height: u32, value: u8) -> Vec<u8> {
+        let pixels = RgbaImage::from_pixel(width, height, Rgba([value, 2, 3, 255]));
+        let mut cursor = Cursor::new(Vec::new());
+        DynamicImage::ImageRgba8(pixels).write_to(&mut cursor, ImageFormat::Png).unwrap();
+        cursor.into_inner()
+    }
+
+    fn planning_output(first: Vec<u8>, second: Vec<u8>) -> ConverterOutput {
+        let provenance = || Provenance {
+            kind: ProvenanceKind::NativeParser,
+            provider: "test.converter".into(),
+            locator: SourceLocator::default(),
+            confidence: Some(1.0),
+        };
+        ConverterOutput::new(
+            Document {
+                blocks: vec![
+                    BlockNode {
+                        id: NodeId("image-first".into()),
+                        block: Block::Image { asset: AssetId("asset-first".into()), alt: None },
+                        provenance: provenance(),
+                    },
+                    BlockNode {
+                        id: NodeId("image-second".into()),
+                        block: Block::Image { asset: AssetId("asset-second".into()), alt: None },
+                        provenance: provenance(),
+                    },
+                ],
+                ..Document::default()
+            },
+            vec![
+                Asset {
+                    id: AssetId("asset-first".into()),
+                    filename: Some("first.png".into()),
+                    media_type: "image/png".into(),
+                    bytes: first,
+                    external_uri: None,
+                },
+                Asset {
+                    id: AssetId("asset-second".into()),
+                    filename: Some("second.png".into()),
+                    media_type: "image/png".into(),
+                    bytes: second,
+                    external_uri: None,
+                },
+            ],
+            vec![],
+        )
+    }
+
+    #[test]
+    fn provider_preflight_preserves_asset_order_and_first_error() {
+        let mut first_bytes = png_with_dimensions(2, 3, 11);
+        let mut second_bytes = png_with_dimensions(7, 5, 29);
+        if Sha256::digest(&first_bytes) < Sha256::digest(&second_bytes) {
+            std::mem::swap(&mut first_bytes, &mut second_bytes);
+        }
+        let first_dimensions = image_dimensions(&first_bytes).unwrap();
+        let second_dimensions = image_dimensions(&second_bytes).unwrap();
+        assert!(Sha256::digest(&first_bytes) > Sha256::digest(&second_bytes));
+        let source = planning_output(first_bytes, second_bytes);
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+
+        let recorder =
+            Arc::new(PlanningOrderOcr { dimensions: Mutex::new(Vec::new()), fail_at: None });
+        let services = Services { ocr: Some(recorder.clone()), ..Services::default() };
+        assert!(matches!(
+            plan_enrichment(&source, InputFormat::Docx, &options, &services, &context).unwrap(),
+            EnrichmentPlan::Reserve(_)
+        ));
+        assert_eq!(*recorder.dimensions.lock().unwrap(), [first_dimensions, second_dimensions]);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let failing = Arc::new(PlanningOrderOcr {
+            dimensions: Mutex::new(Vec::new()),
+            fail_at: Some(first_dimensions),
+        });
+        let services = Services { ocr: Some(failing.clone()), ..Services::default() };
+        let error =
+            plan_enrichment(&source, InputFormat::Docx, &options, &services, &context).unwrap_err();
+        assert!(matches!(
+            error,
+            ConversionError::ResourceLimit { limit: "max_memory_bytes", detail }
+                if detail == "planning-order sentinel"
+        ));
+        assert_eq!(*failing.dimensions.lock().unwrap(), [first_dimensions]);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn low_memory_preserves_first_dangling_reference_before_index_reservation() {
+        let first_bytes = png_with_dimensions(2, 3, 11);
+        let second_bytes = png_with_dimensions(7, 5, 29);
+        let complete = planning_output(first_bytes.clone(), second_bytes.clone());
+        let mut dangling = planning_output(first_bytes, second_bytes);
+        let Block::Image { asset, .. } = &mut dangling.document.blocks[0].block else {
+            unreachable!("fixture starts with an image")
+        };
+        *asset = AssetId("z-missing".into());
+        let Block::Image { asset, .. } = &mut dangling.document.blocks[1].block else {
+            unreachable!("fixture ends with an image")
+        };
+        *asset = AssetId("a-missing".into());
+
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        options.limits.max_memory_bytes = 1;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let error =
+            plan_enrichment(&dangling, InputFormat::Docx, &options, &Services::default(), &context)
+                .unwrap_err();
+        assert!(matches!(
+            error,
+            ConversionError::Internal { detail }
+                if detail == "image node references missing asset z-missing"
+        ));
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        assert!(matches!(
+            plan_enrichment(&complete, InputFormat::Docx, &options, &Services::default(), &context,),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn referenced_asset_validation_scans_8192_assets_once() {
+        const ASSETS: usize = 8192;
+        let assets = (0..ASSETS)
+            .map(|index| Asset {
+                id: AssetId(format!("asset-{index}-{}", "long-id".repeat(32))),
+                ..asset(index, Vec::new())
+            })
+            .collect::<Vec<_>>();
+        let ids = assets.iter().map(|asset| asset.id.clone()).collect::<Vec<_>>();
+        let (count, id_bytes) = reference_plan(&ids);
+        let exact = reference_index_plan(count, id_bytes).unwrap();
+        let context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: exact, ..ResourceLimits::default() },
+        );
+        let mut references = build_references(&ids, &context).unwrap();
+
+        ASSET_LOOKUPS.set(0);
+        references.validate_assets(&assets, &context).unwrap();
+        assert_eq!(ASSET_LOOKUPS.get(), ASSETS);
+        assert_eq!(context.reserved_memory_bytes(), exact);
+        drop(references);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let low = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: exact - 1, ..ResourceLimits::default() },
+        );
+        assert!(matches!(
+            build_references(&ids, &low),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
+        assert_eq!(low.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn reference_validation_preserves_missing_and_duplicate_id_semantics() {
+        let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+        let duplicate = asset(0, Vec::new());
+        let mut references =
+            build_references(std::slice::from_ref(&duplicate.id), &context).unwrap();
+        references.validate_assets(&[duplicate.clone(), duplicate], &context).unwrap();
+        drop(references);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let missing = [AssetId("z-missing".into()), AssetId("a-missing".into())];
+        let mut references = build_references(&missing, &context).unwrap();
+        let error = references.validate_assets(&[], &context).unwrap_err();
+        assert!(matches!(
+            error,
+            ConversionError::Internal { detail }
+                if detail == "image node references missing asset z-missing"
+        ));
+        drop(references);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn reference_and_candidate_leases_cover_exact_simultaneous_peak_and_errors() {
+        let ids = [AssetId("first-long-reference".repeat(64))];
+        let (count, id_bytes) = reference_plan(&ids);
+        let reference_bytes = reference_index_plan(count, id_bytes).unwrap();
+        let candidate_bytes = candidate_buffer_plan(count).unwrap();
+        let grouping_bytes = candidate_index_plan(count).unwrap();
+        let exact = reference_bytes + candidate_bytes + grouping_bytes;
+        let assets = vec![asset(0, b"payload".to_vec())];
+        let context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: exact, ..ResourceLimits::default() },
+        );
+        let references = build_references(&ids, &context).unwrap();
+        let mut candidates = CandidateBuffer::new(count, &context).unwrap();
+        candidates
+            .push(OcrCandidate {
+                asset_index: 0,
+                reference_count: 1,
+                dimensions: (1, 1),
+                digest: Sha256::digest(&assets[0].bytes).into(),
+            })
+            .unwrap();
+        let grouping = group_candidates(&candidates, &assets, &context).unwrap();
+        assert_eq!(context.reserved_memory_bytes(), exact);
+        drop(grouping);
+        drop(candidates);
+        drop(references);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let low = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: exact - 1, ..ResourceLimits::default() },
+        );
+        let references = build_references(&ids, &low).unwrap();
+        let mut candidates = CandidateBuffer::new(count, &low).unwrap();
+        candidates
+            .push(OcrCandidate {
+                asset_index: 0,
+                reference_count: 1,
+                dimensions: (1, 1),
+                digest: Sha256::digest(&assets[0].bytes).into(),
+            })
+            .unwrap();
+        assert!(matches!(
+            group_candidates(&candidates, &assets, &low),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
+        drop(candidates);
+        drop(references);
+        assert_eq!(low.reserved_memory_bytes(), 0);
+
+        let cancellation = into_markdown_core::CancellationToken::new();
+        cancellation.cancel();
+        let cancelled = ExecutionContext::new(
+            ExecutionOptions { cancellation, ..ExecutionOptions::default() },
+            ResourceLimits::default(),
+        );
+        assert!(matches!(build_references(&ids, &cancelled), Err(ConversionError::Cancelled)));
+        assert!(matches!(CandidateBuffer::new(count, &cancelled), Err(ConversionError::Cancelled)));
+        assert_eq!(cancelled.reserved_memory_bytes(), 0);
+
+        let bounded = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: reference_bytes, ..ResourceLimits::default() },
+        );
+        let mut references = ReferenceIndex::new(count, id_bytes, &bounded).unwrap();
+        references.record(&ids[0]).unwrap();
+        assert!(matches!(
+            references.record(&ids[0]),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
+        drop(references);
+        assert_eq!(bounded.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn index_is_linear_for_4096_unique_assets_and_collision_safe() {
+        const ASSETS: usize = 4096;
+        let assets = (0..ASSETS)
+            .map(|index| asset(index, u64::try_from(index).unwrap().to_le_bytes().to_vec()))
+            .collect::<Vec<_>>();
+        let candidates = assets
+            .iter()
+            .enumerate()
+            .map(|(asset_index, asset)| OcrCandidate {
+                asset_index,
+                reference_count: 1,
+                dimensions: (1, 1),
+                digest: Sha256::digest(&asset.bytes).into(),
+            })
+            .collect::<Vec<_>>();
+        let exact = candidate_index_plan(candidates.len()).unwrap();
+        let exact_context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: exact, ..ResourceLimits::default() },
+        );
+        FULL_BYTE_COMPARISONS.set(0);
+        let grouping = group_candidates(&candidates, &assets, &exact_context).unwrap();
+        assert_eq!(grouping.groups.len(), ASSETS);
+        assert_eq!(grouping.membership.len(), ASSETS);
+        assert_eq!(grouping.digest_order.len(), ASSETS);
+        assert_eq!(FULL_BYTE_COMPARISONS.get(), 0);
+        assert_eq!(exact_context.reserved_memory_bytes(), exact);
+        drop(grouping);
+        assert_eq!(exact_context.reserved_memory_bytes(), 0);
+
+        let low_context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: exact - 1, ..ResourceLimits::default() },
+        );
+        assert!(matches!(
+            group_candidates(&candidates, &assets, &low_context),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
+        assert_eq!(low_context.reserved_memory_bytes(), 0);
+
+        let collision_assets = vec![
+            asset(0, b"same".to_vec()),
+            asset(1, b"different".to_vec()),
+            asset(2, b"same".to_vec()),
+        ];
+        let collision_candidates = (0..3)
+            .map(|asset_index| OcrCandidate {
+                asset_index,
+                reference_count: u64::try_from(asset_index + 1).unwrap(),
+                dimensions: (1, 1),
+                digest: [7; 32],
+            })
+            .collect::<Vec<_>>();
+        let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+        FULL_BYTE_COMPARISONS.set(0);
+        let collision =
+            group_candidates(&collision_candidates, &collision_assets, &context).unwrap();
+        assert_eq!(collision.groups.len(), 2);
+        assert_eq!(collision.membership, [0, 1, 0]);
+        assert_eq!(collision.groups[0].reference_copies, 4);
+        assert_eq!(collision.groups[0].asset_copies, 2);
+        assert_eq!(collision.groups[1].reference_copies, 2);
+        assert!(FULL_BYTE_COMPARISONS.get() > 0);
+        assert!(FULL_BYTE_COMPARISONS.get() < 16);
+
+        let forced_collision_candidates = candidates
+            .iter()
+            .map(|candidate| OcrCandidate { digest: [9; 32], ..*candidate })
+            .collect::<Vec<_>>();
+        FULL_BYTE_COMPARISONS.set(0);
+        let forced = group_candidates(&forced_collision_candidates, &assets, &context).unwrap();
+        assert_eq!(forced.groups.len(), ASSETS);
+        assert!(
+            FULL_BYTE_COMPARISONS.get() < ASSETS * 64,
+            "forced digest collisions remain logarithmic instead of quadratic"
+        );
+    }
+
+    #[test]
+    fn digest_order_and_membership_match_legacy_non_collision_semantics() {
+        let assets =
+            vec![asset(0, b"z".to_vec()), asset(1, b"a".to_vec()), asset(2, b"z".to_vec())];
+        let candidates = assets
+            .iter()
+            .enumerate()
+            .map(|(asset_index, asset)| OcrCandidate {
+                asset_index,
+                reference_count: 1,
+                dimensions: (1, 1),
+                digest: Sha256::digest(&asset.bytes).into(),
+            })
+            .collect::<Vec<_>>();
+        let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+        let grouping = group_candidates(&candidates, &assets, &context).unwrap();
+        let ordered_digests = grouping
+            .digest_order
+            .iter()
+            .map(|group| candidates[grouping.groups[*group].representative].digest)
+            .collect::<Vec<_>>();
+        let mut expected = candidates.iter().map(|candidate| candidate.digest).collect::<Vec<_>>();
+        expected.sort_unstable();
+        expected.dedup();
+        assert_eq!(ordered_digests, expected);
+        assert_eq!(grouping.membership[0], grouping.membership[2]);
+        assert_ne!(grouping.membership[0], grouping.membership[1]);
+    }
+
+    #[test]
+    fn cancellation_releases_the_candidate_index_lease() {
+        let assets = vec![asset(0, b"one".to_vec())];
+        let candidates = vec![OcrCandidate {
+            asset_index: 0,
+            reference_count: 1,
+            dimensions: (1, 1),
+            digest: Sha256::digest(&assets[0].bytes).into(),
+        }];
+        let cancellation = into_markdown_core::CancellationToken::new();
+        cancellation.cancel();
+        let context = ExecutionContext::new(
+            ExecutionOptions { cancellation, ..ExecutionOptions::default() },
+            ResourceLimits::default(),
+        );
+
+        assert!(matches!(
+            group_candidates(&candidates, &assets, &context),
+            Err(ConversionError::Cancelled)
+        ));
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

- count visual references without allocation, reserve the complete reference inventory, then build it; validate the authenticated asset list with exactly one ordered-map lookup per asset
- if the reference-index lease cannot be acquired, run a failure-only allocation-free scan so dangling `AssetId`s remain hard errors in first document-reference order instead of becoming an optional OCR skip
- preserve candidate/asset order for provider preflight and the established digest order for execution
- replace quadratic candidate deduplication and per-unique rescans with digest buckets whose borrowed full-byte sub-index is the final identity authority; forced digest collisions remain distinct unless complete bytes are equal
- reuse one grouping for unique count, reference-copy count, asset-copy count, OCR order, and asset mapping, so identical images are still recognized once
- isolate indexing, bounded buffers, failure fallback, leases, and focused regressions in `candidate_index.rs`; the main enricher is net 3 lines smaller than `main`

Closes #275

## Deterministic complexity, semantics, and lease gates

- 8,192 long-ID assets / references: exactly 8,192 asset lookups
- 4,096 ordinary unique assets: 4,096 groups and zero full-byte comparisons because every digest has its own bucket
- 4,096 forced same-digest distinct assets: all remain distinct and byte comparisons stay below 262,144, ruling out the former quadratic candidate path
- forced collision fixture: equal bytes coalesce, distinct bytes never merge, and reference/asset copy totals remain exact
- duplicate-byte integration coverage: one OCR provider call with per-reference remapping and stable content/order/evidence
- missing IDs `z-missing`, then `a-missing`: both indexed validation and the low-memory fallback return `z-missing`
- plan-level low-memory coverage proves dangling references return the hard `Internal` error while a complete reference set returns the original `ResourceLimit`, with zero residual reservation
- Engine coverage proves `best-effort + ocr=auto` cannot turn that low-memory dangling-reference error into `presentation.optionalOcrSkipped`
- provider preflight records asset dimensions in candidate order and stops on the first candidate error; execution digest ordering remains covered separately
- every owned collection is reserved before allocation: reference inventory = 4 KiB + 256 bytes/reference + measured ID bytes; candidate buffer = 1 KiB + 128 bytes/capacity; grouping = 4 KiB + 1 KiB/candidate
- deterministic accounting gates pass at the exact simultaneous logical sum; limit - 1, pre-cancel, bounded overflow, and exercised errors release to zero reserved bytes

These are deterministic `ExecutionContext` exact/limit-1 gates. The CLI does not yet expose authoritative shared-lease `resourceUsage`; real report metrics are tracked by #269 and are not claimed here.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p into-markdown-converters --all-targets -- -D warnings`
- `cargo clippy -p into-markdown --lib -- -D warnings`
- `cargo test -p into-markdown-converters`: 447 passed, 1 existing explicit PDFium quality target ignored
- `cargo test -p into-markdown embedded_visual_ocr -- --nocapture`: 7 passed, 1 existing pinned-PDFium test ignored
- `git diff --check`

No lint exemption, sample special case, or unrelated integration change was added.

## Real-file performance

Conclusion: performance-neutral wall-clock/RSS behavior with a deterministic complexity improvement. No large speedup is claimed. Windows x86_64, same `main` SHA, warmed filesystem cache, serial `--ocr auto`, release binaries, Markdown output, assets omitted, alternating order.

| Input | Raw order and times | Mean base | Mean patch | Delta | Mean peak RSS | Output parity |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| repository `normal.xlsx`, 5,293 B | B 86.388 / H 74.561; H 87.378 / B 87.750; B 83.931 / H 105.936; H 102.313 / B 103.043; B 88.302 / H 88.039; H 87.820 / B 118.236 ms | 94.608 ms | 91.008 ms | -3.81% | 14.788 / 14.703 MiB | same 175 bytes and SHA-256 |
| corpus `ecnu-ai-case-09.pptx`, 18,841,829 B | H 1.3870 / B 1.4041; B 1.3861 / H 1.3864 s | 1.3951 s | 1.3867 s | -0.60% | 67.820 / 67.859 MiB | same 9,396 bytes and SHA-256 |

The final independent alternating audit measured the small XLSX at -1.48% and the large PPTX at +2.91%; RSS and output bytes/SHA stayed equal. Both independent results are neutral and far inside the requested <50% ordinary-path fallback guard.

Fresh per-process `TEMP`/`TMP` isolation showed the same system/runtime temporary-file peak for base and patch: 30,252,577 bytes (about 28.85 MiB), with zero residue after process completion. This is relative-baseline evidence only; it is not described as request-owned transaction temp or authoritative shared-lease reporting.

## Diff boundary and risk

Only the OCR implementation/module and its API engine regression change:

- `crates/converters/src/embedded_visual_ocr.rs`
- `crates/converters/src/embedded_visual_ocr/candidate_index.rs`
- `crates/api/src/embedded_visual_ocr_tests.rs`

The source branch is based directly on `9e797178e7072a84146da6b0a3bfb22d8d62fde5`, the current `origin/main`.

The normal path remains one reference inventory plus one asset scan. Only reference-index memory-reservation failure uses the allocation-free fallback scan; this intentionally trades failure-path time for preserving the hard dangling-reference invariant. Digest ordering is preserved for ordinary execution inputs, while provider planning uses asset order to preserve first-error behavior. Within a forced cryptographic collision bucket, full-byte ordering/equality is authoritative; comparisons are O(C log C) in candidate count but still proportional to compared payload prefixes. Logical leases are conservative deterministic bounds, not allocator-RSS measurements.