### PR TITLE
Fix EPUB best-effort compatibility for noncanonical packages

### DIFF
--- a/crates/api/src/epub_regression_tests.rs
+++ b/crates/api/src/epub_regression_tests.rs
@@ -1,8 +1,8 @@
 use crate::{ConversionError, ErrorCode};
 
 use super::epub_tests::{
-    PNG, chapter_one, chapter_two, container, convert, epub, epub2_one, epub2_package, epub3_book,
-    epub3_package, nav3, ncx2,
+    PNG, chapter_one, chapter_two, container, convert, convert_strict, epub, epub2_one,
+    epub2_package, epub3_book, epub3_package, nav3, ncx2,
 };
 
 #[test]
@@ -45,6 +45,89 @@ fn xml_base_dot_segments_and_unicode_ncnames_resolve_portably() {
         convert(epub3_book(missing.as_bytes(), Some(nav3()))).unwrap_err().code(),
         ErrorCode::Malformed
     );
+}
+
+#[test]
+fn noncritical_package_metadata_is_optional_only_in_best_effort() {
+    let base = String::from_utf8(epub3_package().to_vec()).unwrap();
+    for (needle, expected) in [
+        ("<dc:title>Original EPUB Three</dc:title>", "dc:title"),
+        ("<dc:language>en</dc:language>", "dc:language"),
+        ("<meta property=\"dcterms:modified\">2026-08-13T00:00:00Z</meta>", "dcterms:modified"),
+    ] {
+        let package = base.replace(needle, "");
+        let bytes = epub3_book(package.as_bytes(), Some(nav3()));
+        let result = convert(bytes.clone()).unwrap();
+        assert!(result.markdown.contains("Alpha"));
+        assert!(result.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == "epub.metadataMissing" && diagnostic.message.contains(expected)
+        }));
+        assert_eq!(convert_strict(bytes).unwrap_err().code(), ErrorCode::Malformed);
+    }
+}
+
+#[test]
+fn chapter_recovery_is_scoped_after_epub_security_validation() {
+    let processing_instruction = br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><?ocr artifact?><p>omit me</p></body></html>"#;
+    let recovered = epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", epub3_package()),
+        ("OPS/nav.xhtml", nav3()),
+        ("OPS/text/one.xhtml", processing_instruction),
+        ("OPS/text/two.xhtml", chapter_two()),
+        ("OPS/text/extra.xhtml", chapter_two()),
+        ("OPS/images/cover.png", PNG),
+        ("OPS/styles/book.css", b"body{}"),
+    ]);
+    let result = convert(recovered.clone()).unwrap();
+    assert!(result.markdown.contains("Omega"));
+    assert!(!result.markdown.contains("omit me"));
+    assert!(
+        result.diagnostics.iter().any(|diagnostic| diagnostic.code == "epub.spine.chapterOmitted")
+    );
+    assert_eq!(convert_strict(recovered).unwrap_err().code(), ErrorCode::Malformed);
+
+    for malicious in [
+        br#"<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "https://example.invalid/xhtml11.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><body><p>DTD</p></body></html>"#.as_slice(),
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><p>&custom;</p></body></html>"#.as_slice(),
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><a href="../../../escape">escape</a></body></html>"#.as_slice(),
+    ] {
+        let bytes = epub(&[
+            ("META-INF/container.xml", container()),
+            ("OPS/content.opf", epub3_package()),
+            ("OPS/nav.xhtml", nav3()),
+            ("OPS/text/one.xhtml", malicious),
+            ("OPS/text/two.xhtml", chapter_two()),
+            ("OPS/text/extra.xhtml", chapter_two()),
+            ("OPS/images/cover.png", PNG),
+            ("OPS/styles/book.css", b"body{}"),
+        ]);
+        assert_eq!(convert(bytes).unwrap_err().code(), ErrorCode::Malformed);
+    }
+}
+
+#[test]
+fn duplicate_spine_and_all_empty_or_unreadable_chapters_fail_closed() {
+    let duplicate = String::from_utf8(epub3_package().to_vec())
+        .unwrap()
+        .replace("<itemref idref=\"two\"/>", "<itemref idref=\"one\"/><itemref idref=\"two\"/>");
+    assert_eq!(
+        convert(epub3_book(duplicate.as_bytes(), Some(nav3()))).unwrap_err().code(),
+        ErrorCode::Malformed
+    );
+
+    let empty = br#"<html xmlns="http://www.w3.org/1999/xhtml"><body/></html>"#;
+    let bytes = epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", epub3_package()),
+        ("OPS/nav.xhtml", nav3()),
+        ("OPS/text/one.xhtml", empty),
+        ("OPS/text/two.xhtml", empty),
+        ("OPS/text/extra.xhtml", empty),
+        ("OPS/images/cover.png", PNG),
+        ("OPS/styles/book.css", b"body{}"),
+    ]);
+    assert_eq!(convert(bytes).unwrap_err().code(), ErrorCode::Malformed);
 }
 
 #[test]

--- a/crates/api/src/epub_regression_tests.rs
+++ b/crates/api/src/epub_regression_tests.rs
@@ -1,8 +1,8 @@
 use crate::{ConversionError, ErrorCode};
 
 use super::epub_tests::{
-    PNG, chapter_one, chapter_two, container, convert, convert_strict, epub, epub2_one,
-    epub2_package, epub3_book, epub3_package, nav3, ncx2,
+    PNG, chapter_one, chapter_two, collect_links, container, convert, convert_strict, epub,
+    epub2_one, epub2_package, epub3_book, epub3_package, nav3, ncx2,
 };
 
 #[test]
@@ -104,6 +104,182 @@ fn chapter_recovery_is_scoped_after_epub_security_validation() {
         ]);
         assert_eq!(convert(bytes).unwrap_err().code(), ErrorCode::Malformed);
     }
+
+    for hidden_after_syntax in [
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><p broken='x' <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "https://example.invalid/xhtml11.dtd"><p>later</p></body></html>"#.as_slice(),
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><p broken='x' <p>&custom;</p></body></html>"#.as_slice(),
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><p broken='x' <a href="../../../escape">later</a></body></html>"#.as_slice(),
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><p broken='x' <evil:item/></body></html>"#.as_slice(),
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><p xmlns:evil="urn:forged" broken='x' <evil:item/></body></html>"#.as_slice(),
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><p broken='x' <p xmlns:a="urn:dup" xmlns:b="urn:dup" a:id="one" b:id="two">later</p></body></html>"#.as_slice(),
+    ] {
+        let bytes = epub(&[
+            ("META-INF/container.xml", container()),
+            ("OPS/content.opf", epub3_package()),
+            ("OPS/nav.xhtml", nav3()),
+            ("OPS/text/one.xhtml", hidden_after_syntax),
+            ("OPS/text/two.xhtml", chapter_two()),
+            ("OPS/text/extra.xhtml", chapter_two()),
+            ("OPS/images/cover.png", PNG),
+            ("OPS/styles/book.css", b"body{}"),
+        ]);
+        assert_eq!(convert(bytes.clone()).unwrap_err().code(), ErrorCode::Malformed);
+        assert_eq!(convert_strict(bytes).unwrap_err().code(), ErrorCode::Malformed);
+    }
+}
+
+#[test]
+fn local_xhtml_structure_damage_is_recoverable_only_in_best_effort() {
+    for malformed in [
+        br#"<svg xmlns="http://www.w3.org/2000/svg"><text>wrong root</text></svg>"#.as_slice(),
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><p>first</p></body></html><html xmlns="http://www.w3.org/1999/xhtml"><body><p>second</p></body></html>"#.as_slice(),
+        br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><section><p>broken nesting</section></p></body></html>"#.as_slice(),
+    ] {
+        let bytes = epub(&[
+            ("META-INF/container.xml", container()),
+            ("OPS/content.opf", epub3_package()),
+            ("OPS/nav.xhtml", nav3()),
+            ("OPS/text/one.xhtml", malformed),
+            ("OPS/text/two.xhtml", chapter_two()),
+            ("OPS/text/extra.xhtml", chapter_two()),
+            ("OPS/images/cover.png", PNG),
+            ("OPS/styles/book.css", b"body{}"),
+        ]);
+        let result = convert(bytes.clone()).unwrap();
+        assert!(result.markdown.contains("Omega"));
+        let omitted = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == "epub.spine.chapterOmitted")
+            .unwrap();
+        assert_eq!(omitted.locator.as_ref().and_then(|locator| locator.part.as_deref()), Some("OPS/text/one.xhtml"));
+        assert_eq!(convert_strict(bytes).unwrap_err().code(), ErrorCode::Malformed);
+    }
+}
+
+#[test]
+fn undeclared_active_xhtml_is_sanitized_reported_and_strictly_rejected() {
+    let active = br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><main onclick="steal()"><p>Visible static text</p><script><script>secret()</script></script></main></body></html>"#;
+    let bytes = epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", epub3_package()),
+        ("OPS/nav.xhtml", nav3()),
+        ("OPS/text/one.xhtml", active),
+        ("OPS/text/two.xhtml", chapter_two()),
+        ("OPS/text/extra.xhtml", chapter_two()),
+        ("OPS/images/cover.png", PNG),
+        ("OPS/styles/book.css", b"body{}"),
+    ]);
+    let result = convert(bytes.clone()).unwrap();
+    assert!(result.markdown.contains("Visible static text"));
+    assert!(!result.markdown.contains("secret"));
+    assert!(result.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "epub.spine.activeContentRemoved"
+            && diagnostic.locator.as_ref().and_then(|locator| locator.part.as_deref())
+                == Some("OPS/text/one.xhtml")
+    }));
+    assert_eq!(convert_strict(bytes).unwrap_err().code(), ErrorCode::Unsupported);
+
+    let inert = convert(epub3_book(epub3_package(), Some(nav3()))).unwrap();
+    assert!(
+        !inert
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "epub.spine.activeContentRemoved")
+    );
+}
+
+#[test]
+fn navigation_targets_follow_fallback_or_become_label_only_when_omitted() {
+    let repeated_ncx = String::from_utf8(ncx2().to_vec())
+        .unwrap()
+        .replace("one.xhtml#one", "dummy.svg#one")
+        .replace(
+            "</navMap>",
+            "<navPoint id=\"p3\" playOrder=\"3\"><navLabel><text>Repeated fallback</text></navLabel><content src=\"dummy.svg#one\"/></navPoint></navMap>",
+        );
+    let fallback = epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", epub2_package()),
+        ("OPS/text/toc.ncx", repeated_ncx.as_bytes()),
+        ("OPS/text/dummy.svg", b"<svg xmlns='http://www.w3.org/2000/svg'/>"),
+        ("OPS/text/one.xhtml", epub2_one()),
+        ("OPS/text/two.xhtml", chapter_two()),
+        ("OPS/images/cover.png", PNG),
+    ]);
+    let result = convert(fallback).unwrap();
+    let mut links = Vec::new();
+    let mut footnotes = Vec::new();
+    collect_links(&result.document.blocks, &mut links, &mut footnotes);
+    assert_eq!(links.iter().filter(|target| *target == "OPS/text/one.xhtml#one").count(), 2);
+    assert!(!links.iter().any(|target| target.contains("dummy.svg")));
+
+    let no_fallback_package =
+        String::from_utf8(epub2_package().to_vec()).unwrap().replace(" fallback=\"one\"", "");
+    let omitted = epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", no_fallback_package.as_bytes()),
+        ("OPS/text/toc.ncx", repeated_ncx.as_bytes()),
+        ("OPS/text/dummy.svg", b"<svg xmlns='http://www.w3.org/2000/svg'/>"),
+        ("OPS/text/one.xhtml", epub2_one()),
+        ("OPS/text/two.xhtml", chapter_two()),
+        ("OPS/images/cover.png", PNG),
+    ]);
+    let result = convert(omitted.clone()).unwrap();
+    let mut links = Vec::new();
+    collect_links(&result.document.blocks, &mut links, &mut footnotes);
+    assert!(result.markdown.contains("Repeated fallback"));
+    assert!(!links.iter().any(|target| target.contains("dummy.svg")));
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "epub.spine.chapterOmitted")
+        .unwrap();
+    assert_eq!(
+        diagnostic.locator.as_ref().and_then(|locator| locator.part.as_deref()),
+        Some("OPS/text/dummy.svg")
+    );
+    assert_eq!(convert_strict(omitted).unwrap_err().code(), ErrorCode::Unsupported);
+}
+
+#[test]
+fn emitted_chapter_order_matches_an_independent_linear_spine_oracle() {
+    let package = br#"<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="book"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier id="book">order-oracle</dc:identifier><dc:title>Order Oracle</dc:title><dc:language>en</dc:language><meta property="dcterms:modified">2026-08-30T00:00:00Z</meta></metadata><manifest><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/><item id="shell" href="text/shell.svg" media-type="image/svg+xml" fallback="one"/><item id="one" href="text/one.xhtml" media-type="application/xhtml+xml"/><item id="nonlinear" href="text/nonlinear.xhtml" media-type="application/xhtml+xml"/><item id="broken" href="text/broken.xhtml" media-type="application/xhtml+xml"/><item id="two" href="text/two.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="shell"/><itemref idref="nonlinear" linear="no"/><itemref idref="broken"/><itemref idref="two"/></spine></package>"#;
+    let broken = br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><p>broken"#;
+    let result = convert(epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", package),
+        ("OPS/nav.xhtml", nav3()),
+        ("OPS/text/shell.svg", b"<svg xmlns='http://www.w3.org/2000/svg'/>"),
+        (
+            "OPS/text/one.xhtml",
+            b"<html xmlns='http://www.w3.org/1999/xhtml'><body><h1>One</h1><p>First chapter</p></body></html>",
+        ),
+        (
+            "OPS/text/nonlinear.xhtml",
+            b"<html xmlns='http://www.w3.org/1999/xhtml'><body><p>do not emit</p></body></html>",
+        ),
+        ("OPS/text/broken.xhtml", broken),
+        ("OPS/text/two.xhtml", chapter_two()),
+    ]))
+    .unwrap();
+
+    let observed = result
+        .document
+        .blocks
+        .iter()
+        .filter(|block| block.id.0.starts_with("epub-spine-") && block.id.0.ends_with("-heading"))
+        .map(|block| (block.id.0.as_str(), block.provenance.locator.part.as_deref()))
+        .collect::<Vec<_>>();
+    let expected = vec![
+        ("epub-spine-000001-heading", Some("OPS/text/one.xhtml")),
+        ("epub-spine-000002-heading", Some("OPS/text/two.xhtml")),
+    ];
+    assert_eq!(observed, expected);
+    assert!(!result.markdown.contains("do not emit"));
+    assert!(
+        result.diagnostics.iter().any(|diagnostic| diagnostic.code == "epub.spine.chapterOmitted")
+    );
 }
 
 #[test]
@@ -160,7 +336,15 @@ fn xml_characters_and_xhtml_document_boundaries_are_strict() {
             ("OPS/images/cover.png", PNG),
             ("OPS/styles/book.css", b"body{}"),
         ]);
-        assert_eq!(convert(bytes).unwrap_err().code(), ErrorCode::Malformed);
+        let result = convert(bytes.clone()).unwrap();
+        assert!(result.markdown.contains("Omega"));
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "epub.spine.chapterOmitted")
+        );
+        assert_eq!(convert_strict(bytes).unwrap_err().code(), ErrorCode::Malformed);
     }
 }
 

--- a/crates/api/src/epub_tests.rs
+++ b/crates/api/src/epub_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Block, ConversionError, ConversionOptions, ConversionRequest, ErrorCode, ExecutionOptions,
-    FormatHint, Inline, InputFormat, InputRef, default_engine,
+    Block, ConversionError, ConversionOptions, ConversionRequest, ErrorCode, ErrorPolicy,
+    ExecutionOptions, FormatHint, Inline, InputFormat, InputRef, default_engine,
 };
 use std::fmt::Write as _;
 use std::future::Future;
@@ -48,7 +48,12 @@ pub(super) fn epub(entries: &[(&str, &[u8])]) -> Vec<u8> {
     writer.finish().unwrap().into_inner()
 }
 
-fn invalid_mimetype_layout(deflated: bool, leading_entry: bool) -> Vec<u8> {
+fn noncanonical_mimetype_layout(
+    entries: &[(&str, &[u8])],
+    deflated: bool,
+    leading_entry: bool,
+    extra: Option<bool>,
+) -> Vec<u8> {
     let cursor = Cursor::new(Vec::new());
     let mut writer = zip::ZipWriter::new(cursor);
     let stored = SimpleFileOptions::default()
@@ -58,32 +63,65 @@ fn invalid_mimetype_layout(deflated: bool, leading_entry: bool) -> Vec<u8> {
         writer.start_file("leading.txt", stored).unwrap();
         writer.write_all(b"before mimetype").unwrap();
     }
-    let options = SimpleFileOptions::default()
-        .compression_method(if deflated {
-            zip::CompressionMethod::Deflated
-        } else {
-            zip::CompressionMethod::Stored
-        })
-        .unix_permissions(0o644);
-    writer.start_file("mimetype", options).unwrap();
+    if let Some(central_only) = extra {
+        let mut options = FullFileOptions::default()
+            .compression_method(if deflated {
+                zip::CompressionMethod::Deflated
+            } else {
+                zip::CompressionMethod::Stored
+            })
+            .unix_permissions(0o644);
+        options.add_extra_data(0xcafe, Vec::new().into_boxed_slice(), central_only).unwrap();
+        writer.start_file("mimetype", options).unwrap();
+    } else {
+        let options = SimpleFileOptions::default()
+            .compression_method(if deflated {
+                zip::CompressionMethod::Deflated
+            } else {
+                zip::CompressionMethod::Stored
+            })
+            .unix_permissions(0o644);
+        writer.start_file("mimetype", options).unwrap();
+    }
     writer.write_all(b"application/epub+zip").unwrap();
+    let deflated = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+    for (path, bytes) in entries {
+        writer.start_file(*path, deflated).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
     writer.finish().unwrap().into_inner()
 }
 
-fn mimetype_with_extra(central_only: bool) -> Vec<u8> {
+fn epub_with_mimetype_content(entries: &[(&str, &[u8])], content: &[u8]) -> Vec<u8> {
     let cursor = Cursor::new(Vec::new());
     let mut writer = zip::ZipWriter::new(cursor);
-    let mut options = FullFileOptions::default()
+    let stored = SimpleFileOptions::default()
         .compression_method(zip::CompressionMethod::Stored)
         .unix_permissions(0o644);
-    options.add_extra_data(0xcafe, Vec::new().into_boxed_slice(), central_only).unwrap();
-    writer.start_file("mimetype", options).unwrap();
-    writer.write_all(b"application/epub+zip").unwrap();
+    writer.start_file("mimetype", stored).unwrap();
+    writer.write_all(content).unwrap();
+    let deflated = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+    for (path, bytes) in entries {
+        writer.start_file(*path, deflated).unwrap();
+        writer.write_all(bytes).unwrap();
+    }
     writer.finish().unwrap().into_inner()
 }
 
 pub(super) fn convert(bytes: Vec<u8>) -> Result<crate::ConversionResult, ConversionError> {
     convert_with(bytes, ConversionOptions::default(), ExecutionOptions::default())
+}
+
+pub(super) fn convert_strict(bytes: Vec<u8>) -> Result<crate::ConversionResult, ConversionError> {
+    convert_with(
+        bytes,
+        ConversionOptions { error_policy: ErrorPolicy::Strict, ..ConversionOptions::default() },
+        ExecutionOptions::default(),
+    )
 }
 
 fn convert_with(
@@ -338,17 +376,6 @@ fn malformed_mimetype_and_missing_fragment_are_rejected() {
         .unwrap();
     wrong[position] = b'X';
     assert_eq!(convert(wrong).unwrap_err().code(), ErrorCode::Malformed);
-    assert_eq!(
-        convert(invalid_mimetype_layout(true, false)).unwrap_err().code(),
-        ErrorCode::Malformed
-    );
-    assert_eq!(
-        convert(invalid_mimetype_layout(false, true)).unwrap_err().code(),
-        ErrorCode::Malformed
-    );
-    assert_eq!(convert(mimetype_with_extra(true)).unwrap_err().code(), ErrorCode::Malformed);
-    assert_eq!(convert(mimetype_with_extra(false)).unwrap_err().code(), ErrorCode::Malformed);
-
     let broken_two = br#"<html xmlns="http://www.w3.org/1999/xhtml"><body><main><h1>Two</h1><p>Omega</p></main></body></html>"#;
     let broken = epub(&[
         ("META-INF/container.xml", container()),
@@ -364,6 +391,53 @@ fn malformed_mimetype_and_missing_fragment_are_rejected() {
         ("OPS/styles/book.css", b"body{}"),
     ]);
     assert_eq!(convert(broken).unwrap_err().code(), ErrorCode::Malformed);
+}
+
+#[test]
+fn best_effort_recovers_noncanonical_mimetype_layout_but_strict_rejects_it() {
+    let entries = [
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", epub3_package()),
+        ("OPS/nav.xhtml", nav3()),
+        ("OPS/text/one.xhtml", chapter_one()),
+        ("OPS/text/two.xhtml", chapter_two()),
+        (
+            "OPS/text/extra.xhtml",
+            b"<html xmlns='http://www.w3.org/1999/xhtml'><body><p>x</p></body></html>".as_slice(),
+        ),
+        ("OPS/images/cover.png", PNG),
+        ("OPS/styles/book.css", b"body{}".as_slice()),
+    ];
+    for bytes in [
+        noncanonical_mimetype_layout(&entries, true, false, None),
+        noncanonical_mimetype_layout(&entries, false, true, None),
+        noncanonical_mimetype_layout(&entries, false, false, Some(true)),
+        noncanonical_mimetype_layout(&entries, false, false, Some(false)),
+    ] {
+        let result = convert(bytes.clone()).unwrap();
+        assert!(result.markdown.contains("Alpha"));
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "epub.mimetypeLayoutRecovered")
+        );
+        assert_eq!(convert_strict(bytes).unwrap_err().code(), ErrorCode::Malformed);
+    }
+
+    let crlf = epub_with_mimetype_content(&entries, b"application/epub+zip\r\n");
+    let result = convert(crlf.clone()).unwrap();
+    assert!(result.markdown.contains("Alpha"));
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "epub.mimetypeLayoutRecovered")
+    );
+    assert_eq!(convert_strict(crlf).unwrap_err().code(), ErrorCode::Malformed);
+
+    let trailing_space = epub_with_mimetype_content(&entries, b"application/epub+zip ");
+    assert_eq!(convert(trailing_space).unwrap_err().code(), ErrorCode::Malformed);
 }
 
 #[test]
@@ -383,8 +457,6 @@ fn package_version_metadata_navigation_and_multiple_rootfiles_follow_epub_contra
 
     let invalid = [
         base.replace("version=\"3.0\"", "version=\"3.future\""),
-        base.replace("<dc:language>en</dc:language>", ""),
-        base.replace("<meta property=\"dcterms:modified\">2026-08-13T00:00:00Z</meta>", ""),
         base.replace(" properties=\"nav\"", ""),
     ];
     for package in invalid {
@@ -408,10 +480,7 @@ fn package_version_metadata_navigation_and_multiple_rootfiles_follow_epub_contra
         ("OPS/images/cover.png", PNG),
         ("OPS/styles/book.css", b"body{}"),
     ]);
-    assert_eq!(
-        convert(bytes).unwrap().document.metadata.title.as_deref(),
-        Some("Original EPUB Three")
-    );
+    assert_eq!(convert(bytes).unwrap_err().code(), ErrorCode::Malformed);
 
     let too_deep = deep_nav(16);
     assert!(matches!(
@@ -470,7 +539,6 @@ fn encryption_metadata_distinguishes_font_obfuscation_from_drm() {
 fn package_reference_cycles_missing_ids_and_alias_entries_fail_closed() {
     let base = String::from_utf8(epub3_package().to_vec()).unwrap();
     let cases = [
-        base.replace("idref=\"two\"", "idref=\"missing\""),
         base.replace(
             "id=\"one\" href=\"text/one.xhtml\" media-type=\"application/xhtml+xml\"",
             "id=\"one\" href=\"text/one.xhtml\" media-type=\"application/xhtml+xml\" fallback=\"two\"",
@@ -514,6 +582,48 @@ fn package_reference_cycles_missing_ids_and_alias_entries_fail_closed() {
         ("OPS/styles/book.css", b"body{}"),
     ]);
     assert_eq!(convert(aliases).unwrap_err().code(), ErrorCode::Malformed);
+}
+
+#[test]
+fn missing_spine_targets_are_omitted_only_when_linear_content_remains() {
+    let base = String::from_utf8(epub3_package().to_vec()).unwrap();
+    for package in [
+        base.replace(
+            "<spine><itemref idref=\"one\"/>",
+            "<spine><itemref idref=\"missing-before\"/><itemref idref=\"one\"/>",
+        ),
+        base.replace("idref=\"two\"", "idref=\"missing-after\""),
+    ] {
+        let bytes = epub3_book(package.as_bytes(), Some(nav3()));
+        let result = convert(bytes.clone()).unwrap();
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "epub.spine.missingItemOmitted")
+        );
+        assert_eq!(convert_strict(bytes).unwrap_err().code(), ErrorCode::Malformed);
+    }
+
+    let all_missing = base
+        .replace("idref=\"one\"", "idref=\"missing-one\"")
+        .replace("idref=\"two\"", "idref=\"missing-two\"");
+    assert_eq!(
+        convert(epub3_book(all_missing.as_bytes(), Some(nav3()))).unwrap_err().code(),
+        ErrorCode::Malformed
+    );
+}
+
+#[test]
+fn empty_navigation_is_omitted_only_in_best_effort() {
+    let empty_nav = br#"<?xml version="1.0"?><!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"><body><nav epub:type="toc"><h2>Contents</h2><ol/></nav></body></html>"#;
+    let bytes = epub3_book(epub3_package(), Some(empty_nav));
+    let result = convert(bytes.clone()).unwrap();
+    assert!(result.markdown.contains("Alpha"));
+    assert!(
+        result.diagnostics.iter().any(|diagnostic| diagnostic.code == "epub.navigationOmitted")
+    );
+    assert_eq!(convert_strict(bytes).unwrap_err().code(), ErrorCode::Malformed);
 }
 
 #[test]

--- a/crates/api/src/epub_tests.rs
+++ b/crates/api/src/epub_tests.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Block, ConversionError, ConversionOptions, ConversionRequest, ErrorCode, ErrorPolicy,
-    ExecutionOptions, FormatHint, Inline, InputFormat, InputRef, default_engine,
+    Block, ConversionError, ConversionOptions, ConversionOutcome, ConversionRequest, ErrorCode,
+    ErrorPolicy, ExecutionOptions, FormatHint, Inline, InputFormat, InputRef, default_engine,
 };
 use std::fmt::Write as _;
 use std::future::Future;
@@ -285,6 +285,92 @@ fn only_reachable_styles_and_their_css_dependencies_are_reported_as_omitted() {
         .expect("linked resources must be disclosed");
     assert!(diagnostic.message.contains("1 reachable CSS"));
     assert!(diagnostic.message.contains("1 reachable font"));
+    assert_eq!(result.outcome(), ConversionOutcome::Degraded);
+}
+
+#[test]
+fn authoritative_outcome_distinguishes_compatibility_audit_from_content_loss() {
+    let package = br#"<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="book"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier id="book">outcome-contract</dc:identifier><dc:title>Outcome Contract</dc:title><dc:language>en</dc:language><meta property="dcterms:modified">2026-08-30T00:00:00Z</meta></metadata><manifest><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/><item id="chapter" href="chapter.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="chapter"/></spine></package>"#;
+    let navigation = br#"<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops"><body><nav epub:type="toc"><ol><li><a href="chapter.xhtml">Chapter</a></li></ol></nav></body></html>"#;
+    let chapter = chapter_two();
+    let common = [
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", package),
+        ("OPS/nav.xhtml", navigation),
+        ("OPS/chapter.xhtml", chapter),
+    ];
+
+    let mut audited_entries = common.to_vec();
+    audited_entries.push(("META-INF/rights.xml", b"<rights/>"));
+    let audited = convert(epub(&audited_entries)).unwrap();
+    assert!(audited.diagnostics.iter().any(|item| item.code == "epub.rightsMetadataIgnored"));
+    assert_eq!(
+        audited.outcome(),
+        ConversionOutcome::Complete,
+        "unexpected diagnostics: {:?}",
+        audited.diagnostics
+    );
+
+    let recovered = convert(noncanonical_mimetype_layout(&common, false, true, None)).unwrap();
+    assert!(recovered.diagnostics.iter().any(|item| item.code == "epub.mimetypeLayoutRecovered"));
+    assert_eq!(recovered.outcome(), ConversionOutcome::Complete);
+
+    let active = br#"<html xmlns="http://www.w3.org/1999/xhtml"><head><title>Active</title></head><body><main><script>discard()</script><p>Usable content.</p></main></body></html>"#;
+    let degraded = convert(epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", package),
+        ("OPS/nav.xhtml", navigation),
+        ("OPS/chapter.xhtml", active),
+    ]))
+    .unwrap();
+    assert!(degraded.diagnostics.iter().any(|item| item.code == "epub.spine.activeContentRemoved"));
+    assert_eq!(degraded.outcome(), ConversionOutcome::Degraded);
+}
+
+#[test]
+fn large_navigation_drops_raw_storage_and_a_late_spine_nav_is_read_once() {
+    let mut state = 0x1234_5678_u32;
+    let mut label = String::with_capacity(512 * 1024 + 4);
+    for _ in 0..512 * 1024 {
+        state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+        label.push(char::from(b'a' + u8::try_from((state >> 24) % 26).unwrap()));
+    }
+    label.push_str("TAIL");
+    let navigation = format!(
+        "<html xmlns=\"http://www.w3.org/1999/xhtml\" xmlns:epub=\"http://www.idpf.org/2007/ops\"><head><title>Contents</title></head><body><nav epub:type=\"toc\"><ol><li><a href=\"text/one.xhtml\">{label}</a></li></ol></nav></body></html>"
+    );
+    let package = br#"<?xml version="1.0"?><package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="book"><metadata xmlns:dc="http://purl.org/dc/elements/1.1/"><dc:identifier id="book">nav-memory</dc:identifier><dc:title>Navigation Memory</dc:title><dc:language>en</dc:language><meta property="dcterms:modified">2026-08-30T00:00:00Z</meta></metadata><manifest><item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" properties="nav"/><item id="one" href="text/one.xhtml" media-type="application/xhtml+xml"/></manifest><spine><itemref idref="one"/></spine></package>"#;
+    let mut options = ConversionOptions::default();
+    options.limits.max_memory_bytes = 32 * 1024 * 1024;
+    let outside_spine = convert_with(
+        epub(&[
+            ("META-INF/container.xml", container()),
+            ("OPS/content.opf", package),
+            ("OPS/nav.xhtml", navigation.as_bytes()),
+            ("OPS/text/one.xhtml", chapter_two()),
+        ]),
+        options.clone(),
+        ExecutionOptions::default(),
+    )
+    .unwrap();
+    assert!(outside_spine.markdown.contains("TAIL"));
+
+    let late_package = String::from_utf8(package.to_vec())
+        .unwrap()
+        .replace("</spine>", "<itemref idref=\"nav\"/></spine>");
+    let late_spine = convert_with(
+        epub(&[
+            ("META-INF/container.xml", container()),
+            ("OPS/content.opf", late_package.as_bytes()),
+            ("OPS/nav.xhtml", navigation.as_bytes()),
+            ("OPS/text/one.xhtml", chapter_two()),
+        ]),
+        options,
+        ExecutionOptions::default(),
+    )
+    .unwrap();
+    assert!(late_spine.markdown.contains("TAIL"));
+    assert!(late_spine.markdown.contains("Omega"));
 }
 
 #[test]

--- a/crates/api/src/epub_tests.rs
+++ b/crates/api/src/epub_tests.rs
@@ -256,7 +256,7 @@ fn epub3_spine_navigation_links_footnotes_and_referenced_image_are_stable() {
 fn only_reachable_styles_and_their_css_dependencies_are_reported_as_omitted() {
     let package = std::str::from_utf8(epub3_package()).unwrap().replace(
         "</manifest>",
-        r#"<item id="font" href="fonts/book.woff2" media-type="font/woff2"/></manifest>"#,
+        r#"<item id="imported" href="styles/imported.css" media-type="text/css"/><item id="font" href="fonts/book.woff2" media-type="font/woff2"/></manifest>"#,
     );
     let chapter = std::str::from_utf8(chapter_one()).unwrap().replace(
         "<title>Chapter One</title>",
@@ -273,7 +273,11 @@ fn only_reachable_styles_and_their_css_dependencies_are_reported_as_omitted() {
             b"<html xmlns='http://www.w3.org/1999/xhtml'><body><p>skip me</p></body></html>",
         ),
         ("OPS/images/cover.png", PNG),
-        ("OPS/styles/book.css", b"@font-face{src:url('../fonts/book.woff2')}"),
+        (
+            "OPS/styles/book.css",
+            br#"a{content:"url('../missing-string.woff2')"}/* url('../missing-comment.woff2') */@import url('imported.css');"#,
+        ),
+        ("OPS/styles/imported.css", b"@font-face{src:url('../fonts/book.woff2')}"),
         ("OPS/fonts/book.woff2", b"font"),
     ]);
 
@@ -283,9 +287,109 @@ fn only_reachable_styles_and_their_css_dependencies_are_reported_as_omitted() {
         .iter()
         .find(|item| item.code == "epub.linkedResourcesOmitted")
         .expect("linked resources must be disclosed");
-    assert!(diagnostic.message.contains("1 reachable CSS"));
+    assert!(diagnostic.message.contains("2 reachable CSS"));
     assert!(diagnostic.message.contains("1 reachable font"));
     assert_eq!(result.outcome(), ConversionOutcome::Degraded);
+}
+
+#[test]
+fn large_reachable_css_is_scanned_in_place_under_the_shared_memory_limit() {
+    let css = r#"a{content:"url('../missing-string.woff2')"}/* url('../missing-comment.woff2') */"#
+        .repeat(8 * 1024);
+    let chapter = std::str::from_utf8(chapter_one()).unwrap().replace(
+        "<title>Chapter One</title>",
+        r#"<title>Chapter One</title><link rel="stylesheet" href="../styles/book.css"/>"#,
+    );
+    let bytes = epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", epub3_package()),
+        ("OPS/nav.xhtml", nav3()),
+        ("OPS/text/one.xhtml", chapter.as_bytes()),
+        ("OPS/text/two.xhtml", chapter_two()),
+        (
+            "OPS/text/extra.xhtml",
+            b"<html xmlns='http://www.w3.org/1999/xhtml'><body><p>x</p></body></html>",
+        ),
+        ("OPS/images/cover.png", PNG),
+        ("OPS/styles/book.css", css.as_bytes()),
+    ]);
+    let mut options = ConversionOptions::default();
+    options.limits.max_memory_bytes = 8 * 1024 * 1024;
+    options.limits.max_archive_compression_ratio = 10_000;
+    let result = convert_with(bytes, options, ExecutionOptions::default()).unwrap();
+    assert!(result.markdown.contains("Alpha"));
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "epub.linkedResourcesOmitted")
+        .unwrap();
+    assert!(diagnostic.message.contains("1 reachable CSS"));
+    assert!(diagnostic.message.contains("0 reachable font"));
+}
+
+#[test]
+fn metadata_duplicate_ids_fail_only_when_they_make_retained_relationships_ambiguous() {
+    let base = String::from_utf8(epub3_package().to_vec()).unwrap();
+    let opaque = base.replace(
+        "</metadata>",
+        r#"<meta id="opaque" property="schema:first">first</meta><meta id="opaque" property="schema:second">second</meta></metadata>"#,
+    );
+    let result = convert(epub3_book(opaque.as_bytes(), Some(nav3()))).unwrap();
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "epub.metadataDuplicateIdOmitted")
+    );
+    assert_eq!(
+        result.document.metadata.properties.get("epub.meta.schema:first").map(String::as_str),
+        Some("first")
+    );
+    assert!(!result.document.metadata.properties.contains_key("epub.meta.schema:second"));
+    assert_eq!(
+        convert_strict(epub3_book(opaque.as_bytes(), Some(nav3()))).unwrap_err().code(),
+        ErrorCode::Malformed
+    );
+
+    for ambiguous in [
+        base.replace(
+            "</metadata>",
+            r#"<dc:identifier id="book-id">second</dc:identifier></metadata>"#,
+        ),
+        base.replace(
+            "</metadata>",
+            r##"<meta id="target" property="schema:first">first</meta><meta id="target" property="schema:second">second</meta><meta property="schema:relation" refines="#target">relation</meta></metadata>"##,
+        ),
+    ] {
+        assert_eq!(
+            convert(epub3_book(ambiguous.as_bytes(), Some(nav3()))).unwrap_err().code(),
+            ErrorCode::Malformed
+        );
+    }
+}
+
+#[test]
+fn matching_epub2_and_epub3_cover_declarations_are_not_conflicts() {
+    let epub3 = String::from_utf8(epub3_package().to_vec()).unwrap().replace(
+        "</metadata>",
+        r#"<meta name="cover" content="cover"/><meta name="cover" content="cover"/></metadata>"#,
+    );
+    assert_eq!(convert(epub3_book(epub3.as_bytes(), Some(nav3()))).unwrap().assets.len(), 1);
+
+    let epub2 = String::from_utf8(epub2_package().to_vec()).unwrap().replace(
+        r#"<meta name="cover" content="cover"/>"#,
+        r#"<meta name="cover" content="cover"/><meta name="cover" content="cover"/>"#,
+    );
+    let bytes = epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", epub2.as_bytes()),
+        ("OPS/text/toc.ncx", ncx2()),
+        ("OPS/text/dummy.svg", b"<svg xmlns='http://www.w3.org/2000/svg'/>"),
+        ("OPS/text/one.xhtml", epub2_one()),
+        ("OPS/text/two.xhtml", chapter_two()),
+        ("OPS/images/cover.png", PNG),
+    ]);
+    assert_eq!(convert(bytes).unwrap().assets.len(), 1);
 }
 
 #[test]

--- a/crates/converters/src/epub/container.rs
+++ b/crates/converters/src/epub/container.rs
@@ -124,8 +124,9 @@ pub(super) fn rootfile(
     if !root_seen || !rootfiles_seen || !stack.is_empty() {
         return Err(xml::malformed("container structure is incomplete"));
     }
-    candidates
-        .into_iter()
-        .next()
-        .ok_or_else(|| xml::malformed("container has no supported package rootfile"))
+    match candidates.as_slice() {
+        [path] => Ok(path.clone()),
+        [] => Err(xml::malformed("container has no supported package rootfile")),
+        _ => Err(xml::malformed("container has multiple supported package rootfiles")),
+    }
 }

--- a/crates/converters/src/epub/merge.rs
+++ b/crates/converters/src/epub/merge.rs
@@ -19,7 +19,7 @@ const PROVIDER: &str = "builtin.converter.epub";
 // Assembly owns the cross-module boundary values so all identity rewrites are transactional.
 pub(super) fn assemble(
     mut package: Package,
-    navigation: Option<Navigation>,
+    mut navigation: Option<Navigation>,
     mut spine: SpineResult,
     resources: ResourceStore,
     cover: Option<CoverResource>,
@@ -29,6 +29,16 @@ pub(super) fn assemble(
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
     context.checkpoint()?;
+    if let Some(navigation) = &mut navigation {
+        for entry in &mut navigation.entries {
+            if entry.target.as_deref().is_some_and(|target| {
+                let path = target.split_once('#').map_or(target, |(path, _)| path);
+                spine.omitted_paths.contains(path)
+            }) {
+                entry.target = None;
+            }
+        }
+    }
     let anchors = spine
         .chapters
         .iter()
@@ -50,6 +60,8 @@ pub(super) fn assemble(
     let metadata = std::mem::take(&mut package.metadata);
     let mut output =
         ConverterOutput::new(Document { metadata, ..Document::default() }, Vec::new(), Vec::new());
+    output.diagnostics.append(&mut package.diagnostics);
+    output.diagnostics.append(&mut spine.diagnostics);
     if let Some(navigation) = navigation {
         append_navigation(&mut output.document.blocks, navigation)?;
     }

--- a/crates/converters/src/epub/merge.rs
+++ b/crates/converters/src/epub/merge.rs
@@ -31,12 +31,19 @@ pub(super) fn assemble(
     context.checkpoint()?;
     if let Some(navigation) = &mut navigation {
         for entry in &mut navigation.entries {
-            if entry.target.as_deref().is_some_and(|target| {
-                let path = target.split_once('#').map_or(target, |(path, _)| path);
-                spine.omitted_paths.contains(path)
-            }) {
-                entry.target = None;
-            }
+            let Some(target) = entry.target.take() else { continue };
+            let (path, fragment) = target
+                .split_once('#')
+                .map_or((target.as_str(), None), |(path, fragment)| (path, Some(fragment)));
+            entry.target =
+                match spine.path_resolutions.get(path) {
+                    Some(None) => None,
+                    Some(Some(resolved)) if resolved != path => Some(fragment.map_or_else(
+                        || resolved.clone(),
+                        |fragment| format!("{resolved}#{fragment}"),
+                    )),
+                    _ => Some(target),
+                };
         }
     }
     let anchors = spine
@@ -56,6 +63,7 @@ pub(super) fn assemble(
         }
     }
     validate_targets(&spine, navigation.as_ref(), &anchors, &chapter_paths, &footnote_labels)?;
+    let recovery_memory = spine.recovery_memory;
 
     let metadata = std::mem::take(&mut package.metadata);
     let mut output =
@@ -181,7 +189,9 @@ pub(super) fn assemble(
             }
         }
     })?;
-    output.account_retained(context)
+    let output = output.account_retained(context)?;
+    drop(recovery_memory);
+    Ok(output)
 }
 
 fn non_linear_spine_diagnostic(skipped: usize, package_path: &str) -> Diagnostic {

--- a/crates/converters/src/epub/mod.rs
+++ b/crates/converters/src/epub/mod.rs
@@ -14,12 +14,13 @@ mod reachability;
 mod resources;
 mod spine;
 mod xhtml;
+mod xhtml_security;
 mod xml;
 
 #[cfg(test)]
 mod tests;
 
-use crate::zip_converter::archive_api::{OwnedEntry, SafeArchive};
+use crate::zip_converter::archive_api::SafeArchive;
 use budget::EpubBudget;
 use encryption::EncryptionPolicy;
 use into_markdown_core::{
@@ -135,18 +136,19 @@ async fn convert_epub(
         EncryptionPolicy::default()
     };
     let rights_metadata = archive.contains(RIGHTS_PATH);
-    let NavigationRead { navigation, chapter_entry } =
+    let NavigationRead { navigation, deferred_path } =
         read_navigation(&mut package, &mut archive, &mut budget, options.error_policy)?;
     let mut spine = spine::convert(
         &package,
         &mut archive,
-        chapter_entry,
+        deferred_path,
         options,
         services,
         &mut budget,
         context,
     )
     .await?;
+    let navigation = navigation.or_else(|| spine.navigation.take());
     let omitted = reachability::omitted_resources(
         &package,
         navigation.as_ref(),
@@ -243,6 +245,9 @@ fn read_navigation(
                 return Err(malformed(&item.path, "EPUB navigation item is not XHTML"));
             }
             let path = item.path.clone();
+            if spine::linear_spine_uses_path(package, &path)? {
+                return Ok(NavigationRead { navigation: None, deferred_path: Some(path) });
+            }
             let entry = archive.read(&path)?;
             let navigation =
                 navigation::parse_nav(&path, &entry.bytes, archive, budget, error_policy)?;
@@ -256,12 +261,9 @@ fn read_navigation(
                         ..SourceLocator::default()
                     }),
                 });
-                return Ok(NavigationRead { navigation: None, chapter_entry: Some((path, entry)) });
+                return Ok(NavigationRead { navigation: None, deferred_path: None });
             }
-            return Ok(NavigationRead {
-                navigation: Some(navigation),
-                chapter_entry: Some((path, entry)),
-            });
+            return Ok(NavigationRead { navigation: Some(navigation), deferred_path: None });
         }
         return Err(malformed(&package.path, "EPUB 3 navigation document is missing"));
     }
@@ -273,7 +275,7 @@ fn read_navigation(
             }
             let entry = archive.read(&item.path)?;
             return navigation::parse_ncx(&item.path, &entry.bytes, archive, budget).map(
-                |navigation| NavigationRead { navigation: Some(navigation), chapter_entry: None },
+                |navigation| NavigationRead { navigation: Some(navigation), deferred_path: None },
             );
         }
         return Err(malformed(&package.path, "EPUB 2 NCX navigation document is missing"));
@@ -283,7 +285,7 @@ fn read_navigation(
 
 struct NavigationRead {
     navigation: Option<Navigation>,
-    chapter_entry: Option<(String, OwnedEntry)>,
+    deferred_path: Option<String>,
 }
 
 fn malformed(part: &str, detail: impl Into<String>) -> ConversionError {

--- a/crates/converters/src/epub/mod.rs
+++ b/crates/converters/src/epub/mod.rs
@@ -1,4 +1,4 @@
-//! Strict, offline EPUB 2/3 conversion.
+//! Security-hardened, offline EPUB 2/3 conversion.
 
 mod budget;
 mod container;
@@ -19,12 +19,13 @@ mod xml;
 #[cfg(test)]
 mod tests;
 
-use crate::zip_converter::archive_api::SafeArchive;
+use crate::zip_converter::archive_api::{OwnedEntry, SafeArchive};
 use budget::EpubBudget;
 use encryption::EncryptionPolicy;
 use into_markdown_core::{
-    BoxFuture, ConversionError, ConversionOptions, Converter, ConverterOutput, ExecutionContext,
-    FormatCandidate, InputFormat, ProbeOutcome, ResolvedInput, Services,
+    BoxFuture, ConversionError, ConversionOptions, Converter, ConverterOutput, Diagnostic,
+    DiagnosticSeverity, ErrorPolicy, ExecutionContext, FormatCandidate, InputFormat, ProbeOutcome,
+    ResolvedInput, Services, SourceLocator,
 };
 use navigation::Navigation;
 use resources::ResourceStore;
@@ -101,7 +102,7 @@ async fn convert_epub(
 ) -> Result<ConverterOutput, ConversionError> {
     context.checkpoint()?;
     let mut archive = SafeArchive::open(bytes, options, context)?;
-    validate_mimetype(&mut archive)?;
+    let mimetype_diagnostic = validate_mimetype(&mut archive, options.error_policy)?;
     if !archive.contains(CONTAINER_PATH) {
         return Err(malformed(CONTAINER_PATH, "OCF container document is missing"));
     }
@@ -113,8 +114,17 @@ async fn convert_epub(
         return Err(malformed(&package_path, "package rootfile is missing"));
     }
     let package_entry = archive.read(&package_path)?;
-    let package = package::parse(&package_path, &package_entry.bytes, &archive, &mut budget)?;
+    let mut package = package::parse(
+        &package_path,
+        &package_entry.bytes,
+        &archive,
+        &mut budget,
+        options.error_policy,
+    )?;
     drop(package_entry);
+    if let Some(diagnostic) = mimetype_diagnostic {
+        package.diagnostics.push(diagnostic);
+    }
 
     let encryption = if archive.contains(ENCRYPTION_PATH) {
         let entry = archive.read(ENCRYPTION_PATH)?;
@@ -125,9 +135,18 @@ async fn convert_epub(
         EncryptionPolicy::default()
     };
     let rights_metadata = archive.contains(RIGHTS_PATH);
-    let navigation = read_navigation(&package, &mut archive, &mut budget)?;
-    let mut spine =
-        spine::convert(&package, &mut archive, options, services, &mut budget, context).await?;
+    let NavigationRead { navigation, chapter_entry } =
+        read_navigation(&mut package, &mut archive, &mut budget, options.error_policy)?;
+    let mut spine = spine::convert(
+        &package,
+        &mut archive,
+        chapter_entry,
+        options,
+        services,
+        &mut budget,
+        context,
+    )
+    .await?;
     let omitted = reachability::omitted_resources(
         &package,
         navigation.as_ref(),
@@ -146,6 +165,7 @@ async fn convert_epub(
         )?;
     }
     let cover = resources.cover(&package, &mut archive, context)?;
+    archive.validate_remaining()?;
     merge::assemble(
         package,
         navigation,
@@ -159,36 +179,61 @@ async fn convert_epub(
     )
 }
 
-fn validate_mimetype(archive: &mut SafeArchive<'_, '_>) -> Result<(), ConversionError> {
-    let first = archive
-        .first_physical_entry()
-        .ok_or_else(|| malformed("mimetype", "EPUB archive is empty"))?;
-    if first.path != "mimetype"
-        || first.directory
-        || !first.stored
-        || first.physical_start != 0
-        || first.central_extra_len != 0
-        || first.local_extra_len != 0
-        || first.expanded_size != u64::try_from(MIMETYPE.len()).unwrap_or(u64::MAX)
-        || first.compressed_size != first.expanded_size
-    {
+fn validate_mimetype(
+    archive: &mut SafeArchive<'_, '_>,
+    error_policy: ErrorPolicy,
+) -> Result<Option<Diagnostic>, ConversionError> {
+    let canonical_layout = {
+        let first = archive
+            .first_physical_entry()
+            .ok_or_else(|| malformed("mimetype", "EPUB archive is empty"))?;
+        let mimetype = archive
+            .info("mimetype")
+            .ok_or_else(|| malformed("mimetype", "EPUB mimetype entry is missing"))?;
+        if mimetype.directory {
+            return Err(malformed("mimetype", "mimetype must be a file"));
+        }
+        first.path == "mimetype"
+            && mimetype.stored
+            && mimetype.physical_start == 0
+            && mimetype.central_extra_len == 0
+            && mimetype.local_extra_len == 0
+            && mimetype.expanded_size == u64::try_from(MIMETYPE.len()).unwrap_or(u64::MAX)
+            && mimetype.compressed_size == mimetype.expanded_size
+    };
+    let entry = archive.read("mimetype")?;
+    let canonical_content = entry.bytes == MIMETYPE;
+    let crlf_content = entry.bytes.strip_suffix(b"\r\n") == Some(MIMETYPE);
+    if !canonical_content && !crlf_content {
+        return Err(malformed("mimetype", "mimetype content is not application/epub+zip"));
+    }
+    if canonical_layout && canonical_content {
+        return Ok(None);
+    }
+    if error_policy == ErrorPolicy::Strict {
         return Err(malformed(
             "mimetype",
             "mimetype must be the physical first entry, stored, have no extra fields, and use the exact length",
         ));
     }
-    let entry = archive.read("mimetype")?;
-    if entry.bytes != MIMETYPE {
-        return Err(malformed("mimetype", "mimetype content is not application/epub+zip"));
-    }
-    Ok(())
+    Ok(Some(Diagnostic {
+        code: "epub.mimetypeLayoutRecovered".into(),
+        severity: DiagnosticSeverity::Info,
+        message: if crlf_content {
+            "accepted an EPUB mimetype entry with a non-canonical trailing CRLF".into()
+        } else {
+            "accepted a valid EPUB mimetype entry with a non-canonical ZIP layout".into()
+        },
+        locator: Some(SourceLocator { part: Some("mimetype".into()), ..SourceLocator::default() }),
+    }))
 }
 
 fn read_navigation(
-    package: &package::Package,
+    package: &mut package::Package,
     archive: &mut SafeArchive<'_, '_>,
     budget: &mut EpubBudget<'_>,
-) -> Result<Option<Navigation>, ConversionError> {
+    error_policy: ErrorPolicy,
+) -> Result<NavigationRead, ConversionError> {
     let version =
         package.metadata.properties.get("epub.version").map(String::as_str).unwrap_or_default();
     if version.starts_with('3') {
@@ -197,8 +242,26 @@ fn read_navigation(
             if item.media_type != "application/xhtml+xml" {
                 return Err(malformed(&item.path, "EPUB navigation item is not XHTML"));
             }
-            let entry = archive.read(&item.path)?;
-            return navigation::parse_nav(&item.path, &entry.bytes, archive, budget).map(Some);
+            let path = item.path.clone();
+            let entry = archive.read(&path)?;
+            let navigation =
+                navigation::parse_nav(&path, &entry.bytes, archive, budget, error_policy)?;
+            if navigation.entries.is_empty() {
+                package.diagnostics.push(Diagnostic {
+                    code: "epub.navigationOmitted".into(),
+                    severity: DiagnosticSeverity::Info,
+                    message: "an empty EPUB navigation document was omitted".into(),
+                    locator: Some(SourceLocator {
+                        part: Some(path.clone()),
+                        ..SourceLocator::default()
+                    }),
+                });
+                return Ok(NavigationRead { navigation: None, chapter_entry: Some((path, entry)) });
+            }
+            return Ok(NavigationRead {
+                navigation: Some(navigation),
+                chapter_entry: Some((path, entry)),
+            });
         }
         return Err(malformed(&package.path, "EPUB 3 navigation document is missing"));
     }
@@ -209,11 +272,18 @@ fn read_navigation(
                 return Err(malformed(&item.path, "EPUB NCX item has the wrong media type"));
             }
             let entry = archive.read(&item.path)?;
-            return navigation::parse_ncx(&item.path, &entry.bytes, archive, budget).map(Some);
+            return navigation::parse_ncx(&item.path, &entry.bytes, archive, budget).map(
+                |navigation| NavigationRead { navigation: Some(navigation), chapter_entry: None },
+            );
         }
         return Err(malformed(&package.path, "EPUB 2 NCX navigation document is missing"));
     }
     Err(malformed(&package.path, "unsupported EPUB package version"))
+}
+
+struct NavigationRead {
+    navigation: Option<Navigation>,
+    chapter_entry: Option<(String, OwnedEntry)>,
 }
 
 fn malformed(part: &str, detail: impl Into<String>) -> ConversionError {

--- a/crates/converters/src/epub/navigation.rs
+++ b/crates/converters/src/epub/navigation.rs
@@ -6,7 +6,7 @@ use super::budget::EpubBudget;
 use super::path::{BasePath, Reference};
 use super::xml::{self, Name};
 use crate::zip_converter::archive_api::SafeArchive;
-use into_markdown_core::ConversionError;
+use into_markdown_core::{ConversionError, ErrorPolicy};
 use quick_xml::events::Event;
 use std::collections::BTreeSet;
 
@@ -58,6 +58,7 @@ pub(super) fn parse_nav(
     bytes: &[u8],
     archive: &SafeArchive<'_, '_>,
     budget: &mut EpubBudget<'_>,
+    error_policy: ErrorPolicy,
 ) -> Result<Navigation, ConversionError> {
     let mut reader = xml::reader(bytes);
     let initial_base = BasePath::document(path)?;
@@ -243,7 +244,7 @@ pub(super) fn parse_nav(
                     {
                         append_label_text(parent, " ", budget)?;
                     }
-                    close_nav_frame(frame, &mut stack, &mut entries, budget)?;
+                    close_nav_frame(frame, &mut stack, &mut entries, budget, error_policy)?;
                 } else {
                     stack.push(frame);
                 }
@@ -254,7 +255,7 @@ pub(super) fn parse_nav(
                 if xml::end_name(&reader, element.name())? != frame.name {
                     return Err(xml::malformed("navigation end tag namespace mismatch"));
                 }
-                close_nav_frame(frame, &mut stack, &mut entries, budget)?;
+                close_nav_frame(frame, &mut stack, &mut entries, budget, error_policy)?;
             }
             Event::Text(_) | Event::CData(_) | Event::GeneralRef(_) => {
                 let text = xml::decoded_text(&event)?.unwrap_or_default();
@@ -283,8 +284,11 @@ pub(super) fn parse_nav(
             Event::DocType(_) | Event::Comment(_) | Event::Decl(_) => {}
         }
     }
-    if !root_seen || !toc_seen || !stack.is_empty() || entries.is_empty() {
+    if !root_seen || !toc_seen || !stack.is_empty() {
         return Err(xml::malformed("EPUB navigation toc is missing or incomplete"));
+    }
+    if entries.is_empty() && error_policy == ErrorPolicy::Strict {
+        return Err(xml::malformed("EPUB navigation toc contains no entries"));
     }
     budget.items("navigation", entries.len())?;
     Ok(Navigation { source_path: path.into(), entries, resource_paths })
@@ -295,6 +299,7 @@ fn close_nav_frame(
     stack: &mut [Frame],
     entries: &mut Vec<NavEntry>,
     budget: &EpubBudget<'_>,
+    error_policy: ErrorPolicy,
 ) -> Result<(), ConversionError> {
     if frame.in_toc && label_policy::is_label_content(&frame.name) {
         label_policy::validate_child_count(&frame.name, frame.child_elements)?;
@@ -313,18 +318,23 @@ fn close_nav_frame(
         parent.missing_alternative |= missing_alternative;
     }
     frame.missing_alternative = missing_alternative;
-    finish_nav_frame(frame, entries, budget)
+    finish_nav_frame(frame, entries, budget, error_policy)
 }
 
 fn finish_nav_frame(
     frame: Frame,
     entries: &mut Vec<NavEntry>,
     budget: &EpubBudget<'_>,
+    error_policy: ErrorPolicy,
 ) -> Result<(), ConversionError> {
     if frame.toc_root && frame.nested_lists != 1 {
         return Err(xml::malformed("EPUB toc nav must contain exactly one direct ol"));
     }
-    if frame.in_toc && frame.name.matches(Some(XHTML_NS), b"ol") && frame.list_items == 0 {
+    if frame.in_toc
+        && frame.name.matches(Some(XHTML_NS), b"ol")
+        && frame.list_items == 0
+        && error_policy == ErrorPolicy::Strict
+    {
         return Err(xml::malformed("EPUB toc ol must contain at least one direct li"));
     }
     if frame.in_toc && frame.name.matches(Some(XHTML_NS), b"li") && frame.label_sources != 1 {

--- a/crates/converters/src/epub/package.rs
+++ b/crates/converters/src/epub/package.rs
@@ -66,6 +66,7 @@ struct Frame {
     meta_content: Option<String>,
     meta_property: Option<String>,
     meta_refines: Option<String>,
+    duplicate_metadata_id: bool,
 }
 
 #[allow(clippy::too_many_lines)] // OPF section and reference invariants are checked in one pass.
@@ -82,6 +83,9 @@ pub(super) fn parse(
     let mut root_seen = false;
     let mut sections = BTreeSet::new();
     let mut ids = BTreeSet::new();
+    let mut metadata_ids = BTreeSet::new();
+    let mut duplicate_metadata_ids = BTreeSet::new();
+    let mut refined_metadata_ids = BTreeSet::new();
     let mut manifest_paths = BTreeSet::new();
     let mut manifest = BTreeMap::new();
     let mut spine = Vec::new();
@@ -120,12 +124,30 @@ pub(super) fn parse(
                 let base = xml::optional(&attributes, Some(xml::XML_NS), b"base")
                     .map_or_else(|| Ok(parent_base.clone()), |value| parent_base.apply(value))?;
                 let id = xml::optional(&attributes, None, b"id").map(str::to_owned);
-                if let Some(id) = &id
-                    && (!valid_id(id) || !ids.insert(id.clone()))
-                {
-                    return Err(xml::malformed("package contains an invalid or duplicate ID"));
-                }
                 let depth = stack.len() + 1;
+                let metadata_child = depth == 3
+                    && stack
+                        .last()
+                        .is_some_and(|frame| frame.name.matches(Some(OPF_NS), b"metadata"));
+                let mut duplicate_metadata_id = false;
+                if let Some(id) = &id {
+                    if !valid_id(id) {
+                        return Err(xml::malformed("package contains an invalid ID"));
+                    }
+                    if !ids.insert(id.clone()) {
+                        if error_policy == ErrorPolicy::BestEffort
+                            && metadata_child
+                            && metadata_ids.contains(id)
+                        {
+                            duplicate_metadata_ids.insert(id.clone());
+                            duplicate_metadata_id = true;
+                        } else {
+                            return Err(xml::malformed("package contains a duplicate ID"));
+                        }
+                    } else if metadata_child {
+                        metadata_ids.insert(id.clone());
+                    }
+                }
                 if depth == 1 {
                     if !name.matches(Some(OPF_NS), b"package") {
                         return Err(xml::malformed("expected OPF package root and namespace"));
@@ -171,10 +193,8 @@ pub(super) fn parse(
                     {
                         return Err(xml::malformed("multiple EPUB navigation items"));
                     }
-                    if item.properties.contains("cover-image")
-                        && cover_id.replace(item.id.clone()).is_some()
-                    {
-                        return Err(xml::malformed("multiple EPUB cover-image items"));
+                    if item.properties.contains("cover-image") {
+                        select_cover(&mut cover_id, item.id.clone())?;
                     }
                     if manifest.insert(item.id.clone(), item).is_some() {
                         return Err(xml::malformed("duplicate manifest item ID"));
@@ -205,7 +225,15 @@ pub(super) fn parse(
                     meta_content: xml::optional(&attributes, None, b"content").map(str::to_owned),
                     meta_property: xml::optional(&attributes, None, b"property").map(str::to_owned),
                     meta_refines: xml::optional(&attributes, None, b"refines").map(str::to_owned),
+                    duplicate_metadata_id,
                 };
+                if metadata_child
+                    && !duplicate_metadata_id
+                    && let Some(target) = frame.meta_refines.as_deref()
+                    && let Some(target) = target.strip_prefix('#')
+                {
+                    refined_metadata_ids.insert(target.to_owned());
+                }
                 if empty {
                     finish_frame(
                         frame,
@@ -263,6 +291,27 @@ pub(super) fn parse(
     }
     let unique_identifier =
         unique_identifier.ok_or_else(|| xml::malformed("unique identifier missing"))?;
+    if duplicate_metadata_ids.contains(&unique_identifier)
+        || duplicate_metadata_ids.iter().any(|id| refined_metadata_ids.contains(id))
+    {
+        return Err(xml::malformed(
+            "duplicate metadata ID makes unique-identifier or refines relationships ambiguous",
+        ));
+    }
+    if !duplicate_metadata_ids.is_empty() {
+        diagnostics.push(Diagnostic {
+            code: "epub.metadataDuplicateIdOmitted".into(),
+            severity: DiagnosticSeverity::Info,
+            message: format!(
+                "omitted {} metadata field(s) with duplicate unreferenced IDs",
+                duplicate_metadata_ids.len()
+            ),
+            locator: Some(SourceLocator {
+                part: Some(package_path.into()),
+                ..SourceLocator::default()
+            }),
+        });
+    }
     let identifier =
         identifiers.get(&unique_identifier).filter(|value| !value.is_empty()).ok_or_else(|| {
             xml::malformed("package unique-identifier does not name a non-empty dc:identifier")
@@ -386,6 +435,9 @@ fn finish_frame(
     modified: &mut Option<String>,
     budget: &EpubBudget<'_>,
 ) -> Result<(), ConversionError> {
+    if frame.duplicate_metadata_id {
+        return Ok(());
+    }
     let text = normalize(&frame.text);
     budget.field("metadata field", text.len())?;
     if frame.name.namespace.as_deref() == Some(DC_NS) {
@@ -394,7 +446,7 @@ fn finish_frame(
             b"creator" if !text.is_empty() => metadata.authors.push(text),
             b"identifier" if !text.is_empty() => {
                 if let Some(id) = frame.id {
-                    identifiers.insert(id, text);
+                    identifiers.entry(id).or_insert(text);
                 }
             }
             b"language" if !text.is_empty() => {
@@ -412,9 +464,7 @@ fn finish_frame(
                 .meta_content
                 .filter(|value| !value.is_empty())
                 .ok_or_else(|| xml::malformed("EPUB 2 cover meta is missing its manifest ID"))?;
-            if cover_id.replace(value).is_some() {
-                return Err(xml::malformed("multiple EPUB 2 cover metadata entries"));
-            }
+            select_cover(cover_id, value)?;
         } else if let Some(property) = frame.meta_property
             && !text.is_empty()
         {
@@ -426,6 +476,15 @@ fn finish_frame(
                 metadata.properties.entry(format!("epub.meta.{property}")).or_insert(text);
             }
         }
+    }
+    Ok(())
+}
+
+fn select_cover(cover_id: &mut Option<String>, value: String) -> Result<(), ConversionError> {
+    match cover_id {
+        None => *cover_id = Some(value),
+        Some(current) if current == &value => {}
+        Some(_) => return Err(xml::malformed("conflicting EPUB cover declarations")),
     }
     Ok(())
 }

--- a/crates/converters/src/epub/package.rs
+++ b/crates/converters/src/epub/package.rs
@@ -4,7 +4,9 @@ use super::budget::EpubBudget;
 use super::path::{BasePath, Reference};
 use super::xml::{self, Attribute, Name};
 use crate::zip_converter::archive_api::SafeArchive;
-use into_markdown_core::{ConversionError, DocumentMetadata};
+use into_markdown_core::{
+    ConversionError, Diagnostic, DiagnosticSeverity, DocumentMetadata, ErrorPolicy, SourceLocator,
+};
 use quick_xml::events::Event;
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -35,6 +37,7 @@ pub(super) struct Package {
     pub(super) nav_id: Option<String>,
     pub(super) ncx_id: Option<String>,
     pub(super) cover_id: Option<String>,
+    pub(super) diagnostics: Vec<Diagnostic>,
 }
 
 impl Package {
@@ -71,6 +74,7 @@ pub(super) fn parse(
     bytes: &[u8],
     archive: &SafeArchive<'_, '_>,
     budget: &mut EpubBudget<'_>,
+    error_policy: ErrorPolicy,
 ) -> Result<Package, ConversionError> {
     let mut reader = xml::reader(bytes);
     let initial_base = BasePath::document(package_path)?;
@@ -90,6 +94,7 @@ pub(super) fn parse(
     let mut ncx_id = None;
     let mut cover_id = None;
     let mut modified = None;
+    let mut diagnostics = Vec::new();
     let mut document_events = xml::DocumentEvents::default();
     loop {
         let event = reader.read_event().map_err(|error| xml::malformed(error.to_string()))?;
@@ -263,21 +268,62 @@ pub(super) fn parse(
             xml::malformed("package unique-identifier does not name a non-empty dc:identifier")
         })?;
     if metadata.title.as_deref().is_none_or(str::is_empty) {
-        return Err(xml::malformed("package dc:title is missing"));
+        if error_policy == ErrorPolicy::Strict {
+            return Err(xml::malformed("package dc:title is missing"));
+        }
+        diagnostics.push(metadata_missing_diagnostic(
+            package_path,
+            "package dc:title is missing; chapter titles and paths remain available",
+        ));
     }
     if metadata.properties.get("epub.language").is_none_or(String::is_empty) {
-        return Err(xml::malformed("package dc:language is missing"));
+        if error_policy == ErrorPolicy::Strict {
+            return Err(xml::malformed("package dc:language is missing"));
+        }
+        diagnostics.push(metadata_missing_diagnostic(
+            package_path,
+            "package dc:language is missing; content language remains unspecified",
+        ));
     }
     let version = version.ok_or_else(|| xml::malformed("package version missing"))?;
     if version.starts_with('3') {
-        let modified = modified
-            .as_deref()
-            .filter(|value| valid_modified(value))
-            .ok_or_else(|| xml::malformed("EPUB 3 dcterms:modified is missing or invalid"))?;
-        metadata.properties.insert("epub.meta.dcterms:modified".into(), modified.into());
+        match modified.as_deref().filter(|value| valid_modified(value)) {
+            Some(modified) => {
+                metadata.properties.insert("epub.meta.dcterms:modified".into(), modified.into());
+            }
+            None if error_policy == ErrorPolicy::Strict => {
+                return Err(xml::malformed("EPUB 3 dcterms:modified is missing or invalid"));
+            }
+            None => diagnostics.push(metadata_missing_diagnostic(
+                package_path,
+                "EPUB 3 dcterms:modified is missing or invalid; content ordering is unaffected",
+            )),
+        }
     }
     metadata.properties.insert("epub.identifier".into(), identifier.clone());
     metadata.properties.insert("epub.version".into(), version);
+    let missing_spine_items =
+        spine.iter().filter(|item| !manifest.contains_key(&item.idref)).count();
+    if missing_spine_items != 0 {
+        if error_policy == ErrorPolicy::Strict {
+            return Err(xml::malformed("spine itemref names a missing manifest item"));
+        }
+        spine.retain(|item| manifest.contains_key(&item.idref));
+        if !spine.iter().any(|item| item.linear) {
+            return Err(xml::malformed("all linear spine itemrefs name missing manifest items"));
+        }
+        diagnostics.push(Diagnostic {
+            code: "epub.spine.missingItemOmitted".into(),
+            severity: DiagnosticSeverity::Warning,
+            message: format!(
+                "omitted {missing_spine_items} spine itemref(s) with no manifest declaration"
+            ),
+            locator: Some(SourceLocator {
+                part: Some(package_path.into()),
+                ..SourceLocator::default()
+            }),
+        });
+    }
     validate_references(
         &manifest,
         &spine,
@@ -285,7 +331,28 @@ pub(super) fn parse(
         ncx_id.as_deref(),
         cover_id.as_deref(),
     )?;
-    Ok(Package { path: package_path.into(), metadata, manifest, spine, nav_id, ncx_id, cover_id })
+    Ok(Package {
+        path: package_path.into(),
+        metadata,
+        manifest,
+        spine,
+        nav_id,
+        ncx_id,
+        cover_id,
+        diagnostics,
+    })
+}
+
+fn metadata_missing_diagnostic(package_path: &str, message: &str) -> Diagnostic {
+    Diagnostic {
+        code: "epub.metadataMissing".into(),
+        severity: DiagnosticSeverity::Info,
+        message: message.into(),
+        locator: Some(SourceLocator {
+            part: Some(package_path.into()),
+            ..SourceLocator::default()
+        }),
+    }
 }
 
 fn manifest_item(

--- a/crates/converters/src/epub/path.rs
+++ b/crates/converters/src/epub/path.rs
@@ -20,6 +20,10 @@ pub(super) enum Reference {
 }
 
 impl BasePath {
+    pub(super) fn retained_path_bytes(&self) -> usize {
+        self.path.capacity()
+    }
+
     pub(super) fn document(path: &str) -> Result<Self, ConversionError> {
         Ok(Self { path: portable_identity(path, false)?, directory: false })
     }

--- a/crates/converters/src/epub/reachability.rs
+++ b/crates/converters/src/epub/reachability.rs
@@ -47,7 +47,7 @@ pub(super) fn omitted_resources(
             "text/css" => {
                 omitted.css += 1;
                 let entry = archive.read(&path)?;
-                let references = css_references(&path, &entry.bytes, archive)?;
+                let references = css_references(&path, &entry.bytes, archive, context)?;
                 drop(entry);
                 queue.extend(references);
             }
@@ -65,86 +65,189 @@ fn css_references(
     path: &str,
     bytes: &[u8],
     archive: &SafeArchive<'_, '_>,
+    context: &ExecutionContext,
 ) -> Result<BTreeSet<String>, ConversionError> {
     let text = std::str::from_utf8(bytes).map_err(|_| ConversionError::Malformed {
         part: Some(path.into()),
         detail: "reachable CSS resource is not UTF-8".into(),
     })?;
-    let without_comments = strip_comments(text);
-    let lower = without_comments.to_ascii_lowercase();
     let base = BasePath::document(path)?;
-    let mut values = Vec::new();
-    let mut cursor = 0;
-    while let Some(relative) = lower[cursor..].find("url(") {
-        let start = cursor + relative + 4;
-        let end =
-            without_comments[start..].find(')').ok_or_else(|| ConversionError::Malformed {
-                part: Some(path.into()),
-                detail: "reachable CSS contains an unterminated url()".into(),
-            })? + start;
-        values.push(trim_css_url(&without_comments[start..end])?);
-        cursor = end + 1;
-    }
-    cursor = 0;
-    while let Some(relative) = lower[cursor..].find("@import") {
-        let start = cursor + relative + "@import".len();
-        let tail = without_comments[start..].trim_start();
-        if let Some(quote @ ('\'' | '"')) = tail.chars().next() {
-            let value = &tail[quote.len_utf8()..];
-            let end = value.find(quote).ok_or_else(|| ConversionError::Malformed {
-                part: Some(path.into()),
-                detail: "reachable CSS contains an unterminated @import".into(),
-            })?;
-            values.push(value[..end].trim());
-        }
-        cursor = start;
-    }
+    let bytes = text.as_bytes();
     let mut output = BTreeSet::new();
-    for value in values {
-        if value.is_empty() || value.starts_with('#') || value.starts_with("data:") {
+    let mut cursor = 0;
+    let mut next_checkpoint = 4 * 1024;
+    while cursor < bytes.len() {
+        if cursor >= next_checkpoint {
+            context.checkpoint()?;
+            next_checkpoint = next_checkpoint.saturating_add(4 * 1024);
+        }
+        if starts_comment(bytes, cursor) {
+            cursor = skip_comment(bytes, cursor);
             continue;
         }
-        let reference = base.resolve(value)?.require_existing(archive)?;
-        if let Reference::Internal { path, .. } = reference {
-            output.insert(path);
+        if matches!(bytes[cursor], b'\'' | b'"') {
+            cursor = quoted_value(text, cursor)?.1;
+            continue;
         }
+        if bytes[cursor] == b'@' {
+            let name_start = cursor + 1;
+            let name_end = identifier_end(bytes, name_start);
+            if bytes[name_start..name_end].eq_ignore_ascii_case(b"import") {
+                let start = skip_layout(bytes, name_end);
+                if start < bytes.len() && matches!(bytes[start], b'\'' | b'"') {
+                    let (value, end) = quoted_value(text, start)?;
+                    insert_reference(value, &base, archive, &mut output)?;
+                    cursor = end;
+                    continue;
+                }
+                let token_end = identifier_end(bytes, start);
+                if bytes[start..token_end].eq_ignore_ascii_case(b"url") {
+                    let open = skip_layout(bytes, token_end);
+                    if bytes.get(open) == Some(&b'(') {
+                        let (value, end) = url_value(text, open)?;
+                        insert_reference(value, &base, archive, &mut output)?;
+                        cursor = end;
+                        continue;
+                    }
+                }
+            }
+            cursor = name_end.max(cursor + 1);
+            continue;
+        }
+        if identifier_byte(bytes[cursor]) {
+            let end = identifier_end(bytes, cursor);
+            if bytes[cursor..end].eq_ignore_ascii_case(b"url") {
+                let open = skip_layout(bytes, end);
+                if bytes.get(open) == Some(&b'(') {
+                    let (value, end) = url_value(text, open)?;
+                    insert_reference(value, &base, archive, &mut output)?;
+                    cursor = end;
+                    continue;
+                }
+            }
+            cursor = end;
+            continue;
+        }
+        cursor += 1;
     }
     Ok(output)
 }
 
-fn trim_css_url(value: &str) -> Result<&str, ConversionError> {
+fn insert_reference(
+    value: &str,
+    base: &BasePath,
+    archive: &SafeArchive<'_, '_>,
+    output: &mut BTreeSet<String>,
+) -> Result<(), ConversionError> {
     let value = value.trim();
-    if let Some(quote @ ('\'' | '"')) = value.chars().next() {
-        return value
-            .strip_prefix(quote)
-            .and_then(|value| value.strip_suffix(quote))
-            .map(str::trim)
-            .ok_or_else(|| ConversionError::Malformed {
-                part: None,
-                detail: "reachable CSS contains mismatched url() quotes".into(),
-            });
+    if value.is_empty()
+        || value.starts_with('#')
+        || value.get(..5).is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:"))
+    {
+        return Ok(());
     }
-    Ok(value)
+    let reference = base.resolve(value)?.require_existing(archive)?;
+    if let Reference::Internal { path, .. } = reference {
+        output.insert(path);
+    }
+    Ok(())
 }
 
-fn strip_comments(value: &str) -> String {
-    let mut output = String::with_capacity(value.len());
-    let mut remaining = value;
-    while let Some(start) = remaining.find("/*") {
-        output.push_str(&remaining[..start]);
-        let Some(end) = remaining[start + 2..].find("*/") else { return output };
-        remaining = &remaining[start + 2 + end + 2..];
+fn url_value(text: &str, open: usize) -> Result<(&str, usize), ConversionError> {
+    let bytes = text.as_bytes();
+    let start = skip_layout(bytes, open + 1);
+    if start >= bytes.len() {
+        return Err(malformed_css("unterminated url()"));
     }
-    output.push_str(remaining);
-    output
+    if matches!(bytes[start], b'\'' | b'"') {
+        let (value, end) = quoted_value(text, start)?;
+        let close = skip_layout(bytes, end);
+        if bytes.get(close) != Some(&b')') {
+            return Err(malformed_css("url() has trailing tokens or no closing parenthesis"));
+        }
+        return Ok((value, close + 1));
+    }
+    let mut cursor = start;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b')' => return Ok((&text[start..cursor], cursor + 1)),
+            b'\\' => cursor = (cursor + 2).min(bytes.len()),
+            b'\'' | b'"' => return Err(malformed_css("url() contains an unexpected quote")),
+            _ => cursor += 1,
+        }
+    }
+    Err(malformed_css("unterminated url()"))
+}
+
+fn quoted_value(text: &str, start: usize) -> Result<(&str, usize), ConversionError> {
+    let bytes = text.as_bytes();
+    let quote = bytes[start];
+    let value_start = start + 1;
+    let mut cursor = value_start;
+    while cursor < bytes.len() {
+        match bytes[cursor] {
+            b'\\' => cursor = (cursor + 2).min(bytes.len()),
+            value if value == quote => return Ok((&text[value_start..cursor], cursor + 1)),
+            _ => cursor += 1,
+        }
+    }
+    Err(malformed_css("unterminated string"))
+}
+
+fn skip_layout(bytes: &[u8], mut cursor: usize) -> usize {
+    loop {
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        if !starts_comment(bytes, cursor) {
+            return cursor;
+        }
+        cursor = skip_comment(bytes, cursor);
+    }
+}
+
+fn starts_comment(bytes: &[u8], cursor: usize) -> bool {
+    bytes.get(cursor) == Some(&b'/') && bytes.get(cursor + 1) == Some(&b'*')
+}
+
+fn skip_comment(bytes: &[u8], mut cursor: usize) -> usize {
+    cursor += 2;
+    while cursor + 1 < bytes.len() {
+        if bytes[cursor] == b'*' && bytes[cursor + 1] == b'/' {
+            return cursor + 2;
+        }
+        cursor += 1;
+    }
+    bytes.len()
+}
+
+fn identifier_end(bytes: &[u8], mut cursor: usize) -> usize {
+    while bytes.get(cursor).is_some_and(|byte| identifier_byte(*byte)) {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_')
+}
+
+fn malformed_css(detail: &str) -> ConversionError {
+    ConversionError::Malformed { part: None, detail: format!("reachable CSS contains {detail}") }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::strip_comments;
+    use super::{identifier_end, quoted_value, skip_comment, skip_layout, url_value};
 
     #[test]
-    fn comments_do_not_create_resource_edges() {
-        assert_eq!(strip_comments("a{/* url(orphan.woff) */color:red}"), "a{color:red}");
+    fn css_scanner_skips_comments_and_strings_without_normalizing_the_document() {
+        let css = r#"/* url(orphan.woff) */a{content:"url('text.woff')";src:url(real.woff)}"#;
+        assert_eq!(skip_comment(css.as_bytes(), 0), 22);
+        let quote = css.find('"').unwrap();
+        assert_eq!(quoted_value(css, quote).unwrap().0, "url('text.woff')");
+        let url = css.rfind("url").unwrap();
+        let open = skip_layout(css.as_bytes(), identifier_end(css.as_bytes(), url));
+        assert_eq!(url_value(css, open).unwrap().0, "real.woff");
     }
 }

--- a/crates/converters/src/epub/spine.rs
+++ b/crates/converters/src/epub/spine.rs
@@ -3,10 +3,11 @@
 use super::budget::EpubBudget;
 use super::package::{ManifestItem, Package};
 use super::xhtml::{self, Footnote};
-use crate::zip_converter::archive_api::SafeArchive;
+use crate::zip_converter::archive_api::{OwnedEntry, SafeArchive};
 use into_markdown_core::{
-    ConversionError, ConversionOptions, ConverterOutput, ExecutionContext, FormatHint, InputFormat,
-    NestedConversionRequest, ResolvedInput, Services, SourceMetadata,
+    ConversionError, ConversionOptions, ConverterOutput, Diagnostic, DiagnosticSeverity,
+    ErrorPolicy, ExecutionContext, FormatHint, InputFormat, NestedConversionRequest, ResolvedInput,
+    ResourceReservation, Services, SourceLocator, SourceMetadata,
 };
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
@@ -28,11 +29,14 @@ pub(super) struct Chapter {
 pub(super) struct SpineResult {
     pub(super) chapters: Vec<Chapter>,
     pub(super) skipped_non_linear: usize,
+    pub(super) diagnostics: Vec<Diagnostic>,
+    pub(super) omitted_paths: BTreeSet<String>,
 }
 
 pub(super) async fn convert(
     package: &Package,
     archive: &mut SafeArchive<'_, '_>,
+    mut navigation_entry: Option<(String, OwnedEntry)>,
     options: &ConversionOptions,
     services: &Services,
     budget: &mut EpubBudget<'_>,
@@ -45,6 +49,8 @@ pub(super) async fn convert(
     let mut chapters = Vec::new();
     let mut selected_paths = BTreeSet::new();
     let mut skipped_non_linear = 0;
+    let mut diagnostics = Vec::new();
+    let mut omitted_paths = BTreeSet::new();
     let mut offline = options.clone();
     offline.network.enabled = false;
     offline.network.allowed_hosts.clear();
@@ -54,43 +60,44 @@ pub(super) async fn convert(
             skipped_non_linear += 1;
             continue;
         }
-        let item = select_xhtml(package, &itemref.idref)?;
-        if item.properties.contains("scripted") {
-            return Err(ConversionError::Unsupported {
-                detail: format!("scripted EPUB spine item {} is not supported", item.path),
-            });
-        }
+        let Some(item) =
+            select_spine_item(package, &itemref.idref, options.error_policy, &mut diagnostics)?
+        else {
+            continue;
+        };
+        handle_scripted_item(item, options.error_policy, &mut diagnostics)?;
         if !selected_paths.insert(item.path.clone()) {
             return Err(ConversionError::Malformed {
                 part: Some(item.path.clone()),
                 detail: "multiple spine entries resolve to the same XHTML resource".into(),
             });
         }
-        let entry = archive.read(&item.path)?;
-        let prepared = xhtml::prepare(&item.path, &entry.bytes, archive, budget, context)?;
+        let entry = if navigation_entry.as_ref().is_some_and(|(path, _)| path == &item.path) {
+            navigation_entry
+                .take()
+                .ok_or_else(|| ConversionError::Internal {
+                    detail: "EPUB navigation chapter entry was lost before spine conversion".into(),
+                })?
+                .1
+        } else {
+            archive.read(&item.path)?
+        };
+        let prepared = match xhtml::prepare(&item.path, &entry.bytes, archive, budget, context) {
+            Ok(prepared) => prepared,
+            Err(error) if options.error_policy == ErrorPolicy::BestEffort && error.is_syntax() => {
+                drop(entry);
+                let error = locate_chapter_error(error.into_conversion_error(), &item.path);
+                push_chapter_omitted(&mut diagnostics, &item.path, error.to_string())?;
+                omitted_paths.insert(item.path.clone());
+                continue;
+            }
+            Err(error) => {
+                return Err(locate_chapter_error(error.into_conversion_error(), &item.path));
+            }
+        };
         drop(entry);
-        let size = u64::try_from(prepared.bytes.len()).unwrap_or(u64::MAX);
-        let shared_plan = size
-            .checked_add(u64::try_from(std::mem::size_of::<usize>() * 2).unwrap_or(u64::MAX))
-            .ok_or_else(|| memory_limit("EPUB chapter Arc size overflowed"))?;
-        let _shared_memory = context.reserve_memory(shared_plan)?;
-        let input = ResolvedInput {
-            bytes: Arc::from(prepared.bytes.as_slice()),
-            metadata: SourceMetadata {
-                name: Some(item.path.clone()),
-                media_type: Some(item.media_type.clone()),
-                uri: Some(super::path::synthetic_document_url(&item.path)?),
-                size,
-            },
-        };
-        let hint = FormatHint {
-            format: Some(InputFormat::Html),
-            filename: Some(item.path.clone()),
-            extension: item.path.rsplit_once('.').map(|(_, extension)| extension.to_owned()),
-            media_type: Some(item.media_type.clone()),
-            charset: Some("utf-8".into()),
-        };
-        let output = nested
+        let (input, hint, _shared_memory) = chapter_input(item, &prepared, context)?;
+        let output = match nested
             .convert(
                 NestedConversionRequest {
                     input: &input,
@@ -100,7 +107,22 @@ pub(super) async fn convert(
                 },
                 context,
             )
-            .await?;
+            .await
+        {
+            Ok(output) => output,
+            Err(error)
+                if options.error_policy == ErrorPolicy::BestEffort
+                    && matches!(
+                        error,
+                        ConversionError::Unsupported { .. } | ConversionError::Malformed { .. }
+                    ) =>
+            {
+                push_chapter_omitted(&mut diagnostics, &item.path, error.to_string())?;
+                omitted_paths.insert(item.path.clone());
+                continue;
+            }
+            Err(error) => return Err(error),
+        };
         chapters.push(Chapter {
             path: item.path.clone(),
             output,
@@ -117,7 +139,77 @@ pub(super) async fn convert(
             detail: "EPUB spine has no linear XHTML content".into(),
         });
     }
-    Ok(SpineResult { chapters, skipped_non_linear })
+    Ok(SpineResult { chapters, skipped_non_linear, diagnostics, omitted_paths })
+}
+
+fn select_spine_item<'a>(
+    package: &'a Package,
+    idref: &str,
+    policy: ErrorPolicy,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Result<Option<&'a ManifestItem>, ConversionError> {
+    match select_xhtml(package, idref) {
+        Ok(item) => Ok(Some(item)),
+        Err(error)
+            if policy == ErrorPolicy::BestEffort
+                && matches!(error, ConversionError::Unsupported { .. }) =>
+        {
+            push_chapter_omitted(
+                diagnostics,
+                &package.path,
+                format!("spine item {idref} was omitted: {error}"),
+            )?;
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+fn handle_scripted_item(
+    item: &ManifestItem,
+    policy: ErrorPolicy,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Result<(), ConversionError> {
+    if !item.properties.contains("scripted") {
+        return Ok(());
+    }
+    if policy == ErrorPolicy::Strict {
+        return Err(ConversionError::Unsupported {
+            detail: format!("scripted EPUB spine item {} is not supported", item.path),
+        });
+    }
+    push_spine_diagnostic(
+        diagnostics,
+        "epub.spine.activeContentRemoved",
+        &item.path,
+        "active script content was removed while preserving static chapter content".into(),
+    )
+}
+
+fn push_chapter_omitted(
+    diagnostics: &mut Vec<Diagnostic>,
+    part: &str,
+    message: String,
+) -> Result<(), ConversionError> {
+    push_spine_diagnostic(diagnostics, "epub.spine.chapterOmitted", part, message)
+}
+
+fn push_spine_diagnostic(
+    diagnostics: &mut Vec<Diagnostic>,
+    code: &'static str,
+    part: &str,
+    message: String,
+) -> Result<(), ConversionError> {
+    diagnostics
+        .try_reserve(1)
+        .map_err(|error| memory_limit(format!("cannot reserve EPUB spine diagnostic: {error}")))?;
+    diagnostics.push(Diagnostic {
+        code: code.into(),
+        severity: DiagnosticSeverity::Warning,
+        message,
+        locator: Some(SourceLocator { part: Some(part.into()), ..SourceLocator::default() }),
+    });
+    Ok(())
 }
 
 fn select_xhtml<'a>(package: &'a Package, id: &str) -> Result<&'a ManifestItem, ConversionError> {
@@ -132,4 +224,42 @@ fn select_xhtml<'a>(package: &'a Package, id: &str) -> Result<&'a ManifestItem, 
 
 fn memory_limit(detail: impl Into<String>) -> ConversionError {
     ConversionError::ResourceLimit { limit: "max_memory_bytes", detail: detail.into() }
+}
+
+fn locate_chapter_error(error: ConversionError, path: &str) -> ConversionError {
+    match error {
+        ConversionError::Malformed { part: None, detail } => {
+            ConversionError::Malformed { part: Some(path.into()), detail }
+        }
+        error => error,
+    }
+}
+
+fn chapter_input(
+    item: &ManifestItem,
+    prepared: &xhtml::PreparedXhtml,
+    context: &ExecutionContext,
+) -> Result<(ResolvedInput, FormatHint, ResourceReservation), ConversionError> {
+    let size = u64::try_from(prepared.bytes.len()).unwrap_or(u64::MAX);
+    let shared_plan = size
+        .checked_add(u64::try_from(std::mem::size_of::<usize>() * 2).unwrap_or(u64::MAX))
+        .ok_or_else(|| memory_limit("EPUB chapter Arc size overflowed"))?;
+    let shared_memory = context.reserve_memory(shared_plan)?;
+    let input = ResolvedInput {
+        bytes: Arc::from(prepared.bytes.as_slice()),
+        metadata: SourceMetadata {
+            name: Some(item.path.clone()),
+            media_type: Some(item.media_type.clone()),
+            uri: Some(super::path::synthetic_document_url(&item.path)?),
+            size,
+        },
+    };
+    let hint = FormatHint {
+        format: Some(InputFormat::Html),
+        filename: Some(item.path.clone()),
+        extension: item.path.rsplit_once('.').map(|(_, extension)| extension.to_owned()),
+        media_type: Some(item.media_type.clone()),
+        charset: Some("utf-8".into()),
+    };
+    Ok((input, hint, shared_memory))
 }

--- a/crates/converters/src/epub/spine.rs
+++ b/crates/converters/src/epub/spine.rs
@@ -1,15 +1,19 @@
 //! Stable spine selection and nested HTML conversion.
 
 use super::budget::EpubBudget;
+use super::navigation::{self, Navigation};
 use super::package::{ManifestItem, Package};
 use super::xhtml::{self, Footnote};
-use crate::zip_converter::archive_api::{OwnedEntry, SafeArchive};
+use super::xhtml_security;
+use crate::zip_converter::archive_api::SafeArchive;
 use into_markdown_core::{
     ConversionError, ConversionOptions, ConverterOutput, Diagnostic, DiagnosticSeverity,
-    ErrorPolicy, ExecutionContext, FormatHint, InputFormat, NestedConversionRequest, ResolvedInput,
-    ResourceReservation, Services, SourceLocator, SourceMetadata,
+    ErrorPolicy, ExecutionContext, FormatHint, InputFormat, NestedConversionRequest,
+    NestedConversionService, ResolvedInput, ResourceReservation, Services, SourceLocator,
+    SourceMetadata,
 };
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::{self, Write as _};
 use std::sync::Arc;
 
 const EPUB_ID: &str = "builtin.converter.epub";
@@ -30,13 +34,185 @@ pub(super) struct SpineResult {
     pub(super) chapters: Vec<Chapter>,
     pub(super) skipped_non_linear: usize,
     pub(super) diagnostics: Vec<Diagnostic>,
-    pub(super) omitted_paths: BTreeSet<String>,
+    pub(super) path_resolutions: BTreeMap<String, Option<String>>,
+    pub(super) recovery_memory: ResourceReservation,
+    pub(super) navigation: Option<Navigation>,
+}
+
+struct ChapterDispatch<'a> {
+    options: &'a ConversionOptions,
+    nested: &'a dyn NestedConversionService,
+    context: &'a ExecutionContext,
+}
+
+impl ChapterDispatch<'_> {
+    async fn convert(
+        &self,
+        item: &ManifestItem,
+        original: &ManifestItem,
+        prepared: xhtml::PreparedXhtml,
+        recovery: &mut RecoveryInventory,
+    ) -> Result<Option<Chapter>, ConversionError> {
+        let (input, hint, _shared_memory) = chapter_input(item, &prepared, self.context)?;
+        let mut output = match self
+            .nested
+            .convert(
+                NestedConversionRequest {
+                    input: &input,
+                    hint: &hint,
+                    options: self.options,
+                    excluded_converter_ids: EXCLUDED,
+                },
+                self.context,
+            )
+            .await
+        {
+            Ok(output) => output,
+            Err(error)
+                if self.options.error_policy == ErrorPolicy::BestEffort
+                    && matches!(
+                        error,
+                        ConversionError::Unsupported { .. } | ConversionError::Malformed { .. }
+                    ) =>
+            {
+                recovery.diagnostic(
+                    "epub.spine.chapterOmitted",
+                    DiagnosticSeverity::Warning,
+                    &item.path,
+                    &error,
+                )?;
+                recovery.omit(&original.path, Some(&item.path))?;
+                return Ok(None);
+            }
+            Err(error) => return Err(error),
+        };
+        normalize_chapter_diagnostics(&mut output);
+        Ok(Some(Chapter {
+            path: item.path.clone(),
+            output,
+            references: prepared.references,
+            internal_targets: prepared.internal_targets,
+            anchors: prepared.anchors,
+            footnotes: prepared.footnotes,
+            resource_paths: prepared.resource_paths,
+        }))
+    }
+}
+
+struct RecoveryInventory {
+    diagnostics: Vec<Diagnostic>,
+    path_resolutions: BTreeMap<String, Option<String>>,
+    selected_paths: BTreeSet<String>,
+    memory: ResourceReservation,
+}
+
+impl RecoveryInventory {
+    fn new(context: &ExecutionContext) -> Result<Self, ConversionError> {
+        Ok(Self {
+            diagnostics: Vec::new(),
+            path_resolutions: BTreeMap::new(),
+            selected_paths: BTreeSet::new(),
+            memory: context.reserve_memory(0)?,
+        })
+    }
+
+    fn select(&mut self, path: &str) -> Result<bool, ConversionError> {
+        self.charge(path.len(), 0, 512)?;
+        Ok(self.selected_paths.insert(path.into()))
+    }
+
+    fn resolve(&mut self, original: &str, selected: Option<&str>) -> Result<(), ConversionError> {
+        let selected_bytes = selected.map_or(0, str::len);
+        self.charge(original.len(), selected_bytes, 768)?;
+        let next = selected.map(str::to_owned);
+        if let Some(previous) = self.path_resolutions.insert(original.into(), next.clone())
+            && previous != next
+        {
+            return Err(ConversionError::Malformed {
+                part: Some(original.into()),
+                detail: "one EPUB spine path resolves inconsistently".into(),
+            });
+        }
+        Ok(())
+    }
+
+    fn omit(&mut self, original: &str, selected: Option<&str>) -> Result<(), ConversionError> {
+        self.omit_path(original)?;
+        if let Some(selected) = selected
+            && selected != original
+        {
+            self.omit_path(selected)?;
+        }
+        Ok(())
+    }
+
+    fn omit_path(&mut self, path: &str) -> Result<(), ConversionError> {
+        self.charge(path.len(), 0, 768)?;
+        self.path_resolutions.insert(path.into(), None);
+        Ok(())
+    }
+
+    fn diagnostic(
+        &mut self,
+        code: &'static str,
+        severity: DiagnosticSeverity,
+        part: &str,
+        message: impl fmt::Display,
+    ) -> Result<(), ConversionError> {
+        let mut count = ByteCount::default();
+        write!(&mut count, "{message}")
+            .map_err(|_| memory_limit("EPUB recovery diagnostic size overflowed"))?;
+        self.charge(code.len() + part.len(), count.bytes, 1_024)?;
+        let mut rendered = String::new();
+        rendered.try_reserve_exact(count.bytes).map_err(|error| {
+            memory_limit(format!("cannot reserve EPUB spine diagnostic message: {error}"))
+        })?;
+        write!(&mut rendered, "{message}").map_err(|_| ConversionError::Internal {
+            detail: "EPUB recovery diagnostic formatting failed after preflight".into(),
+        })?;
+        self.diagnostics.try_reserve_exact(1).map_err(|error| {
+            memory_limit(format!("cannot reserve EPUB spine diagnostic: {error}"))
+        })?;
+        self.diagnostics.push(Diagnostic {
+            code: code.into(),
+            severity,
+            message: rendered,
+            locator: Some(SourceLocator { part: Some(part.into()), ..SourceLocator::default() }),
+        });
+        Ok(())
+    }
+
+    fn charge(
+        &mut self,
+        first: usize,
+        second: usize,
+        overhead: usize,
+    ) -> Result<(), ConversionError> {
+        let bytes = first
+            .checked_add(second)
+            .and_then(|bytes| bytes.checked_add(overhead))
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .ok_or_else(|| memory_limit("EPUB recovery inventory memory plan overflowed"))?;
+        self.memory.grow(bytes)
+    }
+}
+
+#[derive(Default)]
+struct ByteCount {
+    bytes: usize,
+}
+
+impl fmt::Write for ByteCount {
+    fn write_str(&mut self, value: &str) -> fmt::Result {
+        self.bytes = self.bytes.checked_add(value.len()).ok_or(fmt::Error)?;
+        Ok(())
+    }
 }
 
 pub(super) async fn convert(
     package: &Package,
     archive: &mut SafeArchive<'_, '_>,
-    mut navigation_entry: Option<(String, OwnedEntry)>,
+    mut deferred_navigation_path: Option<String>,
     options: &ConversionOptions,
     services: &Services,
     budget: &mut EpubBudget<'_>,
@@ -47,106 +223,145 @@ pub(super) async fn convert(
         detail: "the engine did not provide EPUB chapter dispatch".into(),
     })?;
     let mut chapters = Vec::new();
-    let mut selected_paths = BTreeSet::new();
     let mut skipped_non_linear = 0;
-    let mut diagnostics = Vec::new();
-    let mut omitted_paths = BTreeSet::new();
+    let mut recovery = RecoveryInventory::new(context)?;
+    let mut navigation = None;
     let mut offline = options.clone();
     offline.network.enabled = false;
     offline.network.allowed_hosts.clear();
+    let dispatch = ChapterDispatch { options: &offline, nested: nested.as_ref(), context };
     for itemref in &package.spine {
         budget.checkpoint()?;
         if !itemref.linear {
             skipped_non_linear += 1;
             continue;
         }
-        let Some(item) =
-            select_spine_item(package, &itemref.idref, options.error_policy, &mut diagnostics)?
+        let original = package.item(&itemref.idref)?;
+        let Some(item) = select_spine_item(
+            package,
+            original,
+            &itemref.idref,
+            options.error_policy,
+            &mut recovery,
+        )?
         else {
             continue;
         };
-        handle_scripted_item(item, options.error_policy, &mut diagnostics)?;
-        if !selected_paths.insert(item.path.clone()) {
+        recovery.resolve(&original.path, Some(&item.path))?;
+        if !recovery.select(&item.path)? {
             return Err(ConversionError::Malformed {
                 part: Some(item.path.clone()),
                 detail: "multiple spine entries resolve to the same XHTML resource".into(),
             });
         }
-        let entry = if navigation_entry.as_ref().is_some_and(|(path, _)| path == &item.path) {
-            navigation_entry
-                .take()
-                .ok_or_else(|| ConversionError::Internal {
-                    detail: "EPUB navigation chapter entry was lost before spine conversion".into(),
-                })?
-                .1
-        } else {
-            archive.read(&item.path)?
-        };
+        let entry = archive.read(&item.path)?;
+        if deferred_navigation_path.as_deref() == Some(&item.path) {
+            let parsed = navigation::parse_nav(
+                &item.path,
+                &entry.bytes,
+                archive,
+                budget,
+                options.error_policy,
+            )?;
+            if parsed.entries.is_empty() {
+                recovery.diagnostic(
+                    "epub.navigationOmitted",
+                    DiagnosticSeverity::Info,
+                    &item.path,
+                    "an empty EPUB navigation document was omitted",
+                )?;
+            } else {
+                navigation = Some(parsed);
+            }
+            deferred_navigation_path = None;
+        }
+        xhtml_security::audit(&item.path, &entry.bytes, archive, budget, context)
+            .map_err(|error| locate_chapter_error(error, &item.path))?;
         let prepared = match xhtml::prepare(&item.path, &entry.bytes, archive, budget, context) {
             Ok(prepared) => prepared,
             Err(error) if options.error_policy == ErrorPolicy::BestEffort && error.is_syntax() => {
                 drop(entry);
                 let error = locate_chapter_error(error.into_conversion_error(), &item.path);
-                push_chapter_omitted(&mut diagnostics, &item.path, error.to_string())?;
-                omitted_paths.insert(item.path.clone());
+                recovery.diagnostic(
+                    "epub.spine.chapterOmitted",
+                    DiagnosticSeverity::Warning,
+                    &item.path,
+                    &error,
+                )?;
+                recovery.omit(&original.path, Some(&item.path))?;
                 continue;
             }
             Err(error) => {
                 return Err(locate_chapter_error(error.into_conversion_error(), &item.path));
             }
         };
+        handle_scripted_item(
+            item,
+            prepared.active_content_removed,
+            options.error_policy,
+            &mut recovery,
+        )?;
         drop(entry);
-        let (input, hint, _shared_memory) = chapter_input(item, &prepared, context)?;
-        let output = match nested
-            .convert(
-                NestedConversionRequest {
-                    input: &input,
-                    hint: &hint,
-                    options: &offline,
-                    excluded_converter_ids: EXCLUDED,
-                },
-                context,
-            )
-            .await
-        {
-            Ok(output) => output,
-            Err(error)
-                if options.error_policy == ErrorPolicy::BestEffort
-                    && matches!(
-                        error,
-                        ConversionError::Unsupported { .. } | ConversionError::Malformed { .. }
-                    ) =>
-            {
-                push_chapter_omitted(&mut diagnostics, &item.path, error.to_string())?;
-                omitted_paths.insert(item.path.clone());
-                continue;
-            }
-            Err(error) => return Err(error),
-        };
-        chapters.push(Chapter {
-            path: item.path.clone(),
-            output,
-            references: prepared.references,
-            internal_targets: prepared.internal_targets,
-            anchors: prepared.anchors,
-            footnotes: prepared.footnotes,
-            resource_paths: prepared.resource_paths,
-        });
+        if let Some(chapter) = dispatch.convert(item, original, prepared, &mut recovery).await? {
+            chapters.push(chapter);
+        }
     }
+    finish(
+        package,
+        deferred_navigation_path.is_some(),
+        chapters,
+        skipped_non_linear,
+        recovery,
+        navigation,
+    )
+}
+
+fn finish(
+    package: &Package,
+    deferred_navigation_pending: bool,
+    chapters: Vec<Chapter>,
+    skipped_non_linear: usize,
+    recovery: RecoveryInventory,
+    navigation: Option<Navigation>,
+) -> Result<SpineResult, ConversionError> {
     if chapters.is_empty() {
         return Err(ConversionError::Malformed {
             part: Some(package.path.clone()),
             detail: "EPUB spine has no linear XHTML content".into(),
         });
     }
-    Ok(SpineResult { chapters, skipped_non_linear, diagnostics, omitted_paths })
+    if deferred_navigation_pending {
+        return Err(ConversionError::Internal {
+            detail: "deferred EPUB navigation was not consumed by the linear spine".into(),
+        });
+    }
+    Ok(SpineResult {
+        chapters,
+        skipped_non_linear,
+        diagnostics: recovery.diagnostics,
+        path_resolutions: recovery.path_resolutions,
+        recovery_memory: recovery.memory,
+        navigation,
+    })
+}
+
+fn normalize_chapter_diagnostics(output: &mut ConverterOutput) {
+    for diagnostic in &mut output.diagnostics {
+        if matches!(
+            diagnostic.code.as_str(),
+            "html.parseRecovered" | "html.sourceLocationUnavailable"
+        ) {
+            diagnostic.severity = DiagnosticSeverity::Info;
+        }
+    }
 }
 
 fn select_spine_item<'a>(
     package: &'a Package,
+    original: &'a ManifestItem,
     idref: &str,
     policy: ErrorPolicy,
-    diagnostics: &mut Vec<Diagnostic>,
+    recovery: &mut RecoveryInventory,
 ) -> Result<Option<&'a ManifestItem>, ConversionError> {
     match select_xhtml(package, idref) {
         Ok(item) => Ok(Some(item)),
@@ -154,11 +369,13 @@ fn select_spine_item<'a>(
             if policy == ErrorPolicy::BestEffort
                 && matches!(error, ConversionError::Unsupported { .. }) =>
         {
-            push_chapter_omitted(
-                diagnostics,
-                &package.path,
-                format!("spine item {idref} was omitted: {error}"),
+            recovery.diagnostic(
+                "epub.spine.chapterOmitted",
+                DiagnosticSeverity::Warning,
+                &original.path,
+                format_args!("spine item {idref} was omitted: {error}"),
             )?;
+            recovery.omit(&original.path, None)?;
             Ok(None)
         }
         Err(error) => Err(error),
@@ -167,49 +384,30 @@ fn select_spine_item<'a>(
 
 fn handle_scripted_item(
     item: &ManifestItem,
+    active_content_removed: bool,
     policy: ErrorPolicy,
-    diagnostics: &mut Vec<Diagnostic>,
+    recovery: &mut RecoveryInventory,
 ) -> Result<(), ConversionError> {
-    if !item.properties.contains("scripted") {
+    let declared = item.properties.contains("scripted");
+    if !declared && !active_content_removed {
         return Ok(());
     }
     if policy == ErrorPolicy::Strict {
         return Err(ConversionError::Unsupported {
-            detail: format!("scripted EPUB spine item {} is not supported", item.path),
+            detail: format!("active EPUB spine item {} is not supported", item.path),
         });
     }
-    push_spine_diagnostic(
-        diagnostics,
+    let message = if active_content_removed {
+        "active script content or event handlers were removed while preserving static chapter content"
+    } else {
+        "a producer-declared scripted chapter was converted as inert static content"
+    };
+    recovery.diagnostic(
         "epub.spine.activeContentRemoved",
+        DiagnosticSeverity::Warning,
         &item.path,
-        "active script content was removed while preserving static chapter content".into(),
-    )
-}
-
-fn push_chapter_omitted(
-    diagnostics: &mut Vec<Diagnostic>,
-    part: &str,
-    message: String,
-) -> Result<(), ConversionError> {
-    push_spine_diagnostic(diagnostics, "epub.spine.chapterOmitted", part, message)
-}
-
-fn push_spine_diagnostic(
-    diagnostics: &mut Vec<Diagnostic>,
-    code: &'static str,
-    part: &str,
-    message: String,
-) -> Result<(), ConversionError> {
-    diagnostics
-        .try_reserve(1)
-        .map_err(|error| memory_limit(format!("cannot reserve EPUB spine diagnostic: {error}")))?;
-    diagnostics.push(Diagnostic {
-        code: code.into(),
-        severity: DiagnosticSeverity::Warning,
         message,
-        locator: Some(SourceLocator { part: Some(part.into()), ..SourceLocator::default() }),
-    });
-    Ok(())
+    )
 }
 
 fn select_xhtml<'a>(package: &'a Package, id: &str) -> Result<&'a ManifestItem, ConversionError> {
@@ -220,6 +418,23 @@ fn select_xhtml<'a>(package: &'a Package, id: &str) -> Result<&'a ManifestItem, 
         .ok_or_else(|| ConversionError::Unsupported {
             detail: format!("EPUB spine item {id:?} has no HTML/XHTML fallback"),
         })
+}
+
+pub(super) fn linear_spine_uses_path(
+    package: &Package,
+    path: &str,
+) -> Result<bool, ConversionError> {
+    for itemref in &package.spine {
+        if !itemref.linear {
+            continue;
+        }
+        match select_xhtml(package, &itemref.idref) {
+            Ok(item) if item.path == path => return Ok(true),
+            Ok(_) | Err(ConversionError::Unsupported { .. }) => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(false)
 }
 
 fn memory_limit(detail: impl Into<String>) -> ConversionError {
@@ -262,4 +477,77 @@ fn chapter_input(
         charset: Some("utf-8".into()),
     };
     Ok((input, hint, shared_memory))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown_core::{CancellationToken, ErrorCode, ExecutionOptions, ResourceLimits};
+
+    fn context(memory: u64) -> ExecutionContext {
+        ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: memory, ..ResourceLimits::default() },
+        )
+    }
+
+    #[test]
+    fn recovery_inventory_leases_one_hundred_thousand_omissions_and_releases() {
+        let context = context(512 * 1024 * 1024);
+        let mut inventory = RecoveryInventory::new(&context).unwrap();
+        for index in 0..100_000 {
+            let path = format!("OPS/chapter-{index:06}.xhtml");
+            inventory
+                .diagnostic(
+                    "epub.spine.chapterOmitted",
+                    DiagnosticSeverity::Warning,
+                    &path,
+                    "locally malformed chapter omitted",
+                )
+                .unwrap();
+            inventory.omit(&path, None).unwrap();
+        }
+        assert_eq!(inventory.diagnostics.len(), 100_000);
+        assert_eq!(inventory.path_resolutions.len(), 100_000);
+        assert!(context.reserved_memory_bytes() > 100_000);
+        drop(inventory);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn recovery_inventory_low_memory_cancellation_and_error_release() {
+        let low = context(2_048);
+        let mut inventory = RecoveryInventory::new(&low).unwrap();
+        let error = inventory
+            .diagnostic(
+                "epub.spine.chapterOmitted",
+                DiagnosticSeverity::Warning,
+                "OPS/large.xhtml",
+                format_args!("{:>4096}", ""),
+            )
+            .unwrap_err();
+        assert_eq!(error.code(), ErrorCode::ResourceLimit);
+        drop(inventory);
+        assert_eq!(low.reserved_memory_bytes(), 0);
+
+        let cancellation = CancellationToken::new();
+        let cancelled = ExecutionContext::new(
+            ExecutionOptions { cancellation: cancellation.clone(), ..ExecutionOptions::default() },
+            ResourceLimits::default(),
+        );
+        let mut inventory = RecoveryInventory::new(&cancelled).unwrap();
+        cancellation.cancel();
+        let error = inventory.omit("OPS/cancelled.xhtml", None).unwrap_err();
+        assert_eq!(error.code(), ErrorCode::Cancelled);
+        drop(inventory);
+        assert_eq!(cancelled.reserved_memory_bytes(), 0);
+
+        let context = context(64 * 1024);
+        let mut inventory = RecoveryInventory::new(&context).unwrap();
+        inventory.resolve("OPS/original.svg", Some("OPS/one.xhtml")).unwrap();
+        let error = inventory.resolve("OPS/original.svg", Some("OPS/two.xhtml")).unwrap_err();
+        assert_eq!(error.code(), ErrorCode::Malformed);
+        drop(inventory);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
 }

--- a/crates/converters/src/epub/xhtml.rs
+++ b/crates/converters/src/epub/xhtml.rs
@@ -29,6 +29,31 @@ pub(super) struct PreparedXhtml {
     pub(super) _memory: ResourceReservation,
 }
 
+/// Typed boundary between recoverable chapter syntax damage and authoritative
+/// EPUB security and relationship failures discovered during preparation.
+pub(super) enum PrepareError {
+    Syntax(ConversionError),
+    Fatal(ConversionError),
+}
+
+impl PrepareError {
+    pub(super) const fn is_syntax(&self) -> bool {
+        matches!(self, Self::Syntax(_))
+    }
+
+    pub(super) fn into_conversion_error(self) -> ConversionError {
+        match self {
+            Self::Syntax(error) | Self::Fatal(error) => error,
+        }
+    }
+}
+
+impl From<ConversionError> for PrepareError {
+    fn from(error: ConversionError) -> Self {
+        Self::Fatal(error)
+    }
+}
+
 struct Frame {
     name: Name,
     base: BasePath,
@@ -56,7 +81,7 @@ pub(super) fn prepare(
     archive: &SafeArchive<'_, '_>,
     budget: &mut EpubBudget<'_>,
     context: &ExecutionContext,
-) -> Result<PreparedXhtml, ConversionError> {
+) -> Result<PreparedXhtml, PrepareError> {
     let equals =
         bytes.iter().fold(0_usize, |count, byte| count.saturating_add(usize::from(*byte == b'=')));
     let planned = bytes
@@ -88,40 +113,63 @@ pub(super) fn prepare(
     let mut anchors = BTreeSet::new();
     let mut footnotes = Vec::new();
     loop {
-        let event = reader.read_event().map_err(|error| xml::malformed(error.to_string()))?;
+        let event = reader.read_event().map_err(|error| match error {
+            quick_xml::Error::Syntax(_) | quick_xml::Error::IllFormed(_) => {
+                PrepareError::Syntax(xml::malformed(error.to_string()))
+            }
+            _ => PrepareError::Fatal(xml::malformed(error.to_string())),
+        })?;
         let empty = matches!(&event, Event::Empty(_));
         let depth = stack
             .len()
             .saturating_add(usize::from(matches!(&event, Event::Start(_) | Event::Empty(_))));
         budget.event(depth)?;
+        if matches!(&event, Event::PI(_)) {
+            return Err(PrepareError::Syntax(xml::malformed(
+                "XHTML processing instruction is unsupported",
+            )));
+        }
         document_events.validate(&event, root_seen, !stack.is_empty(), xml::DoctypePolicy::Html)?;
         match event {
             Event::DocType(value) => {
                 writer.write_event(Event::DocType(value.into_owned())).map_err(write_error)?;
             }
-            Event::PI(_) => unreachable!("rejected above"),
+            Event::PI(_) => unreachable!("classified above"),
             Event::Start(element) | Event::Empty(element) => {
                 if stack.is_empty() && root_seen {
-                    return Err(xml::malformed("XHTML has multiple root elements"));
+                    return Err(xml::malformed("XHTML has multiple root elements").into());
+                }
+                if !xml::valid_qname(element.name().as_ref()) {
+                    return Err(PrepareError::Syntax(xml::malformed(
+                        "XHTML contains an invalid element QName",
+                    )));
                 }
                 let name = xml::name(&reader, &element)?;
-                let attributes = xml::attributes(&reader, &element)?;
+                let attributes =
+                    xml::attributes_typed(&reader, &element).map_err(|error| match error {
+                        xml::AttributeError::InvalidQName => PrepareError::Syntax(xml::malformed(
+                            "XHTML contains an invalid attribute QName",
+                        )),
+                        xml::AttributeError::Fatal(error) => PrepareError::Fatal(error),
+                    })?;
                 let parent_base = stack.last().map_or(&initial_base, |frame| &frame.base);
                 let base = xml::optional(&attributes, Some(xml::XML_NS), b"base")
                     .map_or_else(|| Ok(parent_base.clone()), |value| parent_base.apply(value))?;
                 if stack.is_empty() {
                     if !name.matches(Some(XHTML_NS), b"html") {
-                        return Err(xml::malformed("spine document root is not XHTML html"));
+                        return Err(xml::malformed("spine document root is not XHTML html").into());
                     }
                     root_seen = true;
                 }
                 if name.matches(Some(XHTML_NS), b"base") {
-                    return Err(xml::malformed("HTML base elements are forbidden in EPUB XHTML"));
+                    return Err(
+                        xml::malformed("HTML base elements are forbidden in EPUB XHTML").into()
+                    );
                 }
                 if let Some(id) = xml::optional(&attributes, None, b"id") {
                     let target = initial_base.anchor(id)?.canonical_target();
                     if !anchors.insert(target) {
-                        return Err(xml::malformed("duplicate XHTML anchor identity"));
+                        return Err(xml::malformed("duplicate XHTML anchor identity").into());
                     }
                 }
                 let types = xml::optional(&attributes, Some(EPUB_NS), b"type")
@@ -130,7 +178,9 @@ pub(super) fn prepare(
                     .collect::<BTreeSet<_>>();
                 let is_footnote = types.contains("footnote") || types.contains("endnote");
                 if is_footnote && stack.iter().any(|frame| frame.footnote.is_some()) {
-                    return Err(xml::malformed("nested EPUB footnote definitions are invalid"));
+                    return Err(
+                        xml::malformed("nested EPUB footnote definitions are invalid").into()
+                    );
                 }
                 let footnote = if is_footnote {
                     let id = xml::required(&attributes, None, b"id", "footnote id")?;
@@ -144,8 +194,9 @@ pub(super) fn prepare(
                 let suppressed_text = stack.last().is_some_and(|frame| frame.suppressed_text)
                     || name.namespace.as_deref() == Some(XHTML_NS)
                         && matches!(name.local.as_slice(), b"script" | b"style");
-                let suppressed_output =
-                    is_footnote || stack.last().is_some_and(|frame| frame.suppressed_output);
+                let suppressed_output = is_footnote
+                    || stack.last().is_some_and(|frame| frame.suppressed_output)
+                    || name.matches(Some(XHTML_NS), b"script");
                 if !suppressed_output {
                     let rewritten =
                         rewrite_element(&reader, &element, &name, &base, archive, &mut inventory)?;
@@ -165,9 +216,14 @@ pub(super) fn prepare(
                 }
             }
             Event::End(element) => {
+                if !xml::valid_qname(element.name().as_ref()) {
+                    return Err(PrepareError::Syntax(xml::malformed(
+                        "XHTML contains an invalid end-tag QName",
+                    )));
+                }
                 let frame = stack.pop().ok_or_else(|| xml::malformed("orphan XHTML end tag"))?;
                 if xml::end_name(&reader, element.name())? != frame.name {
-                    return Err(xml::malformed("XHTML end tag namespace mismatch"));
+                    return Err(xml::malformed("XHTML end tag namespace mismatch").into());
                 }
                 if !frame.suppressed_output {
                     writer.write_event(Event::End(element.into_owned())).map_err(write_error)?;
@@ -177,7 +233,7 @@ pub(super) fn prepare(
             Event::Text(_) | Event::CData(_) | Event::GeneralRef(_) => {
                 let decoded = xml::decoded_text(&event)?.unwrap_or_default();
                 if stack.is_empty() && !decoded.chars().all(char::is_whitespace) {
-                    return Err(xml::malformed("character data outside XHTML root"));
+                    return Err(xml::malformed("character data outside XHTML root").into());
                 }
                 let suppressed = stack.last().is_some_and(|frame| frame.suppressed_text);
                 if !decoded.is_empty()
@@ -206,7 +262,7 @@ pub(super) fn prepare(
         }
     }
     if !root_seen || !stack.is_empty() {
-        return Err(xml::malformed("XHTML root is missing or incomplete"));
+        return Err(PrepareError::Syntax(xml::malformed("XHTML root is missing or incomplete")));
     }
     let mut output = writer.into_inner();
     let actual = u64::try_from(output.capacity()).unwrap_or(u64::MAX);

--- a/crates/converters/src/epub/xhtml.rs
+++ b/crates/converters/src/epub/xhtml.rs
@@ -26,6 +26,7 @@ pub(super) struct PreparedXhtml {
     pub(super) anchors: BTreeSet<String>,
     pub(super) footnotes: Vec<Footnote>,
     pub(super) resource_paths: BTreeSet<String>,
+    pub(super) active_content_removed: bool,
     pub(super) _memory: ResourceReservation,
 }
 
@@ -112,6 +113,7 @@ pub(super) fn prepare(
     let mut inventory = RewriteInventory::default();
     let mut anchors = BTreeSet::new();
     let mut footnotes = Vec::new();
+    let mut active_content_removed = false;
     loop {
         let event = reader.read_event().map_err(|error| match error {
             quick_xml::Error::Syntax(_) | quick_xml::Error::IllFormed(_) => {
@@ -137,7 +139,9 @@ pub(super) fn prepare(
             Event::PI(_) => unreachable!("classified above"),
             Event::Start(element) | Event::Empty(element) => {
                 if stack.is_empty() && root_seen {
-                    return Err(xml::malformed("XHTML has multiple root elements").into());
+                    return Err(PrepareError::Syntax(xml::malformed(
+                        "XHTML has multiple root elements",
+                    )));
                 }
                 if !xml::valid_qname(element.name().as_ref()) {
                     return Err(PrepareError::Syntax(xml::malformed(
@@ -157,7 +161,9 @@ pub(super) fn prepare(
                     .map_or_else(|| Ok(parent_base.clone()), |value| parent_base.apply(value))?;
                 if stack.is_empty() {
                     if !name.matches(Some(XHTML_NS), b"html") {
-                        return Err(xml::malformed("spine document root is not XHTML html").into());
+                        return Err(PrepareError::Syntax(xml::malformed(
+                            "spine document root is not XHTML html",
+                        )));
                     }
                     root_seen = true;
                 }
@@ -178,9 +184,9 @@ pub(super) fn prepare(
                     .collect::<BTreeSet<_>>();
                 let is_footnote = types.contains("footnote") || types.contains("endnote");
                 if is_footnote && stack.iter().any(|frame| frame.footnote.is_some()) {
-                    return Err(
-                        xml::malformed("nested EPUB footnote definitions are invalid").into()
-                    );
+                    return Err(PrepareError::Syntax(xml::malformed(
+                        "nested EPUB footnote definitions are invalid",
+                    )));
                 }
                 let footnote = if is_footnote {
                     let id = xml::required(&attributes, None, b"id", "footnote id")?;
@@ -197,9 +203,11 @@ pub(super) fn prepare(
                 let suppressed_output = is_footnote
                     || stack.last().is_some_and(|frame| frame.suppressed_output)
                     || name.matches(Some(XHTML_NS), b"script");
+                active_content_removed |= name.matches(Some(XHTML_NS), b"script");
                 if !suppressed_output {
-                    let rewritten =
+                    let (rewritten, sanitized_attributes) =
                         rewrite_element(&reader, &element, &name, &base, archive, &mut inventory)?;
+                    active_content_removed |= sanitized_attributes;
                     writer
                         .write_event(if empty {
                             Event::Empty(rewritten)
@@ -210,7 +218,7 @@ pub(super) fn prepare(
                 }
                 let frame = Frame { name, base, footnote, suppressed_text, suppressed_output };
                 if empty {
-                    finish_frame(frame, &mut footnotes, budget)?;
+                    finish_frame(frame, &mut footnotes, budget).map_err(PrepareError::Syntax)?;
                 } else {
                     stack.push(frame);
                 }
@@ -221,19 +229,25 @@ pub(super) fn prepare(
                         "XHTML contains an invalid end-tag QName",
                     )));
                 }
-                let frame = stack.pop().ok_or_else(|| xml::malformed("orphan XHTML end tag"))?;
+                let frame = stack
+                    .pop()
+                    .ok_or_else(|| PrepareError::Syntax(xml::malformed("orphan XHTML end tag")))?;
                 if xml::end_name(&reader, element.name())? != frame.name {
-                    return Err(xml::malformed("XHTML end tag namespace mismatch").into());
+                    return Err(PrepareError::Syntax(xml::malformed(
+                        "XHTML end tag namespace mismatch",
+                    )));
                 }
                 if !frame.suppressed_output {
                     writer.write_event(Event::End(element.into_owned())).map_err(write_error)?;
                 }
-                finish_frame(frame, &mut footnotes, budget)?;
+                finish_frame(frame, &mut footnotes, budget).map_err(PrepareError::Syntax)?;
             }
             Event::Text(_) | Event::CData(_) | Event::GeneralRef(_) => {
                 let decoded = xml::decoded_text(&event)?.unwrap_or_default();
                 if stack.is_empty() && !decoded.chars().all(char::is_whitespace) {
-                    return Err(xml::malformed("character data outside XHTML root").into());
+                    return Err(PrepareError::Syntax(xml::malformed(
+                        "character data outside XHTML root",
+                    )));
                 }
                 let suppressed = stack.last().is_some_and(|frame| frame.suppressed_text);
                 if !decoded.is_empty()
@@ -283,6 +297,7 @@ pub(super) fn prepare(
         anchors,
         footnotes,
         resource_paths: inventory.resource_paths,
+        active_content_removed,
         _memory: memory,
     })
 }
@@ -294,11 +309,12 @@ fn rewrite_element(
     base: &BasePath,
     archive: &SafeArchive<'_, '_>,
     inventory: &mut RewriteInventory,
-) -> Result<BytesStart<'static>, ConversionError> {
+) -> Result<(BytesStart<'static>, bool), ConversionError> {
     let element_name = element.name();
     let qname = std::str::from_utf8(element_name.as_ref())
         .map_err(|_| xml::malformed("XHTML element QName is not UTF-8"))?;
     let mut output = BytesStart::new(qname.to_owned());
+    let mut active_content_removed = false;
     for attribute in element.attributes() {
         let attribute = attribute.map_err(|error| xml::malformed(error.to_string()))?;
         let raw = std::str::from_utf8(attribute.key.as_ref())
@@ -313,6 +329,14 @@ fn rewrite_element(
         let (namespace, local) = reader.resolve_attribute(attribute.key);
         if matches!(namespace, ResolveResult::Unknown(_)) {
             return Err(xml::malformed("unbound XHTML attribute prefix"));
+        }
+        if matches!(namespace, ResolveResult::Unbound)
+            && name.namespace.as_deref() == Some(XHTML_NS)
+            && raw.len() > 2
+            && raw.as_bytes()[..2].eq_ignore_ascii_case(b"on")
+        {
+            active_content_removed = true;
+            continue;
         }
         let mut value = attribute
             .decode_and_unescape_value(reader.decoder())
@@ -354,7 +378,7 @@ fn rewrite_element(
         }
         output.push_attribute((raw, value.as_str()));
     }
-    Ok(output.into_owned())
+    Ok((output.into_owned(), active_content_removed))
 }
 
 fn finish_frame(

--- a/crates/converters/src/epub/xhtml_security.rs
+++ b/crates/converters/src/epub/xhtml_security.rs
@@ -1,0 +1,510 @@
+//! Complete, recovery-independent security audit for one XHTML spine member.
+
+use super::budget::EpubBudget;
+use super::path::BasePath;
+use super::xml;
+use crate::zip_converter::archive_api::SafeArchive;
+use into_markdown_core::{ConversionError, ExecutionContext, ResourceReservation};
+use std::mem::size_of;
+
+const XMLNS_NS: &str = "http://www.w3.org/2000/xmlns/";
+const XML_NS: &str = "http://www.w3.org/XML/1998/namespace";
+const CHECKPOINT_BYTES: usize = 4 * 1024;
+
+#[derive(Clone, Copy)]
+struct Binding<'a> {
+    prefix: &'a str,
+    uri: &'a str,
+}
+
+struct Frame<'a> {
+    qname: &'a str,
+    binding_start: usize,
+    base: Option<BasePath>,
+}
+
+#[derive(Clone, Copy)]
+struct RawAttribute<'a> {
+    name: &'a str,
+    value: &'a str,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+struct ExpandedName<'a> {
+    namespace: Option<&'a str>,
+    local: &'a str,
+}
+
+struct Scratch<'a> {
+    frames: Vec<Frame<'a>>,
+    bindings: Vec<Binding<'a>>,
+    attributes: Vec<RawAttribute<'a>>,
+    expanded: Vec<ExpandedName<'a>>,
+    memory: ResourceReservation,
+}
+
+/// Audit the complete raw chapter independently from the parser used for
+/// recovery and rewriting. Local syntax damage never terminates this pass.
+pub(super) fn audit(
+    path: &str,
+    bytes: &[u8],
+    archive: &SafeArchive<'_, '_>,
+    budget: &mut EpubBudget<'_>,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    let source = std::str::from_utf8(bytes)
+        .map_err(|_| xml::malformed("XHTML security scan requires UTF-8 input"))?;
+    xml::validate_xml_chars(source, "chapter")?;
+    let tags = byte_occurrences(bytes, b'<');
+    let attributes = byte_occurrences(bytes, b'=');
+    let planned = planned_scratch(tags, attributes, path.len())?;
+    let memory = context.reserve_memory(planned)?;
+    let mut scratch = Scratch {
+        frames: reserve(tags, "XHTML security frame")?,
+        bindings: reserve(attributes, "XHTML namespace binding")?,
+        attributes: reserve(attributes, "XHTML security attribute")?,
+        expanded: reserve(attributes, "XHTML expanded attribute")?,
+        memory,
+    };
+    let actual = scratch_bytes(&scratch)?;
+    if actual > planned {
+        scratch.memory.grow(actual - planned)?;
+    } else if planned > actual {
+        scratch.memory.shrink(planned - actual)?;
+    }
+    let initial_base = BasePath::document(path)?;
+    scan(source, archive, budget, context, &initial_base, &mut scratch)
+}
+
+fn byte_occurrences(bytes: &[u8], needle: u8) -> usize {
+    bytes.split(|byte| *byte == needle).count().saturating_sub(1)
+}
+
+fn scan<'a>(
+    source: &'a str,
+    archive: &SafeArchive<'_, '_>,
+    budget: &mut EpubBudget<'_>,
+    context: &ExecutionContext,
+    initial_base: &BasePath,
+    scratch: &mut Scratch<'a>,
+) -> Result<(), ConversionError> {
+    let bytes = source.as_bytes();
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        if cursor.is_multiple_of(CHECKPOINT_BYTES) {
+            context.checkpoint()?;
+        }
+        let Some(relative) = bytes[cursor..].iter().position(|byte| *byte == b'<') else {
+            scan_entities(&source[cursor..])?;
+            break;
+        };
+        let start = cursor + relative;
+        scan_entities(&source[cursor..start])?;
+        if starts(bytes, start, b"<!--") {
+            cursor = find_after(bytes, start + 4, b"-->").unwrap_or(bytes.len());
+            continue;
+        }
+        if starts(bytes, start, b"<![CDATA[") {
+            cursor = find_after(bytes, start + 9, b"]]>").unwrap_or(bytes.len());
+            continue;
+        }
+        if starts_ascii_case(bytes, start, b"<!DOCTYPE") {
+            let (end, next) = declaration_end(bytes, start + 2);
+            let declaration = source[start + 2..end].trim();
+            if !declaration.eq_ignore_ascii_case("doctype html") {
+                return Err(xml::malformed("XML doctype is forbidden or unsupported"));
+            }
+            cursor = next;
+            continue;
+        }
+        if starts_ascii_case(bytes, start, b"<!ENTITY") {
+            return Err(xml::malformed("custom XML entities are forbidden"));
+        }
+        if starts(bytes, start, b"<!") {
+            return Err(xml::malformed("XHTML contains an unsupported declaration"));
+        }
+        if starts(bytes, start, b"<?") {
+            cursor = find_after(bytes, start + 2, b"?>").unwrap_or(bytes.len());
+            continue;
+        }
+        let (end, next, complete) = tag_end(bytes, start + 1);
+        if starts(bytes, start, b"</") {
+            close_frame(source[start + 2..end].trim(), scratch);
+        } else {
+            audit_start_tag(
+                source[start + 1..end].trim(),
+                complete,
+                archive,
+                budget,
+                initial_base,
+                scratch,
+            )?;
+        }
+        cursor = next.max(start + 1);
+    }
+    context.checkpoint()
+}
+
+fn audit_start_tag<'a>(
+    content: &'a str,
+    complete: bool,
+    archive: &SafeArchive<'_, '_>,
+    budget: &mut EpubBudget<'_>,
+    initial_base: &BasePath,
+    scratch: &mut Scratch<'a>,
+) -> Result<(), ConversionError> {
+    scratch.attributes.clear();
+    scratch.expanded.clear();
+    let (qname, empty, syntax_valid) = parse_start(content, &mut scratch.attributes);
+    let scope_valid = complete && syntax_valid && xml::valid_qname(qname.as_bytes());
+    budget.checkpoint()?;
+    EpubBudget::attributes(scratch.attributes.len())?;
+    let binding_start = scratch.bindings.len();
+    for attribute in &scratch.attributes {
+        if attribute.name == "xmlns" {
+            validate_namespace_binding("", attribute.value)?;
+            scratch.bindings.push(Binding { prefix: "", uri: attribute.value });
+        } else if let Some(prefix) = attribute.name.strip_prefix("xmlns:") {
+            if !xml::valid_ncname(prefix) {
+                return Err(xml::malformed("invalid XML namespace declaration prefix"));
+            }
+            validate_namespace_binding(prefix, attribute.value)?;
+            scratch.bindings.push(Binding { prefix, uri: attribute.value });
+        }
+    }
+    if xml::valid_qname(qname.as_bytes()) {
+        resolve_element(qname, &scratch.bindings)?;
+    }
+    let inherited_base =
+        scratch.frames.iter().rev().find_map(|frame| frame.base.as_ref()).unwrap_or(initial_base);
+    let mut base = None;
+    for attribute in &scratch.attributes {
+        scan_entities(attribute.value)?;
+        if attribute.name == "xmlns" || attribute.name.starts_with("xmlns:") {
+            continue;
+        }
+        let Some((prefix, local)) = split_valid_qname(attribute.name) else {
+            continue;
+        };
+        let namespace = resolve_attribute(prefix, &scratch.bindings)?;
+        let expanded = ExpandedName { namespace, local };
+        if scratch.expanded.contains(&expanded) {
+            return Err(xml::malformed("duplicate expanded XML attribute name"));
+        }
+        scratch.expanded.push(expanded);
+        if namespace == Some(XML_NS) && local == "base" {
+            let growth = inherited_base
+                .retained_path_bytes()
+                .checked_add(attribute.value.len())
+                .and_then(|bytes| bytes.checked_add(256))
+                .and_then(|bytes| u64::try_from(bytes).ok())
+                .ok_or_else(memory_overflow)?;
+            scratch.memory.grow(growth)?;
+            base = Some(inherited_base.apply(attribute.value)?);
+        }
+    }
+    let effective_base =
+        if scope_valid { base.as_ref().unwrap_or(inherited_base) } else { inherited_base };
+    for attribute in &scratch.attributes {
+        let Some((prefix, local)) = split_valid_qname(attribute.name) else {
+            continue;
+        };
+        if attribute.name == "xmlns" || prefix == Some("xmlns") {
+            continue;
+        }
+        let namespace = resolve_attribute(prefix, &scratch.bindings)?;
+        if namespace.is_none() && is_container_url_attribute(local) {
+            effective_base.resolve(attribute.value)?.require_existing(archive)?;
+        }
+    }
+    if empty || !scope_valid {
+        scratch.bindings.truncate(binding_start);
+    } else {
+        scratch.frames.push(Frame { qname, binding_start, base });
+    }
+    Ok(())
+}
+
+fn close_frame<'a>(content: &'a str, scratch: &mut Scratch<'a>) {
+    let qname = content.split_whitespace().next().unwrap_or_default();
+    if !xml::valid_qname(qname.as_bytes()) {
+        return;
+    }
+    if let Some(index) = scratch.frames.iter().rposition(|frame| frame.qname == qname) {
+        let binding_start = scratch.frames[index].binding_start;
+        scratch.frames.truncate(index);
+        scratch.bindings.truncate(binding_start);
+    }
+}
+
+fn parse_start<'a>(content: &'a str, output: &mut Vec<RawAttribute<'a>>) -> (&'a str, bool, bool) {
+    let bytes = content.as_bytes();
+    let mut cursor = skip_space(bytes, 0);
+    let name_start = cursor;
+    while cursor < bytes.len() && !bytes[cursor].is_ascii_whitespace() && bytes[cursor] != b'/' {
+        cursor += 1;
+    }
+    let qname = &content[name_start..cursor];
+    let mut empty = false;
+    let mut syntax_valid = !qname.is_empty();
+    while cursor < bytes.len() {
+        cursor = skip_space(bytes, cursor);
+        if cursor >= bytes.len() {
+            break;
+        }
+        if bytes[cursor] == b'/' {
+            empty = true;
+            syntax_valid &= skip_space(bytes, cursor + 1) == bytes.len();
+            break;
+        }
+        let attribute_start = cursor;
+        while cursor < bytes.len()
+            && !bytes[cursor].is_ascii_whitespace()
+            && !matches!(bytes[cursor], b'=' | b'/')
+        {
+            cursor += 1;
+        }
+        let name = &content[attribute_start..cursor];
+        cursor = skip_space(bytes, cursor);
+        if cursor >= bytes.len() || bytes[cursor] != b'=' {
+            syntax_valid = false;
+            continue;
+        }
+        cursor += 1;
+        cursor = skip_space(bytes, cursor);
+        if cursor >= bytes.len() {
+            break;
+        }
+        let quote = bytes[cursor];
+        let (value_start, value_end) = if matches!(quote, b'\'' | b'"') {
+            cursor += 1;
+            let start = cursor;
+            while cursor < bytes.len() && bytes[cursor] != quote {
+                cursor += 1;
+            }
+            let end = cursor;
+            cursor = cursor.saturating_add(1).min(bytes.len());
+            (start, end)
+        } else {
+            syntax_valid = false;
+            let start = cursor;
+            while cursor < bytes.len()
+                && !bytes[cursor].is_ascii_whitespace()
+                && bytes[cursor] != b'/'
+            {
+                cursor += 1;
+            }
+            (start, cursor)
+        };
+        if !name.is_empty() {
+            output.push(RawAttribute { name, value: &content[value_start..value_end] });
+        }
+    }
+    (qname, empty, syntax_valid)
+}
+
+fn resolve_element<'a>(
+    qname: &'a str,
+    bindings: &[Binding<'a>],
+) -> Result<Option<&'a str>, ConversionError> {
+    let (prefix, _) = split_valid_qname(qname).ok_or_else(|| xml::malformed("invalid QName"))?;
+    match prefix {
+        Some("xml") => Ok(Some(XML_NS)),
+        Some(prefix) => resolve_prefix(prefix, bindings).map(Some),
+        None => Ok(bindings.iter().rev().find(|binding| binding.prefix.is_empty()).map(|b| b.uri)),
+    }
+}
+
+fn resolve_attribute<'a>(
+    prefix: Option<&'a str>,
+    bindings: &[Binding<'a>],
+) -> Result<Option<&'a str>, ConversionError> {
+    match prefix {
+        Some("xml") => Ok(Some(XML_NS)),
+        Some(prefix) => resolve_prefix(prefix, bindings).map(Some),
+        None => Ok(None),
+    }
+}
+
+fn resolve_prefix<'a>(prefix: &str, bindings: &[Binding<'a>]) -> Result<&'a str, ConversionError> {
+    bindings
+        .iter()
+        .rev()
+        .find(|binding| binding.prefix == prefix)
+        .map(|binding| binding.uri)
+        .ok_or_else(|| xml::malformed(format!("unbound XML namespace prefix {prefix:?}")))
+}
+
+fn validate_namespace_binding(prefix: &str, uri: &str) -> Result<(), ConversionError> {
+    scan_entities(uri)?;
+    if prefix == "xmlns"
+        || uri == XMLNS_NS
+        || prefix == "xml" && uri != XML_NS
+        || prefix != "xml" && uri == XML_NS
+        || !prefix.is_empty() && uri.is_empty()
+    {
+        return Err(xml::malformed("invalid reserved XML namespace binding"));
+    }
+    Ok(())
+}
+
+fn scan_entities(value: &str) -> Result<(), ConversionError> {
+    let bytes = value.as_bytes();
+    let mut cursor = 0;
+    while let Some(relative) = bytes[cursor..].iter().position(|byte| *byte == b'&') {
+        let start = cursor + relative + 1;
+        let Some(end_relative) = bytes[start..].iter().position(|byte| *byte == b';') else {
+            break;
+        };
+        let end = start + end_relative;
+        let entity = &value[start..end];
+        if !matches!(entity, "amp" | "lt" | "gt" | "apos" | "quot")
+            && !valid_character_reference(entity)
+        {
+            return Err(xml::malformed("custom XML entities are forbidden"));
+        }
+        cursor = end + 1;
+    }
+    Ok(())
+}
+
+fn valid_character_reference(entity: &str) -> bool {
+    entity
+        .strip_prefix("#x")
+        .and_then(|digits| u32::from_str_radix(digits, 16).ok())
+        .or_else(|| entity.strip_prefix('#').and_then(|digits| digits.parse().ok()))
+        .and_then(char::from_u32)
+        .is_some_and(|character| {
+            xml::validate_xml_chars(&character.to_string(), "character reference").is_ok()
+        })
+}
+
+fn split_valid_qname(value: &str) -> Option<(Option<&str>, &str)> {
+    if !xml::valid_qname(value.as_bytes()) {
+        return None;
+    }
+    Some(value.split_once(':').map_or((None, value), |(prefix, local)| (Some(prefix), local)))
+}
+
+fn is_container_url_attribute(local: &str) -> bool {
+    matches!(local, "href" | "src" | "action" | "poster" | "data" | "formaction")
+}
+
+fn tag_end(bytes: &[u8], mut cursor: usize) -> (usize, usize, bool) {
+    let mut quote = None;
+    while cursor < bytes.len() {
+        match (quote, bytes[cursor]) {
+            (Some(expected), byte) if byte == expected => quote = None,
+            (_, b'<') => return (cursor, cursor, false),
+            (None, byte @ (b'\'' | b'"')) => quote = Some(byte),
+            (None, b'>') => return (cursor, cursor + 1, true),
+            _ => {}
+        }
+        cursor += 1;
+    }
+    (bytes.len(), bytes.len(), false)
+}
+
+fn declaration_end(bytes: &[u8], mut cursor: usize) -> (usize, usize) {
+    let mut quote = None;
+    let mut subset = 0_u32;
+    while cursor < bytes.len() {
+        match (quote, bytes[cursor]) {
+            (Some(expected), byte) if byte == expected => quote = None,
+            (None, byte @ (b'\'' | b'"')) => quote = Some(byte),
+            (None, b'[') => subset = subset.saturating_add(1),
+            (None, b']') => subset = subset.saturating_sub(1),
+            (None, b'>') if subset == 0 => return (cursor, cursor + 1),
+            _ => {}
+        }
+        cursor += 1;
+    }
+    (bytes.len(), bytes.len())
+}
+
+fn find_after(bytes: &[u8], start: usize, needle: &[u8]) -> Option<usize> {
+    bytes[start..]
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .map(|position| start + position + needle.len())
+}
+
+fn starts(bytes: &[u8], start: usize, prefix: &[u8]) -> bool {
+    bytes.get(start..start.saturating_add(prefix.len())) == Some(prefix)
+}
+
+fn starts_ascii_case(bytes: &[u8], start: usize, prefix: &[u8]) -> bool {
+    bytes
+        .get(start..start.saturating_add(prefix.len()))
+        .is_some_and(|value| value.eq_ignore_ascii_case(prefix))
+}
+
+fn skip_space(bytes: &[u8], mut cursor: usize) -> usize {
+    while cursor < bytes.len() && bytes[cursor].is_ascii_whitespace() {
+        cursor += 1;
+    }
+    cursor
+}
+
+fn planned_scratch(tags: usize, attributes: usize, path: usize) -> Result<u64, ConversionError> {
+    tags.checked_mul(size_of::<Frame<'_>>())
+        .and_then(|bytes| {
+            attributes
+                .checked_mul(
+                    size_of::<Binding<'_>>()
+                        + size_of::<RawAttribute<'_>>()
+                        + size_of::<ExpandedName<'_>>(),
+                )
+                .and_then(|attributes| bytes.checked_add(attributes))
+        })
+        .and_then(|bytes| bytes.checked_add(path))
+        .and_then(|bytes| bytes.checked_add(1_024))
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .ok_or_else(memory_overflow)
+}
+
+fn scratch_bytes(scratch: &Scratch<'_>) -> Result<u64, ConversionError> {
+    scratch
+        .frames
+        .capacity()
+        .checked_mul(size_of::<Frame<'_>>())
+        .and_then(|bytes| {
+            scratch
+                .bindings
+                .capacity()
+                .checked_mul(size_of::<Binding<'_>>())
+                .and_then(|value| bytes.checked_add(value))
+        })
+        .and_then(|bytes| {
+            scratch
+                .attributes
+                .capacity()
+                .checked_mul(size_of::<RawAttribute<'_>>())
+                .and_then(|value| bytes.checked_add(value))
+        })
+        .and_then(|bytes| {
+            scratch
+                .expanded
+                .capacity()
+                .checked_mul(size_of::<ExpandedName<'_>>())
+                .and_then(|value| bytes.checked_add(value))
+        })
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .ok_or_else(memory_overflow)
+}
+
+fn reserve<T>(capacity: usize, label: &str) -> Result<Vec<T>, ConversionError> {
+    let mut output = Vec::new();
+    output.try_reserve_exact(capacity).map_err(|error| ConversionError::ResourceLimit {
+        limit: "max_memory_bytes",
+        detail: format!("reserve {label}: {error}"),
+    })?;
+    Ok(output)
+}
+
+fn memory_overflow() -> ConversionError {
+    ConversionError::ResourceLimit {
+        limit: "max_memory_bytes",
+        detail: "EPUB XHTML security scan memory plan overflowed".into(),
+    }
+}

--- a/crates/converters/src/epub/xml.rs
+++ b/crates/converters/src/epub/xml.rs
@@ -280,7 +280,7 @@ fn xml_name_character(character: char) -> bool {
         )
 }
 
-fn validate_xml_chars(value: &str, label: &str) -> Result<(), ConversionError> {
+pub(super) fn validate_xml_chars(value: &str, label: &str) -> Result<(), ConversionError> {
     if value.chars().all(|character| {
         matches!(character,
             '\u{0009}' | '\u{000a}' | '\u{000d}'

--- a/crates/converters/src/epub/xml.rs
+++ b/crates/converters/src/epub/xml.rs
@@ -85,6 +85,20 @@ pub(super) struct Attribute {
     pub(super) value: String,
 }
 
+pub(super) enum AttributeError {
+    InvalidQName,
+    Fatal(ConversionError),
+}
+
+impl AttributeError {
+    fn into_conversion_error(self) -> ConversionError {
+        match self {
+            Self::InvalidQName => malformed("invalid XML attribute QName"),
+            Self::Fatal(error) => error,
+        }
+    }
+}
+
 pub(super) fn reader(bytes: &[u8]) -> NsReader<&[u8]> {
     let mut reader = NsReader::from_reader(bytes);
     let config = reader.config_mut();
@@ -116,29 +130,42 @@ pub(super) fn attributes(
     reader: &NsReader<&[u8]>,
     element: &BytesStart<'_>,
 ) -> Result<Vec<Attribute>, ConversionError> {
+    attributes_typed(reader, element).map_err(AttributeError::into_conversion_error)
+}
+
+pub(super) fn attributes_typed(
+    reader: &NsReader<&[u8]>,
+    element: &BytesStart<'_>,
+) -> Result<Vec<Attribute>, AttributeError> {
     let mut output = Vec::new();
     let mut unique = BTreeSet::new();
     for attribute in element.attributes() {
-        let attribute =
-            attribute.map_err(|error| malformed(format!("invalid attribute: {error}")))?;
+        let attribute = attribute.map_err(|error| {
+            AttributeError::Fatal(malformed(format!("invalid attribute: {error}")))
+        })?;
         let raw_name = attribute.key.as_ref();
+        if !valid_qname(raw_name) {
+            return Err(AttributeError::InvalidQName);
+        }
         if raw_name == b"xmlns" || raw_name.starts_with(b"xmlns:") {
             continue;
         }
         let (resolved, local) = reader.resolve_attribute(attribute.key);
-        let namespace = namespace(resolved)?;
+        let namespace = namespace(resolved).map_err(AttributeError::Fatal)?;
         let key = (namespace.clone(), local.as_ref().to_vec());
         if !unique.insert(key.clone()) {
-            return Err(malformed("duplicate expanded XML attribute name"));
+            return Err(AttributeError::Fatal(malformed("duplicate expanded XML attribute name")));
         }
         let value = attribute
             .decode_and_unescape_value(reader.decoder())
-            .map_err(|error| malformed(format!("invalid XML attribute value: {error}")))?
+            .map_err(|error| {
+                AttributeError::Fatal(malformed(format!("invalid XML attribute value: {error}")))
+            })?
             .into_owned();
-        validate_xml_chars(&value, "attribute")?;
+        validate_xml_chars(&value, "attribute").map_err(AttributeError::Fatal)?;
         output.push(Attribute { namespace: key.0, local: key.1, value });
     }
-    EpubBudget::attributes(output.len())?;
+    EpubBudget::attributes(output.len()).map_err(AttributeError::Fatal)?;
     Ok(output)
 }
 
@@ -221,6 +248,16 @@ pub(super) fn decoded_text(event: &Event<'_>) -> Result<Option<String>, Conversi
 pub(super) fn valid_ncname(value: &str) -> bool {
     let mut characters = value.chars();
     characters.next().is_some_and(xml_name_start) && characters.all(xml_name_character)
+}
+
+pub(super) fn valid_qname(value: &[u8]) -> bool {
+    let Ok(value) = std::str::from_utf8(value) else {
+        return false;
+    };
+    let mut parts = value.split(':');
+    let first = parts.next().unwrap_or_default();
+    let second = parts.next();
+    parts.next().is_none() && valid_ncname(first) && second.is_none_or(valid_ncname)
 }
 
 fn xml_name_start(character: char) -> bool {

--- a/crates/converters/src/zip/archive.rs
+++ b/crates/converters/src/zip/archive.rs
@@ -4,6 +4,10 @@ use super::raw_central::RawInventory;
 use into_markdown_core::{ConversionError, ResourceReservation};
 use std::io::{Cursor, Read};
 
+const VALIDATION_SCRATCH_BYTES: usize = 64 * 1024;
+const VALIDATION_SCRATCH_MEMORY_BYTES: u64 = 64 * 1024;
+const DEFLATE_WORKSPACE_BYTES: u64 = 256 * 1024;
+
 #[cfg(test)]
 use std::cell::Cell;
 
@@ -23,6 +27,7 @@ pub(super) struct EntryMeta {
     pub(super) physical_start: usize,
     pub(super) central_extra_len: usize,
     pub(super) local_extra_len: usize,
+    pub(super) verified: bool,
 }
 
 pub(super) struct EntryData {
@@ -121,6 +126,63 @@ impl<'a> Archive<'a> {
             )));
         }
         Ok(EntryData { bytes, memory })
+    }
+
+    /// Stream one member through the decoder so length and CRC are checked
+    /// without retaining its expanded bytes.
+    pub(super) fn validate_entry(
+        &mut self,
+        meta: &EntryMeta,
+        budget: &mut ArchiveBudget<'_>,
+    ) -> Result<(), ConversionError> {
+        budget.validate_member(&meta.name, meta.compressed_size, meta.expanded_size)?;
+        budget.charge_expanded(&meta.name, meta.expanded_size)?;
+        let working_bytes = VALIDATION_SCRATCH_MEMORY_BYTES
+            + if meta.deflated { DEFLATE_WORKSPACE_BYTES } else { 0 };
+        let mut working_memory = budget.context().reserve_memory(working_bytes)?;
+        let mut scratch = Vec::new();
+        scratch.try_reserve_exact(VALIDATION_SCRATCH_BYTES).map_err(|error| {
+            memory_limit(format!("reserve ZIP validation scratch buffer: {error}"))
+        })?;
+        let actual_scratch = u64::try_from(scratch.capacity()).unwrap_or(u64::MAX);
+        if actual_scratch > VALIDATION_SCRATCH_MEMORY_BYTES {
+            working_memory.grow(actual_scratch - VALIDATION_SCRATCH_MEMORY_BYTES)?;
+        } else {
+            working_memory.shrink(VALIDATION_SCRATCH_MEMORY_BYTES - actual_scratch)?;
+        }
+        scratch.resize(VALIDATION_SCRATCH_BYTES, 0);
+        let mut entry = self.inner.by_index(meta.index).map_err(|error| {
+            malformed(format!("cannot open archive member {:?}: {error}", meta.name))
+        })?;
+        let mut expanded = 0_u64;
+        loop {
+            budget.context().checkpoint()?;
+            let read = entry.read(&mut scratch).map_err(|error| {
+                malformed(format!(
+                    "archive member {:?} failed CRC/length validation: {error}",
+                    meta.name
+                ))
+            })?;
+            if read == 0 {
+                break;
+            }
+            expanded = expanded
+                .checked_add(u64::try_from(read).unwrap_or(u64::MAX))
+                .ok_or_else(|| malformed("archive member expanded length overflowed"))?;
+            if expanded > meta.expanded_size {
+                return Err(malformed(format!(
+                    "archive member {:?} expands beyond its declared size",
+                    meta.name
+                )));
+            }
+        }
+        if expanded != meta.expanded_size {
+            return Err(malformed(format!(
+                "archive member {:?} expanded to {expanded} bytes, expected {}",
+                meta.name, meta.expanded_size
+            )));
+        }
+        Ok(())
     }
 }
 

--- a/crates/converters/src/zip/archive_api.rs
+++ b/crates/converters/src/zip/archive_api.rs
@@ -69,10 +69,19 @@ impl<'bytes, 'request> SafeArchive<'bytes, 'request> {
     }
 
     pub(crate) fn read(&mut self, path: &str) -> Result<OwnedEntry, ConversionError> {
-        let meta = self.meta(path).cloned().ok_or_else(|| ConversionError::Malformed {
-            part: Some(path.into()),
-            detail: format!("EPUB package part {path:?} is missing"),
-        })?;
+        let index =
+            self.entries.binary_search_by(|entry| entry.name.as_str().cmp(path)).map_err(|_| {
+                ConversionError::Malformed {
+                    part: Some(path.into()),
+                    detail: format!("EPUB package part {path:?} is missing"),
+                }
+            })?;
+        if self.entries[index].verified {
+            return Err(ConversionError::Internal {
+                detail: format!("validated archive member {path:?} was requested more than once"),
+            });
+        }
+        let meta = self.entries[index].clone();
         if meta.kind != EntryKind::File {
             return Err(ConversionError::Malformed {
                 part: Some(path.into()),
@@ -80,8 +89,23 @@ impl<'bytes, 'request> SafeArchive<'bytes, 'request> {
             });
         }
         let entry = self.inner.read_entry(&meta, &mut self.budget)?;
+        self.entries[index].verified = true;
         let (bytes, memory) = entry.into_parts();
         Ok(OwnedEntry { bytes, memory })
+    }
+
+    /// Stream every unread file through the decoder so CRC and declared length
+    /// are validated without retaining unused package members.
+    pub(crate) fn validate_remaining(&mut self) -> Result<(), ConversionError> {
+        for index in 0..self.entries.len() {
+            if self.entries[index].kind != EntryKind::File || self.entries[index].verified {
+                continue;
+            }
+            let meta = self.entries[index].clone();
+            self.inner.validate_entry(&meta, &mut self.budget)?;
+            self.entries[index].verified = true;
+        }
+        Ok(())
     }
 
     fn meta(&self, path: &str) -> Option<&EntryMeta> {
@@ -109,4 +133,57 @@ fn entry_info(entry: &EntryMeta) -> EntryInfo<'_> {
 /// used for every raw archive entry.
 pub(crate) fn portable_identity(path: &str, directory: bool) -> Result<String, ConversionError> {
     super::entry_policy::portable_identity(path, directory)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown_core::{ExecutionOptions, ResourceLimits};
+    use std::io::{Cursor, Write as _};
+    use zip::write::SimpleFileOptions;
+
+    fn stored(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        for (name, bytes) in entries {
+            writer.start_file(*name, options).unwrap();
+            writer.write_all(bytes).unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    #[test]
+    fn remaining_crc_is_streamed_without_recharging_previously_read_entries() {
+        let first = b"already-read";
+        let second = b"unused-content";
+        let bytes = stored(&[("a.txt", first), ("unused.bin", second)]);
+        let mut options = ConversionOptions::default();
+        options.limits.max_decompressed_bytes = (first.len() + second.len()) as u64;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let mut archive = SafeArchive::open(&bytes, &options, &context).unwrap();
+        let metadata_memory = context.reserved_memory_bytes();
+        drop(archive.read("a.txt").unwrap());
+        assert!(matches!(archive.read("a.txt"), Err(ConversionError::Internal { .. })));
+        archive.validate_remaining().unwrap();
+        assert_eq!(context.reserved_memory_bytes(), metadata_memory);
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+        drop(archive);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+
+        let mut corrupt = bytes;
+        let offset = corrupt.windows(second.len()).position(|window| window == second).unwrap();
+        corrupt[offset] ^= 1;
+        let options = ConversionOptions::default();
+        let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+        let mut archive = SafeArchive::open(&corrupt, &options, &context).unwrap();
+        drop(archive.read("a.txt").unwrap());
+        let error = archive.validate_remaining().unwrap_err();
+        assert!(matches!(error, ConversionError::Malformed { .. }));
+        assert!(error.to_string().contains("CRC/length"));
+        drop(archive);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+    }
 }

--- a/crates/converters/src/zip/archive_api.rs
+++ b/crates/converters/src/zip/archive_api.rs
@@ -94,11 +94,11 @@ impl<'bytes, 'request> SafeArchive<'bytes, 'request> {
         Ok(OwnedEntry { bytes, memory })
     }
 
-    /// Stream every unread file through the decoder so CRC and declared length
-    /// are validated without retaining unused package members.
+    /// Stream every unread physical member through the decoder so CRC and
+    /// declared length are validated without retaining unused package members.
     pub(crate) fn validate_remaining(&mut self) -> Result<(), ConversionError> {
         for index in 0..self.entries.len() {
-            if self.entries[index].kind != EntryKind::File || self.entries[index].verified {
+            if self.entries[index].verified {
                 continue;
             }
             let meta = self.entries[index].clone();
@@ -138,7 +138,7 @@ pub(crate) fn portable_identity(path: &str, directory: bool) -> Result<String, C
 #[cfg(test)]
 mod tests {
     use super::*;
-    use into_markdown_core::{ExecutionOptions, ResourceLimits};
+    use into_markdown_core::{CancellationToken, ErrorCode, ExecutionOptions, ResourceLimits};
     use std::io::{Cursor, Write as _};
     use zip::write::SimpleFileOptions;
 
@@ -150,6 +150,16 @@ mod tests {
             writer.start_file(*name, options).unwrap();
             writer.write_all(bytes).unwrap();
         }
+        writer.finish().unwrap().into_inner()
+    }
+
+    fn stored_with_directory() -> Vec<u8> {
+        let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+        let options =
+            SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+        writer.start_file("read.txt", options).unwrap();
+        writer.write_all(b"x").unwrap();
+        writer.add_directory("unused-dir/", options).unwrap();
         writer.finish().unwrap().into_inner()
     }
 
@@ -182,6 +192,47 @@ mod tests {
         let error = archive.validate_remaining().unwrap_err();
         assert!(matches!(error, ConversionError::Malformed { .. }));
         assert!(error.to_string().contains("CRC/length"));
+        drop(archive);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+    }
+
+    #[test]
+    fn directory_entries_are_validated_or_nonzero_payloads_are_rejected() {
+        let payload = b"directory-payload";
+        let nonzero = stored(&[("read.txt", b"x"), ("unused-dir/", payload)]);
+        let options = ConversionOptions::default();
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let Err(error) = SafeArchive::open(&nonzero, &options, &context) else {
+            panic!("accepted a directory entry with a physical payload");
+        };
+        assert_eq!(error.code(), ErrorCode::Malformed);
+        assert!(error.to_string().contains("directory marker conflicts"));
+        assert_eq!(context.reserved_memory_bytes(), 0);
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+
+        let bytes = stored_with_directory();
+        let mut options = ConversionOptions::default();
+        options.limits.max_decompressed_bytes = 1;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let mut archive = SafeArchive::open(&bytes, &options, &context).unwrap();
+        drop(archive.read("read.txt").unwrap());
+        archive.validate_remaining().unwrap();
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+        drop(archive);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let cancellation = CancellationToken::new();
+        let context = ExecutionContext::new(
+            ExecutionOptions { cancellation: cancellation.clone(), ..ExecutionOptions::default() },
+            ResourceLimits::default(),
+        );
+        let conversion = ConversionOptions::default();
+        let mut archive = SafeArchive::open(&bytes, &conversion, &context).unwrap();
+        drop(archive.read("read.txt").unwrap());
+        cancellation.cancel();
+        let error = archive.validate_remaining().unwrap_err();
+        assert_eq!(error.code(), ErrorCode::Cancelled);
         drop(archive);
         assert_eq!(context.reserved_memory_bytes(), 0);
         assert_eq!(context.reserved_temporary_bytes(), 0);

--- a/crates/converters/src/zip/raw_central.rs
+++ b/crates/converters/src/zip/raw_central.rs
@@ -427,7 +427,10 @@ fn validate_flags(flags: u16, method: u16) -> Result<(), ConversionError> {
     if !matches!(method, 0 | 8) {
         return Err(malformed(format!("unsupported compression method {method}")));
     }
-    if flags & !0x080e != 0 || method == 0 && flags & 0x0006 != 0 {
+    // Bits 1-2 are compressor hints for methods that define them. Some
+    // producers retain those inert hints on stored members; they do not alter
+    // framing, encryption, sizes, CRC validation, or the selected decoder.
+    if flags & !0x080e != 0 {
         return Err(malformed(format!("unsupported general-purpose flags {flags:#06x}")));
     }
     Ok(())
@@ -560,5 +563,14 @@ mod filename_tests {
     fn invalid_explicit_zip_charset_is_stable() {
         let error = decode_name(&[0x80], 0, &[], Some("definitely-not-an-encoding")).unwrap_err();
         assert!(matches!(error, ConversionError::Malformed { .. }));
+    }
+
+    #[test]
+    fn inert_compression_hints_do_not_broaden_zip_authority() {
+        validate_flags(0x0802, 0).unwrap();
+        validate_flags(0x0806, 8).unwrap();
+        assert!(validate_flags(0x0810, 8).is_err());
+        assert!(matches!(validate_flags(0x0801, 8), Err(ConversionError::Encrypted)));
+        assert!(validate_flags(0x0802, 9).is_err());
     }
 }

--- a/crates/converters/src/zip/raw_central.rs
+++ b/crates/converters/src/zip/raw_central.rs
@@ -180,6 +180,7 @@ fn collect_records(
             physical_start: record.local_start,
             central_extra_len: record.central_extra_len,
             local_extra_len: record.local_extra_len,
+            verified: false,
         });
         cursor = next;
     }


### PR DESCRIPTION
Closes #267

Rebased onto `main@a40ae3460b5c31486768598048fa23e87d5b1c11`. This PR keeps the shared empty-result/outcome policy authoritative and does not duplicate #268.

## Summary

- recover safe noncanonical EPUB `mimetype` placement/compression/extra-field layouts, exact CRLF content, and inert ZIP compression-hint flags only in best-effort mode
- recover absent non-identity metadata, empty navigation, missing optional spine items, and individually malformed/unsupported chapters only when readable linear content remains
- keep DTD/entities, relationship ambiguity, traversal/aliasing, unsafe references, corrupt ZIP members, duplicate spine targets, missing required EPUB 3 navigation, and all-empty output fail-closed
- keep container/package parsing, XML/XHTML security, recovery inventory, spine conversion, CSS reachability, and HTML-to-Markdown dispatch separated; no filename/sample special cases or lint exemptions

## Frozen-review blocker fixes

- duplicate metadata IDs: best-effort omits and diagnoses later unreferenced metadata fields with duplicate IDs; strict still rejects them. A duplicate ID remains a hard failure when it is the package `unique-identifier` target or a `refines` target. Structural/non-metadata duplicate IDs remain hard failures.
- cover declarations: repeated same-value EPUB 2 `meta name="cover"` declarations and an EPUB 2 cover meta matching an EPUB 3 `cover-image` item select the same resource instead of conflicting; different cover targets still fail.
- CSS reachability: a bounded single-pass state machine skips comments and strings, so `content:"url('../missing.woff2')"` is inert text. Real `url()` and quoted/`url()` `@import` edges remain resolved through confined container paths.
- large CSS: removed the full-size decommented and lowercase `String` copies. Reachable CSS is scanned directly from the archive entry's already leased bytes with periodic cancellation checkpoints.

## Independent seven-file classification

Classification used static ZIP/XML/container inspection before conversion; output was not used to classify input.

- `raw`: 7 physical inputs
- `valid_allowed`: 4 Internet Archive EPUBs
- `valid_but_policy_rejected`: 3 Tika fixtures; this is a product-policy bucket, not a claim that all are fully specification-conforming
  - `testEPUB_xml_ext`: external PUBLIC DTD in NCX and 2 XHTML documents
  - `testEPUB`: external PUBLIC DTD in NCX and 4 XHTML documents
  - `testEPUB_multi-metadata-vals`: duplicate `publisher` ID with 5 `refines` consumers and duplicate `type-designer` ID with 3 consumers, so relationships remain ambiguous

Best-effort is 4 success / 3 hard rejection, not “7/7 legal”. Strict is 0/7 with no output.

## Fixed 17-file corpus

The 17 physical files are the 7 issue files, 5 upstream reference fixtures, 1 repository fixture, and 4 source-named byte-identical copies of the allowed issue files. The copies verify filename independence and are not presented as distinct content.

- latest-main baseline: 1/17 success
- current branch: 11/17 success
- common-success cohort: 1 file, repository `normal.epub`
- current success summary from result JSON: 3,502,796 Markdown bytes; 3,414,467 text characters; 9 link nodes; 456 image nodes and 456 retained assets
- current hard failures remain the 2 DTD fixtures, duplicated-refines fixture, and 3 EPUB 3 fixtures missing required navigation

For the four distinct allowed issue books, the independent OPF/spine oracle still reports 944 linear entries, 898 emitted chapters, 46 explicit omission diagnostics, strict spine-order subsequences, zero duplicate chapters, and 98.121%–99.716% source-token recall.

## Common-success performance

Fresh Windows x86_64 release binaries for `main@a40ae34` and this branch were run in 10 interleaved measured processes after two warm-ups each. Per-file figures:

| file | revision | mean / median | mean / max RSS | temp peak | output |
| --- | --- | ---: | ---: | ---: | ---: |
| `normal.epub` | baseline | 31.411 / 31.581 ms | 14.532 / 14.574 MiB | 232 B | 116 B |
| `normal.epub` | current | 30.557 / 30.100 ms | 14.559 / 14.621 MiB | 232 B | 116 B |

The one-file common cohort mean changed `-2.718%`, below the requested 50% regression ceiling. Outputs are byte-identical, SHA-256 `5ab7b571b4e58865126f51f61f4d4df2bedfcd9b2b835212d4352f2910a842f6`. The temporary boundary is exact for both builds: 231 bytes fails on the second 116-byte output reservation and 232 bytes succeeds.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p into-markdown-converters -p into-markdown-engine --all-targets --no-deps -- -D warnings`
- `cargo clippy -p into-markdown --lib --no-deps -- -D warnings`
- `cargo test -p into-markdown-converters epub`: 19 passed
- `cargo test -p into-markdown --lib epub`: 33 passed
- release classification of all fixed 17 files, 10-run common-success performance, exact temporary boundary, and result-JSON content/link/asset summary

## Risk

Full CRC validation still performs work proportional to every archive member. The CSS scanner intentionally implements the required resource-bearing CSS subset rather than a rendering engine; malformed real resource functions remain fail-closed, while strings and comments are inert. Recovery remains restricted to noncritical defects: DTD/entity authority, referenced duplicate metadata IDs, conflicting covers, traversal, corrupt containers, and missing required EPUB 3 navigation do not degrade to success.