### PR TITLE
perf(engine): make collecting conversion single-shot

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1499,6 +1499,7 @@ dependencies = [
  "into-markdown-task-store",
  "serde_json",
  "sha2",
+ "sysinfo",
  "tempfile",
  "zip 2.4.2",
 ]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -42,6 +42,7 @@ into-markdown-task-store = { path = "../task-store" }
 image.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+sysinfo.workspace = true
 tempfile.workspace = true
 zip.workspace = true
 

--- a/crates/api/tests/collecting_parity.rs
+++ b/crates/api/tests/collecting_parity.rs
@@ -1,0 +1,431 @@
+//! Public aggregate-versus-collecting parity gates for issue 272.
+
+use into_markdown::*;
+use into_markdown_converters::{
+    EmbeddedVisualOcrEnricher, HintFormatDetector, MemorySourceResolver, PresentationConverter,
+    WorkbookConverter,
+};
+use std::fmt::Write as _;
+use std::future::Future;
+use std::io::{Cursor, Write as _};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+fn test_fixture_root() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../fixtures")
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = std::pin::pin!(future);
+    let waker = std::task::Waker::noop();
+    let mut context = std::task::Context::from_waker(waker);
+    loop {
+        match future.as_mut().poll(&mut context) {
+            std::task::Poll::Ready(output) => return output,
+            std::task::Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
+fn aggregate(
+    converter: &dyn Converter,
+    bytes: Arc<[u8]>,
+    name: &str,
+    format: InputFormat,
+) -> ConverterOutput {
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    let input = ResolvedInput {
+        metadata: SourceMetadata {
+            name: Some(name.into()),
+            size: u64::try_from(bytes.len()).unwrap(),
+            ..SourceMetadata::default()
+        },
+        bytes,
+    };
+    let candidate = FormatCandidate::new(format, 1.0, "test.aggregate.authority");
+    let plan = converter.planned_output_bytes(&input, &candidate, &options, &context).unwrap();
+    let mut admission = context.reserve_memory(plan).unwrap();
+    let credit = context.with_memory_credit(&mut admission).unwrap();
+    block_on(converter.convert(&input, &candidate, &options, &Services::default(), &credit))
+        .unwrap()
+}
+
+fn assert_public_matches_aggregate(
+    converter: &dyn Converter,
+    bytes: Arc<[u8]>,
+    name: &str,
+    format: InputFormat,
+) {
+    let expected = aggregate(converter, Arc::clone(&bytes), name, format);
+    let expected_markdown =
+        render_markdown(&expected.document, &expected.assets, &ConversionOptions::default())
+            .unwrap();
+    let result =
+        block_on(default_engine().unwrap().convert(ConversionRequest::new(InputRef::Bytes {
+            data: bytes,
+            name: Some(name.into()),
+        })))
+        .unwrap();
+    assert_eq!(result.document, expected.document);
+    assert_eq!(result.markdown, expected_markdown);
+    assert_eq!(result.assets, expected.assets);
+    assert_eq!(result.diagnostics, expected.diagnostics);
+}
+
+fn public(bytes: Arc<[u8]>, name: &str) -> ConversionResult {
+    block_on(
+        default_engine().unwrap().convert(ConversionRequest::new(InputRef::Bytes {
+            data: bytes,
+            name: Some(name.into()),
+        })),
+    )
+    .unwrap()
+}
+
+fn assert_results_equal(actual: &ConversionResult, expected: &ConversionResult) {
+    assert_eq!(actual.document, expected.document);
+    assert_eq!(actual.markdown.as_bytes(), expected.markdown.as_bytes());
+    assert_eq!(actual.assets, expected.assets);
+    assert_eq!(actual.diagnostics, expected.diagnostics);
+}
+
+struct AggregateOnly<T>(T);
+
+impl<T: Converter> Converter for AggregateOnly<T> {
+    fn id(&self) -> &'static str {
+        self.0.id()
+    }
+
+    fn priority(&self) -> i32 {
+        self.0.priority()
+    }
+
+    fn supported_formats(&self) -> &'static [InputFormat] {
+        self.0.supported_formats()
+    }
+
+    fn probe<'a>(
+        &'a self,
+        input: &'a ResolvedInput,
+        candidate: &'a FormatCandidate,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ProbeOutcome, ConversionError>> {
+        self.0.probe(input, candidate, context)
+    }
+
+    fn planned_output_bytes(
+        &self,
+        input: &ResolvedInput,
+        candidate: &FormatCandidate,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        self.0.planned_output_bytes(input, candidate, options, context)
+    }
+
+    fn convert<'a>(
+        &'a self,
+        input: &'a ResolvedInput,
+        candidate: &'a FormatCandidate,
+        options: &'a ConversionOptions,
+        services: &'a Services,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        self.0.convert(input, candidate, options, services, context)
+    }
+}
+
+fn aggregate_engine(converter: Arc<dyn Converter>) -> Engine {
+    let mut builder = EngineBuilder::new()
+        .renderer(Arc::new(into_markdown_render_markdown::GfmRenderer))
+        .enricher(Arc::new(EmbeddedVisualOcrEnricher))
+        .enricher(Arc::new(StructuredAiPatchEnricher));
+    builder
+        .registry_mut()
+        .register_source_resolver(Arc::new(MemorySourceResolver))
+        .register_format_detector(Arc::new(HintFormatDetector))
+        .register_converter(converter);
+    builder.build().unwrap()
+}
+
+fn convert_with(engine: &Engine, bytes: Arc<[u8]>, name: &str) -> ConversionResult {
+    block_on(
+        engine.convert(ConversionRequest::new(InputRef::Bytes {
+            data: bytes,
+            name: Some(name.into()),
+        })),
+    )
+    .unwrap()
+}
+
+#[derive(Clone, Copy, Default)]
+struct Profile {
+    elapsed_us: u128,
+    logical_memory_peak: u64,
+    temporary_peak: u64,
+    rss_delta_peak: u64,
+}
+
+fn profile_conversion(engine: &Engine, bytes: Arc<[u8]>, name: &str) -> Profile {
+    let request = ConversionRequest::new(InputRef::Bytes { data: bytes, name: Some(name.into()) });
+    let context = ExecutionContext::new(request.execution.clone(), request.options.limits.clone());
+    let limit = request.options.limits.max_memory_bytes;
+    let stop = Arc::new(AtomicBool::new(false));
+    let memory_peak = Arc::new(AtomicU64::new(0));
+    let temporary_peak = Arc::new(AtomicU64::new(0));
+    let rss_peak = Arc::new(AtomicU64::new(0));
+    let baseline_rss = process_rss();
+    let sampler_context = context.clone();
+    let sampler_stop = Arc::clone(&stop);
+    let sampler_memory = Arc::clone(&memory_peak);
+    let sampler_temporary = Arc::clone(&temporary_peak);
+    let sampler_rss = Arc::clone(&rss_peak);
+    let sampler = std::thread::spawn(move || {
+        use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+        let pid = Pid::from_u32(std::process::id());
+        let mut system = System::new();
+        while !sampler_stop.load(Ordering::Acquire) {
+            sampler_memory.fetch_max(
+                limit.saturating_sub(sampler_context.available_memory_bytes()),
+                Ordering::Relaxed,
+            );
+            sampler_temporary
+                .fetch_max(sampler_context.reserved_temporary_bytes(), Ordering::Relaxed);
+            system.refresh_processes_specifics(
+                ProcessesToUpdate::Some(&[pid]),
+                false,
+                ProcessRefreshKind::nothing().with_memory(),
+            );
+            let rss = system.process(pid).map_or(0, sysinfo::Process::memory);
+            sampler_rss.fetch_max(rss, Ordering::Relaxed);
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    });
+    let started = Instant::now();
+    let result = block_on(engine.convert_with_context(request, context)).unwrap();
+    let elapsed_us = started.elapsed().as_micros();
+    stop.store(true, Ordering::Release);
+    sampler.join().unwrap();
+    drop(result);
+    Profile {
+        elapsed_us,
+        logical_memory_peak: memory_peak.load(Ordering::Relaxed),
+        temporary_peak: temporary_peak.load(Ordering::Relaxed),
+        rss_delta_peak: rss_peak.load(Ordering::Relaxed).saturating_sub(baseline_rss),
+    }
+}
+
+fn process_rss() -> u64 {
+    use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+    let pid = Pid::from_u32(std::process::id());
+    let mut system = System::new();
+    system.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&[pid]),
+        false,
+        ProcessRefreshKind::nothing().with_memory(),
+    );
+    system.process(pid).map_or(0, sysinfo::Process::memory)
+}
+
+fn alternating_profile(
+    native: &Engine,
+    aggregate: &Engine,
+    bytes: &Arc<[u8]>,
+    name: &str,
+) -> (Profile, Profile) {
+    const RUNS: u128 = 4;
+    drop(convert_with(native, Arc::clone(bytes), name));
+    drop(convert_with(aggregate, Arc::clone(bytes), name));
+    let mut native_total = Profile::default();
+    let mut aggregate_total = Profile::default();
+    for run in 0..RUNS {
+        let (first, second) =
+            if run.is_multiple_of(2) { (native, aggregate) } else { (aggregate, native) };
+        let first_profile = profile_conversion(first, Arc::clone(bytes), name);
+        let second_profile = profile_conversion(second, Arc::clone(bytes), name);
+        let (native_profile, aggregate_profile) = if run.is_multiple_of(2) {
+            (first_profile, second_profile)
+        } else {
+            (second_profile, first_profile)
+        };
+        merge_profile(&mut native_total, native_profile);
+        merge_profile(&mut aggregate_total, aggregate_profile);
+    }
+    native_total.elapsed_us /= RUNS;
+    aggregate_total.elapsed_us /= RUNS;
+    (native_total, aggregate_total)
+}
+
+fn merge_profile(total: &mut Profile, sample: Profile) {
+    total.elapsed_us += sample.elapsed_us;
+    total.logical_memory_peak = total.logical_memory_peak.max(sample.logical_memory_peak);
+    total.temporary_peak = total.temporary_peak.max(sample.temporary_peak);
+    total.rss_delta_peak = total.rss_delta_peak.max(sample.rss_delta_peak);
+}
+
+fn replace_zip_entry(source: &[u8], target: &str, replacement: &[u8]) -> Vec<u8> {
+    let mut input = zip::ZipArchive::new(Cursor::new(source)).unwrap();
+    let mut output = Cursor::new(Vec::new());
+    {
+        let mut writer = zip::ZipWriter::new(&mut output);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        for index in 0..input.len() {
+            let mut entry = input.by_index(index).unwrap();
+            if entry.is_dir() {
+                writer.add_directory(entry.name(), options).unwrap();
+                continue;
+            }
+            writer.start_file(entry.name(), options).unwrap();
+            if entry.name() == target {
+                writer.write_all(replacement).unwrap();
+            } else {
+                std::io::copy(&mut entry, &mut writer).unwrap();
+            }
+        }
+        writer.finish().unwrap();
+    }
+    output.into_inner()
+}
+
+fn zip_entry(source: &[u8], target: &str) -> String {
+    let mut archive = zip::ZipArchive::new(Cursor::new(source)).unwrap();
+    let mut entry = archive.by_name(target).unwrap();
+    let mut value = String::new();
+    std::io::Read::read_to_string(&mut entry, &mut value).unwrap();
+    value
+}
+
+fn large_sparse_worksheet() -> Vec<u8> {
+    const ROWS: usize = 4_096;
+    let mut xml = String::from(
+        "<?xml version=\"1.0\"?><worksheet xmlns=\"http://schemas.openxmlformats.org/spreadsheetml/2006/main\"><dimension ref=\"A1:A65521\"/><sheetData>",
+    );
+    for index in 0..ROWS {
+        let row = index * 16 + 1;
+        write!(
+            xml,
+            "<row r=\"{row}\"><c r=\"A{row}\" t=\"inlineStr\"><is><t>row-{index:04}-sparse-production-content-{index:04}</t></is></c></row>"
+        )
+        .unwrap();
+    }
+    xml.push_str("</sheetData></worksheet>");
+    assert!(xml.len() >= 256 * 1024);
+    xml.into_bytes()
+}
+
+fn large_presentation(source: &[u8]) -> Vec<u8> {
+    let original = zip_entry(source, "ppt/slides/slide1.xml");
+    let marker = "</p:txBody></p:sp></p:spTree>";
+    let mut paragraphs = String::new();
+    for index in 0..2_048 {
+        write!(
+            paragraphs,
+            "<a:p><a:r><a:rPr lang=\"en-US\"/><a:t>slide-production-{index:04}-{}</a:t></a:r></a:p>",
+            "content".repeat(8)
+        )
+        .unwrap();
+    }
+    let replacement = original.replacen(marker, &format!("{paragraphs}{marker}"), 1);
+    assert!(replacement.len() > original.len() + 256 * 1024);
+    replace_zip_entry(source, "ppt/slides/slide1.xml", replacement.as_bytes())
+}
+
+#[test]
+fn pptx_collecting_matches_aggregate_document_markdown_assets_and_diagnostics() {
+    let small = std::fs::read(test_fixture_root().join("small/pptx/normal.pptx")).unwrap();
+    assert_public_matches_aggregate(
+        &PresentationConverter,
+        Arc::from(small.clone()),
+        "ordinary.pptx",
+        InputFormat::Pptx,
+    );
+    let bytes: Arc<[u8]> = large_presentation(&small).into();
+    assert_public_matches_aggregate(
+        &PresentationConverter,
+        bytes,
+        "normal.pptx",
+        InputFormat::Pptx,
+    );
+}
+
+#[test]
+fn large_sparse_xlsx_collecting_matches_aggregate_while_small_uses_fallback() {
+    let small = std::fs::read(test_fixture_root().join("small/xlsx/normal.xlsx")).unwrap();
+    let aggregate = aggregate_engine(Arc::new(AggregateOnly(WorkbookConverter)));
+    let small: Arc<[u8]> = small.into();
+    let expected_small = convert_with(&aggregate, Arc::clone(&small), "ordinary.xlsx");
+    let collected_small = public(Arc::clone(&small), "ordinary.xlsx");
+    assert_results_equal(&collected_small, &expected_small);
+
+    let large: Arc<[u8]> =
+        replace_zip_entry(&small, "xl/worksheets/sheet1.xml", &large_sparse_worksheet()).into();
+    let expected = convert_with(&aggregate, Arc::clone(&large), "normal.xlsx");
+    let collected = public(large, "normal.xlsx");
+    assert_results_equal(&collected, &expected);
+}
+
+#[test]
+fn production_large_inputs_have_bounded_native_overhead_and_resources() {
+    let pptx_small = std::fs::read(test_fixture_root().join("small/pptx/normal.pptx")).unwrap();
+    let pptx: Arc<[u8]> = large_presentation(&pptx_small).into();
+    let pptx_native = default_engine().unwrap();
+    let pptx_aggregate = aggregate_engine(Arc::new(AggregateOnly(PresentationConverter)));
+    let (pptx_native_profile, pptx_aggregate_profile) =
+        alternating_profile(&pptx_native, &pptx_aggregate, &pptx, "production-large.pptx");
+    let (small_pptx_native_profile, small_pptx_aggregate_profile) =
+        alternating_profile(&pptx_native, &pptx_aggregate, &Arc::from(pptx_small), "ordinary.pptx");
+
+    let xlsx_small = std::fs::read(test_fixture_root().join("small/xlsx/normal.xlsx")).unwrap();
+    let xlsx: Arc<[u8]> =
+        replace_zip_entry(&xlsx_small, "xl/worksheets/sheet1.xml", &large_sparse_worksheet())
+            .into();
+    let xlsx_native = default_engine().unwrap();
+    let xlsx_aggregate = aggregate_engine(Arc::new(AggregateOnly(WorkbookConverter)));
+    let (xlsx_native_profile, xlsx_aggregate_profile) =
+        alternating_profile(&xlsx_native, &xlsx_aggregate, &xlsx, "production-sparse.xlsx");
+    let (small_xlsx_native_profile, small_xlsx_aggregate_profile) =
+        alternating_profile(&xlsx_native, &xlsx_aggregate, &Arc::from(xlsx_small), "ordinary.xlsx");
+
+    for (format, native, aggregate) in [
+        ("large-pptx", &pptx_native_profile, &pptx_aggregate_profile),
+        ("large-xlsx", &xlsx_native_profile, &xlsx_aggregate_profile),
+        ("ordinary-pptx", &small_pptx_native_profile, &small_pptx_aggregate_profile),
+        ("ordinary-xlsx", &small_xlsx_native_profile, &small_xlsx_aggregate_profile),
+    ] {
+        assert!(
+            native.elapsed_us <= aggregate.elapsed_us.saturating_mul(3) / 2 + 5_000,
+            "{format} native average {}us exceeds aggregate {}us by more than 50%",
+            native.elapsed_us,
+            aggregate.elapsed_us
+        );
+        assert_eq!(native.temporary_peak, 0, "{format} native temporary bytes");
+        assert!(native.logical_memory_peak <= 2 * 1024 * 1024 * 1024);
+        println!(
+            "production profile {format}: native={}us aggregate={}us native_logical_peak={} aggregate_logical_peak={} native_rss_delta={} aggregate_rss_delta={} native_temp={} aggregate_temp={}",
+            native.elapsed_us,
+            aggregate.elapsed_us,
+            native.logical_memory_peak,
+            aggregate.logical_memory_peak,
+            native.rss_delta_peak,
+            aggregate.rss_delta_peak,
+            native.temporary_peak,
+            aggregate.temporary_peak,
+        );
+    }
+}
+
+#[test]
+fn compound_file_pptx_preserves_the_encrypted_error() {
+    let mut request = ConversionRequest::new(InputRef::Bytes {
+        data: Arc::from(&b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"[..]),
+        name: Some("encrypted.pptx".into()),
+    });
+    request.hint.format = Some(InputFormat::Pptx);
+    assert!(matches!(
+        block_on(default_engine().unwrap().convert(request)),
+        Err(ConversionError::Encrypted)
+    ));
+}

--- a/crates/converters/src/presentation/mod.rs
+++ b/crates/converters/src/presentation/mod.rs
@@ -23,16 +23,19 @@ mod xml;
 mod xml_base;
 
 #[cfg(test)]
+mod stream_tests;
+#[cfg(test)]
 mod test_observer;
 
 use allocation::try_clone_string;
 use error::{limit, malformed};
 use geometry::sort_shapes_for_reading;
 use into_markdown_core::{
-    Block, BoxFuture, ConversionError, ConversionOptions, Converter, ConverterOutput, Diagnostic,
-    DiagnosticSeverity, ExecutionContext, FormatCandidate, Inline, InputFormat, ProbeOutcome,
-    ResolvedInput, Services, SourceLocator, estimate_retained_output,
-    estimate_validation_working_set,
+    Block, BoxFuture, ConversionError, ConversionOptions, Converter, ConverterEventSink,
+    ConverterOutput, ConverterStream, ConverterStreamCompletion, ConverterStreamMode, Diagnostic,
+    DiagnosticSeverity, ExecutionContext, FormatCandidate, Inline, InputFormat, LocalBoxFuture,
+    ProbeOutcome, ResolvedInput, Services, SourceLocator, StreamConsumerKind,
+    estimate_retained_output, estimate_validation_working_set, stream_converter_output,
 };
 use model::{Package, ParseState};
 use output::shapes_to_blocks;
@@ -79,6 +82,10 @@ impl Converter for PresentationConverter {
 
     fn supported_formats(&self) -> &'static [InputFormat] {
         FORMATS
+    }
+
+    fn stream_support(&self) -> Option<&dyn ConverterStream> {
+        Some(self)
     }
 
     fn probe<'a>(
@@ -131,6 +138,43 @@ impl Converter for PresentationConverter {
         context: &'a ExecutionContext,
     ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
         Box::pin(async move { convert_presentation(&input.bytes, options, context) })
+    }
+}
+
+impl ConverterStream for PresentationConverter {
+    fn stream_mode(&self) -> ConverterStreamMode {
+        ConverterStreamMode::Native
+    }
+
+    fn stream_mode_for(
+        &self,
+        input: &ResolvedInput,
+        _: &FormatCandidate,
+        _: &ConversionOptions,
+        consumer: StreamConsumerKind,
+    ) -> ConverterStreamMode {
+        if consumer == StreamConsumerKind::Collecting
+            && input.bytes.starts_with(COMPOUND_FILE_SIGNATURE)
+        {
+            ConverterStreamMode::AggregateAdapter
+        } else {
+            ConverterStreamMode::Native
+        }
+    }
+
+    fn convert_stream<'a>(
+        &'a self,
+        input: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        options: &'a ConversionOptions,
+        _: &'a Services,
+        context: &'a ExecutionContext,
+        sink: &'a mut dyn ConverterEventSink,
+    ) -> LocalBoxFuture<'a, Result<ConverterStreamCompletion, ConversionError>> {
+        Box::pin(async move {
+            let output = convert_presentation(&input.bytes, options, context)?;
+            stream_converter_output(output, sink)
+        })
     }
 }
 

--- a/crates/converters/src/presentation/stream_tests.rs
+++ b/crates/converters/src/presentation/stream_tests.rs
@@ -1,0 +1,46 @@
+use super::PresentationConverter;
+use into_markdown_core::{
+    ConversionOptions, ConverterStream, ConverterStreamMode, FormatCandidate, InputFormat,
+    ResolvedInput, SourceMetadata, StreamConsumerKind,
+};
+use std::sync::Arc;
+
+#[test]
+fn pptx_collecting_uses_native_stream_independent_of_name() {
+    let converter = PresentationConverter;
+    let candidate = FormatCandidate::new(InputFormat::Pptx, 1.0, "test");
+    for name in [None, Some("ordinary.pptx".into()), Some("unrelated.bin".into())] {
+        let input = ResolvedInput {
+            bytes: Arc::from(&b"PK\x03\x04"[..]),
+            metadata: SourceMetadata { name, size: 4, ..SourceMetadata::default() },
+        };
+        assert_eq!(
+            converter.stream_mode_for(
+                &input,
+                &candidate,
+                &ConversionOptions::default(),
+                StreamConsumerKind::Collecting,
+            ),
+            ConverterStreamMode::Native
+        );
+    }
+}
+
+#[test]
+fn compound_file_wrapper_keeps_encrypted_aggregate_error_path() {
+    let converter = PresentationConverter;
+    let candidate = FormatCandidate::new(InputFormat::Pptx, 1.0, "test");
+    let input = ResolvedInput {
+        bytes: Arc::from(&super::COMPOUND_FILE_SIGNATURE[..]),
+        metadata: SourceMetadata { size: 8, ..SourceMetadata::default() },
+    };
+    assert_eq!(
+        converter.stream_mode_for(
+            &input,
+            &candidate,
+            &ConversionOptions::default(),
+            StreamConsumerKind::Collecting,
+        ),
+        ConverterStreamMode::AggregateAdapter
+    );
+}

--- a/crates/converters/src/workbook/mod.rs
+++ b/crates/converters/src/workbook/mod.rs
@@ -24,12 +24,15 @@ mod xlsx;
 mod tests;
 
 use into_markdown_core::{
-    BoxFuture, ConversionError, ConversionOptions, Converter, ConverterOutput, ExecutionContext,
-    FormatCandidate, InputFormat, ProbeOutcome, ResolvedInput, Services,
+    BoxFuture, ConversionError, ConversionOptions, Converter, ConverterEventSink, ConverterOutput,
+    ConverterStream, ConverterStreamCompletion, ConverterStreamMode, ExecutionContext,
+    FormatCandidate, InputFormat, LocalBoxFuture, ProbeOutcome, ResolvedInput, Services,
+    StreamConsumerKind, stream_converter_output,
 };
 
 const FORMATS: &[InputFormat] = &[InputFormat::Xlsx];
 const PROVIDER_ID: &str = "builtin.converter.workbook";
+const COLLECTING_STREAM_MIN_WORKSHEET_BYTES: u64 = 256 * 1024;
 
 /// Strict workbook converter. Formulae are preserved but never evaluated.
 #[derive(Debug, Default)]
@@ -54,6 +57,10 @@ impl Converter for WorkbookConverter {
 
     fn supported_formats(&self) -> &'static [InputFormat] {
         FORMATS
+    }
+
+    fn stream_support(&self) -> Option<&dyn ConverterStream> {
+        Some(self)
     }
 
     fn probe<'a>(
@@ -109,4 +116,133 @@ impl Converter for WorkbookConverter {
         // directory/materialization and codec working sets.
         Ok(context.available_memory_bytes())
     }
+}
+
+impl ConverterStream for WorkbookConverter {
+    fn stream_mode(&self) -> ConverterStreamMode {
+        ConverterStreamMode::Native
+    }
+
+    fn stream_mode_for(
+        &self,
+        input: &ResolvedInput,
+        _: &FormatCandidate,
+        _: &ConversionOptions,
+        consumer: StreamConsumerKind,
+    ) -> ConverterStreamMode {
+        if consumer == StreamConsumerKind::Collecting && !has_large_worksheet_payload(&input.bytes)
+        {
+            ConverterStreamMode::AggregateAdapter
+        } else {
+            ConverterStreamMode::Native
+        }
+    }
+
+    fn convert_stream<'a>(
+        &'a self,
+        input: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        options: &'a ConversionOptions,
+        _: &'a Services,
+        context: &'a ExecutionContext,
+        sink: &'a mut dyn ConverterEventSink,
+    ) -> LocalBoxFuture<'a, Result<ConverterStreamCompletion, ConversionError>> {
+        Box::pin(async move {
+            let output = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                orchestrator::convert_workbook(&input.bytes, options, context)
+            }))
+            .unwrap_or_else(|_| {
+                Err(error::malformed(None, "workbook parser rejected invalid structure"))
+            })?;
+            stream_converter_output(output, sink)
+        })
+    }
+}
+
+fn has_large_worksheet_payload(bytes: &[u8]) -> bool {
+    const EOCD: &[u8; 4] = b"PK\x05\x06";
+    const CENTRAL: &[u8; 4] = b"PK\x01\x02";
+    let search_start = bytes.len().saturating_sub(65_557);
+    let Some(eocd) = bytes[search_start..]
+        .windows(EOCD.len())
+        .rposition(|window| window == EOCD)
+        .map(|offset| search_start + offset)
+    else {
+        return false;
+    };
+    let Some(mut cursor) = checked_add(eocd, 16)
+        .and_then(|offset| le32_at(bytes, offset))
+        .and_then(|value| usize::try_from(value).ok())
+    else {
+        return false;
+    };
+    let Some(entries) =
+        checked_add(eocd, 10).and_then(|offset| le16_at(bytes, offset)).map(usize::from)
+    else {
+        return false;
+    };
+    let mut worksheet_bytes = 0_u64;
+    for _ in 0..entries {
+        let Some(signature_end) = checked_add(cursor, 4) else {
+            return false;
+        };
+        if bytes.get(cursor..signature_end) != Some(CENTRAL) {
+            return false;
+        }
+        let Some(name_len) =
+            checked_add(cursor, 28).and_then(|offset| le16_at(bytes, offset)).map(usize::from)
+        else {
+            return false;
+        };
+        let Some(extra_len) =
+            checked_add(cursor, 30).and_then(|offset| le16_at(bytes, offset)).map(usize::from)
+        else {
+            return false;
+        };
+        let Some(comment_len) =
+            checked_add(cursor, 32).and_then(|offset| le16_at(bytes, offset)).map(usize::from)
+        else {
+            return false;
+        };
+        let Some(name_start) = checked_add(cursor, 46) else {
+            return false;
+        };
+        let Some(name_end) = name_start.checked_add(name_len) else {
+            return false;
+        };
+        let Some(name) = bytes.get(name_start..name_end) else {
+            return false;
+        };
+        if name.starts_with(b"xl/worksheets/")
+            && (name.ends_with(b".xml") || name.ends_with(b".bin"))
+        {
+            let Some(size) = checked_add(cursor, 24).and_then(|offset| le32_at(bytes, offset))
+            else {
+                return false;
+            };
+            worksheet_bytes = worksheet_bytes.saturating_add(u64::from(size));
+            if worksheet_bytes >= COLLECTING_STREAM_MIN_WORKSHEET_BYTES {
+                return true;
+            }
+        }
+        let Some(next) =
+            name_end.checked_add(extra_len).and_then(|value| value.checked_add(comment_len))
+        else {
+            return false;
+        };
+        cursor = next;
+    }
+    false
+}
+
+fn le16_at(bytes: &[u8], offset: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(bytes.get(offset..checked_add(offset, 2)?)?.try_into().ok()?))
+}
+
+fn le32_at(bytes: &[u8], offset: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(bytes.get(offset..checked_add(offset, 4)?)?.try_into().ok()?))
+}
+
+fn checked_add(left: usize, right: usize) -> Option<usize> {
+    left.checked_add(right)
 }

--- a/crates/converters/src/workbook/tests/mod.rs
+++ b/crates/converters/src/workbook/tests/mod.rs
@@ -3,6 +3,7 @@ mod extras;
 mod formulas;
 mod opc;
 mod resources;
+mod stream_mode;
 mod support;
 mod xlsb;
 mod xlsx;

--- a/crates/converters/src/workbook/tests/stream_mode.rs
+++ b/crates/converters/src/workbook/tests/stream_mode.rs
@@ -1,0 +1,77 @@
+use super::super::WorkbookConverter;
+use into_markdown_core::{
+    ConversionOptions, ConverterStream, ConverterStreamMode, FormatCandidate, InputFormat,
+    ResolvedInput, SourceMetadata, StreamConsumerKind,
+};
+use std::sync::Arc;
+use std::{io::Cursor, io::Write};
+
+fn input(worksheet_bytes: usize, unrelated_bytes: usize, name: Option<&str>) -> ResolvedInput {
+    let mut output = Cursor::new(Vec::new());
+    {
+        let mut writer = zip::ZipWriter::new(&mut output);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored);
+        writer.start_file("xl/worksheets/sheet1.xml", options).unwrap();
+        writer.write_all(&vec![b'x'; worksheet_bytes]).unwrap();
+        writer.start_file("customXml/unrelated.bin", options).unwrap();
+        writer.write_all(&vec![b'p'; unrelated_bytes]).unwrap();
+        writer.finish().unwrap();
+    }
+    let bytes: Arc<[u8]> = output.into_inner().into();
+    ResolvedInput {
+        bytes: Arc::clone(&bytes),
+        metadata: SourceMetadata {
+            name: name.map(str::to_owned),
+            size: u64::try_from(bytes.len()).unwrap(),
+            ..SourceMetadata::default()
+        },
+    }
+}
+
+#[test]
+fn collecting_keeps_small_workbooks_on_real_aggregate_fallback() {
+    let converter = WorkbookConverter;
+    let candidate = FormatCandidate::new(InputFormat::Xlsx, 1.0, "test");
+    assert_eq!(
+        converter.stream_mode_for(
+            &input(4 * 1024, 0, Some("small.xlsx")),
+            &candidate,
+            &ConversionOptions::default(),
+            StreamConsumerKind::Collecting,
+        ),
+        ConverterStreamMode::AggregateAdapter
+    );
+}
+
+#[test]
+fn collecting_native_selection_depends_on_worksheet_payload_not_name() {
+    let converter = WorkbookConverter;
+    let candidate = FormatCandidate::new(InputFormat::Xlsx, 1.0, "test");
+    for name in [None, Some("ordinary.xlsx"), Some("unrelated.bin")] {
+        assert_eq!(
+            converter.stream_mode_for(
+                &input(256 * 1024, 0, name),
+                &candidate,
+                &ConversionOptions::default(),
+                StreamConsumerKind::Collecting,
+            ),
+            ConverterStreamMode::Native
+        );
+    }
+}
+
+#[test]
+fn unrelated_zip_padding_cannot_select_native_collecting() {
+    let converter = WorkbookConverter;
+    let candidate = FormatCandidate::new(InputFormat::Xlsx, 1.0, "test");
+    assert_eq!(
+        converter.stream_mode_for(
+            &input(4 * 1024, 2 * 1024 * 1024, Some("padded.xlsx")),
+            &candidate,
+            &ConversionOptions::default(),
+            StreamConsumerKind::Collecting,
+        ),
+        ConverterStreamMode::AggregateAdapter
+    );
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,8 @@ mod nested;
 mod ocr_binding;
 mod options;
 mod spi;
+mod stream;
+mod summary;
 
 pub use dto::{
     AssetDto, BUNDLE_SCHEMA_VERSION, BatchItemDto, BatchItemOutcome, BatchItemStatus,
@@ -71,4 +73,8 @@ pub use spi::{
 pub use spi::{
     estimate_retained_blocks, estimate_retained_output, estimate_retained_result,
     estimate_validation_working_set,
+};
+pub use stream::{
+    ConverterEventSink, ConverterStream, ConverterStreamCompletion, ConverterStreamMode,
+    LocalBoxFuture, StreamConsumerKind, stream_converter_output,
 };

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -141,7 +141,7 @@ pub enum ConversionOutcome {
 }
 
 /// Bounded completion metadata returned after all sink writes succeed.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug)]
 pub struct ConversionSummary {
     /// Authoritative format selected after probing.
     pub format: Option<InputFormat>,
@@ -153,6 +153,7 @@ pub struct ConversionSummary {
     pub markdown_bytes: u64,
     /// Number of assets written.
     pub assets: u64,
+    pub(crate) _memory_lease: OutputMemoryLease,
 }
 
 /// Ordered destination for incremental Markdown and asset payloads.
@@ -1217,6 +1218,10 @@ pub trait Converter: Send + Sync {
     }
     /// Formats implemented by this converter.
     fn supported_formats(&self) -> &'static [InputFormat];
+    /// Expose an optional native semantic-stream capability.
+    fn stream_support(&self) -> Option<&dyn crate::ConverterStream> {
+        None
+    }
     /// Cheap applicability check that must not perform full conversion.
     fn probe<'a>(
         &'a self,

--- a/crates/core/src/stream.rs
+++ b/crates/core/src/stream.rs
@@ -1,0 +1,161 @@
+//! Converter-to-engine semantic streaming contracts.
+//!
+//! This module owns the one-shot stream protocol so the general service-provider
+//! interface in `spi` does not keep growing with engine execution details.
+
+use crate::{
+    Asset, ConversionError, ConversionOptions, Converter, ConverterOutput, Diagnostic, Document,
+    ExecutionContext, FormatCandidate, ResolvedInput, Services,
+};
+use std::future::Future;
+use std::pin::Pin;
+
+/// Thread-local boxed future used by synchronous stream callbacks.
+pub type LocalBoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
+
+/// Retention behavior of the engine-side stream consumer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamConsumerKind {
+    /// Consume artifacts without retaining a backwards-compatible result.
+    Immediate,
+    /// Retain the semantic stream as a backwards-compatible aggregate result.
+    Collecting,
+}
+
+/// How a converter participates in semantic streaming.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConverterStreamMode {
+    /// Run the source-compatible aggregate converter and move its output into the stream.
+    AggregateAdapter,
+    /// Run the converter's native one-shot stream entry point.
+    Native,
+}
+
+/// Optional native semantic-stream capability implemented independently from
+/// the general converter SPI.
+pub trait ConverterStream: Converter {
+    /// Declare whether this converter has a native one-shot semantic stream.
+    fn stream_mode(&self) -> ConverterStreamMode {
+        ConverterStreamMode::AggregateAdapter
+    }
+
+    /// Select the stream mode for this exact input and consumer.
+    fn stream_mode_for(
+        &self,
+        input: &ResolvedInput,
+        candidate: &FormatCandidate,
+        options: &ConversionOptions,
+        consumer: StreamConsumerKind,
+    ) -> ConverterStreamMode {
+        let _ = (input, candidate, options, consumer);
+        self.stream_mode()
+    }
+
+    /// Conservative peak for the selected semantic stream producer.
+    ///
+    /// # Errors
+    ///
+    /// Returns a stable component or resource error when no safe stream plan
+    /// can be declared for this request.
+    fn planned_stream_bytes(
+        &self,
+        input: &ResolvedInput,
+        candidate: &FormatCandidate,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+        consumer: StreamConsumerKind,
+    ) -> Result<u64, ConversionError> {
+        let _ = consumer;
+        self.planned_output_bytes(input, candidate, options, context)
+    }
+
+    /// Convert through the owned semantic stream.
+    fn convert_stream<'a>(
+        &'a self,
+        input: &'a ResolvedInput,
+        candidate: &'a FormatCandidate,
+        options: &'a ConversionOptions,
+        services: &'a Services,
+        context: &'a ExecutionContext,
+        sink: &'a mut dyn ConverterEventSink,
+    ) -> LocalBoxFuture<'a, Result<ConverterStreamCompletion, ConversionError>> {
+        let _ = (input, candidate, options, services, context, sink);
+        Box::pin(async move {
+            Err(ConversionError::Unsupported {
+                detail: format!("converter {} requires aggregate adaptation", self.id()),
+            })
+        })
+    }
+}
+
+/// Synchronous destination for owned converter events.
+pub trait ConverterEventSink {
+    /// Observe cancellation or timeout before the next allocation or callback.
+    ///
+    /// # Errors
+    ///
+    /// Returns a cancellation, timeout, or sink-defined failure.
+    fn checkpoint(&mut self) -> Result<(), ConversionError> {
+        Ok(())
+    }
+
+    /// Take ownership of the complete semantic document and asset inventory.
+    /// Existing nested Vec allocations and capacities must be preserved rather
+    /// than copied into a second collector inventory.
+    ///
+    /// # Errors
+    ///
+    /// Returns a protocol, resource, cancellation, or destination failure.
+    fn write_output(
+        &mut self,
+        document: Document,
+        assets: Vec<Asset>,
+    ) -> Result<(), ConversionError>;
+}
+
+/// Terminal converter state after every semantic event was accepted.
+///
+/// The residual output retains diagnostics and authenticated memory ownership;
+/// document and asset ownership has already moved to the sink.
+#[derive(Debug)]
+pub struct ConverterStreamCompletion {
+    residual: ConverterOutput,
+}
+
+impl ConverterStreamCompletion {
+    /// Reassemble the converter output without losing its authenticated leases.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn into_output(mut self, document: Document, assets: Vec<Asset>) -> ConverterOutput {
+        self.residual.document = document;
+        self.residual.assets = assets;
+        self.residual
+    }
+
+    /// Borrow terminal diagnostics.
+    #[must_use]
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.residual.diagnostics
+    }
+}
+
+/// Move one aggregate converter output through the canonical semantic stream.
+///
+/// No document node, asset payload, or diagnostic is cloned. This is the sole
+/// aggregate adapter used by the engine and by native converters that share an
+/// existing parser while adopting the single-execution stream contract.
+///
+/// # Errors
+///
+/// Returns the first sink or cancellation error.
+#[doc(hidden)]
+pub fn stream_converter_output(
+    mut output: ConverterOutput,
+    sink: &mut dyn ConverterEventSink,
+) -> Result<ConverterStreamCompletion, ConversionError> {
+    sink.checkpoint()?;
+    let document = std::mem::take(&mut output.document);
+    let assets = std::mem::take(&mut output.assets);
+    sink.write_output(document, assets)?;
+    Ok(ConverterStreamCompletion { residual: output })
+}

--- a/crates/core/src/summary.rs
+++ b/crates/core/src/summary.rs
@@ -1,0 +1,80 @@
+//! Completion-summary ownership and accounting.
+
+use crate::spi::OutputMemoryLease;
+use crate::{ConversionOutcome, ConversionResult, ConversionSummary};
+
+impl Clone for ConversionSummary {
+    fn clone(&self) -> Self {
+        Self {
+            format: self.format,
+            outcome: self.outcome,
+            diagnostics: self.diagnostics.clone(),
+            markdown_bytes: self.markdown_bytes,
+            assets: self.assets,
+            _memory_lease: OutputMemoryLease::default(),
+        }
+    }
+}
+
+impl PartialEq for ConversionSummary {
+    fn eq(&self, other: &Self) -> bool {
+        self.format == other.format
+            && self.outcome == other.outcome
+            && self.diagnostics == other.diagnostics
+            && self.markdown_bytes == other.markdown_bytes
+            && self.assets == other.assets
+    }
+}
+
+impl ConversionResult {
+    /// Consume a completed result into bounded streaming completion metadata.
+    /// Diagnostic ownership and the authenticated result lease move without a
+    /// second allocation; the lease may conservatively retain the former
+    /// result charge until the summary is dropped.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn into_summary(self) -> ConversionSummary {
+        let outcome = if self.diagnostics.is_empty() {
+            ConversionOutcome::Complete
+        } else {
+            ConversionOutcome::Degraded
+        };
+        ConversionSummary {
+            format: self.detected_format,
+            outcome,
+            diagnostics: self.diagnostics,
+            markdown_bytes: u64::try_from(self.markdown.len()).unwrap_or(u64::MAX),
+            assets: u64::try_from(self.assets.len()).unwrap_or(u64::MAX),
+            _memory_lease: self.memory_lease,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Diagnostic, DiagnosticSeverity, Document};
+
+    #[test]
+    fn moves_diagnostics_without_cloning_the_inventory() {
+        let mut diagnostics = Vec::with_capacity(128);
+        diagnostics.push(Diagnostic {
+            code: "moved".into(),
+            severity: DiagnosticSeverity::Warning,
+            message: "owned".into(),
+            locator: None,
+        });
+        let pointer = diagnostics.as_ptr();
+        let capacity = diagnostics.capacity();
+        let result = ConversionResult::new(
+            Document::default(),
+            "markdown".into(),
+            Vec::new(),
+            diagnostics,
+            Vec::new(),
+        );
+        let summary = result.into_summary();
+        assert_eq!(summary.diagnostics.as_ptr(), pointer);
+        assert_eq!(summary.diagnostics.capacity(), capacity);
+    }
+}

--- a/crates/engine/src/collecting.rs
+++ b/crates/engine/src/collecting.rs
@@ -1,0 +1,171 @@
+//! Engine-owned semantic output collection.
+//!
+//! The collector adopts converter-owned allocations. It never creates a
+//! second block, table-row, asset, or payload inventory.
+
+use into_markdown_core::{
+    Asset, ConversionError, ConverterEventSink, ConverterOutput, ConverterStreamCompletion,
+    Document, ExecutionContext,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Phase {
+    AwaitOutput,
+    Finished,
+}
+
+pub(crate) struct CollectingArtifactSink<'a> {
+    context: &'a ExecutionContext,
+    phase: Phase,
+    document: Option<Document>,
+    assets: Option<Vec<Asset>>,
+}
+
+impl<'a> CollectingArtifactSink<'a> {
+    pub(crate) fn new(context: &'a ExecutionContext) -> Self {
+        Self { context, phase: Phase::AwaitOutput, document: None, assets: None }
+    }
+
+    pub(crate) fn finish(
+        mut self,
+        completion: ConverterStreamCompletion,
+    ) -> Result<ConverterOutput, ConversionError> {
+        self.context.checkpoint()?;
+        if self.phase != Phase::Finished {
+            return Err(protocol("semantic stream ended before its owned output"));
+        }
+        let document =
+            self.document.take().ok_or_else(|| protocol("semantic document is missing"))?;
+        let assets =
+            self.assets.take().ok_or_else(|| protocol("semantic asset inventory is missing"))?;
+        Ok(completion.into_output(document, assets))
+    }
+}
+
+impl ConverterEventSink for CollectingArtifactSink<'_> {
+    fn checkpoint(&mut self) -> Result<(), ConversionError> {
+        self.context.checkpoint()
+    }
+
+    fn write_output(
+        &mut self,
+        document: Document,
+        assets: Vec<Asset>,
+    ) -> Result<(), ConversionError> {
+        self.context.checkpoint()?;
+        if self.phase == Phase::Finished {
+            return Err(protocol("semantic stream repeated its owned output"));
+        }
+        self.document = Some(document);
+        self.assets = Some(assets);
+        self.phase = Phase::Finished;
+        Ok(())
+    }
+}
+
+fn protocol(detail: &str) -> ConversionError {
+    ConversionError::Internal { detail: detail.into() }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown_core::{
+        AssetId, Block, BlockNode, ConverterOutput, Diagnostic, DiagnosticSeverity,
+        DocumentMetadata, ExecutionOptions, NodeId, Provenance, ProvenanceKind, ResourceLimits,
+        SourceLocator, stream_converter_output,
+    };
+
+    fn node(index: usize) -> BlockNode {
+        BlockNode {
+            id: NodeId(format!("node-{index}")),
+            block: Block::Rule,
+            provenance: Provenance {
+                kind: ProvenanceKind::NativeParser,
+                provider: "test.collecting".into(),
+                locator: SourceLocator::default(),
+                confidence: None,
+            },
+        }
+    }
+
+    fn source(schema_version: u32, blocks: usize) -> ConverterOutput {
+        ConverterOutput::new(
+            Document {
+                schema_version,
+                metadata: DocumentMetadata { title: Some("exact".into()), ..Default::default() },
+                blocks: (0..blocks).map(node).collect(),
+            },
+            vec![Asset {
+                id: AssetId("asset".into()),
+                filename: Some("asset.bin".into()),
+                media_type: "application/octet-stream".into(),
+                bytes: vec![0, 1, 2, 255],
+                external_uri: None,
+            }],
+            vec![Diagnostic {
+                code: "exact".into(),
+                severity: DiagnosticSeverity::Warning,
+                message: "preserved".into(),
+                locator: None,
+            }],
+        )
+    }
+
+    #[test]
+    fn adapter_preserves_document_assets_diagnostics_and_capacities_without_growth() {
+        let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+        let expected = source(999, 32_768);
+        let block_capacity = expected.document.blocks.capacity();
+        let block_pointer = expected.document.blocks.as_ptr();
+        let asset_capacity = expected.assets.capacity();
+        let asset_pointer = expected.assets.as_ptr();
+        let asset_bytes_pointer = expected.assets[0].bytes.as_ptr();
+        let diagnostic_pointer = expected.diagnostics.as_ptr();
+        let mut sink = CollectingArtifactSink::new(&context);
+        let completion = stream_converter_output(expected, &mut sink).unwrap();
+        let output = sink.finish(completion).unwrap();
+        assert_eq!(output.document.schema_version, 999);
+        assert_eq!(output.document.blocks.len(), 32_768);
+        assert_eq!(output.document.blocks.capacity(), block_capacity);
+        assert_eq!(output.document.blocks.as_ptr(), block_pointer);
+        assert_eq!(output.assets.capacity(), asset_capacity);
+        assert_eq!(output.assets.as_ptr(), asset_pointer);
+        assert_eq!(output.assets[0].bytes.as_ptr(), asset_bytes_pointer);
+        assert_eq!(output.diagnostics.as_ptr(), diagnostic_pointer);
+        assert_eq!(output.diagnostics[0].code, "exact");
+    }
+
+    #[test]
+    fn cancellation_and_protocol_failure_never_finalize() {
+        let cancellation = into_markdown_core::CancellationToken::new();
+        let context = ExecutionContext::new(
+            ExecutionOptions { cancellation: cancellation.clone(), ..ExecutionOptions::default() },
+            ResourceLimits::default(),
+        );
+        let mut sink = CollectingArtifactSink::new(&context);
+        cancellation.cancel();
+        let mut output = source(1, 1);
+        let document = std::mem::take(&mut output.document);
+        let assets = std::mem::take(&mut output.assets);
+        assert!(matches!(sink.write_output(document, assets), Err(ConversionError::Cancelled)));
+
+        let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+        let mut sink = CollectingArtifactSink::new(&context);
+        let mut first = source(1, 0);
+        sink.write_output(std::mem::take(&mut first.document), std::mem::take(&mut first.assets))
+            .unwrap();
+        let mut second = source(1, 0);
+        assert!(matches!(
+            sink.write_output(
+                std::mem::take(&mut second.document),
+                std::mem::take(&mut second.assets),
+            ),
+            Err(ConversionError::Internal { .. })
+        ));
+    }
+}
+
+#[cfg(test)]
+#[path = "collecting/integration_tests.rs"]
+mod integration_tests;

--- a/crates/engine/src/collecting/integration_tests.rs
+++ b/crates/engine/src/collecting/integration_tests.rs
@@ -1,0 +1,623 @@
+use crate::{Engine, EngineBuilder};
+use into_markdown_core::{
+    ArtifactSink, Asset, AssetId, AssetStreamInfo, Block, BlockNode, BoxFuture, ConversionError,
+    ConversionOptions, ConversionRequest, Converter, ConverterEventSink, ConverterOutput,
+    ConverterStream, ConverterStreamCompletion, ConverterStreamMode, Diagnostic,
+    DiagnosticSeverity, Document, ExecutionContext, ExecutionOptions, ExecutionStage,
+    FormatCandidate, FormatDetector, FormatHint, InputFormat, InputRef, LocalBoxFuture,
+    MarkdownRenderer, NodeId, ProbeOutcome, ProgressEvent, ProgressListener, Provenance,
+    ProvenanceKind, ResolvedInput, Services, SourceLocator, SourceMetadata, SourceResolver,
+    stream_converter_output,
+};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    let mut future = std::pin::pin!(future);
+    let waker = std::task::Waker::noop();
+    let mut context = std::task::Context::from_waker(waker);
+    loop {
+        match future.as_mut().poll(&mut context) {
+            std::task::Poll::Ready(output) => return output,
+            std::task::Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
+struct BytesResolver;
+
+impl SourceResolver for BytesResolver {
+    fn id(&self) -> &'static str {
+        "test.collecting.bytes"
+    }
+
+    fn supports(&self, input: &InputRef) -> bool {
+        matches!(input, InputRef::Bytes { .. })
+    }
+
+    fn resolve<'a>(
+        &'a self,
+        input: &'a InputRef,
+        _: &'a ConversionOptions,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ResolvedInput, ConversionError>> {
+        Box::pin(async move {
+            let InputRef::Bytes { data, name } = input else {
+                return Err(ConversionError::Unsupported { detail: "expected bytes".into() });
+            };
+            Ok(ResolvedInput {
+                bytes: Arc::clone(data),
+                metadata: SourceMetadata {
+                    name: name.clone(),
+                    size: u64::try_from(data.len()).unwrap_or(u64::MAX),
+                    ..SourceMetadata::default()
+                },
+            })
+        })
+    }
+}
+
+struct Detector;
+
+impl FormatDetector for Detector {
+    fn id(&self) -> &'static str {
+        "test.collecting.detector"
+    }
+
+    fn detect<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatHint,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<Vec<FormatCandidate>, ConversionError>> {
+        Box::pin(async {
+            Ok(vec![FormatCandidate::new(InputFormat::Text, 1.0, "collecting test")])
+        })
+    }
+}
+
+struct Renderer;
+
+impl MarkdownRenderer for Renderer {
+    fn id(&self) -> &'static str {
+        "test.collecting.renderer"
+    }
+
+    fn planned_markdown_bytes(
+        &self,
+        _: &Document,
+        _: &[Asset],
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        Ok(8 * 1024 * 1024)
+    }
+
+    fn render<'a>(
+        &'a self,
+        document: &'a Document,
+        _: &'a [Asset],
+        _: &'a ConversionOptions,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<String, ConversionError>> {
+        Box::pin(async move {
+            if document.blocks.len() == 1 {
+                Ok("native\n".into())
+            } else {
+                Ok("x".repeat(4 * 1024 * 1024))
+            }
+        })
+    }
+}
+
+struct CountingNative {
+    aggregate_calls: Arc<AtomicUsize>,
+    native_calls: Arc<AtomicUsize>,
+    plan: u64,
+    schema_version: u32,
+    block_count: usize,
+}
+
+impl Converter for CountingNative {
+    fn id(&self) -> &'static str {
+        "test.collecting.native"
+    }
+
+    fn supported_formats(&self) -> &'static [InputFormat] {
+        &[InputFormat::Text]
+    }
+
+    fn stream_support(&self) -> Option<&dyn ConverterStream> {
+        Some(self)
+    }
+
+    fn probe<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ProbeOutcome, ConversionError>> {
+        Box::pin(async { Ok(ProbeOutcome::Match { confidence: 1.0 }) })
+    }
+
+    fn planned_output_bytes(
+        &self,
+        _: &ResolvedInput,
+        _: &FormatCandidate,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        Ok(self.plan)
+    }
+
+    fn convert<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        _: &'a ConversionOptions,
+        _: &'a Services,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        self.aggregate_calls.fetch_add(1, Ordering::SeqCst);
+        let schema_version = self.schema_version;
+        let block_count = self.block_count;
+        Box::pin(async move { Ok(output(schema_version, block_count)) })
+    }
+}
+
+impl ConverterStream for CountingNative {
+    fn stream_mode(&self) -> ConverterStreamMode {
+        ConverterStreamMode::Native
+    }
+
+    fn convert_stream<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        _: &'a ConversionOptions,
+        _: &'a Services,
+        _: &'a ExecutionContext,
+        sink: &'a mut dyn ConverterEventSink,
+    ) -> LocalBoxFuture<'a, Result<ConverterStreamCompletion, ConversionError>> {
+        self.native_calls.fetch_add(1, Ordering::SeqCst);
+        let schema_version = self.schema_version;
+        let block_count = self.block_count;
+        Box::pin(async move { stream_converter_output(output(schema_version, block_count), sink) })
+    }
+}
+
+fn output(schema_version: u32, block_count: usize) -> ConverterOutput {
+    ConverterOutput::new(
+        Document {
+            schema_version,
+            blocks: (0..block_count)
+                .map(|index| BlockNode {
+                    id: NodeId(format!("native-{index}")),
+                    block: Block::Rule,
+                    provenance: Provenance {
+                        kind: ProvenanceKind::NativeParser,
+                        provider: "test.collecting.native".into(),
+                        locator: SourceLocator::default(),
+                        confidence: None,
+                    },
+                })
+                .collect(),
+            ..Document::default()
+        },
+        vec![Asset {
+            id: AssetId("asset".into()),
+            filename: Some("asset.bin".into()),
+            media_type: "application/octet-stream".into(),
+            bytes: vec![0, 1, 2, 255],
+            external_uri: None,
+        }],
+        vec![Diagnostic {
+            code: "native.diagnostic".into(),
+            severity: DiagnosticSeverity::Warning,
+            message: "preserved".into(),
+            locator: None,
+        }],
+    )
+}
+
+fn engine(converter: CountingNative) -> Engine {
+    let mut builder = EngineBuilder::new().renderer(Arc::new(Renderer));
+    builder
+        .registry_mut()
+        .register_source_resolver(Arc::new(BytesResolver))
+        .register_format_detector(Arc::new(Detector))
+        .register_converter(Arc::new(converter));
+    builder.build().unwrap()
+}
+
+fn request() -> ConversionRequest {
+    ConversionRequest::new(InputRef::bytes(b"native".as_slice(), Some("native.txt")))
+}
+
+#[derive(Default)]
+struct RecordingSink {
+    markdown: Vec<u8>,
+    assets: Vec<(AssetStreamInfo, Vec<u8>)>,
+    current: Option<(AssetStreamInfo, Vec<u8>)>,
+}
+
+impl ArtifactSink for RecordingSink {
+    fn write_markdown(&mut self, chunk: &[u8]) -> Result<(), ConversionError> {
+        self.markdown.extend_from_slice(chunk);
+        Ok(())
+    }
+
+    fn begin_asset(&mut self, asset: &AssetStreamInfo) -> Result<(), ConversionError> {
+        self.current = Some((asset.clone(), Vec::new()));
+        Ok(())
+    }
+
+    fn write_asset(&mut self, chunk: &[u8]) -> Result<(), ConversionError> {
+        self.current.as_mut().unwrap().1.extend_from_slice(chunk);
+        Ok(())
+    }
+
+    fn end_asset(&mut self) -> Result<(), ConversionError> {
+        self.assets.push(self.current.take().unwrap());
+        Ok(())
+    }
+}
+
+#[test]
+fn public_convert_executes_native_once_without_aggregate_fallback() {
+    let aggregate_calls = Arc::new(AtomicUsize::new(0));
+    let native_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(CountingNative {
+        aggregate_calls: Arc::clone(&aggregate_calls),
+        native_calls: Arc::clone(&native_calls),
+        plan: 1024 * 1024,
+        schema_version: into_markdown_core::DOCUMENT_SCHEMA_VERSION,
+        block_count: 1,
+    });
+
+    let result = block_on(engine.convert(request())).unwrap();
+
+    assert_eq!(aggregate_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(native_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(result.markdown.as_bytes(), b"native\n");
+    let expected = output(into_markdown_core::DOCUMENT_SCHEMA_VERSION, 1);
+    assert_eq!(result.document.blocks, expected.document.blocks);
+    assert_eq!(result.assets, expected.assets);
+    assert_eq!(result.diagnostics, expected.diagnostics);
+}
+
+#[test]
+fn production_collecting_uses_one_exact_inventory_for_many_blocks_and_large_markdown() {
+    const BLOCKS: usize = 32_768;
+    let aggregate_calls = Arc::new(AtomicUsize::new(0));
+    let native_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(CountingNative {
+        aggregate_calls: Arc::clone(&aggregate_calls),
+        native_calls: Arc::clone(&native_calls),
+        plan: 256 * 1024 * 1024,
+        schema_version: into_markdown_core::DOCUMENT_SCHEMA_VERSION,
+        block_count: BLOCKS,
+    });
+    let started = std::time::Instant::now();
+    let result = block_on(engine.convert(request())).unwrap();
+    println!(
+        "production collecting: blocks={BLOCKS} markdown={} elapsed_us={}",
+        result.markdown.len(),
+        started.elapsed().as_micros()
+    );
+    assert_eq!(aggregate_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(native_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(result.document.blocks.len(), BLOCKS);
+    assert_eq!(result.document.blocks.capacity(), BLOCKS);
+    assert_eq!(result.markdown.len(), 4 * 1024 * 1024);
+}
+
+#[test]
+fn native_admission_has_stable_exact_minus_one_and_releases_on_drop() {
+    let expected = output(into_markdown_core::DOCUMENT_SCHEMA_VERSION, 8);
+    let retained = into_markdown_core::estimate_retained_output(
+        &expected.document,
+        &expected.assets,
+        &expected.diagnostics,
+    )
+    .unwrap();
+    let validation = into_markdown_core::estimate_validation_working_set(
+        &expected.document,
+        &expected.assets,
+        &expected.diagnostics,
+    )
+    .unwrap();
+    let plan = retained + validation;
+    let calls = Arc::new(AtomicUsize::new(0));
+    let converter = |calls: Arc<AtomicUsize>| CountingNative {
+        aggregate_calls: Arc::new(AtomicUsize::new(0)),
+        native_calls: calls,
+        plan,
+        schema_version: into_markdown_core::DOCUMENT_SCHEMA_VERSION,
+        block_count: 8,
+    };
+    let input = ResolvedInput {
+        bytes: Arc::from(&b"native"[..]),
+        metadata: SourceMetadata { size: 6, ..SourceMetadata::default() },
+    };
+    let candidate = FormatCandidate::new(InputFormat::Text, 1.0, "exact boundary");
+    let options = ConversionOptions {
+        limits: into_markdown_core::ResourceLimits {
+            max_memory_bytes: plan - 1,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let low = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    assert!(matches!(
+        block_on(crate::stream_execution::invoke_native_collecting(
+            &converter(Arc::clone(&calls)),
+            &input,
+            &candidate,
+            &options,
+            &Services::default(),
+            &low,
+        )),
+        Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+    ));
+    assert_eq!(calls.load(Ordering::SeqCst), 0);
+    assert_eq!(low.available_memory_bytes(), plan - 1);
+
+    let options = ConversionOptions {
+        limits: into_markdown_core::ResourceLimits { max_memory_bytes: plan, ..Default::default() },
+        ..Default::default()
+    };
+    let exact = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    let output = block_on(crate::stream_execution::invoke_native_collecting(
+        &converter(Arc::clone(&calls)),
+        &input,
+        &candidate,
+        &options,
+        &Services::default(),
+        &exact,
+    ))
+    .unwrap();
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(output.document.blocks.len(), 8);
+    drop(output);
+    assert_eq!(exact.available_memory_bytes(), plan);
+}
+
+#[test]
+fn native_collecting_preserves_and_rejects_invalid_document_schema() {
+    let aggregate_calls = Arc::new(AtomicUsize::new(0));
+    let native_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(CountingNative {
+        aggregate_calls: Arc::clone(&aggregate_calls),
+        native_calls: Arc::clone(&native_calls),
+        plan: 1024 * 1024,
+        schema_version: 999,
+        block_count: 1,
+    });
+    let error = block_on(engine.convert(request())).unwrap_err();
+    assert!(matches!(error, ConversionError::Internal { .. }));
+    assert!(error.to_string().contains("schemaVersion"));
+    assert_eq!(aggregate_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(native_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn aggregate_and_streamed_public_bytes_assets_and_diagnostics_match() {
+    let aggregate_calls = Arc::new(AtomicUsize::new(0));
+    let native_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(CountingNative {
+        aggregate_calls,
+        native_calls,
+        plan: 1024 * 1024,
+        schema_version: into_markdown_core::DOCUMENT_SCHEMA_VERSION,
+        block_count: 1,
+    });
+    let aggregate = block_on(engine.convert(request())).unwrap();
+    let mut streamed = RecordingSink::default();
+    let summary = block_on(engine.convert_into(request(), &mut streamed)).unwrap();
+
+    assert_eq!(streamed.markdown, aggregate.markdown.as_bytes());
+    assert_eq!(streamed.assets.len(), aggregate.assets.len());
+    assert_eq!(streamed.assets[0].0.id, aggregate.assets[0].id);
+    assert_eq!(streamed.assets[0].1, aggregate.assets[0].bytes);
+    assert_eq!(summary.diagnostics, aggregate.diagnostics);
+}
+
+struct StageListener(Arc<Mutex<Vec<ExecutionStage>>>);
+
+impl ProgressListener for StageListener {
+    fn on_progress(&self, event: ProgressEvent) {
+        self.0.lock().unwrap().push(event.stage);
+    }
+}
+
+#[test]
+fn collecting_capacity_failure_never_reports_completed() {
+    let stages = Arc::new(Mutex::new(Vec::new()));
+    let engine = engine(CountingNative {
+        aggregate_calls: Arc::new(AtomicUsize::new(0)),
+        native_calls: Arc::new(AtomicUsize::new(0)),
+        plan: 0,
+        schema_version: into_markdown_core::DOCUMENT_SCHEMA_VERSION,
+        block_count: 1,
+    });
+    let mut request = request();
+    request.execution.progress_listener = Some(Arc::new(StageListener(Arc::clone(&stages))));
+
+    assert!(matches!(
+        block_on(engine.convert(request)),
+        Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+    ));
+    std::thread::sleep(std::time::Duration::from_millis(25));
+    assert!(!stages.lock().unwrap().contains(&ExecutionStage::Completed));
+}
+
+#[derive(Clone, Copy)]
+enum ChunkFailure {
+    Markdown,
+    BeginAsset,
+    AssetBytes,
+    EndAsset,
+}
+
+struct FailingChunkSink(ChunkFailure);
+
+impl ArtifactSink for FailingChunkSink {
+    fn write_markdown(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        if matches!(self.0, ChunkFailure::Markdown) {
+            Err(ConversionError::Internal { detail: "Markdown sink failure".into() })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn begin_asset(&mut self, _: &AssetStreamInfo) -> Result<(), ConversionError> {
+        if matches!(self.0, ChunkFailure::BeginAsset) {
+            Err(ConversionError::Internal { detail: "asset begin failure".into() })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn write_asset(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        if matches!(self.0, ChunkFailure::AssetBytes) {
+            Err(ConversionError::Internal { detail: "asset byte failure".into() })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn end_asset(&mut self) -> Result<(), ConversionError> {
+        if matches!(self.0, ChunkFailure::EndAsset) {
+            Err(ConversionError::Internal { detail: "asset end failure".into() })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[test]
+fn every_chunk_sink_terminal_failure_precedes_completed() {
+    for failure in [
+        ChunkFailure::Markdown,
+        ChunkFailure::BeginAsset,
+        ChunkFailure::AssetBytes,
+        ChunkFailure::EndAsset,
+    ] {
+        let stages = Arc::new(Mutex::new(Vec::new()));
+        let engine = engine(CountingNative {
+            aggregate_calls: Arc::new(AtomicUsize::new(0)),
+            native_calls: Arc::new(AtomicUsize::new(0)),
+            plan: 1024 * 1024,
+            schema_version: into_markdown_core::DOCUMENT_SCHEMA_VERSION,
+            block_count: 1,
+        });
+        let mut request = request();
+        request.execution.progress_listener = Some(Arc::new(StageListener(Arc::clone(&stages))));
+        assert!(matches!(
+            block_on(engine.convert_into(request, &mut FailingChunkSink(failure))),
+            Err(ConversionError::Internal { .. })
+        ));
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        assert!(!stages.lock().unwrap().contains(&ExecutionStage::Completed));
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CancelCallback {
+    Markdown,
+    BeginAsset,
+    AssetBytes,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct CallbackCounts {
+    markdown: usize,
+    begin_asset: usize,
+    asset_bytes: usize,
+    end_asset: usize,
+}
+
+struct CancellingSink {
+    at: CancelCallback,
+    cancellation: into_markdown_core::CancellationToken,
+    counts: CallbackCounts,
+}
+
+impl ArtifactSink for CancellingSink {
+    fn write_markdown(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        self.counts.markdown += 1;
+        if self.at == CancelCallback::Markdown {
+            self.cancellation.cancel();
+        }
+        Ok(())
+    }
+
+    fn begin_asset(&mut self, _: &AssetStreamInfo) -> Result<(), ConversionError> {
+        self.counts.begin_asset += 1;
+        if self.at == CancelCallback::BeginAsset {
+            self.cancellation.cancel();
+        }
+        Ok(())
+    }
+
+    fn write_asset(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        self.counts.asset_bytes += 1;
+        if self.at == CancelCallback::AssetBytes {
+            self.cancellation.cancel();
+        }
+        Ok(())
+    }
+
+    fn end_asset(&mut self) -> Result<(), ConversionError> {
+        self.counts.end_asset += 1;
+        Ok(())
+    }
+}
+
+fn assert_callback_cancellation(at: CancelCallback, expected: CallbackCounts) {
+    let stages = Arc::new(Mutex::new(Vec::new()));
+    let engine = engine(CountingNative {
+        aggregate_calls: Arc::new(AtomicUsize::new(0)),
+        native_calls: Arc::new(AtomicUsize::new(0)),
+        plan: 8 * 1024 * 1024,
+        schema_version: into_markdown_core::DOCUMENT_SCHEMA_VERSION,
+        block_count: if at == CancelCallback::Markdown { 2 } else { 1 },
+    });
+    let mut request = request();
+    let cancellation = request.execution.cancellation.clone();
+    request.execution.progress_listener = Some(Arc::new(StageListener(Arc::clone(&stages))));
+    let mut sink = CancellingSink { at, cancellation, counts: CallbackCounts::default() };
+
+    assert!(matches!(
+        block_on(engine.convert_into(request, &mut sink)),
+        Err(ConversionError::Cancelled)
+    ));
+    assert_eq!(sink.counts, expected);
+    std::thread::sleep(std::time::Duration::from_millis(25));
+    assert!(!stages.lock().unwrap().contains(&ExecutionStage::Completed));
+}
+
+#[test]
+fn cancellation_inside_first_markdown_callback_stops_all_following_writes() {
+    assert_callback_cancellation(
+        CancelCallback::Markdown,
+        CallbackCounts { markdown: 1, ..CallbackCounts::default() },
+    );
+}
+
+#[test]
+fn cancellation_inside_begin_asset_stops_payload_and_finalization() {
+    assert_callback_cancellation(
+        CancelCallback::BeginAsset,
+        CallbackCounts { markdown: 1, begin_asset: 1, ..CallbackCounts::default() },
+    );
+}
+
+#[test]
+fn cancellation_inside_asset_bytes_stops_end_asset() {
+    assert_callback_cancellation(
+        CancelCallback::AssetBytes,
+        CallbackCounts { markdown: 1, begin_asset: 1, asset_bytes: 1, ..CallbackCounts::default() },
+    );
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,24 +1,33 @@
 //! Deterministic registry and conversion pipeline orchestration.
 
+mod collecting;
 mod fixed_alloc;
 mod nested;
+mod preparation;
 mod recovery;
+mod rendering;
+mod result_sink;
+mod stream_execution;
 
 pub use recovery::{RecoveryStore, RecoveryToken, TaskCheckpoint, TaskPhase};
 
 use fixed_alloc::{FixedSlots, try_clone_string};
 use into_markdown_core::{
     AiMode, ArtifactSink, Asset, AssetStreamInfo, Block, BlockNode, ConversionError,
-    ConversionOptions, ConversionOutcome, ConversionRequest, ConversionResult, ConversionSummary,
-    Converter, ConverterOutput, DetectionRequest, DetectionResult, Diagnostic, DiagnosticSeverity,
-    Document, EnrichmentPlan, ErrorPolicy, ExecutionContext, ExecutionStage, FormatCandidate,
-    FormatDetector, FormatHint, InputFormat, MarkdownRenderer, OcrPolicy, OutputEnricher,
-    ProbeOutcome, Provenance, ResolvedInput, ResourceReservation, Services, SourceLocator,
-    SourceMetadata, SourceResolver, TextDecodingMode, estimate_retained_result,
-    estimate_validation_working_set,
+    ConversionOptions, ConversionRequest, ConversionResult, ConversionSummary, Converter,
+    ConverterOutput, ConverterStreamMode, DetectionRequest, DetectionResult, Diagnostic,
+    DiagnosticSeverity, Document, EnrichmentPlan, ErrorPolicy, ExecutionContext, ExecutionStage,
+    FormatCandidate, FormatDetector, FormatHint, MarkdownRenderer, OcrPolicy, OutputEnricher,
+    Provenance, ResolvedInput, ResourceReservation, Services, SourceLocator, SourceMetadata,
+    SourceResolver, StreamConsumerKind, estimate_validation_working_set,
 };
 use std::collections::BTreeSet;
 use std::sync::Arc;
+
+#[cfg(test)]
+use into_markdown_core::ConversionOutcome;
+#[cfg(test)]
+use into_markdown_core::ProbeOutcome;
 
 /// Explicit registry used by built-ins and future process-isolated plugins.
 #[derive(Default)]
@@ -253,7 +262,6 @@ impl Engine {
     ///
     /// Returns a typed [`ConversionError`] from source resolution, detection,
     /// converter selection/conversion, or Markdown rendering.
-    #[allow(clippy::too_many_lines)]
     pub async fn convert(
         &self,
         request: ConversionRequest,
@@ -276,39 +284,22 @@ impl Engine {
         request: ConversionRequest,
         sink: &mut dyn ArtifactSink,
     ) -> Result<ConversionSummary, ConversionError> {
-        let result = self.convert(request).await?;
-        for chunk in result.markdown.as_bytes().chunks(64 * 1024) {
-            sink.write_markdown(chunk)?;
-        }
-        for asset in &result.assets {
-            let size =
-                u64::try_from(asset.bytes.len()).map_err(|_| ConversionError::ResourceLimit {
-                    limit: "max_asset_bytes",
-                    detail: "asset byte length cannot be represented".into(),
-                })?;
-            sink.begin_asset(&AssetStreamInfo {
-                id: asset.id.clone(),
-                filename: asset.filename.clone(),
-                media_type: asset.media_type.clone(),
-                size,
-                external_uri: asset.external_uri.clone(),
-            })?;
-            for chunk in asset.bytes.chunks(64 * 1024) {
-                sink.write_asset(chunk)?;
-            }
-            sink.end_asset()?;
-        }
-        Ok(ConversionSummary {
-            format: result.detected_format(),
-            outcome: if result.diagnostics.is_empty() {
-                ConversionOutcome::Complete
-            } else {
-                ConversionOutcome::Degraded
-            },
-            diagnostics: result.diagnostics.clone(),
-            markdown_bytes: u64::try_from(result.markdown.len()).unwrap_or(u64::MAX),
-            assets: u64::try_from(result.assets.len()).unwrap_or(u64::MAX),
-        })
+        let context =
+            ExecutionContext::new(request.execution.clone(), request.options.limits.clone());
+        self.convert_into_with_context(request, context, sink).await
+    }
+
+    async fn convert_into_with_context(
+        &self,
+        request: ConversionRequest,
+        context: ExecutionContext,
+        sink: &mut dyn ArtifactSink,
+    ) -> Result<ConversionSummary, ConversionError> {
+        let result = self.execute_aggregate_with_context(request, context.clone()).await?;
+        emit_conversion_result(&result, sink, &context)?;
+        let summary = result.into_summary();
+        context.report(ExecutionStage::Completed, Some(1), Some(1), None::<String>)?;
+        Ok(summary)
     }
 
     /// Convert using an independently controlled context backed by a caller-owned
@@ -318,86 +309,61 @@ impl Engine {
     /// primarily used by bounded batch schedulers; ordinary callers should use
     /// [`Self::convert`].
     #[doc(hidden)]
-    #[allow(clippy::too_many_lines)]
     pub async fn convert_with_context(
         &self,
-        mut request: ConversionRequest,
+        request: ConversionRequest,
         context: ExecutionContext,
     ) -> Result<ConversionResult, ConversionError> {
-        if context.resource_limits() != &request.options.limits {
-            return Err(ConversionError::Internal {
-                detail: "shared execution context limits do not match conversion request".into(),
-            });
-        }
-        if request.options.text.charset.is_none() {
-            request.options.text.charset.clone_from(&request.hint.charset);
-        }
-        context.report(ExecutionStage::Resolving, None, None, None::<String>)?;
-        let mut source = self.resolve_input(&request.input, &request.options, &context).await?;
-        measured_input_bytes(source.input(), &request.options)?;
-        source.ensure_memory_reservation(&context)?;
+        let terminal_context = context.clone();
+        let mut sink = result_sink::CollectingResultSink::default();
+        let result = self.execute_aggregate_with_context(request, context).await?;
+        sink.write_result(result)?;
+        let result = sink.finish()?;
+        terminal_context.report(ExecutionStage::Completed, Some(1), Some(1), None::<String>)?;
+        Ok(result)
+    }
 
-        context.report(ExecutionStage::Detecting, None, None, None::<String>)?;
-        let candidates = self.detect_formats(source.input(), &request.hint, &context).await?;
-        if candidates.is_empty() {
-            return Err(ConversionError::Unsupported {
-                detail: "format detectors produced no candidates".into(),
-            });
-        }
-        context.record_detected_format(candidates[0].format);
-
-        context.report(ExecutionStage::Probing, Some(0), None, None::<String>)?;
-        let mut attempts = Vec::new();
-        for candidate in &candidates {
-            for converter in &self.converters {
-                if !converter.supported_formats().contains(&candidate.format) {
-                    continue;
-                }
-                match context.run(converter.probe(source.input(), candidate, &context)).await?? {
-                    ProbeOutcome::NotApplicable => {}
-                    ProbeOutcome::Match { confidence } => attempts.push(Attempt {
-                        converter: Arc::clone(converter),
-                        candidate: candidate.clone(),
-                        explicit: candidate.explicit,
-                        confidence: candidate.confidence * normalize_confidence(confidence),
-                        priority: converter.priority(),
-                    }),
-                }
-            }
-        }
-
-        attempts.sort_by(|left, right| {
-            right
-                .explicit
-                .cmp(&left.explicit)
-                .then_with(|| right.confidence.total_cmp(&left.confidence))
-                .then_with(|| right.priority.cmp(&left.priority))
-                .then_with(|| left.converter.id().cmp(right.converter.id()))
-        });
-
-        let Some(attempt) = attempts.into_iter().next() else {
-            let formats = candidates
-                .iter()
-                .map(|candidate| candidate.format.as_str())
-                .collect::<Vec<_>>()
-                .join(",");
-            return Err(ConversionError::NoConverter { format: formats });
-        };
-        context.record_detected_format(attempt.candidate.format);
+    async fn execute_aggregate_with_context(
+        &self,
+        request: ConversionRequest,
+        context: ExecutionContext,
+    ) -> Result<ConversionResult, ConversionError> {
+        let preparation::PreparedConversion { request, context, source, attempt } =
+            preparation::prepare(self, request, context).await?;
 
         // A successful probe makes conversion authoritative. Conversion errors
         // are returned immediately rather than being hidden by another parser.
         context.report(ExecutionStage::Converting, None, None, Some(attempt.converter.id()))?;
-        let output = invoke_converter_preflighted(
-            attempt.converter.as_ref(),
-            source.input(),
-            &attempt.candidate,
-            &request.options,
-            &self.services,
-            &context,
-            |_| Ok(()),
-        )
-        .await?;
+        let native_stream = attempt.converter.stream_support().filter(|stream| {
+            stream.stream_mode_for(
+                source.input(),
+                &attempt.candidate,
+                &request.options,
+                StreamConsumerKind::Collecting,
+            ) == ConverterStreamMode::Native
+        });
+        let output = if let Some(stream) = native_stream {
+            stream_execution::invoke_native_collecting(
+                stream,
+                source.input(),
+                &attempt.candidate,
+                &request.options,
+                &self.services,
+                &context,
+            )
+            .await?
+        } else {
+            invoke_converter_preflighted(
+                attempt.converter.as_ref(),
+                source.input(),
+                &attempt.candidate,
+                &request.options,
+                &self.services,
+                &context,
+                |_| Ok(()),
+            )
+            .await?
+        };
         let output = invoke_enrichers(
             &self.enrichers,
             output,
@@ -411,80 +377,18 @@ impl Engine {
         let renderer = self.renderer.as_ref().ok_or_else(|| ConversionError::Internal {
             detail: "no Markdown renderer is registered".into(),
         })?;
-        let asset_bytes = output.assets.iter().try_fold(0_u64, |total, asset| {
-            let size =
-                u64::try_from(asset.bytes.len()).map_err(|_| ConversionError::ResourceLimit {
-                    limit: "max_asset_bytes",
-                    detail: "asset size cannot be represented as u64".into(),
-                })?;
-            if size > request.options.limits.max_asset_bytes {
-                return Err(ConversionError::ResourceLimit {
-                    limit: "max_asset_bytes",
-                    detail: format!(
-                        "asset {}: {size} > {}",
-                        asset.id.0, request.options.limits.max_asset_bytes
-                    ),
-                });
-            }
-            total.checked_add(size).ok_or_else(|| ConversionError::ResourceLimit {
-                limit: "max_asset_bytes",
-                detail: "asset byte count overflowed".into(),
-            })
-        })?;
-        if asset_bytes > request.options.limits.max_total_asset_bytes {
-            return Err(ConversionError::ResourceLimit {
-                limit: "max_total_asset_bytes",
-                detail: format!("{asset_bytes} > {}", request.options.limits.max_total_asset_bytes),
-            });
-        }
-        context.report(ExecutionStage::Rendering, None, None, Some(renderer.id()))?;
-        let (markdown, markdown_memory) = if attempt.candidate.format == InputFormat::Markdown
-            && request.options.ai.markdown_postprocess == AiMode::Off
-            && request.options.text.charset.is_none()
-            && request.options.text.decoding_mode == TextDecodingMode::Strict
-        {
-            preserve_utf8_markdown(source.input(), &context)?
-        } else {
-            invoke_renderer_preflighted(
-                renderer.as_ref(),
-                &output.document,
-                &output.assets,
-                &request.options,
-                &context,
-            )
-            .await?
-        };
-        let markdown_bytes =
-            u64::try_from(markdown.capacity()).map_err(|_| ConversionError::ResourceLimit {
-                limit: "max_memory_bytes",
-                detail: "rendered Markdown capacity cannot be represented as u64".into(),
-            })?;
-        let (provenance, provenance_memory) =
-            collect_provenance_preflighted(&output.document.blocks, &context)?;
-        let final_required = estimate_retained_result(
-            &output.document,
-            &markdown,
-            &output.assets,
-            &output.diagnostics,
-            &provenance,
-        )?;
-        let final_memory = context.reserve_memory(
-            final_required.saturating_sub(
-                output
-                    .leased_memory_for(&context)
-                    .saturating_add(markdown_bytes)
-                    .saturating_add(provenance_inventory_bytes(&provenance)?),
-            ),
-        )?;
-        let mut result = output.into_conversion_result(
-            markdown,
-            provenance,
-            [Some(markdown_memory), Some(provenance_memory), Some(final_memory)],
-        )?;
-        result.set_detected_format(attempt.candidate.format);
-        context.report(ExecutionStage::Completed, Some(1), Some(1), None::<String>)?;
+        let result = rendering::render(rendering::RenderRequest {
+            renderer: renderer.as_ref(),
+            output,
+            source: source.input(),
+            format: attempt.candidate.format,
+            options: &request.options,
+            context: &context,
+        })
+        .await?;
         // Keep the resolver's source-memory lease through conversion,
-        // rendering, result assembly, and the terminal event.
+        // rendering, and result assembly. The artifact boundary owns the
+        // terminal event so sink/finalization failures cannot follow Completed.
         drop(source);
         Ok(result)
     }
@@ -514,6 +418,41 @@ impl Engine {
     ) -> Result<Vec<FormatCandidate>, ConversionError> {
         nested::detect_formats(&self.format_detectors, input, hint, context).await
     }
+}
+
+fn emit_conversion_result(
+    result: &ConversionResult,
+    sink: &mut dyn ArtifactSink,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    for chunk in result.markdown.as_bytes().chunks(64 * 1024) {
+        context.checkpoint()?;
+        sink.write_markdown(chunk)?;
+    }
+    for asset in &result.assets {
+        let size =
+            u64::try_from(asset.bytes.len()).map_err(|_| ConversionError::ResourceLimit {
+                limit: "max_asset_bytes",
+                detail: "asset byte length cannot be represented".into(),
+            })?;
+        context.checkpoint()?;
+        let info = AssetStreamInfo {
+            id: asset.id.clone(),
+            filename: asset.filename.clone(),
+            media_type: asset.media_type.clone(),
+            size,
+            external_uri: asset.external_uri.clone(),
+        };
+        context.checkpoint()?;
+        sink.begin_asset(&info)?;
+        for chunk in asset.bytes.chunks(64 * 1024) {
+            context.checkpoint()?;
+            sink.write_asset(chunk)?;
+        }
+        context.checkpoint()?;
+        sink.end_asset()?;
+    }
+    Ok(())
 }
 
 fn preserve_utf8_markdown(

--- a/crates/engine/src/preparation.rs
+++ b/crates/engine/src/preparation.rs
@@ -1,0 +1,81 @@
+//! Resolution, detection, and converter selection for one execution.
+
+use super::{Attempt, Engine, measured_input_bytes, normalize_confidence};
+use into_markdown_core::{
+    ConversionError, ConversionRequest, ExecutionContext, ExecutionStage, ProbeOutcome,
+    ResolvedSource,
+};
+use std::sync::Arc;
+
+pub(crate) struct PreparedConversion {
+    pub(crate) request: ConversionRequest,
+    pub(crate) context: ExecutionContext,
+    pub(crate) source: ResolvedSource,
+    pub(crate) attempt: Attempt,
+}
+
+pub(crate) async fn prepare(
+    engine: &Engine,
+    mut request: ConversionRequest,
+    context: ExecutionContext,
+) -> Result<PreparedConversion, ConversionError> {
+    if context.resource_limits() != &request.options.limits {
+        return Err(ConversionError::Internal {
+            detail: "shared execution context limits do not match conversion request".into(),
+        });
+    }
+    if request.options.text.charset.is_none() {
+        request.options.text.charset.clone_from(&request.hint.charset);
+    }
+    context.report(ExecutionStage::Resolving, None, None, None::<String>)?;
+    let mut source = engine.resolve_input(&request.input, &request.options, &context).await?;
+    measured_input_bytes(source.input(), &request.options)?;
+    source.ensure_memory_reservation(&context)?;
+
+    context.report(ExecutionStage::Detecting, None, None, None::<String>)?;
+    let candidates = engine.detect_formats(source.input(), &request.hint, &context).await?;
+    if candidates.is_empty() {
+        return Err(ConversionError::Unsupported {
+            detail: "format detectors produced no candidates".into(),
+        });
+    }
+    context.record_detected_format(candidates[0].format);
+    context.report(ExecutionStage::Probing, Some(0), None, None::<String>)?;
+
+    let mut attempts = Vec::new();
+    for candidate in &candidates {
+        for converter in &engine.converters {
+            if !converter.supported_formats().contains(&candidate.format) {
+                continue;
+            }
+            match context.run(converter.probe(source.input(), candidate, &context)).await?? {
+                ProbeOutcome::NotApplicable => {}
+                ProbeOutcome::Match { confidence } => attempts.push(Attempt {
+                    converter: Arc::clone(converter),
+                    candidate: candidate.clone(),
+                    explicit: candidate.explicit,
+                    confidence: candidate.confidence * normalize_confidence(confidence),
+                    priority: converter.priority(),
+                }),
+            }
+        }
+    }
+    attempts.sort_by(|left, right| {
+        right
+            .explicit
+            .cmp(&left.explicit)
+            .then_with(|| right.confidence.total_cmp(&left.confidence))
+            .then_with(|| right.priority.cmp(&left.priority))
+            .then_with(|| left.converter.id().cmp(right.converter.id()))
+    });
+    let Some(attempt) = attempts.into_iter().next() else {
+        let formats = candidates
+            .iter()
+            .map(|candidate| candidate.format.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+        return Err(ConversionError::NoConverter { format: formats });
+    };
+    context.record_detected_format(attempt.candidate.format);
+    Ok(PreparedConversion { request, context, source, attempt })
+}

--- a/crates/engine/src/rendering.rs
+++ b/crates/engine/src/rendering.rs
@@ -1,0 +1,105 @@
+//! Asset admission, Markdown rendering, and compatibility-result assembly.
+
+use super::{
+    collect_provenance_preflighted, invoke_renderer_preflighted, preserve_utf8_markdown,
+    provenance_inventory_bytes,
+};
+use into_markdown_core::{
+    AiMode, ConversionError, ConversionOptions, ConversionResult, ConverterOutput,
+    ExecutionContext, InputFormat, MarkdownRenderer, ResolvedInput, TextDecodingMode,
+    estimate_retained_result,
+};
+
+pub(crate) struct RenderRequest<'a> {
+    pub(crate) renderer: &'a dyn MarkdownRenderer,
+    pub(crate) output: ConverterOutput,
+    pub(crate) source: &'a ResolvedInput,
+    pub(crate) format: InputFormat,
+    pub(crate) options: &'a ConversionOptions,
+    pub(crate) context: &'a ExecutionContext,
+}
+
+pub(crate) async fn render(
+    request: RenderRequest<'_>,
+) -> Result<ConversionResult, ConversionError> {
+    let RenderRequest { renderer, output, source, format, options, context } = request;
+    validate_asset_limits(&output, options)?;
+    context.report(
+        into_markdown_core::ExecutionStage::Rendering,
+        None,
+        None,
+        Some(renderer.id()),
+    )?;
+    let (markdown, markdown_memory) = if format == InputFormat::Markdown
+        && options.ai.markdown_postprocess == AiMode::Off
+        && options.text.charset.is_none()
+        && options.text.decoding_mode == TextDecodingMode::Strict
+    {
+        preserve_utf8_markdown(source, context)?
+    } else {
+        invoke_renderer_preflighted(renderer, &output.document, &output.assets, options, context)
+            .await?
+    };
+    let markdown_bytes =
+        u64::try_from(markdown.capacity()).map_err(|_| ConversionError::ResourceLimit {
+            limit: "max_memory_bytes",
+            detail: "rendered Markdown capacity cannot be represented as u64".into(),
+        })?;
+    let (provenance, provenance_memory) =
+        collect_provenance_preflighted(&output.document.blocks, context)?;
+    let final_required = estimate_retained_result(
+        &output.document,
+        &markdown,
+        &output.assets,
+        &output.diagnostics,
+        &provenance,
+    )?;
+    let final_memory = context.reserve_memory(
+        final_required.saturating_sub(
+            output
+                .leased_memory_for(context)
+                .saturating_add(markdown_bytes)
+                .saturating_add(provenance_inventory_bytes(&provenance)?),
+        ),
+    )?;
+    let mut result = output.into_conversion_result(
+        markdown,
+        provenance,
+        [Some(markdown_memory), Some(provenance_memory), Some(final_memory)],
+    )?;
+    result.set_detected_format(format);
+    Ok(result)
+}
+
+fn validate_asset_limits(
+    output: &ConverterOutput,
+    options: &ConversionOptions,
+) -> Result<(), ConversionError> {
+    let total = output.assets.iter().try_fold(0_u64, |total, asset| {
+        let size =
+            u64::try_from(asset.bytes.len()).map_err(|_| ConversionError::ResourceLimit {
+                limit: "max_asset_bytes",
+                detail: "asset size cannot be represented as u64".into(),
+            })?;
+        if size > options.limits.max_asset_bytes {
+            return Err(ConversionError::ResourceLimit {
+                limit: "max_asset_bytes",
+                detail: format!(
+                    "asset {}: {size} > {}",
+                    asset.id.0, options.limits.max_asset_bytes
+                ),
+            });
+        }
+        total.checked_add(size).ok_or_else(|| ConversionError::ResourceLimit {
+            limit: "max_asset_bytes",
+            detail: "asset byte count overflowed".into(),
+        })
+    })?;
+    if total > options.limits.max_total_asset_bytes {
+        return Err(ConversionError::ResourceLimit {
+            limit: "max_total_asset_bytes",
+            detail: format!("{total} > {}", options.limits.max_total_asset_bytes),
+        });
+    }
+    Ok(())
+}

--- a/crates/engine/src/result_sink.rs
+++ b/crates/engine/src/result_sink.rs
@@ -1,0 +1,44 @@
+//! Compatibility-result sink used by `Engine::convert`.
+
+use into_markdown_core::{ArtifactSink, AssetStreamInfo, ConversionError, ConversionResult};
+
+#[derive(Default)]
+pub(crate) struct CollectingResultSink {
+    result: Option<ConversionResult>,
+}
+
+impl CollectingResultSink {
+    pub(crate) fn write_result(&mut self, result: ConversionResult) -> Result<(), ConversionError> {
+        if self.result.is_some() {
+            return Err(protocol("collecting sink received multiple terminal results"));
+        }
+        self.result = Some(result);
+        Ok(())
+    }
+
+    pub(crate) fn finish(self) -> Result<ConversionResult, ConversionError> {
+        self.result.ok_or_else(|| protocol("collecting sink finalized without a result"))
+    }
+}
+
+impl ArtifactSink for CollectingResultSink {
+    fn write_markdown(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        Err(protocol("collecting sink received replayed Markdown"))
+    }
+
+    fn begin_asset(&mut self, _: &AssetStreamInfo) -> Result<(), ConversionError> {
+        Err(protocol("collecting sink received a replayed asset"))
+    }
+
+    fn write_asset(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        Err(protocol("collecting sink received replayed asset bytes"))
+    }
+
+    fn end_asset(&mut self) -> Result<(), ConversionError> {
+        Err(protocol("collecting sink received a replayed asset terminator"))
+    }
+}
+
+fn protocol(detail: &str) -> ConversionError {
+    ConversionError::Internal { detail: detail.into() }
+}

--- a/crates/engine/src/stream_execution.rs
+++ b/crates/engine/src/stream_execution.rs
@@ -1,0 +1,54 @@
+//! Native semantic-stream admission and execution.
+//!
+//! Keeping this path separate makes the aggregate fallback, native producer,
+//! and collector admission boundaries independently reviewable.
+
+use crate::collecting::CollectingArtifactSink;
+use into_markdown_core::{
+    ConversionError, ConversionOptions, ConverterOutput, ConverterStream, ExecutionContext,
+    FormatCandidate, ResolvedInput, Services, StreamConsumerKind, estimate_retained_output,
+    estimate_validation_working_set,
+};
+
+pub(crate) async fn invoke_native_collecting(
+    converter: &dyn ConverterStream,
+    input: &ResolvedInput,
+    candidate: &FormatCandidate,
+    options: &ConversionOptions,
+    services: &Services,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    let plan = converter.planned_stream_bytes(
+        input,
+        candidate,
+        options,
+        context,
+        StreamConsumerKind::Collecting,
+    )?;
+    let mut admission = context.reserve_memory(plan)?;
+    let credited = context.with_memory_credit(&mut admission)?;
+    let mut sink = CollectingArtifactSink::new(&credited);
+    let completion = context
+        .run(converter.convert_stream(input, candidate, options, services, &credited, &mut sink))
+        .await??;
+    let output = sink.finish(completion)?;
+    let retained = estimate_retained_output(&output.document, &output.assets, &output.diagnostics)?;
+    let validation =
+        estimate_validation_working_set(&output.document, &output.assets, &output.diagnostics)?;
+    let retained_guard =
+        credited.reserve_memory(retained.saturating_sub(output.leased_memory_for(&credited)))?;
+    let validation_guard = credited.reserve_memory(validation)?;
+    output.document.validate().map_err(|error| ConversionError::Internal {
+        detail: format!(
+            "native converter {} returned invalid document IR ({} at {}): {}",
+            converter.id(),
+            error.code.as_str(),
+            error.path,
+            error.detail
+        ),
+    })?;
+    drop(validation_guard);
+    drop(retained_guard);
+    drop(credited);
+    output.certify_preflight_reservation(context, admission)
+}

--- a/third_party/licenses/cargo-normal-runtime.json
+++ b/third_party/licenses/cargo-normal-runtime.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 1,
   "root": "into-markdown-cli",
-  "cargo_lock_sha256": "71e7fea09687de175b3b14c27bc24f6761d2f3622c61312c8fd92a5d8c8d185f",
+  "cargo_lock_sha256": "1be4bd507d2e2c565c3431a8125a2bd05105f1c1a3d80a82b5ed3504d91a9e2f",
   "workspace_manifest_sha256": {
     "Cargo.toml": "11bfce1064ec89a202761de0b7b5d1ae74c86efaad626818cdb7e7a08fb8655b",
     "apps/cli/Cargo.toml": "5a7badd4acb08c0ea95413aacd2bf2d129bb100290ba1793322b298ad4e96580",
     "apps/official-provider/Cargo.toml": "ff280ebe22ace51d7d9ed6b895cd29ebe636aacefb49d72ac5148830fbabaa75",
     "crates/ai/Cargo.toml": "adffc09c06b695fe830fe58647a2cd1f18df627b1932331b372c690843781eeb",
-    "crates/api/Cargo.toml": "055ab15d210d664c6a361111d848852b0a7fa590d90fce98fd4b966d64f6ec7f",
+    "crates/api/Cargo.toml": "ea7bdb200eef0b32e0bb453fb8424304e4a44a074128c3803b1a511ab9cfc471",
     "crates/asr/Cargo.toml": "3f49f957b4949fc673c81f8514fc5b8834529a8f0e25aeb07455c11c1d87816c",
     "crates/converters/Cargo.toml": "c4feee83625baedf9548f11d3e7a677bee21a1782f5c1ae2e67d4bb187fe5c3b",
     "crates/core/Cargo.toml": "7c93a33a5e435723ab22262f9200637134d6047cf39fa1f162976cb1a643226f",


### PR DESCRIPTION
Closes #272

## 结果

- `Engine::convert` / `convert_with_context` 通过同一条单次 collecting 编排直接取得完成结果，不再先调用 `convert_into`、再序列化/复制 Markdown 与资产；native 计数门禁为 `convert_stream=1`、aggregate `convert=0`。
- canonical adapter 直接转移整个 `Document`、资产 Vec、诊断与其认证 lease；32768 blocks 门禁验证 Vec pointer/capacity、资产 Vec/payload pointer 和诊断 pointer 全部不变，因此 collector 新增 inventory/growth 次数为 0（比 O(log n) 更严格），不存在逐元素 O(n²) 扩容或分配后记账回滚问题。
- native adapter 保留 `schema_version`，并在 rendering 前执行完整 IR 验证；未知 schema 的 native 输出稳定失败。
- PPTX 的 CFB/encrypted 包装在 collecting 时走真实 aggregate fallback，保持 `Encrypted` 错误，不会被 collector admission 改写成 `max_memory_bytes`。
- XLSX native admission 只看 ZIP central directory 中真实 `xl/worksheets/*.xml|*.bin` 未压缩 payload（>=256 KiB）；与文件名无关，且 unrelated ZIP padding 不能触发 native。
- `convert_into` 的 summary 直接移动 diagnostics 与原认证 memory lease，不 clone 诊断 inventory；所有 Markdown/begin asset/asset bytes/end asset sink 失败都发生在 `Completed` 之前。
- 未新增 `too_many_lines` / `too_many_arguments` 豁免，也没有样本名/文件名特判。

## 结构与相对最新 main 的物理行数

| 文件 | main | PR | Δ | 职责 |
|---|---:|---:|---:|---|
| `crates/engine/src/lib.rs` | 2314 | 2253 | -61 | 短 orchestration 与公共入口 |
| `crates/core/src/spi.rs` | 2454 | 2459 | +5 | 通用 Converter 仅保留可选 stream capability 钩子 |
| `crates/render-markdown/src/lib.rs` | 2761 | 2761 | 0 | 未继续增长 |
| `crates/core/src/stream.rs` | 0 | 161 | +161 | 独立 one-shot stream capability/ownership protocol |
| `crates/core/src/summary.rs` | 0 | 80 | +80 | summary ownership/accounting |
| `crates/engine/src/preparation.rs` | 0 | 81 | +81 | resolve/detect/probe/selection |
| `crates/engine/src/rendering.rs` | 0 | 105 | +105 | asset admission/render/result assembly |
| `crates/engine/src/collecting.rs` | 0 | 171 | +171 | owned output sink 状态机 |
| `crates/engine/src/stream_execution.rs` | 0 | 54 | +54 | native admission/validation |
| `crates/engine/src/result_sink.rs` | 0 | 44 | +44 | compatibility result terminal sink |

未带入实验树的 `process_file_task_inner`、`web_tasks/web_artifact_sink.rs` 大函数、重复 match 或 CLI/Web transaction 代码。

## 性能与资源数据

同一进程、warm-up 后 4 轮交替顺序，baseline 为强制 aggregate converter，输入为测试内动态构造的真实大 PPTX（2048 段落）与大稀疏 XLSX（4096 个实际 cell），不是 inert padding：

| 输入 | native 平均 | aggregate 平均 | native 相对开销 |
|---|---:|---:|---:|
| 大 PPTX | 122222 µs | 119301 µs | +2.45% |
| 大稀疏 XLSX | 406153 µs | 386328 µs | +5.13% |
| 普通 PPTX | 4697 µs | 4615 µs | +1.78% |
| 普通 XLSX | 3898 µs | 3581 µs | +8.85% |

四组均由测试强制要求 `native <= aggregate * 1.5 + 5 ms`。大输入的 logical admission 峰值 native/aggregate 均为保守 2 GiB；native 临时空间峰值均为 0，进程 RSS delta 峰值为 PPTX 4,337,664 bytes、XLSX 2,699,264 bytes，未出现第二份结果级 inventory。32768 blocks + 4 MiB Markdown 的 production collecting 单次执行为 74,856 µs。

内存边界门禁另外验证 native `retained + validation` 的 `peak-1` 在 converter 调用前失败（调用数 0），`peak` 成功（调用数 1），结果 drop 后预算完全释放。

## 验证

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked -p into-markdown-core -p into-markdown-engine -p into-markdown-converters`
  - converters: 452 passed, 1 ignored（PDFium 显式环境）
  - core: 99 unit + 8 doc passed
  - engine: 35 passed
- `cargo test --locked -p into-markdown --test collecting_parity -- --nocapture`: 4 passed
- `cargo clippy --locked -p into-markdown-core -p into-markdown-engine -p into-markdown-converters --all-targets --no-deps -- -D warnings`
- `cargo clippy --locked -p into-markdown --test collecting_parity --no-deps -- -D warnings`

完整 workspace 级命令的既有环境 blocker：

- `cargo clippy --workspace --all-targets -- -D warnings` 被未修改的 vendored `third_party/whisper-rs-0.16.0/sys/build.rs:135 unused_mut` 阻断；API 既有 lib-test 另有 `embedded_visual_ocr_tests.rs:128-130 cast_precision_loss`。
- `cargo test --workspace --locked` 完成编译后，运行 `into-markdown` lib test 时因本机缺失动态 DLL 以 `STATUS_DLL_NOT_FOUND` 退出；在此之前执行的测试均通过。

为保持 #272 独立，本 PR 未夹带 vendor、OCR 测试或运行时安装修复。

## Parity / 终态门禁

- public native 单次执行：native=1、aggregate=0。
- 大/普通 PPTX 与大稀疏/普通 XLSX：Document、Markdown bytes、assets、diagnostics 精确一致；普通 XLSX 保持真实 aggregate fallback。
- collector 直接所有权转移保持 schema、顶层 Vec 容量与 pointer、资产 payload 与诊断 inventory。
- cancellation、capacity failure、无效 schema、Markdown/asset 四类 sink failure 均无 `Completed`；Markdown、begin_asset、asset bytes 三类 callback 内取消均立即返回 `Cancelled`，且后续 callback 计数为 0。
- CFB PPTX 保持稳定 `Encrypted` 错误。

## 依赖边界与仍存风险

- #273 的结构化 ArtifactSink、document-level commit、IR/result JSON/bundle/stdout 背压与 spool 不在本 PR；本 PR 只保证已有 chunk sink 的失败终态，不声称 document-level transactional commit。
- #274 的 transaction target 索引、journal 与临时空间记账不在本 PR。
- PPTX/XLSX native 入口复用现有 parser，再以 move-only owned output 交付；本 PR 消除 Engine collecting 的重复执行/兼容 replay/第二 inventory，但不声称 parser 内部已经改成逐节点 streaming。
- XLSX 256 KiB worksheet-payload 阈值是保守 admission 策略；阈值两侧、unrelated padding、文件名无关和真实输出 parity 均有门禁。