### PR TITLE
feat(cli): bounded structured streaming outputs (#273)

### DIFF
--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -16,10 +16,10 @@ use crate::output::{
 use clap::{CommandFactory, Parser};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use into_markdown::{
-    AiMode, AssetMode, ConversionOptions, ConversionRequest, DetectionRequest, ErrorPolicy,
-    FormatHint, InputFormat, InputRef, OcrPolicy, OpenAiCompatibleClient,
-    ProviderConfig as TransportProviderConfig, ProviderNetworkPolicy, RaggedRowsMode,
-    TableHeaderMode, TextDecodingMode,
+    AiMode, ArtifactSink, AssetMode, ConversionOptions, ConversionRequest, ConversionSummary,
+    DetectionRequest, ErrorPolicy, FormatHint, InputFormat, InputRef, OcrPolicy,
+    OpenAiCompatibleClient, ProviderConfig as TransportProviderConfig, ProviderNetworkPolicy,
+    RaggedRowsMode, TableHeaderMode, TextDecodingMode,
 };
 use into_markdown_http_transport::{NetworkPolicy, TransportError, TransportErrorKind};
 use into_markdown_plugin_manager::{ManagerError, ManagerErrorCode, PluginManager};
@@ -4948,16 +4948,18 @@ fn process_stdout(
         plan.item.local_path.as_deref(),
         &policy.working_directory,
     )?;
-    let result = convert_item(&plan.item, policy, asset_output.uri_prefix)?;
+    let (mut spool, summary) = convert_item_into(&plan.item, policy, asset_output.uri_prefix)?;
+    spool.finish()?;
     let mut encoded =
         policy.output_context.temporary_file("into-md-stdout").map_err(CliError::from)?;
-    output::encode_result_into(&result, policy.emit, &mut encoded)?;
+    spool.serialize(policy.emit, &mut encoded)?;
     encoded.sync_all().map_err(CliError::from)?;
     let staged_assets = if let Some(assets_dir) = asset_output.external_directory {
-        (!result.assets.is_empty())
+        spool
+            .has_payloads()
             .then(|| {
-                output::stage_assets(
-                    &result,
+                output::stage_spooled_assets(
+                    &spool,
                     &assets_dir,
                     policy.asset_mode,
                     policy.conflict,
@@ -4967,7 +4969,7 @@ fn process_stdout(
             .transpose()?
     } else if policy.asset_mode == AssetModeArg::Extract
         && policy.emit != EmitKind::Bundle
-        && !result.assets.is_empty()
+        && spool.has_payloads()
     {
         return Err(CliError::usage(
             "stdin and URI inputs with extracted assets require --assets-dir",
@@ -4979,14 +4981,14 @@ fn process_stdout(
     Ok(BatchItemReport {
         input: plan.item.display.clone(),
         output: None,
-        format: result.detected_format().map(|format| format.as_str().into()),
+        format: summary.format.map(|format| format.as_str().into()),
         status: BatchItemStatus::Success,
-        outcome: if result.diagnostics.is_empty() {
+        outcome: if summary.diagnostics.is_empty() {
             BatchItemOutcome::Complete
         } else {
             BatchItemOutcome::Degraded
         },
-        diagnostics: result.diagnostics.iter().map(Into::into).collect(),
+        diagnostics: summary.diagnostics.iter().map(Into::into).collect(),
         error_code: None,
         reason_code: None,
         component: None,
@@ -5120,7 +5122,8 @@ fn process_file_task_inner(
         &output_path,
         &policy.working_directory,
     )?;
-    let result = convert_item(&plan.item, policy, asset_output.uri_prefix)?;
+    let (mut spool, summary) = convert_item_into(&plan.item, policy, asset_output.uri_prefix)?;
+    spool.finish()?;
     let output_parent = output_path
         .parent()
         .ok_or_else(|| CliError::internal("batch output has no parent directory"))?;
@@ -5128,15 +5131,15 @@ fn process_file_task_inner(
         .output_context
         .temporary_file_in(output_parent, "into-md-encoded")
         .map_err(CliError::from)?;
-    output::encode_result_into(&result, policy.emit, &mut encoded)?;
+    spool.serialize(policy.emit, &mut encoded)?;
     encoded.sync_all().map_err(CliError::from)?;
     let outcome = {
         let _guard =
             output_phase.lock().map_err(|_| CliError::internal("batch output lock is poisoned"))?;
-        output::write_output_set_file(
+        output::write_spooled_output_set_file(
             &output_path,
             encoded.as_file().map_err(CliError::from)?,
-            &result,
+            &spool,
             asset_output.external_directory.as_deref(),
             policy.asset_mode,
             policy.conflict,
@@ -5150,18 +5153,18 @@ fn process_file_task_inner(
             outcome.path.display()
         ));
     }
-    Ok((outcome.path, result.detected_format(), result.diagnostics, warnings))
+    Ok((outcome.path, summary.format, summary.diagnostics, warnings))
 }
 
 fn report_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
-fn convert_item(
+fn convert_item_into(
     item: &WorkItem,
     policy: &ExecutionPolicy,
     asset_uri_prefix: Option<String>,
-) -> Result<into_markdown::ConversionResult, CliError> {
+) -> Result<(output::StructuredSpool, ConversionSummary), CliError> {
     validate_input_network(&item.input, &policy.options)?;
     let mut request = ConversionRequest::new(item.input.clone());
     request.options = policy.options.clone();
@@ -5174,9 +5177,16 @@ fn convert_item(
         .map_err(CliError::from)?;
     let context = policy.output_context.fork_with_shared_resources(policy.execution.clone());
     let observed_context = context.clone();
-    futures::executor::block_on(engine.convert_with_context(request, context)).map_err(|error| {
-        CliError::from(error).with_detected_format(observed_context.detected_format())
+    let mut spool = output::StructuredSpool::new(context.clone(), policy.emit)?;
+    let result = futures::executor::block_on(async {
+        let prepared =
+            engine.prepare_into_with_context(request, context, spool.capabilities()).await?;
+        engine.execute_prepared_into(prepared, &mut spool).await
     })
+    .map_err(|error| {
+        CliError::from(error).with_detected_format(observed_context.detected_format())
+    })?;
+    Ok((spool, result))
 }
 
 fn plan_stdout_asset_output(

--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -28,7 +28,7 @@ use sha2::{Digest as _, Sha256};
 use std::collections::{BTreeMap, VecDeque};
 use std::ffi::{OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Seek, Write};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock, mpsc};
 
@@ -4953,8 +4953,6 @@ fn process_stdout(
         policy.output_context.temporary_file("into-md-stdout").map_err(CliError::from)?;
     output::encode_result_into(&result, policy.emit, &mut encoded)?;
     encoded.sync_all().map_err(CliError::from)?;
-    let mut reader = encoded.as_file().map_err(CliError::from)?.try_clone()?;
-    reader.rewind()?;
     let staged_assets = if let Some(assets_dir) = asset_output.external_directory {
         (!result.assets.is_empty())
             .then(|| {
@@ -4977,40 +4975,7 @@ fn process_stdout(
     } else {
         None
     };
-    let mut buffer = [0_u8; 64 * 1024];
-    let write_result = (|| -> Result<(), std::io::Error> {
-        loop {
-            let read = reader.read(&mut buffer)?;
-            if read == 0 {
-                return Ok(());
-            }
-            context.stdout.write_all(&buffer[..read])?;
-        }
-    })();
-    if let Err(error) = write_result {
-        let error = CliError::from(error);
-        if let Some(staged) = staged_assets {
-            if error.is_broken_pipe() {
-                staged.commit()?;
-            } else if let Err(recovery) = staged.abort() {
-                return Err(CliError::new(
-                    crate::error::ExitClass::Io,
-                    "rollbackFailed",
-                    format!(
-                        "stdout failed ({}: {}); staged asset rollback failed ({}: {})",
-                        error.code(),
-                        error.message(),
-                        recovery.code(),
-                        recovery.message()
-                    ),
-                ));
-            }
-        }
-        return Err(error);
-    }
-    if let Some(staged) = staged_assets {
-        staged.commit()?;
-    }
+    output::publish_stdout(&encoded, context.stdout, staged_assets, &policy.output_context)?;
     Ok(BatchItemReport {
         input: plan.item.display.clone(),
         output: None,

--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -16,8 +16,8 @@ use crate::output::{
 use clap::{CommandFactory, Parser};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use into_markdown::{
-    AiMode, ArtifactSink, AssetMode, ConversionOptions, ConversionRequest, ConversionSummary,
-    DetectionRequest, ErrorPolicy, FormatHint, InputFormat, InputRef, OcrPolicy,
+    AiMode, ArtifactSink, AssetMode, ConversionOptions, ConversionOutcome, ConversionRequest,
+    ConversionSummary, DetectionRequest, ErrorPolicy, FormatHint, InputFormat, InputRef, OcrPolicy,
     OpenAiCompatibleClient, ProviderConfig as TransportProviderConfig, ProviderNetworkPolicy,
     RaggedRowsMode, TableHeaderMode, TextDecodingMode,
 };
@@ -4313,18 +4313,14 @@ fn run_conversion(
     } else if plans.len() == 1 {
         let plan = &plans[0];
         let output_phase = Mutex::new(());
-        let (output_path, detected_format, diagnostics, warnings) =
+        let (output_path, detected_format, conversion_outcome, diagnostics, warnings) =
             process_file_task_inner(plan, &policy, &output_phase)?;
         vec![BatchItemReport {
             input: plan.item.display.clone(),
             output: Some(report_path(&output_path)),
             format: detected_format.map(|format| format.as_str().into()),
             status: BatchItemStatus::Success,
-            outcome: if diagnostics.is_empty() && warnings.is_empty() {
-                BatchItemOutcome::Complete
-            } else {
-                BatchItemOutcome::Degraded
-            },
+            outcome: batch_outcome(conversion_outcome, !warnings.is_empty()),
             diagnostics: diagnostics.iter().map(Into::into).collect(),
             error_code: None,
             reason_code: None,
@@ -4983,11 +4979,7 @@ fn process_stdout(
         output: None,
         format: summary.format.map(|format| format.as_str().into()),
         status: BatchItemStatus::Success,
-        outcome: if summary.diagnostics.is_empty() {
-            BatchItemOutcome::Complete
-        } else {
-            BatchItemOutcome::Degraded
-        },
+        outcome: batch_outcome(summary.outcome, false),
         diagnostics: summary.diagnostics.iter().map(Into::into).collect(),
         error_code: None,
         reason_code: None,
@@ -5060,25 +5052,23 @@ fn process_file_task(
 ) -> BatchItemReport {
     let _memory_guard = memory_phase.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     match process_file_task_inner(&plan, policy, output_phase) {
-        Ok((output_path, detected_format, diagnostics, warnings)) => BatchItemReport {
-            input: plan.item.display,
-            output: Some(report_path(&output_path)),
-            format: detected_format.map(|format| format.as_str().into()),
-            status: BatchItemStatus::Success,
-            outcome: if diagnostics.is_empty() && warnings.is_empty() {
-                BatchItemOutcome::Complete
-            } else {
-                BatchItemOutcome::Degraded
-            },
-            diagnostics: diagnostics.iter().map(Into::into).collect(),
-            error_code: None,
-            reason_code: None,
-            component: None,
-            part: None,
-            limit: None,
-            message: None,
-            warnings,
-        },
+        Ok((output_path, detected_format, conversion_outcome, diagnostics, warnings)) => {
+            BatchItemReport {
+                input: plan.item.display,
+                output: Some(report_path(&output_path)),
+                format: detected_format.map(|format| format.as_str().into()),
+                status: BatchItemStatus::Success,
+                outcome: batch_outcome(conversion_outcome, !warnings.is_empty()),
+                diagnostics: diagnostics.iter().map(Into::into).collect(),
+                error_code: None,
+                reason_code: None,
+                component: None,
+                part: None,
+                limit: None,
+                message: None,
+                warnings,
+            }
+        }
         Err(error) => BatchItemReport {
             input: plan.item.display,
             output: plan.output.as_deref().map(report_path),
@@ -5103,11 +5093,14 @@ fn process_file_task(
     }
 }
 
+type FileTaskOutput =
+    (PathBuf, Option<InputFormat>, ConversionOutcome, Vec<into_markdown::Diagnostic>, Vec<String>);
+
 fn process_file_task_inner(
     plan: &WorkPlan,
     policy: &ExecutionPolicy,
     output_phase: &Mutex<()>,
-) -> Result<(PathBuf, Option<InputFormat>, Vec<into_markdown::Diagnostic>, Vec<String>), CliError> {
+) -> Result<FileTaskOutput, CliError> {
     let requested =
         plan.output.as_deref().ok_or_else(|| CliError::internal("batch output path is absent"))?;
     let output_path = {
@@ -5133,7 +5126,7 @@ fn process_file_task_inner(
         .map_err(CliError::from)?;
     spool.serialize(policy.emit, &mut encoded)?;
     encoded.sync_all().map_err(CliError::from)?;
-    let outcome = {
+    let write_outcome = {
         let _guard =
             output_phase.lock().map_err(|_| CliError::internal("batch output lock is poisoned"))?;
         output::write_spooled_output_set_file(
@@ -5147,13 +5140,21 @@ fn process_file_task_inner(
         )?
     };
     let mut warnings = Vec::new();
-    if outcome.renamed || output_path != requested {
+    if write_outcome.renamed || output_path != requested {
         warnings.push(format!(
             "output renamed to {} because the requested path existed",
-            outcome.path.display()
+            write_outcome.path.display()
         ));
     }
-    Ok((outcome.path, summary.format, summary.diagnostics, warnings))
+    Ok((write_outcome.path, summary.format, summary.outcome, summary.diagnostics, warnings))
+}
+
+fn batch_outcome(outcome: ConversionOutcome, has_cli_warnings: bool) -> BatchItemOutcome {
+    match (outcome, has_cli_warnings) {
+        (ConversionOutcome::Complete, false) => BatchItemOutcome::Complete,
+        (ConversionOutcome::Complete | ConversionOutcome::Degraded, true)
+        | (ConversionOutcome::Degraded, false) => BatchItemOutcome::Degraded,
+    }
 }
 
 fn report_path(path: &Path) -> String {
@@ -5177,7 +5178,7 @@ fn convert_item_into(
         .map_err(CliError::from)?;
     let context = policy.output_context.fork_with_shared_resources(policy.execution.clone());
     let observed_context = context.clone();
-    let mut spool = output::StructuredSpool::new(context.clone(), policy.emit)?;
+    let mut spool = output::StructuredSpool::new(context.clone(), policy.emit, policy.asset_mode)?;
     let result = futures::executor::block_on(async {
         let prepared =
             engine.prepare_into_with_context(request, context, spool.capabilities()).await?;
@@ -5797,6 +5798,29 @@ mod tests {
     use pulldown_cmark::{Event, Parser as MarkdownParser, Tag};
     use sha2::{Digest, Sha256};
     use std::io::Cursor;
+
+    #[test]
+    fn stdout_and_batch_outcomes_preserve_authoritative_conversion_semantics() {
+        let informational_diagnostics = [into_markdown::Diagnostic {
+            code: "informational".into(),
+            severity: into_markdown::DiagnosticSeverity::Info,
+            message: "lossless note".into(),
+            locator: None,
+        }];
+        assert!(!informational_diagnostics.is_empty());
+        assert_eq!(
+            batch_outcome(ConversionOutcome::Complete, false),
+            BatchItemOutcome::Complete,
+            "stdout and batch must not infer degradation from informational diagnostics"
+        );
+        assert_eq!(batch_outcome(ConversionOutcome::Degraded, false), BatchItemOutcome::Degraded);
+        assert_eq!(
+            batch_outcome(ConversionOutcome::Complete, true),
+            BatchItemOutcome::Degraded,
+            "a CLI output warning may only promote complete to degraded"
+        );
+        assert_eq!(batch_outcome(ConversionOutcome::Degraded, true), BatchItemOutcome::Degraded);
+    }
 
     fn controlled_test_secret_environment() -> &'static str {
         [

--- a/apps/cli/src/output.rs
+++ b/apps/cli/src/output.rs
@@ -4,6 +4,7 @@ mod assets;
 mod bundle;
 mod commit;
 mod serialization;
+mod stdout;
 #[cfg(test)]
 mod stream;
 
@@ -18,6 +19,7 @@ use commit::write_preflighted_file;
 pub(crate) use commit::{preflight_file, write_file, write_output_set_file, write_report};
 pub(crate) use serialization::encode_result;
 pub(crate) use serialization::encode_result_into;
+pub(crate) use stdout::publish as publish_stdout;
 
 #[cfg(test)]
 use crate::args::{AssetModeArg, ConflictPolicy, EmitKind};

--- a/apps/cli/src/output.rs
+++ b/apps/cli/src/output.rs
@@ -1,477 +1,47 @@
-//! Stable CLI serialization, bundles, batch reports, and atomic output writes.
+//! Stable CLI artifact streaming, serialization, and atomic publication.
 
+mod assets;
+mod bundle;
+mod commit;
+mod serialization;
+#[cfg(test)]
+mod stream;
+
+pub(crate) use assets::stage_assets;
+#[cfg(test)]
+pub(crate) use assets::write_assets;
+#[cfg(test)]
+use assets::{plan_asset_writes, write_assets_with_hook};
+pub(crate) use bundle::write_bundle;
+#[cfg(test)]
+use commit::write_preflighted_file;
+pub(crate) use commit::{preflight_file, write_file, write_output_set_file, write_report};
+pub(crate) use serialization::encode_result;
+pub(crate) use serialization::encode_result_into;
+
+#[cfg(test)]
 use crate::args::{AssetModeArg, ConflictPolicy, EmitKind};
-use crate::error::{CliError, ExitClass};
-use crate::transaction::{self, FileTarget, PreparedTransaction, Target};
+use into_markdown::BatchReportDto;
+#[cfg(test)]
 use into_markdown::{
-    BUNDLE_SCHEMA_VERSION, BatchReportDto, ConversionOptions, ConversionResult, DTO_SCHEMA_VERSION,
-    DiagnosticsDto, DtoJsonStyle, ExecutionContext, ProvenanceListDto, ResultDto, plan_assets,
+    BUNDLE_SCHEMA_VERSION, DTO_SCHEMA_VERSION, DtoJsonStyle, ExecutionContext, ResultDto,
+    plan_assets,
 };
-use serde::Serialize;
 #[cfg(test)]
 use std::fs;
-use std::io::{Cursor, Seek, Write};
-use std::path::{Path, PathBuf};
-use zip::write::SimpleFileOptions;
+#[cfg(test)]
+use std::io::Cursor;
 
 pub use into_markdown::{
     BatchItemDto as BatchItemReport, BatchItemOutcome, BatchItemStatus, BatchLimitDto,
 };
 pub type BatchReport = BatchReportDto;
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct StreamingBundleAsset<'a> {
-    id: &'a str,
-    source_asset_ids: &'a [String],
-    path: String,
-    media_type: &'a str,
-    size: u64,
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct StreamingBundleManifest<'a> {
-    schema_version: u32,
-    markdown: &'static str,
-    document_ir: &'static str,
-    diagnostics: &'static str,
-    diagnostics_schema_version: u32,
-    provenance: &'static str,
-    provenance_schema_version: u32,
-    assets: &'a [StreamingBundleAsset<'a>],
-}
-
-/// Serialize a conversion result into the selected primary artifact.
-pub fn encode_result(result: &ConversionResult, emit: EmitKind) -> Result<Vec<u8>, CliError> {
-    let mut destination = Cursor::new(Vec::new());
-    encode_result_into(result, emit, &mut destination)?;
-    Ok(destination.into_inner())
-}
-
-/// Stream a conversion result into a seekable destination without allocating
-/// another complete primary-artifact buffer.
-pub fn encode_result_into<W: Write + Seek>(
-    result: &ConversionResult,
-    emit: EmitKind,
-    mut destination: W,
-) -> Result<(), CliError> {
-    match emit {
-        EmitKind::Markdown => {
-            for chunk in result.markdown.as_bytes().chunks(64 * 1024) {
-                destination.write_all(chunk)?;
-            }
-        }
-        EmitKind::IrJson => {
-            result
-                .document
-                .validate()
-                .map_err(|error| CliError::internal(format!("validate document IR: {error}")))?;
-            serde_json::to_writer_pretty(&mut destination, &result.document)
-                .map_err(|error| CliError::internal(format!("serialize document IR: {error}")))?;
-            destination.write_all(b"\n")?;
-        }
-        EmitKind::ResultJson => {
-            ResultDto::write_json_from_result(result, DtoJsonStyle::Pretty, &mut destination)
-                .map_err(|error| CliError::internal(format!("serialize result DTO: {error}")))?;
-            destination.write_all(b"\n")?;
-        }
-        EmitKind::Bundle => write_bundle(result, destination)?,
-    }
-    Ok(())
-}
-
-/// Write extracted assets using safe, deterministic filenames.
-#[cfg(test)]
-pub fn write_assets(
-    result: &ConversionResult,
-    directory: &Path,
-    mode: AssetModeArg,
-    conflict: ConflictPolicy,
-) -> Result<Vec<WriteOutcome>, CliError> {
-    write_assets_with_hook(result, directory, mode, conflict, || Ok(()))
-}
-
-/// Fully staged external assets whose targets have not been mutated yet.
-pub struct StagedAssets {
-    transaction: Option<PreparedTransaction>,
-    targets: Vec<PathBuf>,
-}
-
-/// Preflight, write, and fsync every external asset without changing targets.
-pub fn stage_assets(
-    result: &ConversionResult,
-    directory: &Path,
-    mode: AssetModeArg,
-    conflict: ConflictPolicy,
-    context: &ExecutionContext,
-) -> Result<StagedAssets, CliError> {
-    let planned = plan_asset_writes(result, directory, mode, conflict, Some(context))?;
-    if planned.is_empty() {
-        return Ok(StagedAssets { transaction: None, targets: vec![] });
-    }
-    let targets_with_bytes = planned
-        .iter()
-        .map(|(source_index, path)| Target {
-            path: path.clone(),
-            bytes: result.assets[*source_index].bytes.as_slice(),
-        })
-        .collect::<Vec<_>>();
-    let transaction =
-        transaction::prepare(&targets_with_bytes, conflict == ConflictPolicy::Overwrite, context)?;
-    Ok(StagedAssets {
-        transaction: Some(transaction),
-        targets: planned.into_iter().map(|(_, path)| path).collect(),
-    })
-}
-
-impl StagedAssets {
-    /// Commit all staged assets after the stdout stream succeeds.
-    pub fn commit(mut self) -> Result<Vec<WriteOutcome>, CliError> {
-        if let Some(transaction) = self.transaction.take() {
-            transaction.commit()?;
-        }
-        Ok(self.targets.into_iter().map(|path| WriteOutcome { path, renamed: false }).collect())
-    }
-
-    /// Discard staged resources without modifying external targets.
-    pub fn abort(mut self) -> Result<(), CliError> {
-        self.transaction.take().map_or(Ok(()), PreparedTransaction::abort)
-    }
-}
-
-#[cfg(test)]
-fn write_assets_with_hook(
-    result: &ConversionResult,
-    directory: &Path,
-    mode: AssetModeArg,
-    conflict: ConflictPolicy,
-    after_preflight: impl FnOnce() -> Result<(), CliError>,
-) -> Result<Vec<WriteOutcome>, CliError> {
-    let planned = plan_asset_writes(result, directory, mode, conflict, None)?;
-    if planned.is_empty() {
-        return Ok(Vec::new());
-    }
-    fs::create_dir_all(directory)?;
-    after_preflight()?;
-    let mut outcomes = Vec::with_capacity(planned.len());
-    for (source_index, path) in planned {
-        write_exact_file(
-            &path,
-            &result.assets[source_index].bytes,
-            conflict == ConflictPolicy::Overwrite,
-        )?;
-        outcomes.push(WriteOutcome { path, renamed: false });
-    }
-    Ok(outcomes)
-}
-
-fn plan_asset_writes(
-    result: &ConversionResult,
-    directory: &Path,
-    mode: AssetModeArg,
-    conflict: ConflictPolicy,
-    context: Option<&ExecutionContext>,
-) -> Result<Vec<(usize, PathBuf)>, CliError> {
-    if mode != AssetModeArg::Extract || result.assets.is_empty() {
-        return Ok(Vec::new());
-    }
-    let plan = plan_assets(&result.document, &result.assets, &ConversionOptions::default())
-        .map_err(CliError::from)?;
-    let mut planned = Vec::with_capacity(plan.entries().len());
-    let mut targets = std::collections::BTreeSet::new();
-    for asset in plan.entries() {
-        let path = directory.join(&asset.filename);
-        if !targets.insert(path.clone()) {
-            return Err(CliError::internal(format!(
-                "multiple assets resolve to {}",
-                path.display()
-            )));
-        }
-        planned.push((asset.source_index, path));
-    }
-    if let Some(context) = context {
-        let paths = planned.iter().map(|(_, path)| path.clone()).collect::<Vec<_>>();
-        transaction::recover_for_paths(&paths, context)?;
-    }
-    if let Some((_, path)) =
-        planned.iter().find(|(_, path)| path.exists() && conflict != ConflictPolicy::Overwrite)
-    {
-        return Err(CliError::new(
-            ExitClass::Io,
-            "assetConflict",
-            format!(
-                "stable asset output already exists and cannot be renamed safely: {}",
-                path.display()
-            ),
-        ));
-    }
-    Ok(planned)
-}
-
-/// Outcome of one atomic file write.
-#[derive(Debug, Clone)]
-pub struct WriteOutcome {
-    pub path: PathBuf,
-    pub renamed: bool,
-}
-
-/// Atomically commit a file-backed primary artifact and in-memory companion assets.
-pub fn write_output_set_file(
-    primary: &Path,
-    primary_file: &std::fs::File,
-    result: &ConversionResult,
-    asset_directory: Option<&Path>,
-    mode: AssetModeArg,
-    conflict: ConflictPolicy,
-    context: &ExecutionContext,
-) -> Result<WriteOutcome, CliError> {
-    let primary = primary.to_path_buf();
-    let planned_assets = asset_directory
-        .map(|directory| plan_asset_writes(result, directory, mode, conflict, Some(context)))
-        .transpose()?
-        .unwrap_or_default();
-    let companions = planned_assets
-        .iter()
-        .map(|(source_index, path)| Target {
-            path: path.clone(),
-            bytes: result.assets[*source_index].bytes.as_slice(),
-        })
-        .collect::<Vec<_>>();
-    transaction::prepare_file_and_bytes(
-        &FileTarget { path: primary.clone(), file: primary_file },
-        &companions,
-        conflict == ConflictPolicy::Overwrite,
-        context,
-    )?
-    .commit()?;
-    Ok(WriteOutcome { path: primary, renamed: false })
-}
-
-/// Write a primary artifact using the requested conflict policy.
-pub fn write_file(
-    requested: &Path,
-    bytes: &[u8],
-    conflict: ConflictPolicy,
-    context: &ExecutionContext,
-) -> Result<WriteOutcome, CliError> {
-    transaction::recover_for_paths(&[requested.to_path_buf()], context)?;
-    let (path, renamed) = resolve_conflict(requested, conflict)?;
-    transaction::prepare(
-        &[Target { path: path.clone(), bytes }],
-        conflict == ConflictPolicy::Overwrite,
-        context,
-    )?
-    .commit()?;
-    Ok(WriteOutcome { path, renamed })
-}
-
-/// Resolve an output conflict without writing the file.
-pub fn preflight_file(
-    path: &Path,
-    conflict: ConflictPolicy,
-    context: &ExecutionContext,
-) -> Result<PathBuf, CliError> {
-    transaction::recover_for_paths(&[path.to_path_buf()], context)?;
-    resolve_conflict(path, conflict).map(|(resolved, _)| resolved)
-}
-
-/// Atomically write a previously resolved path without recalculating its name.
-#[cfg(test)]
-pub fn write_preflighted_file(
-    path: &Path,
-    bytes: &[u8],
-    conflict: ConflictPolicy,
-) -> Result<WriteOutcome, CliError> {
-    write_exact_file(path, bytes, conflict == ConflictPolicy::Overwrite)?;
-    Ok(WriteOutcome { path: path.to_path_buf(), renamed: false })
-}
-
-/// Write a versioned JSON report atomically.
-pub fn write_report(
-    path: &Path,
-    report: &BatchReport,
-    context: &ExecutionContext,
-) -> Result<WriteOutcome, CliError> {
-    let json = report
-        .to_pretty_json()
-        .map_err(|error| CliError::internal(format!("serialize batch report DTO: {error}")))?;
-    write_file(path, &json_with_newline(json), ConflictPolicy::Overwrite, context)
-}
-
-fn json_with_newline(json: String) -> Vec<u8> {
-    let mut bytes = json.into_bytes();
-    bytes.push(b'\n');
-    bytes
-}
-
-/// Stream a deterministic portable bundle to a seekable destination.
-pub fn write_bundle<W: Write + Seek>(
-    result: &ConversionResult,
-    destination: W,
-) -> Result<(), CliError> {
-    if let Some(asset) = result.assets.iter().find(|asset| asset.bytes.is_empty()) {
-        return Err(CliError::new(
-            ExitClass::Conversion,
-            "bundleAssetMissingContent",
-            format!("bundle asset {} has no portable content", asset.id.0),
-        ));
-    }
-    let mut options = ConversionOptions::default();
-    options.output.asset_uri_prefix = Some("assets".into());
-    let plan = plan_assets(&result.document, &result.assets, &options).map_err(CliError::from)?;
-    let mut assets = Vec::new();
-    assets
-        .try_reserve_exact(plan.entries().len())
-        .map_err(|_| CliError::internal("allocate bounded bundle asset plan"))?;
-    for entry in plan.entries() {
-        let id = entry
-            .asset_ids
-            .first()
-            .ok_or_else(|| CliError::internal("bundle asset plan omitted its source ID"))?;
-        assets.push(StreamingBundleAsset {
-            id,
-            source_asset_ids: &entry.asset_ids,
-            path: format!("assets/{}", entry.filename),
-            media_type: &entry.media_type,
-            size: entry.size,
-        });
-    }
-    let manifest = StreamingBundleManifest {
-        schema_version: BUNDLE_SCHEMA_VERSION,
-        markdown: "document.md",
-        document_ir: "document.ir.json",
-        diagnostics: "diagnostics.json",
-        diagnostics_schema_version: DTO_SCHEMA_VERSION,
-        provenance: "provenance.json",
-        provenance_schema_version: DTO_SCHEMA_VERSION,
-        assets: &assets,
-    };
-    {
-        let mut archive = zip::ZipWriter::new(destination);
-        let file_options = SimpleFileOptions::default()
-            .compression_method(zip::CompressionMethod::Deflated)
-            .unix_permissions(0o644);
-        let directory_options = SimpleFileOptions::default()
-            .compression_method(zip::CompressionMethod::Stored)
-            .unix_permissions(0o755);
-        archive
-            .start_file("diagnostics.json", file_options)
-            .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
-        DiagnosticsDto::write_bundle_json_from_diagnostics(&result.diagnostics, &mut archive)
-            .map_err(|error| CliError::internal(format!("serialize diagnostics DTO: {error}")))?;
-        archive.write_all(b"\n")?;
-        result
-            .document
-            .validate()
-            .map_err(|error| CliError::internal(format!("validate document IR: {error}")))?;
-        archive
-            .start_file("document.ir.json", file_options)
-            .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
-        serde_json::to_writer_pretty(&mut archive, &result.document)
-            .map_err(|error| CliError::internal(format!("serialize document IR: {error}")))?;
-        archive.write_all(b"\n")?;
-        archive
-            .start_file("document.md", file_options)
-            .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
-        archive.write_all(result.markdown.as_bytes())?;
-        archive
-            .start_file("manifest.json", file_options)
-            .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
-        serde_json::to_writer_pretty(&mut archive, &manifest)
-            .map_err(|error| CliError::internal(format!("serialize bundle manifest: {error}")))?;
-        archive.write_all(b"\n")?;
-        archive
-            .start_file("provenance.json", file_options)
-            .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
-        ProvenanceListDto::write_bundle_json_from_provenance(&result.provenance, &mut archive)
-            .map_err(|error| CliError::internal(format!("serialize provenance DTO: {error}")))?;
-        archive.write_all(b"\n")?;
-        archive.add_directory("assets/", directory_options).map_err(|error| {
-            CliError::internal(format!("create bundle assets directory: {error}"))
-        })?;
-        for entry in plan.entries() {
-            archive
-                .start_file(format!("assets/{}", entry.filename), file_options)
-                .map_err(|error| CliError::internal(format!("create bundle asset: {error}")))?;
-            archive.write_all(&result.assets[entry.source_index].bytes)?;
-        }
-        archive.finish().map_err(|error| CliError::internal(format!("finish bundle: {error}")))?;
-    }
-    Ok(())
-}
-
-fn resolve_conflict(
-    requested: &Path,
-    conflict: ConflictPolicy,
-) -> Result<(PathBuf, bool), CliError> {
-    if !requested.exists() || conflict == ConflictPolicy::Overwrite {
-        return Ok((requested.to_path_buf(), false));
-    }
-    if conflict == ConflictPolicy::Error {
-        return Err(CliError::new(
-            ExitClass::Io,
-            "outputConflict",
-            format!("output already exists: {}", requested.display()),
-        ));
-    }
-    let parent = requested.parent().unwrap_or_else(|| Path::new("."));
-    let filename = requested.file_name().and_then(|value| value.to_str()).unwrap_or("output");
-    let (stem, extension) = if let Some(stem) = filename.strip_suffix(".mdpkg.zip") {
-        (stem.to_owned(), Some("mdpkg.zip".to_owned()))
-    } else {
-        (
-            requested.file_stem().and_then(|value| value.to_str()).unwrap_or("output").to_owned(),
-            requested.extension().and_then(|value| value.to_str()).map(ToOwned::to_owned),
-        )
-    };
-    for number in 1_u64..=u64::MAX {
-        let name = extension.as_ref().map_or_else(
-            || format!("{stem}-{number}"),
-            |extension| format!("{stem}-{number}.{extension}"),
-        );
-        let candidate = parent.join(name);
-        if !candidate.exists() {
-            return Ok((candidate, true));
-        }
-    }
-    Err(CliError::new(
-        ExitClass::Io,
-        "outputConflict",
-        format!("could not allocate a unique output name for {}", requested.display()),
-    ))
-}
-
-#[cfg(test)]
-fn write_exact_file(path: &Path, bytes: &[u8], overwrite: bool) -> Result<(), CliError> {
-    let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    fs::create_dir_all(parent)?;
-    let filename = path.file_name().and_then(|value| value.to_str()).unwrap_or("output");
-    let mut temporary = tempfile::Builder::new()
-        .prefix(&format!(".{filename}.into-md-"))
-        .suffix(".tmp")
-        .tempfile_in(parent)?;
-    temporary.write_all(bytes)?;
-    temporary.as_file().sync_all()?;
-    let result =
-        if overwrite { temporary.persist(path) } else { temporary.persist_noclobber(path) };
-    result.map_err(|error| {
-        if error.error.kind() == std::io::ErrorKind::AlreadyExists {
-            CliError::new(
-                ExitClass::Io,
-                "outputConflict",
-                format!("output appeared after preflight: {}", path.display()),
-            )
-        } else {
-            CliError::from(error.error)
-        }
-    })?;
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(unix)]
+    use crate::transaction::{self, Target};
     use into_markdown::{
         Asset, AssetId, Block, BlockNode, BundleManifestDto, ConversionOptions, ConversionResult,
         DiagnosticsDto, Document, NodeId, Provenance, ProvenanceKind, ProvenanceListDto,
@@ -479,6 +49,8 @@ mod tests {
     };
     use pulldown_cmark::{Event, Parser, Tag};
     use std::io::Read as _;
+    #[cfg(unix)]
+    use std::path::Path;
 
     fn empty_result() -> ConversionResult {
         ConversionResult::new(

--- a/apps/cli/src/output.rs
+++ b/apps/cli/src/output.rs
@@ -5,10 +5,11 @@ mod bundle;
 mod commit;
 mod serialization;
 mod stdout;
-#[cfg(test)]
 mod stream;
 
+#[cfg(test)]
 pub(crate) use assets::stage_assets;
+pub(crate) use assets::stage_spooled_assets;
 #[cfg(test)]
 pub(crate) use assets::write_assets;
 #[cfg(test)]
@@ -16,10 +17,10 @@ use assets::{plan_asset_writes, write_assets_with_hook};
 pub(crate) use bundle::write_bundle;
 #[cfg(test)]
 use commit::write_preflighted_file;
-pub(crate) use commit::{preflight_file, write_file, write_output_set_file, write_report};
+pub(crate) use commit::{preflight_file, write_file, write_report, write_spooled_output_set_file};
 pub(crate) use serialization::encode_result;
-pub(crate) use serialization::encode_result_into;
 pub(crate) use stdout::publish as publish_stdout;
+pub(crate) use stream::StructuredSpool;
 
 #[cfg(test)]
 use crate::args::{AssetModeArg, ConflictPolicy, EmitKind};
@@ -513,6 +514,51 @@ mod tests {
         .unwrap();
         staged.abort().unwrap();
         assert_eq!(fs::read(&target).unwrap(), [1, 2, 3]);
+    }
+
+    #[test]
+    fn spooled_primary_and_assets_publish_as_one_atomic_file_set() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().canonicalize().unwrap();
+        let assets = root.join("assets");
+        fs::create_dir(&assets).unwrap();
+        let primary = root.join("document.md");
+        let context = output_context();
+        let result = empty_result();
+        let mut spool = StructuredSpool::from_result(&result, context.clone()).unwrap();
+        let asset_name = spool.external_payloads().unwrap()[0].0.to_owned();
+        let asset_target = assets.join(asset_name);
+        fs::write(&asset_target, b"old-asset").unwrap();
+        let mut encoded = context.temporary_file_in(&root, "encoded").unwrap();
+        spool.serialize(EmitKind::Markdown, &mut encoded).unwrap();
+        encoded.sync_all().unwrap();
+
+        let error = write_spooled_output_set_file(
+            &primary,
+            encoded.as_file().unwrap(),
+            &spool,
+            Some(&assets),
+            AssetModeArg::Extract,
+            ConflictPolicy::Error,
+            &context,
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "assetConflict");
+        assert!(!primary.exists());
+        assert_eq!(fs::read(&asset_target).unwrap(), b"old-asset");
+
+        write_spooled_output_set_file(
+            &primary,
+            encoded.as_file().unwrap(),
+            &spool,
+            Some(&assets),
+            AssetModeArg::Extract,
+            ConflictPolicy::Overwrite,
+            &context,
+        )
+        .unwrap();
+        assert_eq!(fs::read(primary).unwrap(), result.markdown.as_bytes());
+        assert_eq!(fs::read(asset_target).unwrap(), [1, 2, 3]);
     }
 
     #[cfg(unix)]

--- a/apps/cli/src/output.rs
+++ b/apps/cli/src/output.rs
@@ -525,7 +525,13 @@ mod tests {
         let primary = root.join("document.md");
         let context = output_context();
         let result = empty_result();
-        let mut spool = StructuredSpool::from_result(&result, context.clone()).unwrap();
+        let mut spool = StructuredSpool::from_result(
+            &result,
+            context.clone(),
+            EmitKind::Markdown,
+            AssetModeArg::Extract,
+        )
+        .unwrap();
         let asset_name = spool.external_payloads().unwrap()[0].0.to_owned();
         let asset_target = assets.join(asset_name);
         fs::write(&asset_target, b"old-asset").unwrap();

--- a/apps/cli/src/output/assets.rs
+++ b/apps/cli/src/output/assets.rs
@@ -1,0 +1,141 @@
+//! External asset planning and transactional staging.
+
+use crate::args::{AssetModeArg, ConflictPolicy};
+use crate::error::{CliError, ExitClass};
+use crate::transaction::{self, PreparedTransaction, Target};
+use into_markdown::{ConversionOptions, ConversionResult, ExecutionContext, plan_assets};
+#[cfg(test)]
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::commit::WriteOutcome;
+#[cfg(test)]
+use super::commit::write_exact_file;
+
+/// Write extracted assets using safe, deterministic filenames.
+#[cfg(test)]
+pub(crate) fn write_assets(
+    result: &ConversionResult,
+    directory: &Path,
+    mode: AssetModeArg,
+    conflict: ConflictPolicy,
+) -> Result<Vec<WriteOutcome>, CliError> {
+    write_assets_with_hook(result, directory, mode, conflict, || Ok(()))
+}
+
+/// Fully staged external assets whose targets have not been mutated yet.
+pub(crate) struct StagedAssets {
+    transaction: Option<PreparedTransaction>,
+    targets: Vec<PathBuf>,
+}
+
+/// Preflight, write, and fsync every external asset without changing targets.
+pub(crate) fn stage_assets(
+    result: &ConversionResult,
+    directory: &Path,
+    mode: AssetModeArg,
+    conflict: ConflictPolicy,
+    context: &ExecutionContext,
+) -> Result<StagedAssets, CliError> {
+    let planned = plan_asset_writes(result, directory, mode, conflict, Some(context))?;
+    if planned.is_empty() {
+        return Ok(StagedAssets { transaction: None, targets: vec![] });
+    }
+    let targets_with_bytes = planned
+        .iter()
+        .map(|(source_index, path)| Target {
+            path: path.clone(),
+            bytes: result.assets[*source_index].bytes.as_slice(),
+        })
+        .collect::<Vec<_>>();
+    let transaction =
+        transaction::prepare(&targets_with_bytes, conflict == ConflictPolicy::Overwrite, context)?;
+    Ok(StagedAssets {
+        transaction: Some(transaction),
+        targets: planned.into_iter().map(|(_, path)| path).collect(),
+    })
+}
+
+impl StagedAssets {
+    /// Commit all staged assets after the stdout stream succeeds.
+    pub(crate) fn commit(mut self) -> Result<Vec<WriteOutcome>, CliError> {
+        if let Some(transaction) = self.transaction.take() {
+            transaction.commit()?;
+        }
+        Ok(self.targets.into_iter().map(|path| WriteOutcome { path, renamed: false }).collect())
+    }
+
+    /// Discard staged resources without modifying external targets.
+    pub(crate) fn abort(mut self) -> Result<(), CliError> {
+        self.transaction.take().map_or(Ok(()), PreparedTransaction::abort)
+    }
+}
+
+#[cfg(test)]
+pub(super) fn write_assets_with_hook(
+    result: &ConversionResult,
+    directory: &Path,
+    mode: AssetModeArg,
+    conflict: ConflictPolicy,
+    after_preflight: impl FnOnce() -> Result<(), CliError>,
+) -> Result<Vec<WriteOutcome>, CliError> {
+    let planned = plan_asset_writes(result, directory, mode, conflict, None)?;
+    if planned.is_empty() {
+        return Ok(Vec::new());
+    }
+    fs::create_dir_all(directory)?;
+    after_preflight()?;
+    let mut outcomes = Vec::with_capacity(planned.len());
+    for (source_index, path) in planned {
+        write_exact_file(
+            &path,
+            &result.assets[source_index].bytes,
+            conflict == ConflictPolicy::Overwrite,
+        )?;
+        outcomes.push(WriteOutcome { path, renamed: false });
+    }
+    Ok(outcomes)
+}
+
+pub(super) fn plan_asset_writes(
+    result: &ConversionResult,
+    directory: &Path,
+    mode: AssetModeArg,
+    conflict: ConflictPolicy,
+    context: Option<&ExecutionContext>,
+) -> Result<Vec<(usize, PathBuf)>, CliError> {
+    if mode != AssetModeArg::Extract || result.assets.is_empty() {
+        return Ok(Vec::new());
+    }
+    let plan = plan_assets(&result.document, &result.assets, &ConversionOptions::default())
+        .map_err(CliError::from)?;
+    let mut planned = Vec::with_capacity(plan.entries().len());
+    let mut targets = std::collections::BTreeSet::new();
+    for asset in plan.entries() {
+        let path = directory.join(&asset.filename);
+        if !targets.insert(path.clone()) {
+            return Err(CliError::internal(format!(
+                "multiple assets resolve to {}",
+                path.display()
+            )));
+        }
+        planned.push((asset.source_index, path));
+    }
+    if let Some(context) = context {
+        let paths = planned.iter().map(|(_, path)| path.clone()).collect::<Vec<_>>();
+        transaction::recover_for_paths(&paths, context)?;
+    }
+    if let Some((_, path)) =
+        planned.iter().find(|(_, path)| path.exists() && conflict != ConflictPolicy::Overwrite)
+    {
+        return Err(CliError::new(
+            ExitClass::Io,
+            "assetConflict",
+            format!(
+                "stable asset output already exists and cannot be renamed safely: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(planned)
+}

--- a/apps/cli/src/output/assets.rs
+++ b/apps/cli/src/output/assets.rs
@@ -2,8 +2,12 @@
 
 use crate::args::{AssetModeArg, ConflictPolicy};
 use crate::error::{CliError, ExitClass};
-use crate::transaction::{self, PreparedTransaction, Target};
-use into_markdown::{ConversionOptions, ConversionResult, ExecutionContext, plan_assets};
+#[cfg(test)]
+use crate::transaction::Target;
+use crate::transaction::{self, FileTarget, PreparedTransaction};
+use into_markdown::ExecutionContext;
+#[cfg(test)]
+use into_markdown::{ConversionOptions, ConversionResult, plan_assets};
 #[cfg(test)]
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -11,6 +15,7 @@ use std::path::{Path, PathBuf};
 use super::commit::WriteOutcome;
 #[cfg(test)]
 use super::commit::write_exact_file;
+use super::stream::StructuredSpool;
 
 /// Write extracted assets using safe, deterministic filenames.
 #[cfg(test)]
@@ -30,6 +35,7 @@ pub(crate) struct StagedAssets {
 }
 
 /// Preflight, write, and fsync every external asset without changing targets.
+#[cfg(test)]
 pub(crate) fn stage_assets(
     result: &ConversionResult,
     directory: &Path,
@@ -54,6 +60,62 @@ pub(crate) fn stage_assets(
         transaction: Some(transaction),
         targets: planned.into_iter().map(|(_, path)| path).collect(),
     })
+}
+
+/// Preflight and stage file-backed asset payloads without materializing them in memory.
+pub(crate) fn stage_spooled_assets(
+    spool: &StructuredSpool,
+    directory: &Path,
+    mode: AssetModeArg,
+    conflict: ConflictPolicy,
+    context: &ExecutionContext,
+) -> Result<StagedAssets, CliError> {
+    let planned = plan_spooled_asset_writes(spool, directory, mode, conflict, context)?;
+    if planned.is_empty() {
+        return Ok(StagedAssets { transaction: None, targets: vec![] });
+    }
+    let files = planned
+        .iter()
+        .map(|(path, file)| FileTarget { path: path.clone(), file })
+        .collect::<Vec<_>>();
+    let transaction =
+        transaction::prepare_files(&files, conflict == ConflictPolicy::Overwrite, context)?;
+    Ok(StagedAssets {
+        transaction: Some(transaction),
+        targets: planned.into_iter().map(|(path, _)| path).collect(),
+    })
+}
+
+pub(super) fn plan_spooled_asset_writes<'a>(
+    spool: &'a StructuredSpool,
+    directory: &Path,
+    mode: AssetModeArg,
+    conflict: ConflictPolicy,
+    context: &ExecutionContext,
+) -> Result<Vec<(PathBuf, &'a std::fs::File)>, CliError> {
+    if mode != AssetModeArg::Extract {
+        return Ok(Vec::new());
+    }
+    let planned = spool
+        .external_payloads()?
+        .into_iter()
+        .map(|(filename, file)| (directory.join(filename), file))
+        .collect::<Vec<_>>();
+    let paths = planned.iter().map(|(path, _)| path.clone()).collect::<Vec<_>>();
+    transaction::recover_for_paths(&paths, context)?;
+    if let Some((path, _)) =
+        planned.iter().find(|(path, _)| path.exists() && conflict != ConflictPolicy::Overwrite)
+    {
+        return Err(CliError::new(
+            ExitClass::Io,
+            "assetConflict",
+            format!(
+                "stable asset output already exists and cannot be renamed safely: {}",
+                path.display()
+            ),
+        ));
+    }
+    Ok(planned)
 }
 
 impl StagedAssets {
@@ -97,6 +159,7 @@ pub(super) fn write_assets_with_hook(
     Ok(outcomes)
 }
 
+#[cfg(test)]
 pub(super) fn plan_asset_writes(
     result: &ConversionResult,
     directory: &Path,

--- a/apps/cli/src/output/bundle.rs
+++ b/apps/cli/src/output/bundle.rs
@@ -1,0 +1,127 @@
+//! Deterministic portable bundle serialization.
+
+use crate::error::{CliError, ExitClass};
+use into_markdown::{
+    BUNDLE_SCHEMA_VERSION, ConversionOptions, ConversionResult, DTO_SCHEMA_VERSION, DiagnosticsDto,
+    ProvenanceListDto, plan_assets,
+};
+use serde::Serialize;
+use std::io::{Seek, Write};
+use zip::write::SimpleFileOptions;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StreamingBundleAsset<'a> {
+    id: &'a str,
+    source_asset_ids: &'a [String],
+    path: String,
+    media_type: &'a str,
+    size: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct StreamingBundleManifest<'a> {
+    schema_version: u32,
+    markdown: &'static str,
+    document_ir: &'static str,
+    diagnostics: &'static str,
+    diagnostics_schema_version: u32,
+    provenance: &'static str,
+    provenance_schema_version: u32,
+    assets: &'a [StreamingBundleAsset<'a>],
+}
+
+/// Stream a deterministic portable bundle to a seekable destination.
+pub(crate) fn write_bundle<W: Write + Seek>(
+    result: &ConversionResult,
+    destination: W,
+) -> Result<(), CliError> {
+    if let Some(asset) = result.assets.iter().find(|asset| asset.bytes.is_empty()) {
+        return Err(CliError::new(
+            ExitClass::Conversion,
+            "bundleAssetMissingContent",
+            format!("bundle asset {} has no portable content", asset.id.0),
+        ));
+    }
+    let mut options = ConversionOptions::default();
+    options.output.asset_uri_prefix = Some("assets".into());
+    let plan = plan_assets(&result.document, &result.assets, &options).map_err(CliError::from)?;
+    let mut assets = Vec::new();
+    assets
+        .try_reserve_exact(plan.entries().len())
+        .map_err(|_| CliError::internal("allocate bounded bundle asset plan"))?;
+    for entry in plan.entries() {
+        let id = entry
+            .asset_ids
+            .first()
+            .ok_or_else(|| CliError::internal("bundle asset plan omitted its source ID"))?;
+        assets.push(StreamingBundleAsset {
+            id,
+            source_asset_ids: &entry.asset_ids,
+            path: format!("assets/{}", entry.filename),
+            media_type: &entry.media_type,
+            size: entry.size,
+        });
+    }
+    let manifest = StreamingBundleManifest {
+        schema_version: BUNDLE_SCHEMA_VERSION,
+        markdown: "document.md",
+        document_ir: "document.ir.json",
+        diagnostics: "diagnostics.json",
+        diagnostics_schema_version: DTO_SCHEMA_VERSION,
+        provenance: "provenance.json",
+        provenance_schema_version: DTO_SCHEMA_VERSION,
+        assets: &assets,
+    };
+    let mut archive = zip::ZipWriter::new(destination);
+    let file_options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated)
+        .unix_permissions(0o644);
+    let directory_options = SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Stored)
+        .unix_permissions(0o755);
+    archive
+        .start_file("diagnostics.json", file_options)
+        .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
+    DiagnosticsDto::write_bundle_json_from_diagnostics(&result.diagnostics, &mut archive)
+        .map_err(|error| CliError::internal(format!("serialize diagnostics DTO: {error}")))?;
+    archive.write_all(b"\n")?;
+    result
+        .document
+        .validate()
+        .map_err(|error| CliError::internal(format!("validate document IR: {error}")))?;
+    archive
+        .start_file("document.ir.json", file_options)
+        .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
+    serde_json::to_writer_pretty(&mut archive, &result.document)
+        .map_err(|error| CliError::internal(format!("serialize document IR: {error}")))?;
+    archive.write_all(b"\n")?;
+    archive
+        .start_file("document.md", file_options)
+        .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
+    archive.write_all(result.markdown.as_bytes())?;
+    archive
+        .start_file("manifest.json", file_options)
+        .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
+    serde_json::to_writer_pretty(&mut archive, &manifest)
+        .map_err(|error| CliError::internal(format!("serialize bundle manifest: {error}")))?;
+    archive.write_all(b"\n")?;
+    archive
+        .start_file("provenance.json", file_options)
+        .map_err(|error| CliError::internal(format!("create bundle entry: {error}")))?;
+    ProvenanceListDto::write_bundle_json_from_provenance(&result.provenance, &mut archive)
+        .map_err(|error| CliError::internal(format!("serialize provenance DTO: {error}")))?;
+    archive.write_all(b"\n")?;
+    archive
+        .add_directory("assets/", directory_options)
+        .map_err(|error| CliError::internal(format!("create bundle assets directory: {error}")))?;
+    for entry in plan.entries() {
+        archive
+            .start_file(format!("assets/{}", entry.filename), file_options)
+            .map_err(|error| CliError::internal(format!("create bundle asset: {error}")))?;
+        archive.write_all(&result.assets[entry.source_index].bytes)?;
+    }
+    archive.finish().map_err(|error| CliError::internal(format!("finish bundle: {error}")))?;
+    Ok(())
+}

--- a/apps/cli/src/output/commit.rs
+++ b/apps/cli/src/output/commit.rs
@@ -1,0 +1,168 @@
+//! Atomic primary-artifact publication and conflict handling.
+
+use super::assets::plan_asset_writes;
+use super::serialization::report_json_with_newline;
+use crate::args::{AssetModeArg, ConflictPolicy};
+use crate::error::{CliError, ExitClass};
+use crate::transaction::{self, FileTarget, Target};
+use into_markdown::{BatchReportDto, ConversionResult, ExecutionContext};
+#[cfg(test)]
+use std::fs;
+#[cfg(test)]
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Outcome of one atomic file write.
+#[derive(Debug, Clone)]
+pub(crate) struct WriteOutcome {
+    pub(crate) path: PathBuf,
+    pub(crate) renamed: bool,
+}
+
+/// Atomically commit a file-backed primary artifact and in-memory companion assets.
+pub(crate) fn write_output_set_file(
+    primary: &Path,
+    primary_file: &std::fs::File,
+    result: &ConversionResult,
+    asset_directory: Option<&Path>,
+    mode: AssetModeArg,
+    conflict: ConflictPolicy,
+    context: &ExecutionContext,
+) -> Result<WriteOutcome, CliError> {
+    let primary = primary.to_path_buf();
+    let planned_assets = asset_directory
+        .map(|directory| plan_asset_writes(result, directory, mode, conflict, Some(context)))
+        .transpose()?
+        .unwrap_or_default();
+    let companions = planned_assets
+        .iter()
+        .map(|(source_index, path)| Target {
+            path: path.clone(),
+            bytes: result.assets[*source_index].bytes.as_slice(),
+        })
+        .collect::<Vec<_>>();
+    transaction::prepare_file_and_bytes(
+        &FileTarget { path: primary.clone(), file: primary_file },
+        &companions,
+        conflict == ConflictPolicy::Overwrite,
+        context,
+    )?
+    .commit()?;
+    Ok(WriteOutcome { path: primary, renamed: false })
+}
+
+/// Write a primary artifact using the requested conflict policy.
+pub(crate) fn write_file(
+    requested: &Path,
+    bytes: &[u8],
+    conflict: ConflictPolicy,
+    context: &ExecutionContext,
+) -> Result<WriteOutcome, CliError> {
+    transaction::recover_for_paths(&[requested.to_path_buf()], context)?;
+    let (path, renamed) = resolve_conflict(requested, conflict)?;
+    transaction::prepare(
+        &[Target { path: path.clone(), bytes }],
+        conflict == ConflictPolicy::Overwrite,
+        context,
+    )?
+    .commit()?;
+    Ok(WriteOutcome { path, renamed })
+}
+
+/// Resolve an output conflict without writing the file.
+pub(crate) fn preflight_file(
+    path: &Path,
+    conflict: ConflictPolicy,
+    context: &ExecutionContext,
+) -> Result<PathBuf, CliError> {
+    transaction::recover_for_paths(&[path.to_path_buf()], context)?;
+    resolve_conflict(path, conflict).map(|(resolved, _)| resolved)
+}
+
+/// Atomically write a previously resolved path without recalculating its name.
+#[cfg(test)]
+pub(super) fn write_preflighted_file(
+    path: &Path,
+    bytes: &[u8],
+    conflict: ConflictPolicy,
+) -> Result<WriteOutcome, CliError> {
+    write_exact_file(path, bytes, conflict == ConflictPolicy::Overwrite)?;
+    Ok(WriteOutcome { path: path.to_path_buf(), renamed: false })
+}
+
+/// Write a versioned JSON report atomically.
+pub(crate) fn write_report(
+    path: &Path,
+    report: &BatchReportDto,
+    context: &ExecutionContext,
+) -> Result<WriteOutcome, CliError> {
+    write_file(path, &report_json_with_newline(report)?, ConflictPolicy::Overwrite, context)
+}
+
+fn resolve_conflict(
+    requested: &Path,
+    conflict: ConflictPolicy,
+) -> Result<(PathBuf, bool), CliError> {
+    if !requested.exists() || conflict == ConflictPolicy::Overwrite {
+        return Ok((requested.to_path_buf(), false));
+    }
+    if conflict == ConflictPolicy::Error {
+        return Err(CliError::new(
+            ExitClass::Io,
+            "outputConflict",
+            format!("output already exists: {}", requested.display()),
+        ));
+    }
+    let parent = requested.parent().unwrap_or_else(|| Path::new("."));
+    let filename = requested.file_name().and_then(|value| value.to_str()).unwrap_or("output");
+    let (stem, extension) = if let Some(stem) = filename.strip_suffix(".mdpkg.zip") {
+        (stem.to_owned(), Some("mdpkg.zip".to_owned()))
+    } else {
+        (
+            requested.file_stem().and_then(|value| value.to_str()).unwrap_or("output").to_owned(),
+            requested.extension().and_then(|value| value.to_str()).map(ToOwned::to_owned),
+        )
+    };
+    for number in 1_u64..=u64::MAX {
+        let name = extension.as_ref().map_or_else(
+            || format!("{stem}-{number}"),
+            |extension| format!("{stem}-{number}.{extension}"),
+        );
+        let candidate = parent.join(name);
+        if !candidate.exists() {
+            return Ok((candidate, true));
+        }
+    }
+    Err(CliError::new(
+        ExitClass::Io,
+        "outputConflict",
+        format!("could not allocate a unique output name for {}", requested.display()),
+    ))
+}
+
+#[cfg(test)]
+pub(super) fn write_exact_file(path: &Path, bytes: &[u8], overwrite: bool) -> Result<(), CliError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent)?;
+    let filename = path.file_name().and_then(|value| value.to_str()).unwrap_or("output");
+    let mut temporary = tempfile::Builder::new()
+        .prefix(&format!(".{filename}.into-md-"))
+        .suffix(".tmp")
+        .tempfile_in(parent)?;
+    temporary.write_all(bytes)?;
+    temporary.as_file().sync_all()?;
+    let result =
+        if overwrite { temporary.persist(path) } else { temporary.persist_noclobber(path) };
+    result.map_err(|error| {
+        if error.error.kind() == std::io::ErrorKind::AlreadyExists {
+            CliError::new(
+                ExitClass::Io,
+                "outputConflict",
+                format!("output appeared after preflight: {}", path.display()),
+            )
+        } else {
+            CliError::from(error.error)
+        }
+    })?;
+    Ok(())
+}

--- a/apps/cli/src/output/commit.rs
+++ b/apps/cli/src/output/commit.rs
@@ -1,11 +1,12 @@
 //! Atomic primary-artifact publication and conflict handling.
 
-use super::assets::plan_asset_writes;
+use super::assets::plan_spooled_asset_writes;
 use super::serialization::report_json_with_newline;
+use super::stream::StructuredSpool;
 use crate::args::{AssetModeArg, ConflictPolicy};
 use crate::error::{CliError, ExitClass};
 use crate::transaction::{self, FileTarget, Target};
-use into_markdown::{BatchReportDto, ConversionResult, ExecutionContext};
+use into_markdown::{BatchReportDto, ExecutionContext};
 #[cfg(test)]
 use std::fs;
 #[cfg(test)]
@@ -19,11 +20,11 @@ pub(crate) struct WriteOutcome {
     pub(crate) renamed: bool,
 }
 
-/// Atomically commit a file-backed primary artifact and in-memory companion assets.
-pub(crate) fn write_output_set_file(
+/// Atomically commit a file-backed primary artifact and file-backed companion assets.
+pub(crate) fn write_spooled_output_set_file(
     primary: &Path,
     primary_file: &std::fs::File,
-    result: &ConversionResult,
+    spool: &StructuredSpool,
     asset_directory: Option<&Path>,
     mode: AssetModeArg,
     conflict: ConflictPolicy,
@@ -31,23 +32,13 @@ pub(crate) fn write_output_set_file(
 ) -> Result<WriteOutcome, CliError> {
     let primary = primary.to_path_buf();
     let planned_assets = asset_directory
-        .map(|directory| plan_asset_writes(result, directory, mode, conflict, Some(context)))
+        .map(|directory| plan_spooled_asset_writes(spool, directory, mode, conflict, context))
         .transpose()?
         .unwrap_or_default();
-    let companions = planned_assets
-        .iter()
-        .map(|(source_index, path)| Target {
-            path: path.clone(),
-            bytes: result.assets[*source_index].bytes.as_slice(),
-        })
-        .collect::<Vec<_>>();
-    transaction::prepare_file_and_bytes(
-        &FileTarget { path: primary.clone(), file: primary_file },
-        &companions,
-        conflict == ConflictPolicy::Overwrite,
-        context,
-    )?
-    .commit()?;
+    let mut files = Vec::with_capacity(planned_assets.len() + 1);
+    files.push(FileTarget { path: primary.clone(), file: primary_file });
+    files.extend(planned_assets.into_iter().map(|(path, file)| FileTarget { path, file }));
+    transaction::prepare_files(&files, conflict == ConflictPolicy::Overwrite, context)?.commit()?;
     Ok(WriteOutcome { path: primary, renamed: false })
 }
 

--- a/apps/cli/src/output/serialization.rs
+++ b/apps/cli/src/output/serialization.rs
@@ -1,0 +1,58 @@
+//! Stable primary-artifact and report serialization.
+
+use super::bundle;
+use crate::args::EmitKind;
+use crate::error::CliError;
+use into_markdown::{BatchReportDto, ConversionResult, DtoJsonStyle, ResultDto};
+use std::io::{Cursor, Seek, Write};
+
+/// Serialize a conversion result into the selected primary artifact.
+pub(crate) fn encode_result(
+    result: &ConversionResult,
+    emit: EmitKind,
+) -> Result<Vec<u8>, CliError> {
+    let mut destination = Cursor::new(Vec::new());
+    encode_result_into(result, emit, &mut destination)?;
+    Ok(destination.into_inner())
+}
+
+/// Stream a conversion result into a seekable destination without allocating
+/// another complete primary-artifact buffer.
+pub(crate) fn encode_result_into<W: Write + Seek>(
+    result: &ConversionResult,
+    emit: EmitKind,
+    mut destination: W,
+) -> Result<(), CliError> {
+    match emit {
+        EmitKind::Markdown => {
+            for chunk in result.markdown.as_bytes().chunks(64 * 1024) {
+                destination.write_all(chunk)?;
+            }
+        }
+        EmitKind::IrJson => {
+            result
+                .document
+                .validate()
+                .map_err(|error| CliError::internal(format!("validate document IR: {error}")))?;
+            serde_json::to_writer_pretty(&mut destination, &result.document)
+                .map_err(|error| CliError::internal(format!("serialize document IR: {error}")))?;
+            destination.write_all(b"\n")?;
+        }
+        EmitKind::ResultJson => {
+            ResultDto::write_json_from_result(result, DtoJsonStyle::Pretty, &mut destination)
+                .map_err(|error| CliError::internal(format!("serialize result DTO: {error}")))?;
+            destination.write_all(b"\n")?;
+        }
+        EmitKind::Bundle => bundle::write_bundle(result, destination)?,
+    }
+    Ok(())
+}
+
+pub(super) fn report_json_with_newline(report: &BatchReportDto) -> Result<Vec<u8>, CliError> {
+    let json = report
+        .to_pretty_json()
+        .map_err(|error| CliError::internal(format!("serialize batch report DTO: {error}")))?;
+    let mut bytes = json.into_bytes();
+    bytes.push(b'\n');
+    Ok(bytes)
+}

--- a/apps/cli/src/output/stdout.rs
+++ b/apps/cli/src/output/stdout.rs
@@ -1,0 +1,88 @@
+//! Accounted stdout publication and companion-asset finalization.
+
+use super::assets::StagedAssets;
+use crate::error::CliError;
+use into_markdown::{ExecutionContext, TemporaryFile};
+use std::io::{Read, Seek, Write};
+
+const COPY_BUFFER_BYTES: usize = 64 * 1024;
+
+/// Copy one fully serialized primary artifact to stdout.
+///
+/// A closed pipe preserves the existing CLI contract: conversion and
+/// serialization already succeeded, so staged companion assets are committed.
+/// Cancellation and every other I/O failure abort the companions.
+pub(crate) fn publish(
+    primary: &TemporaryFile,
+    stdout: &mut dyn Write,
+    staged_assets: Option<StagedAssets>,
+    context: &ExecutionContext,
+) -> Result<(), CliError> {
+    let result = copy_primary(primary, stdout, context);
+    match result {
+        Ok(()) => commit_assets(staged_assets),
+        Err(error) if error.is_broken_pipe() => {
+            commit_assets(staged_assets)?;
+            Err(error)
+        }
+        Err(error) => {
+            abort_assets(staged_assets, &error)?;
+            Err(error)
+        }
+    }
+}
+
+fn copy_primary(
+    primary: &TemporaryFile,
+    stdout: &mut dyn Write,
+    context: &ExecutionContext,
+) -> Result<(), CliError> {
+    let _memory = context
+        .reserve_memory(u64::try_from(COPY_BUFFER_BYTES).unwrap_or(u64::MAX))
+        .map_err(CliError::from)?;
+    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES].into_boxed_slice();
+    let mut reader = primary.as_file().map_err(CliError::from)?.try_clone()?;
+    reader.rewind()?;
+    loop {
+        context.checkpoint().map_err(CliError::from)?;
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(());
+        }
+        stdout.write_all(&buffer[..read])?;
+    }
+}
+
+fn commit_assets(staged_assets: Option<StagedAssets>) -> Result<(), CliError> {
+    if let Some(staged) = staged_assets {
+        staged.commit()?;
+    }
+    Ok(())
+}
+
+fn abort_assets(
+    staged_assets: Option<StagedAssets>,
+    primary_error: &CliError,
+) -> Result<(), CliError> {
+    let Some(staged) = staged_assets else {
+        return Ok(());
+    };
+    if let Err(recovery) = staged.abort() {
+        return Err(CliError::new(
+            crate::error::ExitClass::Io,
+            "rollbackFailed",
+            format!(
+                "stdout failed ({}: {}); staged asset rollback failed ({}: {})",
+                primary_error.code(),
+                primary_error.message(),
+                recovery.code(),
+                recovery.message()
+            ),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "stdout/tests.rs"]
+mod tests;

--- a/apps/cli/src/output/stdout/tests.rs
+++ b/apps/cli/src/output/stdout/tests.rs
@@ -1,0 +1,138 @@
+use super::*;
+use crate::args::{AssetModeArg, ConflictPolicy};
+use crate::output::assets::stage_assets;
+use into_markdown::{
+    Asset, AssetId, Block, BlockNode, ConversionResult, Document, NodeId, Provenance,
+    ProvenanceKind, SourceLocator,
+};
+
+struct FailingWriter {
+    kind: std::io::ErrorKind,
+    remaining: usize,
+}
+
+impl Write for FailingWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if self.remaining == 0 {
+            return Err(std::io::Error::new(self.kind, "injected stdout failure"));
+        }
+        let written = bytes.len().min(self.remaining);
+        self.remaining -= written;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+fn result() -> ConversionResult {
+    let asset = Asset {
+        id: AssetId("image".into()),
+        filename: Some("image.png".into()),
+        media_type: "image/png".into(),
+        bytes: vec![1, 2, 3],
+        external_uri: None,
+    };
+    ConversionResult::new(
+        Document {
+            blocks: vec![BlockNode {
+                id: NodeId("image-node".into()),
+                block: Block::Image { asset: asset.id.clone(), alt: Some("image".into()) },
+                provenance: Provenance {
+                    kind: ProvenanceKind::NativeParser,
+                    provider: "test".into(),
+                    locator: SourceLocator::default(),
+                    confidence: None,
+                },
+            }],
+            ..Document::default()
+        },
+        "![image](assets/image.png)\n".into(),
+        vec![asset],
+        vec![],
+        vec![],
+    )
+}
+
+fn context() -> ExecutionContext {
+    ExecutionContext::new(
+        into_markdown::ExecutionOptions::default(),
+        into_markdown::ResourceLimits::default(),
+    )
+}
+
+#[test]
+fn broken_pipe_commits_fully_staged_assets_and_releases_copy_memory() {
+    let context = context();
+    let temporary = tempfile::tempdir().unwrap();
+    let assets = temporary.path().join("assets");
+    let result = result();
+    let staged =
+        stage_assets(&result, &assets, AssetModeArg::Extract, ConflictPolicy::Error, &context)
+            .unwrap();
+    let mut primary = context.temporary_file("stdout-primary").unwrap();
+    primary.write_all_checked(b"complete primary").unwrap();
+    let mut stdout = FailingWriter { kind: std::io::ErrorKind::BrokenPipe, remaining: 1 };
+
+    let error = publish(&primary, &mut stdout, Some(staged), &context).unwrap_err();
+
+    assert!(error.is_broken_pipe());
+    let written = std::fs::read_dir(&assets).unwrap().collect::<Result<Vec<_>, _>>().unwrap();
+    assert_eq!(written.len(), 1);
+    assert_eq!(std::fs::read(written[0].path()).unwrap(), [1, 2, 3]);
+    assert_eq!(context.reserved_memory_bytes(), 0);
+    drop(primary);
+    assert_eq!(context.reserved_temporary_bytes(), 0);
+}
+
+#[test]
+fn non_pipe_failure_aborts_assets_and_releases_copy_memory() {
+    let context = context();
+    let temporary = tempfile::tempdir().unwrap();
+    let assets = temporary.path().join("assets");
+    let result = result();
+    let staged =
+        stage_assets(&result, &assets, AssetModeArg::Extract, ConflictPolicy::Error, &context)
+            .unwrap();
+    let mut primary = context.temporary_file("stdout-primary").unwrap();
+    primary.write_all_checked(b"complete primary").unwrap();
+    let mut stdout = FailingWriter { kind: std::io::ErrorKind::StorageFull, remaining: 1 };
+
+    let error = publish(&primary, &mut stdout, Some(staged), &context).unwrap_err();
+
+    assert_eq!(error.code(), "io");
+    assert!(!assets.exists() || std::fs::read_dir(&assets).unwrap().next().is_none());
+    assert_eq!(context.reserved_memory_bytes(), 0);
+    drop(primary);
+    assert_eq!(context.reserved_temporary_bytes(), 0);
+}
+
+#[test]
+fn cancellation_before_stdout_copy_aborts_assets() {
+    let cancellation = into_markdown::CancellationToken::new();
+    let context = ExecutionContext::new(
+        into_markdown::ExecutionOptions {
+            cancellation: cancellation.clone(),
+            ..into_markdown::ExecutionOptions::default()
+        },
+        into_markdown::ResourceLimits::default(),
+    );
+    let temporary = tempfile::tempdir().unwrap();
+    let assets = temporary.path().join("assets");
+    let result = result();
+    let staged =
+        stage_assets(&result, &assets, AssetModeArg::Extract, ConflictPolicy::Error, &context)
+            .unwrap();
+    let mut primary = context.temporary_file("stdout-primary").unwrap();
+    primary.write_all_checked(b"complete primary").unwrap();
+    cancellation.cancel();
+
+    let error = publish(&primary, &mut Vec::new(), Some(staged), &context).unwrap_err();
+
+    assert_eq!(error.code(), "cancelled");
+    assert!(!assets.exists() || std::fs::read_dir(&assets).unwrap().next().is_none());
+    assert_eq!(context.reserved_memory_bytes(), 0);
+    drop(primary);
+    assert_eq!(context.reserved_temporary_bytes(), 0);
+}

--- a/apps/cli/src/output/stream.rs
+++ b/apps/cli/src/output/stream.rs
@@ -1,10 +1,9 @@
 //! File-backed structured artifact staging.
 //!
-//! The engine adapter is intentionally added only after the stacked #272
-//! branch is approved. Keeping this module independent lets #273 add the
-//! smallest sink contract and prepare/execute seam against that stable base.
+//! The immutable plan selects only the representations required by the
+//! requested wire artifact and asset mode.
 
-use crate::args::EmitKind;
+use crate::args::{AssetModeArg, EmitKind};
 use crate::error::{CliError, ExitClass};
 use base64::engine::general_purpose::STANDARD;
 use into_markdown::{
@@ -67,10 +66,12 @@ mod bundle;
 mod document;
 mod io;
 mod json;
+mod plan;
 mod sink;
 
 use io::{ChunkRecordingWriter, IndentingWriter, copy_reader, copy_spool, replay_spool_chunks};
 use json::JsonStringSpool;
+use plan::RepresentationPlan;
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum DocumentPhase {
@@ -81,14 +82,15 @@ enum DocumentPhase {
 
 pub(crate) struct StructuredSpool {
     context: ExecutionContext,
+    plan: RepresentationPlan,
     capabilities: ArtifactSinkCapabilities,
-    ir: TemporaryFile,
+    ir: Option<TemporaryFile>,
     ir_write_chunks: Vec<usize>,
-    _ir_chunk_lease: ResourceReservation,
-    markdown: TemporaryFile,
-    markdown_json: JsonStringSpool,
-    diagnostics: TemporaryFile,
-    provenance: TemporaryFile,
+    ir_chunk_lease: Option<ResourceReservation>,
+    markdown: Option<TemporaryFile>,
+    markdown_json: Option<JsonStringSpool>,
+    diagnostics: Option<TemporaryFile>,
+    provenance: Option<TemporaryFile>,
     asset_records: Vec<AssetRecord>,
     payload_records: Vec<PayloadRecord>,
     payload_by_filename: HashMap<String, usize>,
@@ -96,29 +98,53 @@ pub(crate) struct StructuredSpool {
     index_leases: Vec<ResourceReservation>,
     finished: bool,
     serialization_calls: u64,
-    document_phase: DocumentPhase,
+    document_phase: Option<DocumentPhase>,
     first_block: bool,
 }
 
 impl StructuredSpool {
-    pub(crate) fn new(context: ExecutionContext, emit: EmitKind) -> Result<Self, CliError> {
-        let ir = context.temporary_file("into-md-ir").map_err(CliError::from)?;
-        let diagnostics = context.temporary_file("into-md-diagnostics").map_err(CliError::from)?;
-        let provenance = context.temporary_file("into-md-provenance").map_err(CliError::from)?;
-        let markdown = context.temporary_file("into-md-markdown").map_err(CliError::from)?;
-        let markdown_json = JsonStringSpool::new(&context, "into-md-markdown-json")?;
-        let index_lease = context.reserve_memory(INDEX_BASE_BYTES).map_err(CliError::from)?;
-        let ir_chunk_lease = context.reserve_memory(0).map_err(CliError::from)?;
+    pub(crate) fn new(
+        context: ExecutionContext,
+        emit: EmitKind,
+        asset_mode: AssetModeArg,
+    ) -> Result<Self, CliError> {
+        let plan = RepresentationPlan::new(emit, asset_mode);
+        let ir = plan
+            .semantic_ir()
+            .then(|| context.temporary_file("into-md-ir").map_err(CliError::from))
+            .transpose()?;
+        let diagnostics = plan
+            .inventories()
+            .then(|| context.temporary_file("into-md-diagnostics").map_err(CliError::from))
+            .transpose()?;
+        let provenance = plan
+            .inventories()
+            .then(|| context.temporary_file("into-md-provenance").map_err(CliError::from))
+            .transpose()?;
+        let markdown = plan
+            .raw_markdown()
+            .then(|| context.temporary_file("into-md-markdown").map_err(CliError::from))
+            .transpose()?;
+        let markdown_json = plan
+            .escaped_markdown()
+            .then(|| JsonStringSpool::new(&context, "into-md-markdown-json"))
+            .transpose()?;
+        let index_leases = if plan.semantic_ir() || plan.assets {
+            vec![context.reserve_memory(INDEX_BASE_BYTES).map_err(CliError::from)?]
+        } else {
+            Vec::new()
+        };
+        let ir_chunk_lease = plan
+            .semantic_ir()
+            .then(|| context.reserve_memory(0).map_err(CliError::from))
+            .transpose()?;
         Ok(Self {
             context,
-            capabilities: ArtifactSinkCapabilities {
-                markdown: emit != EmitKind::IrJson,
-                semantic_events: true,
-                assets: true,
-            },
+            plan,
+            capabilities: plan.capabilities(),
             ir,
             ir_write_chunks: Vec::new(),
-            _ir_chunk_lease: ir_chunk_lease,
+            ir_chunk_lease,
             markdown,
             markdown_json,
             diagnostics,
@@ -127,10 +153,10 @@ impl StructuredSpool {
             payload_records: Vec::new(),
             payload_by_filename: HashMap::new(),
             active_asset: None,
-            index_leases: vec![index_lease],
+            index_leases,
             finished: false,
             serialization_calls: 0,
-            document_phase: DocumentPhase::AwaitMetadata,
+            document_phase: plan.semantic_ir().then_some(DocumentPhase::AwaitMetadata),
             first_block: true,
         })
     }
@@ -139,45 +165,55 @@ impl StructuredSpool {
     pub(super) fn from_result(
         result: &ConversionResult,
         context: ExecutionContext,
+        emit: EmitKind,
+        asset_mode: AssetModeArg,
     ) -> Result<Self, CliError> {
-        let mut spool = Self::new(context, EmitKind::ResultJson)?;
-        spool
-            .write_document_event(&DocumentStreamEvent::Metadata(&result.document.metadata))
-            .map_err(CliError::from)?;
-        for block in &result.document.blocks {
+        let mut spool = Self::new(context, emit, asset_mode)?;
+        if spool.capabilities.semantic_events {
             spool
-                .write_document_event(&DocumentStreamEvent::RootBlock(block))
+                .write_document_event(&DocumentStreamEvent::Metadata(&result.document.metadata))
+                .map_err(CliError::from)?;
+            for block in &result.document.blocks {
+                spool
+                    .write_document_event(&DocumentStreamEvent::RootBlock(block))
+                    .map_err(CliError::from)?;
+            }
+            spool
+                .finish_document(&result.diagnostics, &result.provenance)
                 .map_err(CliError::from)?;
         }
-        spool.finish_document(&result.diagnostics, &result.provenance).map_err(CliError::from)?;
-        spool.write_markdown(result.markdown.as_bytes())?;
+        if spool.capabilities.markdown {
+            spool.write_markdown(result.markdown.as_bytes())?;
+        }
         let mut options = ConversionOptions::default();
         options.output.asset_uri_prefix = Some("assets".into());
-        let plan =
-            plan_assets(&result.document, &result.assets, &options).map_err(CliError::from)?;
-        let storage_by_id = plan
-            .entries()
-            .iter()
-            .flat_map(|entry| {
-                entry.asset_ids.iter().map(|id| (id.as_str(), entry.filename.as_str()))
-            })
-            .collect::<HashMap<_, _>>();
-        for asset in &result.assets {
-            let storage_filename = storage_by_id.get(asset.id.0.as_str()).copied();
-            spool.begin_asset_inner(AssetStart {
-                id: &asset.id.0,
-                wire_filename: asset.filename.as_deref(),
-                storage_filename,
-                media_type: &asset.media_type,
-                external_uri: asset.external_uri.as_deref(),
-                size: u64::try_from(asset.bytes.len()).unwrap_or(u64::MAX),
-                content_sha256: (!asset.bytes.is_empty())
-                    .then(|| Sha256::digest(&asset.bytes).into()),
-            })?;
-            for chunk in asset.bytes.chunks(COPY_BUFFER_BYTES) {
-                spool.write_asset_inner(chunk)?;
+        if spool.capabilities.assets {
+            let plan =
+                plan_assets(&result.document, &result.assets, &options).map_err(CliError::from)?;
+            let storage_by_id = plan
+                .entries()
+                .iter()
+                .flat_map(|entry| {
+                    entry.asset_ids.iter().map(|id| (id.as_str(), entry.filename.as_str()))
+                })
+                .collect::<HashMap<_, _>>();
+            for asset in &result.assets {
+                let storage_filename = storage_by_id.get(asset.id.0.as_str()).copied();
+                spool.begin_asset_inner(AssetStart {
+                    id: &asset.id.0,
+                    wire_filename: asset.filename.as_deref(),
+                    storage_filename,
+                    media_type: &asset.media_type,
+                    external_uri: asset.external_uri.as_deref(),
+                    size: u64::try_from(asset.bytes.len()).unwrap_or(u64::MAX),
+                    content_sha256: (!asset.bytes.is_empty())
+                        .then(|| Sha256::digest(&asset.bytes).into()),
+                })?;
+                for chunk in asset.bytes.chunks(COPY_BUFFER_BYTES) {
+                    spool.write_asset_inner(chunk)?;
+                }
+                spool.end_asset_inner()?;
             }
-            spool.end_asset_inner()?;
         }
         spool.finish()?;
         Ok(spool)
@@ -187,17 +223,27 @@ impl StructuredSpool {
         if self.finished {
             return Ok(());
         }
+        self.validate_representations()?;
         if self.active_asset.is_some() {
             return Err(CliError::internal("conversion ended during an asset stream"));
         }
-        if self.document_phase != DocumentPhase::Finished {
+        if self.document_phase.is_some_and(|phase| phase != DocumentPhase::Finished) {
             return Err(CliError::internal("semantic document was not finalized"));
         }
-        self.markdown_json.finish()?;
-        self.ir.sync_all().map_err(CliError::from)?;
-        self.markdown.sync_all().map_err(CliError::from)?;
-        self.diagnostics.sync_all().map_err(CliError::from)?;
-        self.provenance.sync_all().map_err(CliError::from)?;
+        if let Some(markdown_json) = self.markdown_json.as_mut() {
+            markdown_json.finish()?;
+        }
+        for spool in [
+            self.ir.as_mut(),
+            self.markdown.as_mut(),
+            self.diagnostics.as_mut(),
+            self.provenance.as_mut(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            spool.sync_all().map_err(CliError::from)?;
+        }
         for payload in &mut self.payload_records {
             payload.file.sync_all().map_err(CliError::from)?;
         }
@@ -213,10 +259,28 @@ impl StructuredSpool {
         if !self.finished {
             return Err(CliError::internal("structured spool is not finalized"));
         }
+        if emit != self.plan.emit {
+            return Err(CliError::internal(
+                "requested emit does not match the frozen representation plan",
+            ));
+        }
+        self.validate_representations()?;
         self.serialization_calls = self.serialization_calls.saturating_add(1);
         match emit {
-            EmitKind::Markdown => copy_spool(&self.context, &self.markdown, destination),
-            EmitKind::IrJson => copy_spool(&self.context, &self.ir, destination),
+            EmitKind::Markdown => copy_spool(
+                &self.context,
+                self.markdown
+                    .as_ref()
+                    .ok_or_else(|| CliError::internal("raw Markdown representation is absent"))?,
+                destination,
+            ),
+            EmitKind::IrJson => copy_spool(
+                &self.context,
+                self.ir
+                    .as_ref()
+                    .ok_or_else(|| CliError::internal("document IR representation is absent"))?,
+                destination,
+            ),
             EmitKind::ResultJson => self.write_result_json(destination),
             EmitKind::Bundle => self.write_bundle(destination),
         }
@@ -237,6 +301,27 @@ impl StructuredSpool {
 
     pub(crate) fn has_payloads(&self) -> bool {
         !self.payload_records.is_empty()
+    }
+
+    fn validate_representations(&self) -> Result<(), CliError> {
+        let valid = self.markdown.is_some() == self.plan.raw_markdown()
+            && self.markdown_json.is_some() == self.plan.escaped_markdown()
+            && self.ir.is_some() == self.plan.semantic_ir()
+            && self.ir_chunk_lease.is_some() == self.plan.semantic_ir()
+            && self.document_phase.is_some() == self.plan.semantic_ir()
+            && self.diagnostics.is_some() == self.plan.inventories()
+            && self.provenance.is_some() == self.plan.inventories()
+            && (self.plan.assets
+                || (self.asset_records.is_empty()
+                    && self.payload_records.is_empty()
+                    && self.active_asset.is_none()));
+        if valid {
+            Ok(())
+        } else {
+            Err(CliError::internal(
+                "structured spool does not match its frozen representation plan",
+            ))
+        }
     }
 }
 

--- a/apps/cli/src/output/stream.rs
+++ b/apps/cli/src/output/stream.rs
@@ -1,8 +1,8 @@
 //! File-backed structured artifact staging.
 //!
 //! The engine adapter is intentionally added only after the stacked #272
-//! branch is available. Keeping this module independent prevents #273 from
-//! copying the engine's streaming contract.
+//! branch is approved. Keeping this module independent lets #273 add the
+//! smallest sink contract and prepare/execute seam against that stable base.
 
 use crate::args::EmitKind;
 use crate::error::{CliError, ExitClass};

--- a/apps/cli/src/output/stream.rs
+++ b/apps/cli/src/output/stream.rs
@@ -8,10 +8,12 @@ use crate::args::EmitKind;
 use crate::error::{CliError, ExitClass};
 use base64::engine::general_purpose::STANDARD;
 use into_markdown::{
-    BUNDLE_SCHEMA_VERSION, ConversionError, ConversionOptions, ConversionResult,
-    DTO_SCHEMA_VERSION, DiagnosticsDto, Document, ExecutionContext, ProvenanceListDto,
-    ResourceReservation, TemporaryFile, plan_assets,
+    ArtifactSink, ArtifactSinkCapabilities, AssetStreamInfo, BUNDLE_SCHEMA_VERSION,
+    ConversionError, DTO_SCHEMA_VERSION, DiagnosticsDto, DocumentStreamEvent, ExecutionContext,
+    ProvenanceListDto, ResourceReservation, TemporaryFile, asset_filename_from_sha256,
 };
+#[cfg(test)]
+use into_markdown::{ConversionOptions, ConversionResult, plan_assets};
 use serde::Serialize;
 use sha2::{Digest as _, Sha256};
 use std::collections::HashMap;
@@ -35,7 +37,7 @@ struct AssetRecord {
 struct PayloadRecord {
     filename: String,
     media_type: String,
-    offset: u64,
+    file: TemporaryFile,
     size: u64,
     sha256: [u8; 32],
 }
@@ -45,8 +47,9 @@ struct ActiveAsset {
     expected: u64,
     written: u64,
     existing_payload: Option<usize>,
-    offset: u64,
+    file: Option<TemporaryFile>,
     hash: Sha256,
+    announced_sha256: Option<[u8; 32]>,
 }
 
 #[derive(Clone, Copy)]
@@ -57,15 +60,28 @@ struct AssetStart<'a> {
     media_type: &'a str,
     external_uri: Option<&'a str>,
     size: u64,
+    content_sha256: Option<[u8; 32]>,
 }
 
 mod bundle;
+mod document;
+mod io;
 mod json;
+mod sink;
 
+use io::{ChunkRecordingWriter, IndentingWriter, copy_reader, copy_spool, replay_spool_chunks};
 use json::JsonStringSpool;
 
-struct StructuredSpool {
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DocumentPhase {
+    AwaitMetadata,
+    Blocks,
+    Finished,
+}
+
+pub(crate) struct StructuredSpool {
     context: ExecutionContext,
+    capabilities: ArtifactSinkCapabilities,
     ir: TemporaryFile,
     ir_write_chunks: Vec<usize>,
     _ir_chunk_lease: ResourceReservation,
@@ -73,7 +89,6 @@ struct StructuredSpool {
     markdown_json: JsonStringSpool,
     diagnostics: TemporaryFile,
     provenance: TemporaryFile,
-    payloads: TemporaryFile,
     asset_records: Vec<AssetRecord>,
     payload_records: Vec<PayloadRecord>,
     payload_by_filename: HashMap<String, usize>,
@@ -81,54 +96,33 @@ struct StructuredSpool {
     index_leases: Vec<ResourceReservation>,
     finished: bool,
     serialization_calls: u64,
+    document_phase: DocumentPhase,
+    first_block: bool,
 }
 
 impl StructuredSpool {
-    fn from_result(result: &ConversionResult, context: ExecutionContext) -> Result<Self, CliError> {
-        let mut ir = context.temporary_file("into-md-ir").map_err(CliError::from)?;
-        let mut ir_write_chunks = Vec::new();
-        let mut ir_chunk_lease = context.reserve_memory(0).map_err(CliError::from)?;
-        result
-            .document
-            .validate()
-            .map_err(|error| CliError::internal(format!("validate document IR: {error}")))?;
-        serde_json::to_writer_pretty(
-            &mut ChunkRecordingWriter {
-                destination: &mut ir,
-                chunks: &mut ir_write_chunks,
-                lease: &mut ir_chunk_lease,
-            },
-            &result.document,
-        )
-        .map_err(|error| map_json_error(&error, "serialize document IR"))?;
-        ir.write_all_checked(b"\n").map_err(CliError::from)?;
-
-        let mut diagnostics =
-            context.temporary_file("into-md-diagnostics").map_err(CliError::from)?;
-        DiagnosticsDto::write_bundle_json_from_diagnostics(&result.diagnostics, &mut diagnostics)
-            .map_err(|error| CliError::internal(format!("serialize diagnostics DTO: {error}")))?;
-        diagnostics.write_all_checked(b"\n").map_err(CliError::from)?;
-
-        let mut provenance =
-            context.temporary_file("into-md-provenance").map_err(CliError::from)?;
-        ProvenanceListDto::write_bundle_json_from_provenance(&result.provenance, &mut provenance)
-            .map_err(|error| CliError::internal(format!("serialize provenance DTO: {error}")))?;
-        provenance.write_all_checked(b"\n").map_err(CliError::from)?;
-
+    pub(crate) fn new(context: ExecutionContext, emit: EmitKind) -> Result<Self, CliError> {
+        let ir = context.temporary_file("into-md-ir").map_err(CliError::from)?;
+        let diagnostics = context.temporary_file("into-md-diagnostics").map_err(CliError::from)?;
+        let provenance = context.temporary_file("into-md-provenance").map_err(CliError::from)?;
         let markdown = context.temporary_file("into-md-markdown").map_err(CliError::from)?;
         let markdown_json = JsonStringSpool::new(&context, "into-md-markdown-json")?;
-        let payloads = context.temporary_file("into-md-assets").map_err(CliError::from)?;
         let index_lease = context.reserve_memory(INDEX_BASE_BYTES).map_err(CliError::from)?;
-        let mut spool = Self {
+        let ir_chunk_lease = context.reserve_memory(0).map_err(CliError::from)?;
+        Ok(Self {
             context,
+            capabilities: ArtifactSinkCapabilities {
+                markdown: emit != EmitKind::IrJson,
+                semantic_events: true,
+                assets: true,
+            },
             ir,
-            ir_write_chunks,
+            ir_write_chunks: Vec::new(),
             _ir_chunk_lease: ir_chunk_lease,
             markdown,
             markdown_json,
             diagnostics,
             provenance,
-            payloads,
             asset_records: Vec::new(),
             payload_records: Vec::new(),
             payload_by_filename: HashMap::new(),
@@ -136,7 +130,26 @@ impl StructuredSpool {
             index_leases: vec![index_lease],
             finished: false,
             serialization_calls: 0,
-        };
+            document_phase: DocumentPhase::AwaitMetadata,
+            first_block: true,
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn from_result(
+        result: &ConversionResult,
+        context: ExecutionContext,
+    ) -> Result<Self, CliError> {
+        let mut spool = Self::new(context, EmitKind::ResultJson)?;
+        spool
+            .write_document_event(&DocumentStreamEvent::Metadata(&result.document.metadata))
+            .map_err(CliError::from)?;
+        for block in &result.document.blocks {
+            spool
+                .write_document_event(&DocumentStreamEvent::RootBlock(block))
+                .map_err(CliError::from)?;
+        }
+        spool.finish_document(&result.diagnostics, &result.provenance).map_err(CliError::from)?;
         spool.write_markdown(result.markdown.as_bytes())?;
         let mut options = ConversionOptions::default();
         options.output.asset_uri_prefix = Some("assets".into());
@@ -151,145 +164,48 @@ impl StructuredSpool {
             .collect::<HashMap<_, _>>();
         for asset in &result.assets {
             let storage_filename = storage_by_id.get(asset.id.0.as_str()).copied();
-            spool.begin_asset(AssetStart {
+            spool.begin_asset_inner(AssetStart {
                 id: &asset.id.0,
                 wire_filename: asset.filename.as_deref(),
                 storage_filename,
                 media_type: &asset.media_type,
                 external_uri: asset.external_uri.as_deref(),
                 size: u64::try_from(asset.bytes.len()).unwrap_or(u64::MAX),
+                content_sha256: (!asset.bytes.is_empty())
+                    .then(|| Sha256::digest(&asset.bytes).into()),
             })?;
             for chunk in asset.bytes.chunks(COPY_BUFFER_BYTES) {
-                spool.write_asset(chunk)?;
+                spool.write_asset_inner(chunk)?;
             }
-            spool.end_asset()?;
+            spool.end_asset_inner()?;
         }
         spool.finish()?;
         Ok(spool)
     }
 
-    fn write_markdown(&mut self, chunk: &[u8]) -> Result<(), CliError> {
-        self.context.checkpoint().map_err(CliError::from)?;
-        self.markdown.write_all_checked(chunk).map_err(CliError::from)?;
-        self.markdown_json.write(chunk)
-    }
-
-    fn begin_asset(&mut self, asset: AssetStart<'_>) -> Result<(), CliError> {
-        if self.active_asset.is_some() {
-            return Err(CliError::internal("nested asset stream"));
-        }
-        let lease =
-            self.context.reserve_memory(asset_index_bytes(&asset)?).map_err(CliError::from)?;
-        self.asset_records
-            .try_reserve(1)
-            .map_err(|error| CliError::internal(format!("reserve asset index: {error}")))?;
-        self.index_leases.push(lease);
-        let existing_payload = asset
-            .storage_filename
-            .and_then(|filename| self.payload_by_filename.get(filename).copied());
-        let offset = self.payloads.seek(SeekFrom::End(0))?;
-        self.active_asset = Some(ActiveAsset {
-            record: AssetRecord {
-                id: asset.id.to_owned(),
-                wire_filename: asset.wire_filename.map(str::to_owned),
-                storage_filename: asset.storage_filename.map(str::to_owned),
-                media_type: asset.media_type.to_owned(),
-                external_uri: asset.external_uri.map(str::to_owned),
-                payload_index: existing_payload,
-            },
-            expected: asset.size,
-            written: 0,
-            existing_payload,
-            offset,
-            hash: Sha256::new(),
-        });
-        Ok(())
-    }
-
-    fn write_asset(&mut self, chunk: &[u8]) -> Result<(), CliError> {
-        self.context.checkpoint().map_err(CliError::from)?;
-        let active = self
-            .active_asset
-            .as_mut()
-            .ok_or_else(|| CliError::internal("asset bytes arrived outside a stream"))?;
-        active.written = active
-            .written
-            .checked_add(u64::try_from(chunk.len()).unwrap_or(u64::MAX))
-            .ok_or_else(|| CliError::internal("asset byte count overflow"))?;
-        if active.written > active.expected {
-            return Err(CliError::internal("asset stream exceeded its announced size"));
-        }
-        active.hash.update(chunk);
-        if active.existing_payload.is_none() {
-            self.payloads.write_all_checked(chunk).map_err(CliError::from)?;
-        }
-        Ok(())
-    }
-
-    fn end_asset(&mut self) -> Result<(), CliError> {
-        let mut active = self
-            .active_asset
-            .take()
-            .ok_or_else(|| CliError::internal("asset stream ended without a beginning"))?;
-        if active.written != active.expected {
-            return Err(CliError::internal(format!(
-                "asset stream ended at {} of {} bytes",
-                active.written, active.expected
-            )));
-        }
-        let digest: [u8; 32] = active.hash.finalize().into();
-        if let Some(index) = active.existing_payload {
-            let existing = self
-                .payload_records
-                .get(index)
-                .ok_or_else(|| CliError::internal("asset payload index is inconsistent"))?;
-            if existing.size != active.written
-                || existing.sha256 != digest
-                || existing.media_type != active.record.media_type
-            {
-                return Err(CliError::new(
-                    ExitClass::Conversion,
-                    "assetMetadataConflict",
-                    "content-addressed asset metadata did not match its prior payload",
-                ));
-            }
-        } else if let Some(filename) = active.record.storage_filename.as_ref() {
-            let index = self.payload_records.len();
-            self.payload_records
-                .try_reserve(1)
-                .map_err(|error| CliError::internal(format!("reserve payload index: {error}")))?;
-            self.payload_by_filename
-                .try_reserve(1)
-                .map_err(|error| CliError::internal(format!("reserve payload lookup: {error}")))?;
-            self.payload_records.push(PayloadRecord {
-                filename: filename.clone(),
-                media_type: active.record.media_type.clone(),
-                offset: active.offset,
-                size: active.written,
-                sha256: digest,
-            });
-            self.payload_by_filename.insert(filename.clone(), index);
-            active.record.payload_index = Some(index);
-        } else if active.written != 0 {
-            return Err(CliError::internal("asset content has no stable storage filename"));
-        }
-        self.asset_records.push(active.record);
-        Ok(())
-    }
-
-    fn finish(&mut self) -> Result<(), CliError> {
+    pub(crate) fn finish(&mut self) -> Result<(), CliError> {
         if self.finished {
             return Ok(());
         }
         if self.active_asset.is_some() {
             return Err(CliError::internal("conversion ended during an asset stream"));
         }
+        if self.document_phase != DocumentPhase::Finished {
+            return Err(CliError::internal("semantic document was not finalized"));
+        }
         self.markdown_json.finish()?;
+        self.ir.sync_all().map_err(CliError::from)?;
+        self.markdown.sync_all().map_err(CliError::from)?;
+        self.diagnostics.sync_all().map_err(CliError::from)?;
+        self.provenance.sync_all().map_err(CliError::from)?;
+        for payload in &mut self.payload_records {
+            payload.file.sync_all().map_err(CliError::from)?;
+        }
         self.finished = true;
         Ok(())
     }
 
-    fn serialize<W: Write + Seek>(
+    pub(crate) fn serialize<W: Write + Seek>(
         &mut self,
         emit: EmitKind,
         destination: &mut W,
@@ -305,160 +221,22 @@ impl StructuredSpool {
             EmitKind::Bundle => self.write_bundle(destination),
         }
     }
-}
 
-fn asset_index_bytes(asset: &AssetStart<'_>) -> Result<u64, CliError> {
-    let strings = [
-        Some(asset.id),
-        asset.wire_filename,
-        asset.storage_filename,
-        Some(asset.media_type),
-        asset.external_uri,
-    ]
-    .into_iter()
-    .flatten()
-    .try_fold(0_u64, |total, value| {
-        total.checked_add(u64::try_from(value.len()).unwrap_or(u64::MAX))
-    })
-    .ok_or_else(|| {
-        CliError::from(ConversionError::ResourceLimit {
-            limit: "max_memory_bytes",
-            detail: "asset index metadata length overflowed".into(),
-        })
-    })?;
-    strings.checked_mul(4).and_then(|bytes| bytes.checked_add(INDEX_ASSET_BYTES)).ok_or_else(|| {
-        CliError::from(ConversionError::ResourceLimit {
-            limit: "max_memory_bytes",
-            detail: "asset index memory estimate overflowed".into(),
-        })
-    })
-}
-
-fn copy_spool<W: Write>(
-    context: &ExecutionContext,
-    spool: &TemporaryFile,
-    destination: &mut W,
-) -> Result<(), CliError> {
-    let mut reader = spool.as_file().map_err(CliError::from)?.try_clone()?;
-    reader.seek(SeekFrom::Start(0))?;
-    copy_reader(context, &mut reader, destination)
-}
-
-struct ChunkRecordingWriter<'a> {
-    destination: &'a mut TemporaryFile,
-    chunks: &'a mut Vec<usize>,
-    lease: &'a mut ResourceReservation,
-}
-
-impl Write for ChunkRecordingWriter<'_> {
-    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
-        self.reserve_slot()?;
-        match self.destination.write(bytes) {
-            Ok(written) => {
-                self.chunks.push(written);
-                Ok(written)
-            }
-            Err(error) => Err(error),
-        }
+    pub(crate) fn external_payloads(&self) -> Result<Vec<(&str, &std::fs::File)>, CliError> {
+        self.payload_records
+            .iter()
+            .map(|payload| {
+                payload
+                    .file
+                    .as_file()
+                    .map(|file| (payload.filename.as_str(), file))
+                    .map_err(CliError::from)
+            })
+            .collect()
     }
 
-    fn flush(&mut self) -> std::io::Result<()> {
-        Write::flush(self.destination)
-    }
-}
-
-impl ChunkRecordingWriter<'_> {
-    fn reserve_slot(&mut self) -> std::io::Result<()> {
-        if self.chunks.len() < self.chunks.capacity() {
-            return Ok(());
-        }
-        let old_capacity = self.chunks.capacity();
-        let target = old_capacity.saturating_mul(2).max(64);
-        let slot_bytes = std::mem::size_of::<usize>();
-        let planned_bytes = target
-            .checked_sub(old_capacity)
-            .and_then(|slots| slots.checked_mul(slot_bytes))
-            .and_then(|bytes| u64::try_from(bytes).ok())
-            .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
-        self.lease.grow(planned_bytes).map_err(std::io::Error::other)?;
-        if let Err(error) = self.chunks.try_reserve_exact(target - self.chunks.len()) {
-            self.lease.shrink(planned_bytes).map_err(std::io::Error::other)?;
-            return Err(std::io::Error::other(error));
-        }
-        let actual_capacity = self.chunks.capacity();
-        if actual_capacity < target {
-            *self.chunks = Vec::new();
-            let target_bytes = target
-                .checked_mul(slot_bytes)
-                .and_then(|bytes| u64::try_from(bytes).ok())
-                .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
-            self.lease.shrink(target_bytes).map_err(std::io::Error::other)?;
-            return Err(std::io::Error::other(
-                "IR replay index reserve returned less than requested capacity",
-            ));
-        }
-        if actual_capacity > target {
-            let extra_bytes = actual_capacity
-                .checked_sub(target)
-                .and_then(|slots| slots.checked_mul(slot_bytes))
-                .and_then(|bytes| u64::try_from(bytes).ok())
-                .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
-            if let Err(error) = self.lease.grow(extra_bytes) {
-                *self.chunks = Vec::new();
-                let target_bytes = target
-                    .checked_mul(slot_bytes)
-                    .and_then(|bytes| u64::try_from(bytes).ok())
-                    .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
-                self.lease.shrink(target_bytes).map_err(std::io::Error::other)?;
-                return Err(std::io::Error::other(error));
-            }
-        }
-        Ok(())
-    }
-}
-
-fn replay_spool_chunks<W: Write>(
-    context: &ExecutionContext,
-    spool: &TemporaryFile,
-    chunks: &[usize],
-    destination: &mut W,
-) -> Result<(), CliError> {
-    let maximum = chunks.iter().copied().max().unwrap_or(0);
-    let memory = context
-        .reserve_memory(u64::try_from(maximum).unwrap_or(u64::MAX))
-        .map_err(CliError::from)?;
-    let mut buffer = Vec::new();
-    buffer
-        .try_reserve_exact(maximum)
-        .map_err(|error| CliError::internal(format!("reserve IR replay buffer: {error}")))?;
-    buffer.resize(maximum, 0);
-    let mut reader = spool.as_file().map_err(CliError::from)?.try_clone()?;
-    reader.seek(SeekFrom::Start(0))?;
-    for &length in chunks {
-        context.checkpoint().map_err(CliError::from)?;
-        reader.read_exact(&mut buffer[..length])?;
-        destination.write_all(&buffer[..length])?;
-    }
-    drop(memory);
-    Ok(())
-}
-
-fn copy_reader<R: Read, W: Write>(
-    context: &ExecutionContext,
-    reader: &mut R,
-    destination: &mut W,
-) -> Result<(), CliError> {
-    let _buffer_lease = context
-        .reserve_memory(u64::try_from(COPY_BUFFER_BYTES).unwrap_or(u64::MAX))
-        .map_err(CliError::from)?;
-    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES].into_boxed_slice();
-    loop {
-        context.checkpoint().map_err(CliError::from)?;
-        let read = reader.read(&mut buffer)?;
-        if read == 0 {
-            return Ok(());
-        }
-        destination.write_all(&buffer[..read])?;
+    pub(crate) fn has_payloads(&self) -> bool {
+        !self.payload_records.is_empty()
     }
 }
 

--- a/apps/cli/src/output/stream.rs
+++ b/apps/cli/src/output/stream.rs
@@ -1,0 +1,471 @@
+//! File-backed structured artifact staging.
+//!
+//! The engine adapter is intentionally added only after the stacked #272
+//! branch is available. Keeping this module independent prevents #273 from
+//! copying the engine's streaming contract.
+
+use crate::args::EmitKind;
+use crate::error::{CliError, ExitClass};
+use base64::engine::general_purpose::STANDARD;
+use into_markdown::{
+    BUNDLE_SCHEMA_VERSION, ConversionError, ConversionOptions, ConversionResult,
+    DTO_SCHEMA_VERSION, DiagnosticsDto, Document, ExecutionContext, ProvenanceListDto,
+    ResourceReservation, TemporaryFile, plan_assets,
+};
+use serde::Serialize;
+use sha2::{Digest as _, Sha256};
+use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom, Write};
+use zip::write::SimpleFileOptions;
+
+const COPY_BUFFER_BYTES: usize = 64 * 1024;
+const INDEX_BASE_BYTES: u64 = 4 * 1024;
+const INDEX_ASSET_BYTES: u64 = 4 * 1024;
+
+#[derive(Clone)]
+struct AssetRecord {
+    id: String,
+    wire_filename: Option<String>,
+    storage_filename: Option<String>,
+    media_type: String,
+    external_uri: Option<String>,
+    payload_index: Option<usize>,
+}
+
+struct PayloadRecord {
+    filename: String,
+    media_type: String,
+    offset: u64,
+    size: u64,
+    sha256: [u8; 32],
+}
+
+struct ActiveAsset {
+    record: AssetRecord,
+    expected: u64,
+    written: u64,
+    existing_payload: Option<usize>,
+    offset: u64,
+    hash: Sha256,
+}
+
+#[derive(Clone, Copy)]
+struct AssetStart<'a> {
+    id: &'a str,
+    wire_filename: Option<&'a str>,
+    storage_filename: Option<&'a str>,
+    media_type: &'a str,
+    external_uri: Option<&'a str>,
+    size: u64,
+}
+
+mod bundle;
+mod json;
+
+use json::JsonStringSpool;
+
+struct StructuredSpool {
+    context: ExecutionContext,
+    ir: TemporaryFile,
+    ir_write_chunks: Vec<usize>,
+    _ir_chunk_lease: ResourceReservation,
+    markdown: TemporaryFile,
+    markdown_json: JsonStringSpool,
+    diagnostics: TemporaryFile,
+    provenance: TemporaryFile,
+    payloads: TemporaryFile,
+    asset_records: Vec<AssetRecord>,
+    payload_records: Vec<PayloadRecord>,
+    payload_by_filename: HashMap<String, usize>,
+    active_asset: Option<ActiveAsset>,
+    index_leases: Vec<ResourceReservation>,
+    finished: bool,
+    serialization_calls: u64,
+}
+
+impl StructuredSpool {
+    fn from_result(result: &ConversionResult, context: ExecutionContext) -> Result<Self, CliError> {
+        let mut ir = context.temporary_file("into-md-ir").map_err(CliError::from)?;
+        let mut ir_write_chunks = Vec::new();
+        let mut ir_chunk_lease = context.reserve_memory(0).map_err(CliError::from)?;
+        result
+            .document
+            .validate()
+            .map_err(|error| CliError::internal(format!("validate document IR: {error}")))?;
+        serde_json::to_writer_pretty(
+            &mut ChunkRecordingWriter {
+                destination: &mut ir,
+                chunks: &mut ir_write_chunks,
+                lease: &mut ir_chunk_lease,
+            },
+            &result.document,
+        )
+        .map_err(|error| map_json_error(&error, "serialize document IR"))?;
+        ir.write_all_checked(b"\n").map_err(CliError::from)?;
+
+        let mut diagnostics =
+            context.temporary_file("into-md-diagnostics").map_err(CliError::from)?;
+        DiagnosticsDto::write_bundle_json_from_diagnostics(&result.diagnostics, &mut diagnostics)
+            .map_err(|error| CliError::internal(format!("serialize diagnostics DTO: {error}")))?;
+        diagnostics.write_all_checked(b"\n").map_err(CliError::from)?;
+
+        let mut provenance =
+            context.temporary_file("into-md-provenance").map_err(CliError::from)?;
+        ProvenanceListDto::write_bundle_json_from_provenance(&result.provenance, &mut provenance)
+            .map_err(|error| CliError::internal(format!("serialize provenance DTO: {error}")))?;
+        provenance.write_all_checked(b"\n").map_err(CliError::from)?;
+
+        let markdown = context.temporary_file("into-md-markdown").map_err(CliError::from)?;
+        let markdown_json = JsonStringSpool::new(&context, "into-md-markdown-json")?;
+        let payloads = context.temporary_file("into-md-assets").map_err(CliError::from)?;
+        let index_lease = context.reserve_memory(INDEX_BASE_BYTES).map_err(CliError::from)?;
+        let mut spool = Self {
+            context,
+            ir,
+            ir_write_chunks,
+            _ir_chunk_lease: ir_chunk_lease,
+            markdown,
+            markdown_json,
+            diagnostics,
+            provenance,
+            payloads,
+            asset_records: Vec::new(),
+            payload_records: Vec::new(),
+            payload_by_filename: HashMap::new(),
+            active_asset: None,
+            index_leases: vec![index_lease],
+            finished: false,
+            serialization_calls: 0,
+        };
+        spool.write_markdown(result.markdown.as_bytes())?;
+        let mut options = ConversionOptions::default();
+        options.output.asset_uri_prefix = Some("assets".into());
+        let plan =
+            plan_assets(&result.document, &result.assets, &options).map_err(CliError::from)?;
+        let storage_by_id = plan
+            .entries()
+            .iter()
+            .flat_map(|entry| {
+                entry.asset_ids.iter().map(|id| (id.as_str(), entry.filename.as_str()))
+            })
+            .collect::<HashMap<_, _>>();
+        for asset in &result.assets {
+            let storage_filename = storage_by_id.get(asset.id.0.as_str()).copied();
+            spool.begin_asset(AssetStart {
+                id: &asset.id.0,
+                wire_filename: asset.filename.as_deref(),
+                storage_filename,
+                media_type: &asset.media_type,
+                external_uri: asset.external_uri.as_deref(),
+                size: u64::try_from(asset.bytes.len()).unwrap_or(u64::MAX),
+            })?;
+            for chunk in asset.bytes.chunks(COPY_BUFFER_BYTES) {
+                spool.write_asset(chunk)?;
+            }
+            spool.end_asset()?;
+        }
+        spool.finish()?;
+        Ok(spool)
+    }
+
+    fn write_markdown(&mut self, chunk: &[u8]) -> Result<(), CliError> {
+        self.context.checkpoint().map_err(CliError::from)?;
+        self.markdown.write_all_checked(chunk).map_err(CliError::from)?;
+        self.markdown_json.write(chunk)
+    }
+
+    fn begin_asset(&mut self, asset: AssetStart<'_>) -> Result<(), CliError> {
+        if self.active_asset.is_some() {
+            return Err(CliError::internal("nested asset stream"));
+        }
+        let lease =
+            self.context.reserve_memory(asset_index_bytes(&asset)?).map_err(CliError::from)?;
+        self.asset_records
+            .try_reserve(1)
+            .map_err(|error| CliError::internal(format!("reserve asset index: {error}")))?;
+        self.index_leases.push(lease);
+        let existing_payload = asset
+            .storage_filename
+            .and_then(|filename| self.payload_by_filename.get(filename).copied());
+        let offset = self.payloads.seek(SeekFrom::End(0))?;
+        self.active_asset = Some(ActiveAsset {
+            record: AssetRecord {
+                id: asset.id.to_owned(),
+                wire_filename: asset.wire_filename.map(str::to_owned),
+                storage_filename: asset.storage_filename.map(str::to_owned),
+                media_type: asset.media_type.to_owned(),
+                external_uri: asset.external_uri.map(str::to_owned),
+                payload_index: existing_payload,
+            },
+            expected: asset.size,
+            written: 0,
+            existing_payload,
+            offset,
+            hash: Sha256::new(),
+        });
+        Ok(())
+    }
+
+    fn write_asset(&mut self, chunk: &[u8]) -> Result<(), CliError> {
+        self.context.checkpoint().map_err(CliError::from)?;
+        let active = self
+            .active_asset
+            .as_mut()
+            .ok_or_else(|| CliError::internal("asset bytes arrived outside a stream"))?;
+        active.written = active
+            .written
+            .checked_add(u64::try_from(chunk.len()).unwrap_or(u64::MAX))
+            .ok_or_else(|| CliError::internal("asset byte count overflow"))?;
+        if active.written > active.expected {
+            return Err(CliError::internal("asset stream exceeded its announced size"));
+        }
+        active.hash.update(chunk);
+        if active.existing_payload.is_none() {
+            self.payloads.write_all_checked(chunk).map_err(CliError::from)?;
+        }
+        Ok(())
+    }
+
+    fn end_asset(&mut self) -> Result<(), CliError> {
+        let mut active = self
+            .active_asset
+            .take()
+            .ok_or_else(|| CliError::internal("asset stream ended without a beginning"))?;
+        if active.written != active.expected {
+            return Err(CliError::internal(format!(
+                "asset stream ended at {} of {} bytes",
+                active.written, active.expected
+            )));
+        }
+        let digest: [u8; 32] = active.hash.finalize().into();
+        if let Some(index) = active.existing_payload {
+            let existing = self
+                .payload_records
+                .get(index)
+                .ok_or_else(|| CliError::internal("asset payload index is inconsistent"))?;
+            if existing.size != active.written
+                || existing.sha256 != digest
+                || existing.media_type != active.record.media_type
+            {
+                return Err(CliError::new(
+                    ExitClass::Conversion,
+                    "assetMetadataConflict",
+                    "content-addressed asset metadata did not match its prior payload",
+                ));
+            }
+        } else if let Some(filename) = active.record.storage_filename.as_ref() {
+            let index = self.payload_records.len();
+            self.payload_records
+                .try_reserve(1)
+                .map_err(|error| CliError::internal(format!("reserve payload index: {error}")))?;
+            self.payload_by_filename
+                .try_reserve(1)
+                .map_err(|error| CliError::internal(format!("reserve payload lookup: {error}")))?;
+            self.payload_records.push(PayloadRecord {
+                filename: filename.clone(),
+                media_type: active.record.media_type.clone(),
+                offset: active.offset,
+                size: active.written,
+                sha256: digest,
+            });
+            self.payload_by_filename.insert(filename.clone(), index);
+            active.record.payload_index = Some(index);
+        } else if active.written != 0 {
+            return Err(CliError::internal("asset content has no stable storage filename"));
+        }
+        self.asset_records.push(active.record);
+        Ok(())
+    }
+
+    fn finish(&mut self) -> Result<(), CliError> {
+        if self.finished {
+            return Ok(());
+        }
+        if self.active_asset.is_some() {
+            return Err(CliError::internal("conversion ended during an asset stream"));
+        }
+        self.markdown_json.finish()?;
+        self.finished = true;
+        Ok(())
+    }
+
+    fn serialize<W: Write + Seek>(
+        &mut self,
+        emit: EmitKind,
+        destination: &mut W,
+    ) -> Result<(), CliError> {
+        if !self.finished {
+            return Err(CliError::internal("structured spool is not finalized"));
+        }
+        self.serialization_calls = self.serialization_calls.saturating_add(1);
+        match emit {
+            EmitKind::Markdown => copy_spool(&self.context, &self.markdown, destination),
+            EmitKind::IrJson => copy_spool(&self.context, &self.ir, destination),
+            EmitKind::ResultJson => self.write_result_json(destination),
+            EmitKind::Bundle => self.write_bundle(destination),
+        }
+    }
+}
+
+fn asset_index_bytes(asset: &AssetStart<'_>) -> Result<u64, CliError> {
+    let strings = [
+        Some(asset.id),
+        asset.wire_filename,
+        asset.storage_filename,
+        Some(asset.media_type),
+        asset.external_uri,
+    ]
+    .into_iter()
+    .flatten()
+    .try_fold(0_u64, |total, value| {
+        total.checked_add(u64::try_from(value.len()).unwrap_or(u64::MAX))
+    })
+    .ok_or_else(|| {
+        CliError::from(ConversionError::ResourceLimit {
+            limit: "max_memory_bytes",
+            detail: "asset index metadata length overflowed".into(),
+        })
+    })?;
+    strings.checked_mul(4).and_then(|bytes| bytes.checked_add(INDEX_ASSET_BYTES)).ok_or_else(|| {
+        CliError::from(ConversionError::ResourceLimit {
+            limit: "max_memory_bytes",
+            detail: "asset index memory estimate overflowed".into(),
+        })
+    })
+}
+
+fn copy_spool<W: Write>(
+    context: &ExecutionContext,
+    spool: &TemporaryFile,
+    destination: &mut W,
+) -> Result<(), CliError> {
+    let mut reader = spool.as_file().map_err(CliError::from)?.try_clone()?;
+    reader.seek(SeekFrom::Start(0))?;
+    copy_reader(context, &mut reader, destination)
+}
+
+struct ChunkRecordingWriter<'a> {
+    destination: &'a mut TemporaryFile,
+    chunks: &'a mut Vec<usize>,
+    lease: &'a mut ResourceReservation,
+}
+
+impl Write for ChunkRecordingWriter<'_> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.reserve_slot()?;
+        match self.destination.write(bytes) {
+            Ok(written) => {
+                self.chunks.push(written);
+                Ok(written)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Write::flush(self.destination)
+    }
+}
+
+impl ChunkRecordingWriter<'_> {
+    fn reserve_slot(&mut self) -> std::io::Result<()> {
+        if self.chunks.len() < self.chunks.capacity() {
+            return Ok(());
+        }
+        let old_capacity = self.chunks.capacity();
+        let target = old_capacity.saturating_mul(2).max(64);
+        let slot_bytes = std::mem::size_of::<usize>();
+        let planned_bytes = target
+            .checked_sub(old_capacity)
+            .and_then(|slots| slots.checked_mul(slot_bytes))
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
+        self.lease.grow(planned_bytes).map_err(std::io::Error::other)?;
+        if let Err(error) = self.chunks.try_reserve_exact(target - self.chunks.len()) {
+            self.lease.shrink(planned_bytes).map_err(std::io::Error::other)?;
+            return Err(std::io::Error::other(error));
+        }
+        let actual_capacity = self.chunks.capacity();
+        if actual_capacity < target {
+            *self.chunks = Vec::new();
+            let target_bytes = target
+                .checked_mul(slot_bytes)
+                .and_then(|bytes| u64::try_from(bytes).ok())
+                .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
+            self.lease.shrink(target_bytes).map_err(std::io::Error::other)?;
+            return Err(std::io::Error::other(
+                "IR replay index reserve returned less than requested capacity",
+            ));
+        }
+        if actual_capacity > target {
+            let extra_bytes = actual_capacity
+                .checked_sub(target)
+                .and_then(|slots| slots.checked_mul(slot_bytes))
+                .and_then(|bytes| u64::try_from(bytes).ok())
+                .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
+            if let Err(error) = self.lease.grow(extra_bytes) {
+                *self.chunks = Vec::new();
+                let target_bytes = target
+                    .checked_mul(slot_bytes)
+                    .and_then(|bytes| u64::try_from(bytes).ok())
+                    .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
+                self.lease.shrink(target_bytes).map_err(std::io::Error::other)?;
+                return Err(std::io::Error::other(error));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn replay_spool_chunks<W: Write>(
+    context: &ExecutionContext,
+    spool: &TemporaryFile,
+    chunks: &[usize],
+    destination: &mut W,
+) -> Result<(), CliError> {
+    let maximum = chunks.iter().copied().max().unwrap_or(0);
+    let memory = context
+        .reserve_memory(u64::try_from(maximum).unwrap_or(u64::MAX))
+        .map_err(CliError::from)?;
+    let mut buffer = Vec::new();
+    buffer
+        .try_reserve_exact(maximum)
+        .map_err(|error| CliError::internal(format!("reserve IR replay buffer: {error}")))?;
+    buffer.resize(maximum, 0);
+    let mut reader = spool.as_file().map_err(CliError::from)?.try_clone()?;
+    reader.seek(SeekFrom::Start(0))?;
+    for &length in chunks {
+        context.checkpoint().map_err(CliError::from)?;
+        reader.read_exact(&mut buffer[..length])?;
+        destination.write_all(&buffer[..length])?;
+    }
+    drop(memory);
+    Ok(())
+}
+
+fn copy_reader<R: Read, W: Write>(
+    context: &ExecutionContext,
+    reader: &mut R,
+    destination: &mut W,
+) -> Result<(), CliError> {
+    let _buffer_lease = context
+        .reserve_memory(u64::try_from(COPY_BUFFER_BYTES).unwrap_or(u64::MAX))
+        .map_err(CliError::from)?;
+    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES].into_boxed_slice();
+    loop {
+        context.checkpoint().map_err(CliError::from)?;
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(());
+        }
+        destination.write_all(&buffer[..read])?;
+    }
+}
+
+mod result;
+
+use result::map_json_error;
+
+#[cfg(test)]
+#[path = "stream/tests.rs"]
+mod tests;

--- a/apps/cli/src/output/stream/bundle.rs
+++ b/apps/cli/src/output/stream/bundle.rs
@@ -65,6 +65,22 @@ impl StructuredSpool {
         &self,
         destination: &mut W,
     ) -> Result<(), CliError> {
+        let markdown = self
+            .markdown
+            .as_ref()
+            .ok_or_else(|| CliError::internal("raw Markdown representation is absent"))?;
+        let ir = self
+            .ir
+            .as_ref()
+            .ok_or_else(|| CliError::internal("document IR representation is absent"))?;
+        let diagnostics = self
+            .diagnostics
+            .as_ref()
+            .ok_or_else(|| CliError::internal("diagnostics representation is absent"))?;
+        let provenance = self
+            .provenance
+            .as_ref()
+            .ok_or_else(|| CliError::internal("provenance representation is absent"))?;
         let groups = self.bundle_groups()?;
         let manifest_assets = groups
             .iter()
@@ -103,15 +119,15 @@ impl StructuredSpool {
         archive
             .start_file("diagnostics.json", files)
             .map_err(|error| map_zip_error(error, "create bundle entry"))?;
-        copy_spool(&self.context, &self.diagnostics, &mut archive)?;
+        copy_spool(&self.context, diagnostics, &mut archive)?;
         archive
             .start_file("document.ir.json", files)
             .map_err(|error| map_zip_error(error, "create bundle entry"))?;
-        replay_spool_chunks(&self.context, &self.ir, &self.ir_write_chunks, &mut archive)?;
+        replay_spool_chunks(&self.context, ir, &self.ir_write_chunks, &mut archive)?;
         archive
             .start_file("document.md", files)
             .map_err(|error| map_zip_error(error, "create bundle entry"))?;
-        copy_spool(&self.context, &self.markdown, &mut archive)?;
+        copy_spool(&self.context, markdown, &mut archive)?;
         archive
             .start_file("manifest.json", files)
             .map_err(|error| map_zip_error(error, "create bundle entry"))?;
@@ -121,7 +137,7 @@ impl StructuredSpool {
         archive
             .start_file("provenance.json", files)
             .map_err(|error| map_zip_error(error, "create bundle entry"))?;
-        copy_spool(&self.context, &self.provenance, &mut archive)?;
+        copy_spool(&self.context, provenance, &mut archive)?;
         archive
             .add_directory("assets/", directory)
             .map_err(|error| map_zip_error(error, "create bundle assets directory"))?;

--- a/apps/cli/src/output/stream/bundle.rs
+++ b/apps/cli/src/output/stream/bundle.rs
@@ -1,0 +1,148 @@
+use super::*;
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BundleAssetWire<'a> {
+    id: &'a str,
+    source_asset_ids: &'a [String],
+    path: String,
+    media_type: &'a str,
+    size: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BundleManifestWire<'a> {
+    schema_version: u32,
+    markdown: &'static str,
+    document_ir: &'static str,
+    diagnostics: &'static str,
+    diagnostics_schema_version: u32,
+    provenance: &'static str,
+    provenance_schema_version: u32,
+    assets: &'a [BundleAssetWire<'a>],
+}
+
+struct BundleAssetGroup {
+    payload_index: usize,
+    ids: Vec<String>,
+}
+
+impl StructuredSpool {
+    fn bundle_groups(&self) -> Result<Vec<BundleAssetGroup>, CliError> {
+        let mut groups = self
+            .payload_records
+            .iter()
+            .enumerate()
+            .map(|(payload_index, _)| BundleAssetGroup { payload_index, ids: Vec::new() })
+            .collect::<Vec<_>>();
+        for asset in &self.asset_records {
+            let payload_index = asset.payload_index.ok_or_else(|| {
+                CliError::new(
+                    ExitClass::Conversion,
+                    "bundleAssetMissingContent",
+                    format!("bundle asset {} has no portable content", asset.id),
+                )
+            })?;
+            groups
+                .get_mut(payload_index)
+                .ok_or_else(|| CliError::internal("bundle payload index is inconsistent"))?
+                .ids
+                .push(asset.id.clone());
+        }
+        for group in &mut groups {
+            group.ids.sort();
+        }
+        groups.sort_by(|left, right| {
+            self.payload_records[left.payload_index]
+                .filename
+                .cmp(&self.payload_records[right.payload_index].filename)
+        });
+        Ok(groups)
+    }
+
+    pub(super) fn write_bundle<W: Write + Seek>(
+        &self,
+        destination: &mut W,
+    ) -> Result<(), CliError> {
+        let groups = self.bundle_groups()?;
+        let manifest_assets = groups
+            .iter()
+            .map(|group| {
+                let payload = &self.payload_records[group.payload_index];
+                let id = group
+                    .ids
+                    .first()
+                    .ok_or_else(|| CliError::internal("bundle asset group is empty"))?;
+                Ok(BundleAssetWire {
+                    id,
+                    source_asset_ids: &group.ids,
+                    path: format!("assets/{}", payload.filename),
+                    media_type: &payload.media_type,
+                    size: payload.size,
+                })
+            })
+            .collect::<Result<Vec<_>, CliError>>()?;
+        let manifest = BundleManifestWire {
+            schema_version: BUNDLE_SCHEMA_VERSION,
+            markdown: "document.md",
+            document_ir: "document.ir.json",
+            diagnostics: "diagnostics.json",
+            diagnostics_schema_version: DTO_SCHEMA_VERSION,
+            provenance: "provenance.json",
+            provenance_schema_version: DTO_SCHEMA_VERSION,
+            assets: &manifest_assets,
+        };
+        let mut archive = zip::ZipWriter::new(destination);
+        let files = SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated)
+            .unix_permissions(0o644);
+        let directory = SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Stored)
+            .unix_permissions(0o755);
+        archive
+            .start_file("diagnostics.json", files)
+            .map_err(|error| map_zip_error(error, "create bundle entry"))?;
+        copy_spool(&self.context, &self.diagnostics, &mut archive)?;
+        archive
+            .start_file("document.ir.json", files)
+            .map_err(|error| map_zip_error(error, "create bundle entry"))?;
+        replay_spool_chunks(&self.context, &self.ir, &self.ir_write_chunks, &mut archive)?;
+        archive.write_all(b"\n")?;
+        archive
+            .start_file("document.md", files)
+            .map_err(|error| map_zip_error(error, "create bundle entry"))?;
+        copy_spool(&self.context, &self.markdown, &mut archive)?;
+        archive
+            .start_file("manifest.json", files)
+            .map_err(|error| map_zip_error(error, "create bundle entry"))?;
+        serde_json::to_writer_pretty(&mut archive, &manifest)
+            .map_err(|error| map_json_error(&error, "serialize bundle manifest"))?;
+        archive.write_all(b"\n")?;
+        archive
+            .start_file("provenance.json", files)
+            .map_err(|error| map_zip_error(error, "create bundle entry"))?;
+        copy_spool(&self.context, &self.provenance, &mut archive)?;
+        archive
+            .add_directory("assets/", directory)
+            .map_err(|error| map_zip_error(error, "create bundle assets directory"))?;
+        for group in groups {
+            let payload = &self.payload_records[group.payload_index];
+            archive
+                .start_file(format!("assets/{}", payload.filename), files)
+                .map_err(|error| map_zip_error(error, "create bundle asset"))?;
+            let mut reader = self.payloads.as_file().map_err(CliError::from)?.try_clone()?;
+            reader.seek(SeekFrom::Start(payload.offset))?;
+            copy_reader(&self.context, &mut reader.take(payload.size), &mut archive)?;
+        }
+        archive.finish().map_err(|error| map_zip_error(error, "finish bundle"))?;
+        Ok(())
+    }
+}
+
+fn map_zip_error(error: zip::result::ZipError, operation: &str) -> CliError {
+    match error {
+        zip::result::ZipError::Io(error) => CliError::from(error),
+        error => CliError::internal(format!("{operation}: {error}")),
+    }
+}

--- a/apps/cli/src/output/stream/bundle.rs
+++ b/apps/cli/src/output/stream/bundle.rs
@@ -108,7 +108,6 @@ impl StructuredSpool {
             .start_file("document.ir.json", files)
             .map_err(|error| map_zip_error(error, "create bundle entry"))?;
         replay_spool_chunks(&self.context, &self.ir, &self.ir_write_chunks, &mut archive)?;
-        archive.write_all(b"\n")?;
         archive
             .start_file("document.md", files)
             .map_err(|error| map_zip_error(error, "create bundle entry"))?;
@@ -131,8 +130,8 @@ impl StructuredSpool {
             archive
                 .start_file(format!("assets/{}", payload.filename), files)
                 .map_err(|error| map_zip_error(error, "create bundle asset"))?;
-            let mut reader = self.payloads.as_file().map_err(CliError::from)?.try_clone()?;
-            reader.seek(SeekFrom::Start(payload.offset))?;
+            let mut reader = payload.file.as_file().map_err(CliError::from)?.try_clone()?;
+            reader.seek(SeekFrom::Start(0))?;
             copy_reader(&self.context, &mut reader.take(payload.size), &mut archive)?;
         }
         archive.finish().map_err(|error| map_zip_error(error, "finish bundle"))?;

--- a/apps/cli/src/output/stream/document.rs
+++ b/apps/cli/src/output/stream/document.rs
@@ -9,14 +9,14 @@ impl StructuredSpool {
     ) -> Result<(), CliError> {
         self.context.checkpoint().map_err(CliError::from)?;
         match (self.document_phase, event) {
-            (DocumentPhase::AwaitMetadata, DocumentStreamEvent::Metadata(metadata)) => {
+            (Some(DocumentPhase::AwaitMetadata), DocumentStreamEvent::Metadata(metadata)) => {
                 self.write_ir_bytes(b"{\n  \"schemaVersion\": 1,\n  \"metadata\": ")?;
                 self.write_ir_value(metadata, b"  ")?;
                 self.write_ir_bytes(b",\n  \"blocks\": [")?;
-                self.document_phase = DocumentPhase::Blocks;
+                self.document_phase = Some(DocumentPhase::Blocks);
                 Ok(())
             }
-            (DocumentPhase::Blocks, DocumentStreamEvent::RootBlock(block)) => {
+            (Some(DocumentPhase::Blocks), DocumentStreamEvent::RootBlock(block)) => {
                 if self.first_block {
                     self.write_ir_bytes(b"\n    ")?;
                     self.first_block = false;
@@ -25,15 +25,18 @@ impl StructuredSpool {
                 }
                 self.write_ir_value(block, b"    ")
             }
-            (DocumentPhase::AwaitMetadata, _) => {
+            (Some(DocumentPhase::AwaitMetadata), _) => {
                 Err(CliError::internal("document block arrived before metadata"))
             }
-            (DocumentPhase::Blocks, DocumentStreamEvent::Metadata(_)) => {
+            (Some(DocumentPhase::Blocks), DocumentStreamEvent::Metadata(_)) => {
                 Err(CliError::internal("document metadata was repeated"))
             }
-            (DocumentPhase::Finished, _) => {
+            (Some(DocumentPhase::Finished), _) => {
                 Err(CliError::internal("document event arrived after finalization"))
             }
+            (None, _) => Err(CliError::internal(
+                "semantic event arrived without a document IR representation",
+            )),
         }
     }
 
@@ -42,7 +45,7 @@ impl StructuredSpool {
         diagnostics: &[into_markdown::Diagnostic],
         provenance: &[into_markdown::Provenance],
     ) -> Result<(), CliError> {
-        if self.document_phase != DocumentPhase::Blocks {
+        if self.document_phase != Some(DocumentPhase::Blocks) {
             return Err(CliError::internal("semantic document is not ready to finalize"));
         }
         if self.first_block {
@@ -50,22 +53,43 @@ impl StructuredSpool {
         } else {
             self.write_ir_bytes(b"\n  ]\n}\n")?;
         }
-        DiagnosticsDto::write_bundle_json_from_diagnostics(diagnostics, &mut self.diagnostics)
-            .map_err(|error| CliError::internal(format!("serialize diagnostics DTO: {error}")))?;
-        self.diagnostics.write_all_checked(b"\n").map_err(CliError::from)?;
-        ProvenanceListDto::write_bundle_json_from_provenance(provenance, &mut self.provenance)
-            .map_err(|error| CliError::internal(format!("serialize provenance DTO: {error}")))?;
-        self.provenance.write_all_checked(b"\n").map_err(CliError::from)?;
-        self.document_phase = DocumentPhase::Finished;
+        match (self.diagnostics.as_mut(), self.provenance.as_mut()) {
+            (Some(diagnostics_spool), Some(provenance_spool)) if self.plan.inventories() => {
+                DiagnosticsDto::write_bundle_json_from_diagnostics(
+                    diagnostics,
+                    &mut *diagnostics_spool,
+                )
+                .map_err(|error| {
+                    CliError::internal(format!("serialize diagnostics DTO: {error}"))
+                })?;
+                diagnostics_spool.write_all_checked(b"\n").map_err(CliError::from)?;
+                ProvenanceListDto::write_bundle_json_from_provenance(
+                    provenance,
+                    &mut *provenance_spool,
+                )
+                .map_err(|error| {
+                    CliError::internal(format!("serialize provenance DTO: {error}"))
+                })?;
+                provenance_spool.write_all_checked(b"\n").map_err(CliError::from)?;
+            }
+            (None, None) if !self.plan.inventories() => {}
+            _ => return Err(CliError::internal("semantic inventory representation is incomplete")),
+        }
+        self.document_phase = Some(DocumentPhase::Finished);
         Ok(())
     }
 
     fn write_ir_bytes(&mut self, bytes: &[u8]) -> Result<(), CliError> {
-        let mut writer = ChunkRecordingWriter {
-            destination: &mut self.ir,
-            chunks: &mut self.ir_write_chunks,
-            lease: &mut self._ir_chunk_lease,
-        };
+        let destination = self
+            .ir
+            .as_mut()
+            .ok_or_else(|| CliError::internal("document IR representation is absent"))?;
+        let lease = self
+            .ir_chunk_lease
+            .as_mut()
+            .ok_or_else(|| CliError::internal("document IR chunk lease is absent"))?;
+        let mut writer =
+            ChunkRecordingWriter { destination, chunks: &mut self.ir_write_chunks, lease };
         writer.write_all(bytes).map_err(CliError::from)
     }
 
@@ -74,11 +98,15 @@ impl StructuredSpool {
         value: &T,
         indent: &'static [u8],
     ) -> Result<(), CliError> {
-        let writer = ChunkRecordingWriter {
-            destination: &mut self.ir,
-            chunks: &mut self.ir_write_chunks,
-            lease: &mut self._ir_chunk_lease,
-        };
+        let destination = self
+            .ir
+            .as_mut()
+            .ok_or_else(|| CliError::internal("document IR representation is absent"))?;
+        let lease = self
+            .ir_chunk_lease
+            .as_mut()
+            .ok_or_else(|| CliError::internal("document IR chunk lease is absent"))?;
+        let writer = ChunkRecordingWriter { destination, chunks: &mut self.ir_write_chunks, lease };
         serde_json::to_writer_pretty(IndentingWriter::new(writer, indent), value)
             .map_err(|error| map_json_error(&error, "serialize document IR event"))
     }

--- a/apps/cli/src/output/stream/document.rs
+++ b/apps/cli/src/output/stream/document.rs
@@ -1,0 +1,85 @@
+//! Incremental semantic-document JSON and final inventories.
+
+use super::*;
+
+impl StructuredSpool {
+    pub(super) fn write_document_event_inner(
+        &mut self,
+        event: &DocumentStreamEvent<'_>,
+    ) -> Result<(), CliError> {
+        self.context.checkpoint().map_err(CliError::from)?;
+        match (self.document_phase, event) {
+            (DocumentPhase::AwaitMetadata, DocumentStreamEvent::Metadata(metadata)) => {
+                self.write_ir_bytes(b"{\n  \"schemaVersion\": 1,\n  \"metadata\": ")?;
+                self.write_ir_value(metadata, b"  ")?;
+                self.write_ir_bytes(b",\n  \"blocks\": [")?;
+                self.document_phase = DocumentPhase::Blocks;
+                Ok(())
+            }
+            (DocumentPhase::Blocks, DocumentStreamEvent::RootBlock(block)) => {
+                if self.first_block {
+                    self.write_ir_bytes(b"\n    ")?;
+                    self.first_block = false;
+                } else {
+                    self.write_ir_bytes(b",\n    ")?;
+                }
+                self.write_ir_value(block, b"    ")
+            }
+            (DocumentPhase::AwaitMetadata, _) => {
+                Err(CliError::internal("document block arrived before metadata"))
+            }
+            (DocumentPhase::Blocks, DocumentStreamEvent::Metadata(_)) => {
+                Err(CliError::internal("document metadata was repeated"))
+            }
+            (DocumentPhase::Finished, _) => {
+                Err(CliError::internal("document event arrived after finalization"))
+            }
+        }
+    }
+
+    pub(super) fn finish_document_inner(
+        &mut self,
+        diagnostics: &[into_markdown::Diagnostic],
+        provenance: &[into_markdown::Provenance],
+    ) -> Result<(), CliError> {
+        if self.document_phase != DocumentPhase::Blocks {
+            return Err(CliError::internal("semantic document is not ready to finalize"));
+        }
+        if self.first_block {
+            self.write_ir_bytes(b"]\n}\n")?;
+        } else {
+            self.write_ir_bytes(b"\n  ]\n}\n")?;
+        }
+        DiagnosticsDto::write_bundle_json_from_diagnostics(diagnostics, &mut self.diagnostics)
+            .map_err(|error| CliError::internal(format!("serialize diagnostics DTO: {error}")))?;
+        self.diagnostics.write_all_checked(b"\n").map_err(CliError::from)?;
+        ProvenanceListDto::write_bundle_json_from_provenance(provenance, &mut self.provenance)
+            .map_err(|error| CliError::internal(format!("serialize provenance DTO: {error}")))?;
+        self.provenance.write_all_checked(b"\n").map_err(CliError::from)?;
+        self.document_phase = DocumentPhase::Finished;
+        Ok(())
+    }
+
+    fn write_ir_bytes(&mut self, bytes: &[u8]) -> Result<(), CliError> {
+        let mut writer = ChunkRecordingWriter {
+            destination: &mut self.ir,
+            chunks: &mut self.ir_write_chunks,
+            lease: &mut self._ir_chunk_lease,
+        };
+        writer.write_all(bytes).map_err(CliError::from)
+    }
+
+    fn write_ir_value<T: Serialize + ?Sized>(
+        &mut self,
+        value: &T,
+        indent: &'static [u8],
+    ) -> Result<(), CliError> {
+        let writer = ChunkRecordingWriter {
+            destination: &mut self.ir,
+            chunks: &mut self.ir_write_chunks,
+            lease: &mut self._ir_chunk_lease,
+        };
+        serde_json::to_writer_pretty(IndentingWriter::new(writer, indent), value)
+            .map_err(|error| map_json_error(&error, "serialize document IR event"))
+    }
+}

--- a/apps/cli/src/output/stream/io.rs
+++ b/apps/cli/src/output/stream/io.rs
@@ -1,0 +1,165 @@
+//! Accounted file replay and serialization writers.
+
+use super::*;
+
+pub(super) struct IndentingWriter<W> {
+    inner: W,
+    indent: &'static [u8],
+}
+
+impl<W> IndentingWriter<W> {
+    pub(super) const fn new(inner: W, indent: &'static [u8]) -> Self {
+        Self { inner, indent }
+    }
+}
+
+impl<W: Write> Write for IndentingWriter<W> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.write_all(bytes)?;
+        Ok(bytes.len())
+    }
+
+    fn write_all(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        let mut start = 0;
+        for (index, byte) in bytes.iter().copied().enumerate() {
+            if byte == b'\n' {
+                self.inner.write_all(&bytes[start..=index])?;
+                self.inner.write_all(self.indent)?;
+                start = index + 1;
+            }
+        }
+        self.inner.write_all(&bytes[start..])
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+pub(super) fn copy_spool<W: Write>(
+    context: &ExecutionContext,
+    spool: &TemporaryFile,
+    destination: &mut W,
+) -> Result<(), CliError> {
+    let mut reader = spool.as_file().map_err(CliError::from)?.try_clone()?;
+    reader.seek(SeekFrom::Start(0))?;
+    copy_reader(context, &mut reader, destination)
+}
+
+pub(super) struct ChunkRecordingWriter<'a> {
+    pub(super) destination: &'a mut TemporaryFile,
+    pub(super) chunks: &'a mut Vec<usize>,
+    pub(super) lease: &'a mut ResourceReservation,
+}
+
+impl Write for ChunkRecordingWriter<'_> {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.reserve_slot()?;
+        match self.destination.write(bytes) {
+            Ok(written) => {
+                self.chunks.push(written);
+                Ok(written)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Write::flush(self.destination)
+    }
+}
+
+impl ChunkRecordingWriter<'_> {
+    fn reserve_slot(&mut self) -> std::io::Result<()> {
+        if self.chunks.len() < self.chunks.capacity() {
+            return Ok(());
+        }
+        let old_capacity = self.chunks.capacity();
+        let target = old_capacity.saturating_mul(2).max(64);
+        let slot_bytes = std::mem::size_of::<usize>();
+        let planned_bytes = target
+            .checked_sub(old_capacity)
+            .and_then(|slots| slots.checked_mul(slot_bytes))
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
+        self.lease.grow(planned_bytes).map_err(std::io::Error::other)?;
+        if let Err(error) = self.chunks.try_reserve_exact(target - self.chunks.len()) {
+            self.lease.shrink(planned_bytes).map_err(std::io::Error::other)?;
+            return Err(std::io::Error::other(error));
+        }
+        let actual_capacity = self.chunks.capacity();
+        if actual_capacity < target {
+            *self.chunks = Vec::new();
+            let target_bytes = target
+                .checked_mul(slot_bytes)
+                .and_then(|bytes| u64::try_from(bytes).ok())
+                .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
+            self.lease.shrink(target_bytes).map_err(std::io::Error::other)?;
+            return Err(std::io::Error::other(
+                "IR replay index reserve returned less than requested capacity",
+            ));
+        }
+        if actual_capacity > target {
+            let extra_bytes = actual_capacity
+                .checked_sub(target)
+                .and_then(|slots| slots.checked_mul(slot_bytes))
+                .and_then(|bytes| u64::try_from(bytes).ok())
+                .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
+            if let Err(error) = self.lease.grow(extra_bytes) {
+                *self.chunks = Vec::new();
+                let target_bytes = target
+                    .checked_mul(slot_bytes)
+                    .and_then(|bytes| u64::try_from(bytes).ok())
+                    .ok_or_else(|| std::io::Error::other("IR replay index capacity overflowed"))?;
+                self.lease.shrink(target_bytes).map_err(std::io::Error::other)?;
+                return Err(std::io::Error::other(error));
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn replay_spool_chunks<W: Write>(
+    context: &ExecutionContext,
+    spool: &TemporaryFile,
+    chunks: &[usize],
+    destination: &mut W,
+) -> Result<(), CliError> {
+    let maximum = chunks.iter().copied().max().unwrap_or(0);
+    let memory = context
+        .reserve_memory(u64::try_from(maximum).unwrap_or(u64::MAX))
+        .map_err(CliError::from)?;
+    let mut buffer = Vec::new();
+    buffer
+        .try_reserve_exact(maximum)
+        .map_err(|error| CliError::internal(format!("reserve IR replay buffer: {error}")))?;
+    buffer.resize(maximum, 0);
+    let mut reader = spool.as_file().map_err(CliError::from)?.try_clone()?;
+    reader.seek(SeekFrom::Start(0))?;
+    for &length in chunks {
+        context.checkpoint().map_err(CliError::from)?;
+        reader.read_exact(&mut buffer[..length])?;
+        destination.write_all(&buffer[..length])?;
+    }
+    drop(memory);
+    Ok(())
+}
+
+pub(super) fn copy_reader<R: Read, W: Write>(
+    context: &ExecutionContext,
+    reader: &mut R,
+    destination: &mut W,
+) -> Result<(), CliError> {
+    let _buffer_lease = context
+        .reserve_memory(u64::try_from(COPY_BUFFER_BYTES).unwrap_or(u64::MAX))
+        .map_err(CliError::from)?;
+    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES].into_boxed_slice();
+    loop {
+        context.checkpoint().map_err(CliError::from)?;
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            return Ok(());
+        }
+        destination.write_all(&buffer[..read])?;
+    }
+}

--- a/apps/cli/src/output/stream/json.rs
+++ b/apps/cli/src/output/stream/json.rs
@@ -1,0 +1,119 @@
+use super::*;
+
+pub(super) struct JsonStringSpool {
+    pub(super) file: TemporaryFile,
+    carry: [u8; 3],
+    carry_len: usize,
+    finished: bool,
+}
+
+impl JsonStringSpool {
+    pub(super) fn new(context: &ExecutionContext, prefix: &str) -> Result<Self, CliError> {
+        let mut file = context.temporary_file(prefix).map_err(CliError::from)?;
+        file.write_all_checked(b"\"").map_err(CliError::from)?;
+        Ok(Self { file, carry: [0; 3], carry_len: 0, finished: false })
+    }
+
+    pub(super) fn write(&mut self, chunk: &[u8]) -> Result<(), CliError> {
+        if self.finished {
+            return Err(CliError::internal("JSON string spool was already finished"));
+        }
+        if self.carry_len == 0 {
+            return self.write_valid_prefix(chunk);
+        }
+        let width = utf8_width(self.carry[0])
+            .ok_or_else(|| CliError::internal("JSON string spool has invalid UTF-8 state"))?;
+        let needed = width.saturating_sub(self.carry_len);
+        if chunk.len() < needed {
+            let end = self.carry_len + chunk.len();
+            self.carry[self.carry_len..end].copy_from_slice(chunk);
+            self.carry_len = end;
+            return Ok(());
+        }
+        let mut sequence = [0_u8; 4];
+        sequence[..self.carry_len].copy_from_slice(&self.carry[..self.carry_len]);
+        sequence[self.carry_len..width].copy_from_slice(&chunk[..needed]);
+        std::str::from_utf8(&sequence[..width])
+            .map_err(|_| CliError::internal("streamed Markdown is not valid UTF-8"))?;
+        self.file.write_all_checked(&sequence[..width]).map_err(CliError::from)?;
+        self.carry_len = 0;
+        self.write_valid_prefix(&chunk[needed..])
+    }
+
+    fn write_valid_prefix(&mut self, chunk: &[u8]) -> Result<(), CliError> {
+        match std::str::from_utf8(chunk) {
+            Ok(_) => write_json_string_bytes(&mut self.file, chunk),
+            Err(error) if error.error_len().is_none() => {
+                let valid = error.valid_up_to();
+                write_json_string_bytes(&mut self.file, &chunk[..valid])?;
+                let tail = &chunk[valid..];
+                if tail.len() > self.carry.len()
+                    || tail.first().copied().and_then(utf8_width).is_none()
+                {
+                    return Err(CliError::internal("streamed Markdown is not valid UTF-8"));
+                }
+                self.carry[..tail.len()].copy_from_slice(tail);
+                self.carry_len = tail.len();
+                Ok(())
+            }
+            Err(_) => Err(CliError::internal("streamed Markdown is not valid UTF-8")),
+        }
+    }
+
+    pub(super) fn finish(&mut self) -> Result<(), CliError> {
+        if self.finished {
+            return Ok(());
+        }
+        if self.carry_len != 0 {
+            return Err(CliError::internal("streamed Markdown ended within a UTF-8 sequence"));
+        }
+        self.file.write_all_checked(b"\"").map_err(CliError::from)?;
+        self.finished = true;
+        Ok(())
+    }
+}
+
+fn write_json_string_bytes(file: &mut TemporaryFile, bytes: &[u8]) -> Result<(), CliError> {
+    let mut start = 0;
+    for (index, byte) in bytes.iter().copied().enumerate() {
+        let escaped: Option<&[u8]> = match byte {
+            b'"' => Some(b"\\\""),
+            b'\\' => Some(b"\\\\"),
+            0x08 => Some(b"\\b"),
+            b'\t' => Some(b"\\t"),
+            b'\n' => Some(b"\\n"),
+            0x0c => Some(b"\\f"),
+            b'\r' => Some(b"\\r"),
+            0x00..=0x1f => None,
+            _ => continue,
+        };
+        if index > start {
+            file.write_all_checked(&bytes[start..index]).map_err(CliError::from)?;
+        }
+        if let Some(escaped) = escaped {
+            file.write_all_checked(escaped).map_err(CliError::from)?;
+        } else {
+            let encoded = [b'\\', b'u', b'0', b'0', hex_digit(byte >> 4), hex_digit(byte & 0x0f)];
+            file.write_all_checked(&encoded).map_err(CliError::from)?;
+        }
+        start = index + 1;
+    }
+    if start < bytes.len() {
+        file.write_all_checked(&bytes[start..]).map_err(CliError::from)?;
+    }
+    Ok(())
+}
+
+const fn hex_digit(value: u8) -> u8 {
+    b"0123456789abcdef"[value as usize]
+}
+
+const fn utf8_width(first: u8) -> Option<usize> {
+    match first {
+        0x00..=0x7f => Some(1),
+        0xc2..=0xdf => Some(2),
+        0xe0..=0xef => Some(3),
+        0xf0..=0xf4 => Some(4),
+        _ => None,
+    }
+}

--- a/apps/cli/src/output/stream/json.rs
+++ b/apps/cli/src/output/stream/json.rs
@@ -1,4 +1,4 @@
-use super::*;
+use super::{CliError, ExecutionContext, TemporaryFile};
 
 pub(super) struct JsonStringSpool {
     pub(super) file: TemporaryFile,

--- a/apps/cli/src/output/stream/plan.rs
+++ b/apps/cli/src/output/stream/plan.rs
@@ -1,0 +1,83 @@
+//! Immutable representation selection for one CLI artifact.
+
+use crate::args::{AssetModeArg, EmitKind};
+use into_markdown::ArtifactSinkCapabilities;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MarkdownRepresentation {
+    None,
+    Raw,
+    Escaped,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SemanticRepresentation {
+    None,
+    Ir,
+    IrWithInventories,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct RepresentationPlan {
+    pub(super) emit: EmitKind,
+    markdown: MarkdownRepresentation,
+    semantic: SemanticRepresentation,
+    pub(super) assets: bool,
+}
+
+impl RepresentationPlan {
+    pub(super) const fn new(emit: EmitKind, asset_mode: AssetModeArg) -> Self {
+        let assets = matches!(emit, EmitKind::ResultJson | EmitKind::Bundle)
+            || matches!(asset_mode, AssetModeArg::Extract);
+        match emit {
+            EmitKind::Markdown => Self {
+                emit,
+                markdown: MarkdownRepresentation::Raw,
+                semantic: SemanticRepresentation::None,
+                assets,
+            },
+            EmitKind::IrJson => Self {
+                emit,
+                markdown: MarkdownRepresentation::None,
+                semantic: SemanticRepresentation::Ir,
+                assets,
+            },
+            EmitKind::ResultJson => Self {
+                emit,
+                markdown: MarkdownRepresentation::Escaped,
+                semantic: SemanticRepresentation::IrWithInventories,
+                assets,
+            },
+            EmitKind::Bundle => Self {
+                emit,
+                markdown: MarkdownRepresentation::Raw,
+                semantic: SemanticRepresentation::IrWithInventories,
+                assets,
+            },
+        }
+    }
+
+    pub(super) const fn raw_markdown(self) -> bool {
+        matches!(self.markdown, MarkdownRepresentation::Raw)
+    }
+
+    pub(super) const fn escaped_markdown(self) -> bool {
+        matches!(self.markdown, MarkdownRepresentation::Escaped)
+    }
+
+    pub(super) const fn semantic_ir(self) -> bool {
+        !matches!(self.semantic, SemanticRepresentation::None)
+    }
+
+    pub(super) const fn inventories(self) -> bool {
+        matches!(self.semantic, SemanticRepresentation::IrWithInventories)
+    }
+
+    pub(super) const fn capabilities(self) -> ArtifactSinkCapabilities {
+        ArtifactSinkCapabilities {
+            markdown: !matches!(self.markdown, MarkdownRepresentation::None),
+            semantic_events: self.semantic_ir(),
+            assets: self.assets,
+        }
+    }
+}

--- a/apps/cli/src/output/stream/result.rs
+++ b/apps/cli/src/output/stream/result.rs
@@ -48,8 +48,8 @@ impl StructuredSpool {
             .payload_records
             .get(payload_index)
             .ok_or_else(|| CliError::internal("asset payload index is inconsistent"))?;
-        let mut reader = self.payloads.as_file().map_err(CliError::from)?.try_clone()?;
-        reader.seek(SeekFrom::Start(payload.offset))?;
+        let mut reader = payload.file.as_file().map_err(CliError::from)?.try_clone()?;
+        reader.seek(SeekFrom::Start(0))?;
         let mut limited = reader.take(payload.size);
         let mut encoder = base64::write::EncoderWriter::new(destination, &STANDARD);
         copy_reader(&self.context, &mut limited, &mut encoder)?;

--- a/apps/cli/src/output/stream/result.rs
+++ b/apps/cli/src/output/stream/result.rs
@@ -2,10 +2,26 @@ use super::*;
 
 impl StructuredSpool {
     pub(super) fn write_result_json<W: Write>(&self, destination: &mut W) -> Result<(), CliError> {
+        let markdown_json = self
+            .markdown_json
+            .as_ref()
+            .ok_or_else(|| CliError::internal("escaped Markdown representation is absent"))?;
+        let ir = self
+            .ir
+            .as_ref()
+            .ok_or_else(|| CliError::internal("document IR representation is absent"))?;
+        let diagnostics = self
+            .diagnostics
+            .as_ref()
+            .ok_or_else(|| CliError::internal("diagnostics representation is absent"))?;
+        let provenance = self
+            .provenance
+            .as_ref()
+            .ok_or_else(|| CliError::internal("provenance representation is absent"))?;
         destination.write_all(b"{\n  \"schemaVersion\": 1,\n  \"markdown\": ")?;
-        copy_spool(&self.context, &self.markdown_json.file, destination)?;
+        copy_spool(&self.context, &markdown_json.file, destination)?;
         destination.write_all(b",\n  \"document\": ")?;
-        copy_spool_indented(&self.context, &self.ir, destination, b"  ", true)?;
+        copy_spool_indented(&self.context, ir, destination, b"  ", true)?;
         destination.write_all(b"  \"assets\": [")?;
         for (index, asset) in self.asset_records.iter().enumerate() {
             if index == 0 {
@@ -32,9 +48,9 @@ impl StructuredSpool {
         } else {
             destination.write_all(b"\n  ],\n  \"diagnostics\": ")?;
         }
-        copy_spool_indented(&self.context, &self.diagnostics, destination, b"  ", true)?;
+        copy_spool_indented(&self.context, diagnostics, destination, b"  ", true)?;
         destination.write_all(b"  \"provenance\": ")?;
-        copy_spool_indented(&self.context, &self.provenance, destination, b"  ", false)?;
+        copy_spool_indented(&self.context, provenance, destination, b"  ", false)?;
         destination.write_all(b"}\n")?;
         Ok(())
     }

--- a/apps/cli/src/output/stream/result.rs
+++ b/apps/cli/src/output/stream/result.rs
@@ -1,0 +1,132 @@
+use super::*;
+
+impl StructuredSpool {
+    pub(super) fn write_result_json<W: Write>(&self, destination: &mut W) -> Result<(), CliError> {
+        destination.write_all(b"{\n  \"schemaVersion\": 1,\n  \"markdown\": ")?;
+        copy_spool(&self.context, &self.markdown_json.file, destination)?;
+        destination.write_all(b",\n  \"document\": ")?;
+        copy_spool_indented(&self.context, &self.ir, destination, b"  ", true)?;
+        destination.write_all(b"  \"assets\": [")?;
+        for (index, asset) in self.asset_records.iter().enumerate() {
+            if index == 0 {
+                destination.write_all(b"\n")?;
+            } else {
+                destination.write_all(b",\n")?;
+            }
+            destination.write_all(b"    {\n      \"id\": ")?;
+            write_json_value(destination, &asset.id)?;
+            destination.write_all(b",\n      \"filename\": ")?;
+            write_json_value(destination, &asset.wire_filename)?;
+            destination.write_all(b",\n      \"mediaType\": ")?;
+            write_json_value(destination, &asset.media_type)?;
+            destination.write_all(b",\n      \"dataBase64\": \"")?;
+            if let Some(payload_index) = asset.payload_index {
+                self.write_payload_base64(payload_index, destination)?;
+            }
+            destination.write_all(b"\",\n      \"externalUri\": ")?;
+            write_json_value(destination, &asset.external_uri)?;
+            destination.write_all(b"\n    }")?;
+        }
+        if self.asset_records.is_empty() {
+            destination.write_all(b"],\n  \"diagnostics\": ")?;
+        } else {
+            destination.write_all(b"\n  ],\n  \"diagnostics\": ")?;
+        }
+        copy_spool_indented(&self.context, &self.diagnostics, destination, b"  ", true)?;
+        destination.write_all(b"  \"provenance\": ")?;
+        copy_spool_indented(&self.context, &self.provenance, destination, b"  ", false)?;
+        destination.write_all(b"}\n")?;
+        Ok(())
+    }
+
+    fn write_payload_base64<W: Write>(
+        &self,
+        payload_index: usize,
+        destination: &mut W,
+    ) -> Result<(), CliError> {
+        let payload = self
+            .payload_records
+            .get(payload_index)
+            .ok_or_else(|| CliError::internal("asset payload index is inconsistent"))?;
+        let mut reader = self.payloads.as_file().map_err(CliError::from)?.try_clone()?;
+        reader.seek(SeekFrom::Start(payload.offset))?;
+        let mut limited = reader.take(payload.size);
+        let mut encoder = base64::write::EncoderWriter::new(destination, &STANDARD);
+        copy_reader(&self.context, &mut limited, &mut encoder)?;
+        encoder.finish()?;
+        Ok(())
+    }
+}
+
+fn write_json_value<W: Write, T: Serialize + ?Sized>(
+    destination: &mut W,
+    value: &T,
+) -> Result<(), CliError> {
+    serde_json::to_writer(destination, value)
+        .map_err(|error| map_json_error(&error, "serialize result JSON field"))
+}
+
+fn copy_spool_indented<W: Write>(
+    context: &ExecutionContext,
+    spool: &TemporaryFile,
+    destination: &mut W,
+    indent: &[u8],
+    trailing_comma: bool,
+) -> Result<(), CliError> {
+    let mut reader = spool.as_file().map_err(CliError::from)?.try_clone()?;
+    reader.seek(SeekFrom::Start(0))?;
+    let length = reader.metadata()?.len().saturating_sub(1);
+    let mut reader = reader.take(length);
+    let _buffer_lease = context
+        .reserve_memory(u64::try_from(COPY_BUFFER_BYTES).unwrap_or(u64::MAX))
+        .map_err(CliError::from)?;
+    let mut buffer = vec![0_u8; COPY_BUFFER_BYTES].into_boxed_slice();
+    loop {
+        context.checkpoint().map_err(CliError::from)?;
+        let read = reader.read(&mut buffer)?;
+        if read == 0 {
+            break;
+        }
+        let mut start = 0;
+        for (index, byte) in buffer[..read].iter().copied().enumerate() {
+            if byte == b'\n' {
+                destination.write_all(&buffer[start..=index])?;
+                destination.write_all(indent)?;
+                start = index + 1;
+            }
+        }
+        if start < read {
+            destination.write_all(&buffer[start..read])?;
+        }
+    }
+    if trailing_comma {
+        destination.write_all(b",\n")?;
+    } else {
+        destination.write_all(b"\n")?;
+    }
+    Ok(())
+}
+
+pub(super) fn map_json_error(error: &serde_json::Error, operation: &str) -> CliError {
+    if error.is_io() {
+        let mut source = std::error::Error::source(&error);
+        while let Some(current) = source {
+            if let Some(io) = current.downcast_ref::<std::io::Error>() {
+                if io.kind() == std::io::ErrorKind::BrokenPipe {
+                    return CliError::from(std::io::Error::new(
+                        std::io::ErrorKind::BrokenPipe,
+                        io.to_string(),
+                    ));
+                }
+                if let Some(conversion) =
+                    io.get_ref().and_then(|inner| inner.downcast_ref::<ConversionError>())
+                {
+                    return CliError::from(conversion.clone());
+                }
+                return CliError::from(std::io::Error::new(io.kind(), io.to_string()));
+            }
+            source = current.source();
+        }
+    }
+    CliError::internal(format!("{operation}: {error}"))
+}

--- a/apps/cli/src/output/stream/sink.rs
+++ b/apps/cli/src/output/stream/sink.rs
@@ -1,0 +1,236 @@
+//! Engine sink callbacks and content-addressed asset staging.
+
+use super::*;
+
+impl StructuredSpool {
+    pub(super) fn write_markdown(&mut self, chunk: &[u8]) -> Result<(), CliError> {
+        self.context.checkpoint().map_err(CliError::from)?;
+        self.markdown.write_all_checked(chunk).map_err(CliError::from)?;
+        self.markdown_json.write(chunk)
+    }
+
+    pub(super) fn begin_asset_inner(&mut self, asset: AssetStart<'_>) -> Result<(), CliError> {
+        if self.active_asset.is_some() {
+            return Err(CliError::internal("nested asset stream"));
+        }
+        let lease =
+            self.context.reserve_memory(asset_index_bytes(&asset)?).map_err(CliError::from)?;
+        self.asset_records
+            .try_reserve(1)
+            .map_err(|error| CliError::internal(format!("reserve asset index: {error}")))?;
+        self.index_leases.push(lease);
+        let storage_filename = match (asset.storage_filename, asset.content_sha256) {
+            (Some(filename), _) => Some(filename.to_owned()),
+            (None, Some(digest)) => Some(storage_filename(digest, asset.media_type)?),
+            (None, None) => None,
+        };
+        let existing_payload = storage_filename
+            .as_deref()
+            .and_then(|filename| self.payload_by_filename.get(filename).copied());
+        let file = if existing_payload.is_none() && storage_filename.is_some() {
+            Some(self.context.temporary_file("into-md-asset").map_err(CliError::from)?)
+        } else {
+            None
+        };
+        self.active_asset = Some(ActiveAsset {
+            record: AssetRecord {
+                id: asset.id.to_owned(),
+                wire_filename: asset.wire_filename.map(str::to_owned),
+                storage_filename,
+                media_type: asset.media_type.to_owned(),
+                external_uri: asset.external_uri.map(str::to_owned),
+                payload_index: existing_payload,
+            },
+            expected: asset.size,
+            written: 0,
+            existing_payload,
+            file,
+            hash: Sha256::new(),
+            announced_sha256: asset.content_sha256,
+        });
+        Ok(())
+    }
+
+    pub(super) fn write_asset_inner(&mut self, chunk: &[u8]) -> Result<(), CliError> {
+        self.context.checkpoint().map_err(CliError::from)?;
+        let active = self
+            .active_asset
+            .as_mut()
+            .ok_or_else(|| CliError::internal("asset bytes arrived outside a stream"))?;
+        active.written = active
+            .written
+            .checked_add(u64::try_from(chunk.len()).unwrap_or(u64::MAX))
+            .ok_or_else(|| CliError::internal("asset byte count overflow"))?;
+        if active.written > active.expected {
+            return Err(CliError::internal("asset stream exceeded its announced size"));
+        }
+        active.hash.update(chunk);
+        if let Some(file) = active.file.as_mut() {
+            file.write_all_checked(chunk).map_err(CliError::from)?;
+        }
+        Ok(())
+    }
+
+    pub(super) fn end_asset_inner(&mut self) -> Result<(), CliError> {
+        let mut active = self
+            .active_asset
+            .take()
+            .ok_or_else(|| CliError::internal("asset stream ended without a beginning"))?;
+        if active.written != active.expected {
+            return Err(CliError::internal(format!(
+                "asset stream ended at {} of {} bytes",
+                active.written, active.expected
+            )));
+        }
+        let digest: [u8; 32] = active.hash.finalize().into();
+        if active.announced_sha256.is_some_and(|announced| announced != digest) {
+            return Err(CliError::new(
+                ExitClass::Conversion,
+                "assetDigestMismatch",
+                "asset payload did not match its announced SHA-256",
+            ));
+        }
+        if let Some(index) = active.existing_payload {
+            let existing = self
+                .payload_records
+                .get(index)
+                .ok_or_else(|| CliError::internal("asset payload index is inconsistent"))?;
+            if existing.size != active.written
+                || existing.sha256 != digest
+                || existing.media_type != active.record.media_type
+            {
+                return Err(CliError::new(
+                    ExitClass::Conversion,
+                    "assetMetadataConflict",
+                    "content-addressed asset metadata did not match its prior payload",
+                ));
+            }
+        } else if let Some(filename) = active.record.storage_filename.as_ref() {
+            let index = self.payload_records.len();
+            self.payload_records
+                .try_reserve(1)
+                .map_err(|error| CliError::internal(format!("reserve payload index: {error}")))?;
+            self.payload_by_filename
+                .try_reserve(1)
+                .map_err(|error| CliError::internal(format!("reserve payload lookup: {error}")))?;
+            self.payload_records.push(PayloadRecord {
+                filename: filename.clone(),
+                media_type: active.record.media_type.clone(),
+                file: active.file.take().ok_or_else(|| {
+                    CliError::internal("unique asset payload has no backing temporary file")
+                })?,
+                size: active.written,
+                sha256: digest,
+            });
+            self.payload_by_filename.insert(filename.clone(), index);
+            active.record.payload_index = Some(index);
+        } else if active.written != 0 {
+            return Err(CliError::internal("asset content has no stable storage filename"));
+        }
+        self.asset_records.push(active.record);
+        Ok(())
+    }
+}
+
+impl ArtifactSink for StructuredSpool {
+    fn capabilities(&self) -> ArtifactSinkCapabilities {
+        self.capabilities
+    }
+
+    fn write_markdown(&mut self, chunk: &[u8]) -> Result<(), ConversionError> {
+        StructuredSpool::write_markdown(self, chunk).map_err(conversion_from_cli)
+    }
+
+    fn begin_asset(&mut self, asset: &AssetStreamInfo) -> Result<(), ConversionError> {
+        self.begin_asset_inner(AssetStart {
+            id: &asset.id.0,
+            wire_filename: asset.filename.as_deref(),
+            storage_filename: None,
+            media_type: &asset.media_type,
+            external_uri: asset.external_uri.as_deref(),
+            size: asset.size,
+            content_sha256: asset.content_sha256,
+        })
+        .map_err(conversion_from_cli)
+    }
+
+    fn write_asset(&mut self, chunk: &[u8]) -> Result<(), ConversionError> {
+        self.write_asset_inner(chunk).map_err(conversion_from_cli)
+    }
+
+    fn end_asset(&mut self) -> Result<(), ConversionError> {
+        self.end_asset_inner().map_err(conversion_from_cli)
+    }
+
+    fn write_document_event(
+        &mut self,
+        event: &DocumentStreamEvent<'_>,
+    ) -> Result<(), ConversionError> {
+        self.write_document_event_inner(event).map_err(conversion_from_cli)
+    }
+
+    fn finish_document(
+        &mut self,
+        diagnostics: &[into_markdown::Diagnostic],
+        provenance: &[into_markdown::Provenance],
+    ) -> Result<(), ConversionError> {
+        self.finish_document_inner(diagnostics, provenance).map_err(conversion_from_cli)
+    }
+}
+
+fn conversion_from_cli(error: CliError) -> ConversionError {
+    match error.code() {
+        "cancelled" => ConversionError::Cancelled,
+        "resourceLimit" => {
+            let (limit, detail) = error.limit().unwrap_or(("max_memory_bytes", error.message()));
+            let limit = match limit {
+                "max_memory_bytes" => "max_memory_bytes",
+                "max_temporary_bytes" => "max_temporary_bytes",
+                "max_output_bytes" => "max_output_bytes",
+                "max_asset_bytes" => "max_asset_bytes",
+                "max_total_asset_bytes" => "max_total_asset_bytes",
+                _ => "max_memory_bytes",
+            };
+            ConversionError::ResourceLimit { limit, detail: detail.to_owned() }
+        }
+        "io" | "brokenPipe" => ConversionError::Io { detail: error.message().to_owned() },
+        _ => ConversionError::Internal { detail: error.to_string() },
+    }
+}
+
+fn storage_filename(digest: [u8; 32], media_type: &str) -> Result<String, CliError> {
+    let mut hex = String::with_capacity(64);
+    for byte in digest {
+        use std::fmt::Write as _;
+        write!(&mut hex, "{byte:02x}")
+            .map_err(|error| CliError::internal(format!("format asset digest: {error}")))?;
+    }
+    asset_filename_from_sha256(&hex, media_type).map_err(CliError::from)
+}
+
+fn asset_index_bytes(asset: &AssetStart<'_>) -> Result<u64, CliError> {
+    let strings = [
+        Some(asset.id),
+        asset.wire_filename,
+        asset.storage_filename,
+        Some(asset.media_type),
+        asset.external_uri,
+    ]
+    .into_iter()
+    .flatten()
+    .try_fold(0_u64, |total, value| {
+        total.checked_add(u64::try_from(value.len()).unwrap_or(u64::MAX))
+    })
+    .ok_or_else(|| {
+        CliError::from(ConversionError::ResourceLimit {
+            limit: "max_memory_bytes",
+            detail: "asset index metadata length overflowed".into(),
+        })
+    })?;
+    strings.checked_mul(4).and_then(|bytes| bytes.checked_add(INDEX_ASSET_BYTES)).ok_or_else(|| {
+        CliError::from(ConversionError::ResourceLimit {
+            limit: "max_memory_bytes",
+            detail: "asset index memory estimate overflowed".into(),
+        })
+    })
+}

--- a/apps/cli/src/output/stream/sink.rs
+++ b/apps/cli/src/output/stream/sink.rs
@@ -4,12 +4,26 @@ use super::*;
 
 impl StructuredSpool {
     pub(super) fn write_markdown(&mut self, chunk: &[u8]) -> Result<(), CliError> {
+        if self.markdown.is_none() && self.markdown_json.is_none() {
+            return Err(CliError::internal(
+                "Markdown chunk arrived without a Markdown representation",
+            ));
+        }
         self.context.checkpoint().map_err(CliError::from)?;
-        self.markdown.write_all_checked(chunk).map_err(CliError::from)?;
-        self.markdown_json.write(chunk)
+        if let Some(markdown) = self.markdown.as_mut() {
+            markdown.write_all_checked(chunk).map_err(CliError::from)?;
+        }
+        if let Some(markdown_json) = self.markdown_json.as_mut() {
+            markdown_json.write(chunk)?;
+        }
+        Ok(())
     }
 
     pub(super) fn begin_asset_inner(&mut self, asset: AssetStart<'_>) -> Result<(), CliError> {
+        if !self.plan.assets {
+            return Err(CliError::internal("asset stream arrived without an asset representation"));
+        }
+        self.context.checkpoint().map_err(CliError::from)?;
         if self.active_asset.is_some() {
             return Err(CliError::internal("nested asset stream"));
         }
@@ -138,7 +152,7 @@ impl ArtifactSink for StructuredSpool {
     }
 
     fn write_markdown(&mut self, chunk: &[u8]) -> Result<(), ConversionError> {
-        StructuredSpool::write_markdown(self, chunk).map_err(conversion_from_cli)
+        StructuredSpool::write_markdown(self, chunk).map_err(|error| conversion_from_cli(&error))
     }
 
     fn begin_asset(&mut self, asset: &AssetStreamInfo) -> Result<(), ConversionError> {
@@ -151,22 +165,22 @@ impl ArtifactSink for StructuredSpool {
             size: asset.size,
             content_sha256: asset.content_sha256,
         })
-        .map_err(conversion_from_cli)
+        .map_err(|error| conversion_from_cli(&error))
     }
 
     fn write_asset(&mut self, chunk: &[u8]) -> Result<(), ConversionError> {
-        self.write_asset_inner(chunk).map_err(conversion_from_cli)
+        self.write_asset_inner(chunk).map_err(|error| conversion_from_cli(&error))
     }
 
     fn end_asset(&mut self) -> Result<(), ConversionError> {
-        self.end_asset_inner().map_err(conversion_from_cli)
+        self.end_asset_inner().map_err(|error| conversion_from_cli(&error))
     }
 
     fn write_document_event(
         &mut self,
         event: &DocumentStreamEvent<'_>,
     ) -> Result<(), ConversionError> {
-        self.write_document_event_inner(event).map_err(conversion_from_cli)
+        self.write_document_event_inner(event).map_err(|error| conversion_from_cli(&error))
     }
 
     fn finish_document(
@@ -174,17 +188,18 @@ impl ArtifactSink for StructuredSpool {
         diagnostics: &[into_markdown::Diagnostic],
         provenance: &[into_markdown::Provenance],
     ) -> Result<(), ConversionError> {
-        self.finish_document_inner(diagnostics, provenance).map_err(conversion_from_cli)
+        self.finish_document_inner(diagnostics, provenance)
+            .map_err(|error| conversion_from_cli(&error))
     }
 }
 
-fn conversion_from_cli(error: CliError) -> ConversionError {
+fn conversion_from_cli(error: &CliError) -> ConversionError {
     match error.code() {
         "cancelled" => ConversionError::Cancelled,
+        "timeout" => ConversionError::Timeout,
         "resourceLimit" => {
             let (limit, detail) = error.limit().unwrap_or(("max_memory_bytes", error.message()));
             let limit = match limit {
-                "max_memory_bytes" => "max_memory_bytes",
                 "max_temporary_bytes" => "max_temporary_bytes",
                 "max_output_bytes" => "max_output_bytes",
                 "max_asset_bytes" => "max_asset_bytes",

--- a/apps/cli/src/output/stream/tests.rs
+++ b/apps/cli/src/output/stream/tests.rs
@@ -1,0 +1,379 @@
+use super::*;
+use into_markdown::{
+    Asset, AssetId, Block, BlockNode, Diagnostic, DiagnosticSeverity, DocumentMetadata, Inline,
+    NodeId, Provenance, ProvenanceKind, SourceLocator,
+};
+use std::collections::BTreeMap;
+use std::io::{Cursor, Seek};
+
+fn context() -> ExecutionContext {
+    ExecutionContext::new(
+        into_markdown::ExecutionOptions::default(),
+        into_markdown::ResourceLimits::default(),
+    )
+}
+
+fn fixture() -> ConversionResult {
+    let provenance = Provenance {
+        kind: ProvenanceKind::NativeParser,
+        provider: "test".into(),
+        locator: SourceLocator { page: Some(1), ..SourceLocator::default() },
+        confidence: Some(1.0),
+    };
+    let document = Document {
+        metadata: DocumentMetadata {
+            title: Some("A \"title\"".into()),
+            authors: vec!["Alice".into()],
+            properties: BTreeMap::from([("language".into(), "中文".into())]),
+        },
+        blocks: vec![BlockNode {
+            id: NodeId("p1".into()),
+            block: Block::Paragraph(vec![Inline::Text {
+                value: "hello\nworld".into(),
+                marks: vec![],
+            }]),
+            provenance: provenance.clone(),
+        }],
+        ..Document::default()
+    };
+    ConversionResult::new(
+        document,
+        "hello\nworld 😀\n".into(),
+        vec![
+            Asset {
+                id: AssetId("z".into()),
+                filename: Some("first.png".into()),
+                media_type: "image/png".into(),
+                bytes: vec![0, 1, 2, 3, 4],
+                external_uri: None,
+            },
+            Asset {
+                id: AssetId("a".into()),
+                filename: Some("duplicate.png".into()),
+                media_type: "image/png".into(),
+                bytes: vec![0, 1, 2, 3, 4],
+                external_uri: None,
+            },
+        ],
+        vec![Diagnostic {
+            code: "test.warning".into(),
+            severity: DiagnosticSeverity::Warning,
+            message: "visible warning".into(),
+            locator: None,
+        }],
+        vec![provenance],
+    )
+}
+
+#[test]
+fn small_outputs_match_legacy_encoder_byte_for_byte() {
+    let result = fixture();
+    for emit in [EmitKind::Markdown, EmitKind::IrJson, EmitKind::ResultJson, EmitKind::Bundle] {
+        let mut spool = StructuredSpool::from_result(&result, context()).unwrap();
+        let mut streamed = Cursor::new(Vec::new());
+        spool.serialize(emit, &mut streamed).unwrap();
+        let legacy = super::super::serialization::encode_result(&result, emit).unwrap();
+        assert_eq!(streamed.into_inner(), legacy, "{emit:?}");
+        assert_eq!(spool.serialization_calls, 1);
+    }
+}
+
+#[test]
+fn split_utf8_and_controls_use_the_same_json_string_wire() {
+    let context = context();
+    let mut spool = JsonStringSpool::new(&context, "json-string").unwrap();
+    for chunk in [b"a\n\"".as_slice(), &[0xf0], &[0x9f, 0x98], &[0x80, b'\t']] {
+        spool.write(chunk).unwrap();
+    }
+    spool.finish().unwrap();
+    let mut encoded = Vec::new();
+    copy_spool(&context, &spool.file, &mut encoded).unwrap();
+    assert_eq!(encoded, serde_json::to_vec("a\n\"😀\t").unwrap());
+}
+
+#[test]
+fn duplicate_assets_share_one_payload_spool() {
+    let result = fixture();
+    let context = context();
+    let spool = StructuredSpool::from_result(&result, context.clone()).unwrap();
+    assert_eq!(spool.payload_records.len(), 1);
+    assert_eq!(spool.asset_records.len(), 2);
+    assert_eq!(spool.payloads.as_file().unwrap().metadata().unwrap().len(), 5);
+    assert!(context.reserved_temporary_bytes() < 16 * 1024);
+}
+
+struct BrokenPipeWriter {
+    remaining: usize,
+}
+
+struct FailAfterWriter {
+    destination: Cursor<Vec<u8>>,
+    remaining: usize,
+    injected: bool,
+}
+
+impl Write for FailAfterWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if self.remaining == 0 && !self.injected {
+            self.injected = true;
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::StorageFull,
+                "injected full destination",
+            ));
+        }
+        let written =
+            if self.remaining == 0 { bytes.len() } else { bytes.len().min(self.remaining) };
+        if self.remaining != 0 {
+            self.remaining -= written;
+        }
+        self.destination.write(&bytes[..written])
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.destination.flush()
+    }
+}
+
+impl Seek for FailAfterWriter {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        self.destination.seek(position)
+    }
+}
+
+struct CancellingWriter {
+    destination: Cursor<Vec<u8>>,
+    cancellation: into_markdown::CancellationToken,
+    cancel_after: usize,
+    written: usize,
+}
+
+struct MeteredTemporary {
+    destination: TemporaryFile,
+    context: ExecutionContext,
+    peak_memory: u64,
+    peak_temporary: u64,
+}
+
+impl MeteredTemporary {
+    fn new(context: &ExecutionContext, prefix: &str) -> Self {
+        Self {
+            destination: context.temporary_file(prefix).unwrap(),
+            context: context.clone(),
+            peak_memory: 0,
+            peak_temporary: 0,
+        }
+    }
+
+    fn sample(&mut self) {
+        self.peak_memory = self.peak_memory.max(self.context.reserved_memory_bytes());
+        self.peak_temporary = self.peak_temporary.max(self.context.reserved_temporary_bytes());
+    }
+}
+
+impl Write for MeteredTemporary {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        self.sample();
+        let written = self.destination.write(bytes);
+        self.sample();
+        written
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.destination.flush().map_err(std::io::Error::other)
+    }
+}
+
+impl Seek for MeteredTemporary {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        self.destination.seek(position)
+    }
+}
+
+impl Write for CancellingWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        let written = self.destination.write(bytes)?;
+        self.written = self.written.saturating_add(written);
+        if self.written >= self.cancel_after {
+            self.cancellation.cancel();
+        }
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.destination.flush()
+    }
+}
+
+impl Seek for CancellingWriter {
+    fn seek(&mut self, position: SeekFrom) -> std::io::Result<u64> {
+        self.destination.seek(position)
+    }
+}
+
+impl Write for BrokenPipeWriter {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        if self.remaining == 0 {
+            return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "closed"));
+        }
+        let written = bytes.len().min(self.remaining);
+        self.remaining -= written;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn stdout_pipe_close_is_typed_and_spools_are_released() {
+    let context = context();
+    let mut spool = StructuredSpool::from_result(&fixture(), context.clone()).unwrap();
+    let mut primary = context.temporary_file("primary").unwrap();
+    spool.serialize(EmitKind::ResultJson, &mut primary).unwrap();
+    let mut writer = BrokenPipeWriter { remaining: 7 };
+    let error = copy_spool(&context, &primary, &mut writer).unwrap_err();
+    assert!(error.is_broken_pipe());
+    drop(primary);
+    drop(spool);
+    assert_eq!(context.reserved_temporary_bytes(), 0);
+    assert_eq!(context.reserved_memory_bytes(), 0);
+}
+
+#[test]
+fn serialization_failure_and_mid_stream_cancellation_release_every_spool() {
+    let failed_context = context();
+    let mut failed_spool =
+        StructuredSpool::from_result(&fixture(), failed_context.clone()).unwrap();
+    let mut failed =
+        FailAfterWriter { destination: Cursor::new(Vec::new()), remaining: 31, injected: false };
+    let error = failed_spool.serialize(EmitKind::Bundle, &mut failed).unwrap_err();
+    assert_eq!(error.code(), "io");
+    assert_eq!(failed_spool.serialization_calls, 1);
+    drop(failed_spool);
+    assert_eq!(failed_context.reserved_temporary_bytes(), 0);
+    assert_eq!(failed_context.reserved_memory_bytes(), 0);
+
+    let cancellation = into_markdown::CancellationToken::new();
+    let cancelled_context = ExecutionContext::new(
+        into_markdown::ExecutionOptions {
+            cancellation: cancellation.clone(),
+            ..into_markdown::ExecutionOptions::default()
+        },
+        into_markdown::ResourceLimits::default(),
+    );
+    let mut cancelled_spool =
+        StructuredSpool::from_result(&fixture(), cancelled_context.clone()).unwrap();
+    let mut destination = CancellingWriter {
+        destination: Cursor::new(Vec::new()),
+        cancellation,
+        cancel_after: 1,
+        written: 0,
+    };
+    let error = cancelled_spool.serialize(EmitKind::ResultJson, &mut destination).unwrap_err();
+    assert_eq!(error.code(), "cancelled");
+    assert_eq!(cancelled_spool.serialization_calls, 1);
+    drop(cancelled_spool);
+    assert_eq!(cancelled_context.reserved_temporary_bytes(), 0);
+    assert_eq!(cancelled_context.reserved_memory_bytes(), 0);
+}
+
+#[test]
+fn multi_megabyte_ir_markdown_and_asset_stay_file_backed() {
+    let mut result = fixture();
+    let large_text = "0123456789abcdef".repeat(128 * 1024);
+    result.markdown = format!("{large_text}\n{large_text}\n");
+    result.document.blocks[0].block =
+        Block::Paragraph(vec![Inline::Text { value: large_text, marks: vec![] }]);
+    let asset_payload = vec![0x5a; 4 * 1024 * 1024];
+    result.assets[0].bytes.clone_from(&asset_payload);
+    result.assets[1].bytes = asset_payload;
+
+    for emit in [EmitKind::ResultJson, EmitKind::Bundle] {
+        let context = context();
+        let mut spool = StructuredSpool::from_result(&result, context.clone()).unwrap();
+        assert_eq!(spool.payload_records.len(), 1);
+        assert!(context.reserved_temporary_bytes() > 10 * 1024 * 1024);
+        assert!(context.reserved_memory_bytes() < 2 * 1024 * 1024);
+        let before_serialization = context.reserved_temporary_bytes();
+        let mut primary = MeteredTemporary::new(&context, "large-primary");
+        spool.serialize(emit, &mut primary).unwrap();
+        assert_eq!(spool.serialization_calls, 1);
+        assert!(context.reserved_temporary_bytes() > before_serialization);
+        assert!(primary.peak_memory < 4 * 1024 * 1024, "{emit:?} memory peak");
+        assert!(primary.peak_temporary < 40 * 1024 * 1024, "{emit:?} temporary peak");
+        drop(primary);
+        drop(spool);
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+}
+
+#[test]
+fn temporary_limit_failure_and_cancellation_release_every_spool() {
+    let result = fixture();
+    let measured_context = context();
+    let measured = StructuredSpool::from_result(&result, measured_context.clone()).unwrap();
+    let exact = measured_context.reserved_temporary_bytes();
+    let exact_memory = measured_context.reserved_memory_bytes();
+    drop(measured);
+    assert_eq!(measured_context.reserved_temporary_bytes(), 0);
+
+    let exact_limits = into_markdown::ResourceLimits {
+        max_temporary_bytes: exact,
+        ..into_markdown::ResourceLimits::default()
+    };
+    let exact_context =
+        ExecutionContext::new(into_markdown::ExecutionOptions::default(), exact_limits);
+    let exact_spool = StructuredSpool::from_result(&result, exact_context.clone()).unwrap();
+    assert_eq!(exact_context.reserved_temporary_bytes(), exact);
+    drop(exact_spool);
+    assert_eq!(exact_context.reserved_temporary_bytes(), 0);
+
+    let limits = into_markdown::ResourceLimits {
+        max_temporary_bytes: exact - 1,
+        ..into_markdown::ResourceLimits::default()
+    };
+    let low = ExecutionContext::new(into_markdown::ExecutionOptions::default(), limits);
+    let error = StructuredSpool::from_result(&result, low.clone()).err().unwrap();
+    assert_eq!(error.code(), "resourceLimit");
+    assert_eq!(low.reserved_temporary_bytes(), 0);
+    assert_eq!(low.reserved_memory_bytes(), 0);
+
+    let exact_memory_limits = into_markdown::ResourceLimits {
+        max_memory_bytes: exact_memory,
+        ..into_markdown::ResourceLimits::default()
+    };
+    let exact_memory_context =
+        ExecutionContext::new(into_markdown::ExecutionOptions::default(), exact_memory_limits);
+    let exact_memory_spool =
+        StructuredSpool::from_result(&result, exact_memory_context.clone()).unwrap();
+    assert_eq!(exact_memory_context.reserved_memory_bytes(), exact_memory);
+    drop(exact_memory_spool);
+    assert_eq!(exact_memory_context.reserved_memory_bytes(), 0);
+
+    let memory_limits = into_markdown::ResourceLimits {
+        max_memory_bytes: exact_memory - 1,
+        ..into_markdown::ResourceLimits::default()
+    };
+    let low_memory =
+        ExecutionContext::new(into_markdown::ExecutionOptions::default(), memory_limits);
+    let error = StructuredSpool::from_result(&result, low_memory.clone()).err().unwrap();
+    assert_eq!(error.code(), "resourceLimit");
+    assert_eq!(low_memory.reserved_temporary_bytes(), 0);
+    assert_eq!(low_memory.reserved_memory_bytes(), 0);
+
+    let cancellation = into_markdown::CancellationToken::new();
+    let cancelled = ExecutionContext::new(
+        into_markdown::ExecutionOptions {
+            cancellation: cancellation.clone(),
+            ..into_markdown::ExecutionOptions::default()
+        },
+        into_markdown::ResourceLimits::default(),
+    );
+    cancellation.cancel();
+    let error = StructuredSpool::from_result(&result, cancelled.clone()).err().unwrap();
+    assert_eq!(error.code(), "cancelled");
+    assert_eq!(cancelled.reserved_temporary_bytes(), 0);
+    assert_eq!(cancelled.reserved_memory_bytes(), 0);
+}

--- a/apps/cli/src/output/stream/tests.rs
+++ b/apps/cli/src/output/stream/tests.rs
@@ -69,7 +69,8 @@ fn fixture() -> ConversionResult {
 fn small_outputs_match_legacy_encoder_byte_for_byte() {
     let result = fixture();
     for emit in [EmitKind::Markdown, EmitKind::IrJson, EmitKind::ResultJson, EmitKind::Bundle] {
-        let mut spool = StructuredSpool::from_result(&result, context()).unwrap();
+        let mut spool =
+            StructuredSpool::from_result(&result, context(), emit, AssetModeArg::Extract).unwrap();
         let mut streamed = Cursor::new(Vec::new());
         spool.serialize(emit, &mut streamed).unwrap();
         let legacy = super::super::serialization::encode_result(&result, emit).unwrap();
@@ -95,11 +96,188 @@ fn split_utf8_and_controls_use_the_same_json_string_wire() {
 fn duplicate_assets_share_one_payload_spool() {
     let result = fixture();
     let context = context();
-    let spool = StructuredSpool::from_result(&result, context.clone()).unwrap();
+    let spool = StructuredSpool::from_result(
+        &result,
+        context.clone(),
+        EmitKind::ResultJson,
+        AssetModeArg::Extract,
+    )
+    .unwrap();
     assert_eq!(spool.payload_records.len(), 1);
     assert_eq!(spool.asset_records.len(), 2);
     assert_eq!(spool.payload_records[0].file.as_file().unwrap().metadata().unwrap().len(), 5);
     assert!(context.reserved_temporary_bytes() < 16 * 1024);
+}
+
+fn spool_len(spool: Option<&TemporaryFile>) -> u64 {
+    spool.map_or(0, |file| file.as_file().unwrap().metadata().unwrap().len())
+}
+
+fn represented_temporary_bytes(spool: &StructuredSpool) -> u64 {
+    spool_len(spool.ir.as_ref())
+        + spool_len(spool.markdown.as_ref())
+        + spool.markdown_json.as_ref().map_or(0, |json| spool_len(Some(&json.file)))
+        + spool_len(spool.diagnostics.as_ref())
+        + spool_len(spool.provenance.as_ref())
+        + spool
+            .payload_records
+            .iter()
+            .map(|payload| payload.file.as_file().unwrap().metadata().unwrap().len())
+            .sum::<u64>()
+}
+
+#[test]
+fn emit_and_asset_mode_materialize_only_the_frozen_representations() {
+    let result = fixture();
+    for emit in [EmitKind::Markdown, EmitKind::IrJson, EmitKind::ResultJson, EmitKind::Bundle] {
+        for asset_mode in [AssetModeArg::Omit, AssetModeArg::Embed, AssetModeArg::Extract] {
+            let context = context();
+            let spool =
+                StructuredSpool::from_result(&result, context.clone(), emit, asset_mode).unwrap();
+            let raw_markdown = emit == EmitKind::Markdown || emit == EmitKind::Bundle;
+            let escaped_markdown = emit == EmitKind::ResultJson;
+            let semantic_ir = emit != EmitKind::Markdown;
+            let inventories = matches!(emit, EmitKind::ResultJson | EmitKind::Bundle);
+            let assets = inventories || asset_mode == AssetModeArg::Extract;
+
+            assert_eq!(spool.markdown.is_some(), raw_markdown, "{emit:?}/{asset_mode:?}");
+            assert_eq!(spool.markdown_json.is_some(), escaped_markdown, "{emit:?}/{asset_mode:?}");
+            assert_eq!(spool.ir.is_some(), semantic_ir, "{emit:?}/{asset_mode:?}");
+            assert_eq!(
+                spool.diagnostics.is_some() && spool.provenance.is_some(),
+                inventories,
+                "{emit:?}/{asset_mode:?}"
+            );
+            assert_eq!(spool.capabilities.markdown, raw_markdown || escaped_markdown);
+            assert_eq!(spool.capabilities.semantic_events, semantic_ir);
+            assert_eq!(spool.capabilities.assets, assets);
+            assert_eq!(!spool.payload_records.is_empty(), assets);
+            assert_eq!(
+                context.reserved_temporary_bytes(),
+                represented_temporary_bytes(&spool),
+                "unrepresented temporary bytes for {emit:?}/{asset_mode:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn absent_representations_and_emit_mismatch_fail_closed_without_writes() {
+    let markdown_context = context();
+    let mut markdown = StructuredSpool::from_result(
+        &fixture(),
+        markdown_context,
+        EmitKind::Markdown,
+        AssetModeArg::Omit,
+    )
+    .unwrap();
+    let semantic_error = ArtifactSink::write_document_event(
+        &mut markdown,
+        &DocumentStreamEvent::Metadata(&DocumentMetadata::default()),
+    )
+    .unwrap_err();
+    assert_eq!(semantic_error.code().as_str(), "internal");
+
+    let mut destination = Cursor::new(Vec::new());
+    let mismatch = markdown.serialize(EmitKind::ResultJson, &mut destination).unwrap_err();
+    assert_eq!(mismatch.code(), "internal");
+    assert!(destination.into_inner().is_empty());
+    assert_eq!(markdown.serialization_calls, 0);
+
+    let incomplete_context = context();
+    let mut incomplete = StructuredSpool::from_result(
+        &fixture(),
+        incomplete_context,
+        EmitKind::Markdown,
+        AssetModeArg::Omit,
+    )
+    .unwrap();
+    drop(incomplete.markdown.take());
+    let mut untouched = Cursor::new(Vec::new());
+    let missing = incomplete.serialize(EmitKind::Markdown, &mut untouched).unwrap_err();
+    assert_eq!(missing.code(), "internal");
+    assert!(untouched.into_inner().is_empty());
+    assert_eq!(incomplete.serialization_calls, 0);
+
+    let ir_context = context();
+    let mut ir =
+        StructuredSpool::from_result(&fixture(), ir_context, EmitKind::IrJson, AssetModeArg::Omit)
+            .unwrap();
+    let markdown_error = ArtifactSink::write_markdown(&mut ir, b"unrequested").unwrap_err();
+    assert_eq!(markdown_error.code().as_str(), "internal");
+    let asset = AssetStreamInfo {
+        id: AssetId("unrequested".into()),
+        filename: Some("unrequested.bin".into()),
+        media_type: "application/octet-stream".into(),
+        size: 0,
+        external_uri: None,
+        content_sha256: None,
+    };
+    let asset_error = ArtifactSink::begin_asset(&mut ir, &asset).unwrap_err();
+    assert_eq!(asset_error.code().as_str(), "internal");
+}
+
+fn deadline_context() -> ExecutionContext {
+    ExecutionContext::new(
+        into_markdown::ExecutionOptions {
+            timeout: Some(std::time::Duration::from_millis(20)),
+            ..into_markdown::ExecutionOptions::default()
+        },
+        into_markdown::ResourceLimits::default(),
+    )
+}
+
+fn assert_timeout_policy(error: ConversionError) {
+    assert_eq!(error.code().as_str(), "timeout");
+    let cli = CliError::from(error);
+    assert_eq!(cli.code(), "timeout");
+    assert_eq!(cli.exit_code(), ExitClass::Policy.code());
+}
+
+#[test]
+fn deadline_is_preserved_in_semantic_markdown_and_asset_callbacks() {
+    let semantic_context = deadline_context();
+    let mut semantic =
+        StructuredSpool::new(semantic_context.clone(), EmitKind::IrJson, AssetModeArg::Omit)
+            .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(30));
+    let error = ArtifactSink::write_document_event(
+        &mut semantic,
+        &DocumentStreamEvent::Metadata(&DocumentMetadata::default()),
+    )
+    .unwrap_err();
+    assert_timeout_policy(error);
+    drop(semantic);
+    assert_eq!(semantic_context.reserved_temporary_bytes(), 0);
+    assert_eq!(semantic_context.reserved_memory_bytes(), 0);
+
+    let markdown_context = deadline_context();
+    let mut markdown =
+        StructuredSpool::new(markdown_context.clone(), EmitKind::Markdown, AssetModeArg::Omit)
+            .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(30));
+    assert_timeout_policy(ArtifactSink::write_markdown(&mut markdown, b"late").unwrap_err());
+    drop(markdown);
+    assert_eq!(markdown_context.reserved_temporary_bytes(), 0);
+    assert_eq!(markdown_context.reserved_memory_bytes(), 0);
+
+    let asset_context = deadline_context();
+    let mut assets =
+        StructuredSpool::new(asset_context.clone(), EmitKind::Markdown, AssetModeArg::Extract)
+            .unwrap();
+    std::thread::sleep(std::time::Duration::from_millis(30));
+    let asset = AssetStreamInfo {
+        id: AssetId("late".into()),
+        filename: Some("late.bin".into()),
+        media_type: "application/octet-stream".into(),
+        size: 0,
+        external_uri: None,
+        content_sha256: None,
+    };
+    assert_timeout_policy(ArtifactSink::begin_asset(&mut assets, &asset).unwrap_err());
+    drop(assets);
+    assert_eq!(asset_context.reserved_temporary_bytes(), 0);
+    assert_eq!(asset_context.reserved_memory_bytes(), 0);
 }
 
 struct BrokenPipeWriter {
@@ -228,7 +406,13 @@ impl Write for BrokenPipeWriter {
 #[test]
 fn stdout_pipe_close_is_typed_and_spools_are_released() {
     let context = context();
-    let mut spool = StructuredSpool::from_result(&fixture(), context.clone()).unwrap();
+    let mut spool = StructuredSpool::from_result(
+        &fixture(),
+        context.clone(),
+        EmitKind::ResultJson,
+        AssetModeArg::Extract,
+    )
+    .unwrap();
     let mut primary = context.temporary_file("primary").unwrap();
     spool.serialize(EmitKind::ResultJson, &mut primary).unwrap();
     let mut writer = BrokenPipeWriter { remaining: 7 };
@@ -243,8 +427,13 @@ fn stdout_pipe_close_is_typed_and_spools_are_released() {
 #[test]
 fn serialization_failure_and_mid_stream_cancellation_release_every_spool() {
     let failed_context = context();
-    let mut failed_spool =
-        StructuredSpool::from_result(&fixture(), failed_context.clone()).unwrap();
+    let mut failed_spool = StructuredSpool::from_result(
+        &fixture(),
+        failed_context.clone(),
+        EmitKind::Bundle,
+        AssetModeArg::Extract,
+    )
+    .unwrap();
     let mut failed =
         FailAfterWriter { destination: Cursor::new(Vec::new()), remaining: 31, injected: false };
     let error = failed_spool.serialize(EmitKind::Bundle, &mut failed).unwrap_err();
@@ -262,8 +451,13 @@ fn serialization_failure_and_mid_stream_cancellation_release_every_spool() {
         },
         into_markdown::ResourceLimits::default(),
     );
-    let mut cancelled_spool =
-        StructuredSpool::from_result(&fixture(), cancelled_context.clone()).unwrap();
+    let mut cancelled_spool = StructuredSpool::from_result(
+        &fixture(),
+        cancelled_context.clone(),
+        EmitKind::ResultJson,
+        AssetModeArg::Extract,
+    )
+    .unwrap();
     let mut destination = CancellingWriter {
         destination: Cursor::new(Vec::new()),
         cancellation,
@@ -289,11 +483,20 @@ fn multi_megabyte_ir_markdown_and_asset_stay_file_backed() {
     result.assets[0].bytes.clone_from(&asset_payload);
     result.assets[1].bytes = asset_payload;
 
-    for emit in [EmitKind::ResultJson, EmitKind::Bundle] {
+    for (emit, asset_mode, expects_payload) in [
+        (EmitKind::Markdown, AssetModeArg::Omit, false),
+        (EmitKind::Markdown, AssetModeArg::Embed, false),
+        (EmitKind::Markdown, AssetModeArg::Extract, true),
+        (EmitKind::IrJson, AssetModeArg::Omit, false),
+        (EmitKind::IrJson, AssetModeArg::Extract, true),
+        (EmitKind::ResultJson, AssetModeArg::Omit, true),
+        (EmitKind::Bundle, AssetModeArg::Omit, true),
+    ] {
         let context = context();
-        let mut spool = StructuredSpool::from_result(&result, context.clone()).unwrap();
-        assert_eq!(spool.payload_records.len(), 1);
-        assert!(context.reserved_temporary_bytes() > 10 * 1024 * 1024);
+        let mut spool =
+            StructuredSpool::from_result(&result, context.clone(), emit, asset_mode).unwrap();
+        assert_eq!(spool.payload_records.len(), usize::from(expects_payload));
+        assert_eq!(context.reserved_temporary_bytes(), represented_temporary_bytes(&spool));
         assert!(context.reserved_memory_bytes() < 2 * 1024 * 1024);
         let before_serialization = context.reserved_temporary_bytes();
         let mut primary = MeteredTemporary::new(&context, "large-primary");
@@ -313,7 +516,13 @@ fn multi_megabyte_ir_markdown_and_asset_stay_file_backed() {
 fn temporary_limit_failure_and_cancellation_release_every_spool() {
     let result = fixture();
     let measured_context = context();
-    let measured = StructuredSpool::from_result(&result, measured_context.clone()).unwrap();
+    let measured = StructuredSpool::from_result(
+        &result,
+        measured_context.clone(),
+        EmitKind::ResultJson,
+        AssetModeArg::Extract,
+    )
+    .unwrap();
     let exact = measured_context.reserved_temporary_bytes();
     let exact_memory = measured_context.reserved_memory_bytes();
     drop(measured);
@@ -325,7 +534,13 @@ fn temporary_limit_failure_and_cancellation_release_every_spool() {
     };
     let exact_context =
         ExecutionContext::new(into_markdown::ExecutionOptions::default(), exact_limits);
-    let exact_spool = StructuredSpool::from_result(&result, exact_context.clone()).unwrap();
+    let exact_spool = StructuredSpool::from_result(
+        &result,
+        exact_context.clone(),
+        EmitKind::ResultJson,
+        AssetModeArg::Extract,
+    )
+    .unwrap();
     assert_eq!(exact_context.reserved_temporary_bytes(), exact);
     drop(exact_spool);
     assert_eq!(exact_context.reserved_temporary_bytes(), 0);
@@ -335,7 +550,14 @@ fn temporary_limit_failure_and_cancellation_release_every_spool() {
         ..into_markdown::ResourceLimits::default()
     };
     let low = ExecutionContext::new(into_markdown::ExecutionOptions::default(), limits);
-    let error = StructuredSpool::from_result(&result, low.clone()).err().unwrap();
+    let error = StructuredSpool::from_result(
+        &result,
+        low.clone(),
+        EmitKind::ResultJson,
+        AssetModeArg::Extract,
+    )
+    .err()
+    .unwrap();
     assert_eq!(error.code(), "resourceLimit");
     assert_eq!(low.reserved_temporary_bytes(), 0);
     assert_eq!(low.reserved_memory_bytes(), 0);
@@ -346,8 +568,13 @@ fn temporary_limit_failure_and_cancellation_release_every_spool() {
     };
     let exact_memory_context =
         ExecutionContext::new(into_markdown::ExecutionOptions::default(), exact_memory_limits);
-    let exact_memory_spool =
-        StructuredSpool::from_result(&result, exact_memory_context.clone()).unwrap();
+    let exact_memory_spool = StructuredSpool::from_result(
+        &result,
+        exact_memory_context.clone(),
+        EmitKind::ResultJson,
+        AssetModeArg::Extract,
+    )
+    .unwrap();
     assert_eq!(exact_memory_context.reserved_memory_bytes(), exact_memory);
     drop(exact_memory_spool);
     assert_eq!(exact_memory_context.reserved_memory_bytes(), 0);
@@ -358,7 +585,14 @@ fn temporary_limit_failure_and_cancellation_release_every_spool() {
     };
     let low_memory =
         ExecutionContext::new(into_markdown::ExecutionOptions::default(), memory_limits);
-    let error = StructuredSpool::from_result(&result, low_memory.clone()).err().unwrap();
+    let error = StructuredSpool::from_result(
+        &result,
+        low_memory.clone(),
+        EmitKind::ResultJson,
+        AssetModeArg::Extract,
+    )
+    .err()
+    .unwrap();
     assert_eq!(error.code(), "resourceLimit");
     assert_eq!(low_memory.reserved_temporary_bytes(), 0);
     assert_eq!(low_memory.reserved_memory_bytes(), 0);
@@ -372,7 +606,14 @@ fn temporary_limit_failure_and_cancellation_release_every_spool() {
         into_markdown::ResourceLimits::default(),
     );
     cancellation.cancel();
-    let error = StructuredSpool::from_result(&result, cancelled.clone()).err().unwrap();
+    let error = StructuredSpool::from_result(
+        &result,
+        cancelled.clone(),
+        EmitKind::ResultJson,
+        AssetModeArg::Extract,
+    )
+    .err()
+    .unwrap();
     assert_eq!(error.code(), "cancelled");
     assert_eq!(cancelled.reserved_temporary_bytes(), 0);
     assert_eq!(cancelled.reserved_memory_bytes(), 0);

--- a/apps/cli/src/output/stream/tests.rs
+++ b/apps/cli/src/output/stream/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use into_markdown::{
-    Asset, AssetId, Block, BlockNode, Diagnostic, DiagnosticSeverity, DocumentMetadata, Inline,
-    NodeId, Provenance, ProvenanceKind, SourceLocator,
+    Asset, AssetId, Block, BlockNode, Diagnostic, DiagnosticSeverity, Document, DocumentMetadata,
+    Inline, NodeId, Provenance, ProvenanceKind, SourceLocator,
 };
 use std::collections::BTreeMap;
 use std::io::{Cursor, Seek};
@@ -98,7 +98,7 @@ fn duplicate_assets_share_one_payload_spool() {
     let spool = StructuredSpool::from_result(&result, context.clone()).unwrap();
     assert_eq!(spool.payload_records.len(), 1);
     assert_eq!(spool.asset_records.len(), 2);
-    assert_eq!(spool.payloads.as_file().unwrap().metadata().unwrap().len(), 5);
+    assert_eq!(spool.payload_records[0].file.as_file().unwrap().metadata().unwrap().len(), 5);
     assert!(context.reserved_temporary_bytes() < 16 * 1024);
 }
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -82,7 +82,8 @@ pub use into_markdown_converters::{
 };
 pub use into_markdown_core::*;
 pub use into_markdown_engine::{
-    Engine, EngineBuilder, RecoveryStore, RecoveryToken, RegistryBuilder, TaskCheckpoint, TaskPhase,
+    Engine, EngineBuilder, PreparedArtifactConversion, RecoveryStore, RecoveryToken,
+    RegistryBuilder, TaskCheckpoint, TaskPhase,
 };
 pub use into_markdown_ocr::{
     AcquiredModelArtifact, ArchiveMember, CharacterSet, DataDirectoryEnvironment, ModelAcquisition,
@@ -95,8 +96,8 @@ pub use into_markdown_ocr::{
 #[cfg(feature = "ocr-provider-runtime")]
 pub use into_markdown_onnxruntime::verify_worker_executable as verify_ocr_worker_executable;
 pub use into_markdown_render_markdown::{
-    AssetPlan, PlannedAsset, PlannedAssetReference, asset_filename, plan_assets,
-    render as render_markdown,
+    AssetPlan, PlannedAsset, PlannedAssetReference, asset_filename, asset_filename_from_sha256,
+    plan_assets, render as render_markdown,
 };
 pub use into_markdown_task_store::{
     ArtifactKind, ArtifactReference, BusyControl, ConfigurationSnapshot, DiagnosticCode,

--- a/crates/core/src/artifact.rs
+++ b/crates/core/src/artifact.rs
@@ -1,0 +1,37 @@
+//! Caller-owned artifact stream capabilities and semantic document events.
+
+use crate::{BlockNode, DocumentMetadata};
+
+/// Representations accepted by one artifact sink for an entire execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtifactSinkCapabilities {
+    /// Receive rendered Markdown chunks.
+    pub markdown: bool,
+    /// Receive semantic document events followed by document finalization.
+    pub semantic_events: bool,
+    /// Receive asset metadata and payload chunks.
+    pub assets: bool,
+}
+
+impl Default for ArtifactSinkCapabilities {
+    fn default() -> Self {
+        Self { markdown: true, semantic_events: false, assets: true }
+    }
+}
+
+impl ArtifactSinkCapabilities {
+    /// Whether this sink consumes at least one conversion representation.
+    #[must_use]
+    pub const fn has_output(self) -> bool {
+        self.markdown || self.semantic_events || self.assets
+    }
+}
+
+/// Borrowed, ordered semantic document event.
+#[derive(Debug, Clone, Copy)]
+pub enum DocumentStreamEvent<'a> {
+    /// Document metadata, emitted exactly once and before body blocks.
+    Metadata(&'a DocumentMetadata),
+    /// One top-level body block in source reading order.
+    RootBlock(&'a BlockNode),
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -5,6 +5,7 @@
 //! runtime, or provider implementation. Implementations depend on this crate;
 //! the dependency never points in the opposite direction.
 
+mod artifact;
 mod dto;
 mod error;
 mod execution;
@@ -19,6 +20,7 @@ mod spi;
 mod stream;
 mod summary;
 
+pub use artifact::{ArtifactSinkCapabilities, DocumentStreamEvent};
 pub use dto::{
     AssetDto, BUNDLE_SCHEMA_VERSION, BatchItemDto, BatchItemOutcome, BatchItemStatus,
     BatchLimitDto, BatchReportDto, BundleAssetDto, BundleManifestDto, DTO_SCHEMA_VERSION,

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -129,6 +129,8 @@ pub struct AssetStreamInfo {
     pub size: u64,
     /// External reference when the asset has no local payload.
     pub external_uri: Option<String>,
+    /// Authoritative SHA-256 for a local payload, absent for external-only assets.
+    pub content_sha256: Option<[u8; 32]>,
 }
 
 /// Semantic result of a completed streaming conversion.
@@ -158,6 +160,11 @@ pub struct ConversionSummary {
 
 /// Ordered destination for incremental Markdown and asset payloads.
 pub trait ArtifactSink {
+    /// Freeze the representations accepted for this execution.
+    fn capabilities(&self) -> crate::ArtifactSinkCapabilities {
+        crate::ArtifactSinkCapabilities::default()
+    }
+
     /// Consume the next ordered Markdown byte chunk.
     ///
     /// # Errors
@@ -189,6 +196,36 @@ pub trait ArtifactSink {
     /// Returns an I/O or destination-specific conversion error when the asset
     /// stream cannot be finalized.
     fn end_asset(&mut self) -> Result<(), ConversionError>;
+
+    /// Consume one ordered semantic document event.
+    ///
+    /// # Errors
+    ///
+    /// The default rejects semantic output so existing Markdown sinks remain
+    /// source compatible until they opt in through [`Self::capabilities`].
+    fn write_document_event(
+        &mut self,
+        _event: &crate::DocumentStreamEvent<'_>,
+    ) -> Result<(), ConversionError> {
+        Err(ConversionError::Unsupported {
+            detail: "artifact sink does not accept semantic document events".into(),
+        })
+    }
+
+    /// Finalize the semantic document and its ordered audit inventories.
+    ///
+    /// # Errors
+    ///
+    /// The default rejects semantic finalization.
+    fn finish_document(
+        &mut self,
+        _diagnostics: &[Diagnostic],
+        _provenance: &[Provenance],
+    ) -> Result<(), ConversionError> {
+        Err(ConversionError::Unsupported {
+            detail: "artifact sink does not accept semantic document finalization".into(),
+        })
+    }
 }
 
 /// Opaque live-memory ownership transferred across conversion pipeline stages.
@@ -572,6 +609,31 @@ impl ConverterOutput {
             provenance,
             memory_lease,
         ))
+    }
+
+    /// Consume an emitted converter output while retaining diagnostics and
+    /// their authenticated request-memory ownership in the bounded summary.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn into_conversion_summary(
+        self,
+        format: InputFormat,
+        markdown_bytes: u64,
+    ) -> ConversionSummary {
+        let Self { assets, diagnostics, memory_lease, .. } = self;
+        let outcome = if diagnostics.is_empty() {
+            ConversionOutcome::Complete
+        } else {
+            ConversionOutcome::Degraded
+        };
+        ConversionSummary {
+            format: Some(format),
+            outcome,
+            diagnostics,
+            markdown_bytes,
+            assets: u64::try_from(assets.len()).unwrap_or(u64::MAX),
+            _memory_lease: memory_lease,
+        }
     }
 
     #[doc(hidden)]

--- a/crates/engine/src/artifact_execution.rs
+++ b/crates/engine/src/artifact_execution.rs
@@ -1,0 +1,82 @@
+//! Prepared single-execution conversion for caller-owned artifact sinks.
+
+use crate::{
+    Engine, PreparedArtifactConversion, artifact_output, invoke_converter_preflighted,
+    invoke_enrichers, rendering, stream_execution,
+};
+use into_markdown_core::{
+    ArtifactSink, ConversionError, ConversionSummary, ConverterStreamMode, ExecutionStage,
+    StreamConsumerKind,
+};
+
+pub(crate) async fn execute(
+    engine: &Engine,
+    prepared: PreparedArtifactConversion,
+    sink: &mut dyn ArtifactSink,
+) -> Result<ConversionSummary, ConversionError> {
+    if sink.capabilities() != prepared.capabilities {
+        return Err(ConversionError::Internal {
+            detail: "artifact sink capabilities changed after preparation".into(),
+        });
+    }
+    let PreparedArtifactConversion { inner, capabilities } = prepared;
+    let crate::preparation::PreparedConversion { request, context, source, attempt } = inner;
+    context.report(ExecutionStage::Converting, None, None, Some(attempt.converter.id()))?;
+    let native = attempt.converter.stream_support().filter(|stream| {
+        stream.stream_mode_for(
+            source.input(),
+            &attempt.candidate,
+            &request.options,
+            StreamConsumerKind::Immediate,
+        ) == ConverterStreamMode::Native
+    });
+    let output = if let Some(stream) = native {
+        stream_execution::invoke_native_immediate(
+            stream,
+            source.input(),
+            &attempt.candidate,
+            &request.options,
+            &engine.services,
+            &context,
+        )
+        .await?
+    } else {
+        invoke_converter_preflighted(
+            attempt.converter.as_ref(),
+            source.input(),
+            &attempt.candidate,
+            &request.options,
+            &engine.services,
+            &context,
+            |_| Ok(()),
+        )
+        .await?
+    };
+    let output = invoke_enrichers(
+        &engine.enrichers,
+        output,
+        attempt.converter.id(),
+        attempt.candidate.format,
+        &request.options,
+        &engine.services,
+        &context,
+    )
+    .await?;
+    let renderer = engine.renderer.as_ref().ok_or_else(|| ConversionError::Internal {
+        detail: "no Markdown renderer is registered".into(),
+    })?;
+    let artifacts = rendering::render_artifacts(rendering::RenderRequest {
+        renderer: renderer.as_ref(),
+        output,
+        source: source.input(),
+        format: attempt.candidate.format,
+        options: &request.options,
+        context: &context,
+    })
+    .await?;
+    let summary =
+        artifact_output::emit(artifacts, attempt.candidate.format, capabilities, sink, &context)?;
+    drop(source);
+    context.report(ExecutionStage::Completed, Some(1), Some(1), None::<String>)?;
+    Ok(summary)
+}

--- a/crates/engine/src/artifact_output.rs
+++ b/crates/engine/src/artifact_output.rs
@@ -1,0 +1,88 @@
+//! Ordered emission of rendered converter artifacts to a caller-owned sink.
+
+use crate::rendering::RenderedArtifacts;
+use into_markdown_core::{
+    ArtifactSink, ArtifactSinkCapabilities, AssetStreamInfo, ConversionError, ConversionSummary,
+    DocumentStreamEvent, ExecutionContext, InputFormat,
+};
+use sha2::{Digest as _, Sha256};
+
+const EMIT_CHUNK_BYTES: usize = 64 * 1024;
+
+pub(crate) fn emit(
+    rendered: RenderedArtifacts,
+    format: InputFormat,
+    capabilities: ArtifactSinkCapabilities,
+    sink: &mut dyn ArtifactSink,
+    context: &ExecutionContext,
+) -> Result<ConversionSummary, ConversionError> {
+    let RenderedArtifacts { output, markdown, provenance, markdown_memory, provenance_memory } =
+        rendered;
+    if capabilities.semantic_events {
+        emit_document(&output, &provenance, sink, context)?;
+    }
+    if capabilities.markdown {
+        for chunk in markdown.as_bytes().chunks(EMIT_CHUNK_BYTES) {
+            context.checkpoint()?;
+            sink.write_markdown(chunk)?;
+        }
+    }
+    if capabilities.assets {
+        emit_assets(&output.assets, sink, context)?;
+    }
+    let markdown_bytes =
+        u64::try_from(markdown.len()).map_err(|_| ConversionError::ResourceLimit {
+            limit: "max_output_bytes",
+            detail: "rendered Markdown byte count cannot be represented".into(),
+        })?;
+    drop(provenance_memory);
+    drop(markdown_memory);
+    drop(markdown);
+    Ok(output.into_conversion_summary(format, markdown_bytes))
+}
+
+fn emit_document(
+    output: &into_markdown_core::ConverterOutput,
+    provenance: &[into_markdown_core::Provenance],
+    sink: &mut dyn ArtifactSink,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    context.checkpoint()?;
+    sink.write_document_event(&DocumentStreamEvent::Metadata(&output.document.metadata))?;
+    for block in &output.document.blocks {
+        context.checkpoint()?;
+        sink.write_document_event(&DocumentStreamEvent::RootBlock(block))?;
+    }
+    context.checkpoint()?;
+    sink.finish_document(&output.diagnostics, provenance)
+}
+
+fn emit_assets(
+    assets: &[into_markdown_core::Asset],
+    sink: &mut dyn ArtifactSink,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    for asset in assets {
+        let size =
+            u64::try_from(asset.bytes.len()).map_err(|_| ConversionError::ResourceLimit {
+                limit: "max_asset_bytes",
+                detail: "asset byte length cannot be represented".into(),
+            })?;
+        context.checkpoint()?;
+        sink.begin_asset(&AssetStreamInfo {
+            id: asset.id.clone(),
+            filename: asset.filename.clone(),
+            media_type: asset.media_type.clone(),
+            size,
+            external_uri: asset.external_uri.clone(),
+            content_sha256: (!asset.bytes.is_empty()).then(|| Sha256::digest(&asset.bytes).into()),
+        })?;
+        for chunk in asset.bytes.chunks(EMIT_CHUNK_BYTES) {
+            context.checkpoint()?;
+            sink.write_asset(chunk)?;
+        }
+        context.checkpoint()?;
+        sink.end_asset()?;
+    }
+    Ok(())
+}

--- a/crates/engine/src/collecting/integration_tests.rs
+++ b/crates/engine/src/collecting/integration_tests.rs
@@ -1,13 +1,13 @@
 use crate::{Engine, EngineBuilder};
 use into_markdown_core::{
-    ArtifactSink, Asset, AssetId, AssetStreamInfo, Block, BlockNode, BoxFuture, ConversionError,
-    ConversionOptions, ConversionRequest, Converter, ConverterEventSink, ConverterOutput,
-    ConverterStream, ConverterStreamCompletion, ConverterStreamMode, Diagnostic,
-    DiagnosticSeverity, Document, ExecutionContext, ExecutionOptions, ExecutionStage,
-    FormatCandidate, FormatDetector, FormatHint, InputFormat, InputRef, LocalBoxFuture,
-    MarkdownRenderer, NodeId, ProbeOutcome, ProgressEvent, ProgressListener, Provenance,
-    ProvenanceKind, ResolvedInput, Services, SourceLocator, SourceMetadata, SourceResolver,
-    stream_converter_output,
+    ArtifactSink, ArtifactSinkCapabilities, Asset, AssetId, AssetStreamInfo, Block, BlockNode,
+    BoxFuture, ConversionError, ConversionOptions, ConversionRequest, Converter,
+    ConverterEventSink, ConverterOutput, ConverterStream, ConverterStreamCompletion,
+    ConverterStreamMode, Diagnostic, DiagnosticSeverity, Document, DocumentStreamEvent,
+    ExecutionContext, ExecutionOptions, ExecutionStage, FormatCandidate, FormatDetector,
+    FormatHint, InputFormat, InputRef, LocalBoxFuture, MarkdownRenderer, NodeId, ProbeOutcome,
+    ProgressEvent, ProgressListener, Provenance, ProvenanceKind, ResolvedInput, Services,
+    SourceLocator, SourceMetadata, SourceResolver, stream_converter_output,
 };
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -421,6 +421,95 @@ fn aggregate_and_streamed_public_bytes_assets_and_diagnostics_match() {
     assert_eq!(streamed.assets[0].0.id, aggregate.assets[0].id);
     assert_eq!(streamed.assets[0].1, aggregate.assets[0].bytes);
     assert_eq!(summary.diagnostics, aggregate.diagnostics);
+}
+
+#[derive(Default)]
+struct SemanticCountingSink {
+    metadata_calls: usize,
+    block_ids: Vec<NodeId>,
+    finalization_calls: usize,
+    markdown_calls: usize,
+    asset_begin_calls: usize,
+    asset_end_calls: usize,
+}
+
+impl ArtifactSink for SemanticCountingSink {
+    fn capabilities(&self) -> ArtifactSinkCapabilities {
+        ArtifactSinkCapabilities { markdown: true, semantic_events: true, assets: true }
+    }
+
+    fn write_markdown(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        self.markdown_calls += 1;
+        Ok(())
+    }
+
+    fn begin_asset(&mut self, _: &AssetStreamInfo) -> Result<(), ConversionError> {
+        self.asset_begin_calls += 1;
+        Ok(())
+    }
+
+    fn write_asset(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        Ok(())
+    }
+
+    fn end_asset(&mut self) -> Result<(), ConversionError> {
+        self.asset_end_calls += 1;
+        Ok(())
+    }
+
+    fn write_document_event(
+        &mut self,
+        event: &DocumentStreamEvent<'_>,
+    ) -> Result<(), ConversionError> {
+        match event {
+            DocumentStreamEvent::Metadata(_) => self.metadata_calls += 1,
+            DocumentStreamEvent::RootBlock(block) => self.block_ids.push(block.id.clone()),
+        }
+        Ok(())
+    }
+
+    fn finish_document(
+        &mut self,
+        diagnostics: &[Diagnostic],
+        provenance: &[Provenance],
+    ) -> Result<(), ConversionError> {
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(provenance.len(), 3);
+        self.finalization_calls += 1;
+        Ok(())
+    }
+}
+
+#[test]
+fn prepared_semantic_artifact_path_executes_and_finalizes_exactly_once() {
+    let aggregate_calls = Arc::new(AtomicUsize::new(0));
+    let native_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(CountingNative {
+        aggregate_calls: Arc::clone(&aggregate_calls),
+        native_calls: Arc::clone(&native_calls),
+        plan: 1024 * 1024,
+        schema_version: into_markdown_core::DOCUMENT_SCHEMA_VERSION,
+        block_count: 3,
+    });
+    let request = request();
+    let context = ExecutionContext::new(request.execution.clone(), request.options.limits.clone());
+    let mut sink = SemanticCountingSink::default();
+    let prepared =
+        block_on(engine.prepare_into_with_context(request, context, sink.capabilities())).unwrap();
+
+    assert_eq!(aggregate_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(native_calls.load(Ordering::SeqCst), 0);
+    let summary = block_on(engine.execute_prepared_into(prepared, &mut sink)).unwrap();
+
+    assert_eq!(aggregate_calls.load(Ordering::SeqCst), 0);
+    assert_eq!(native_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(sink.metadata_calls, 1);
+    assert_eq!(sink.block_ids.len(), 3);
+    assert_eq!(sink.finalization_calls, 1);
+    assert_eq!(sink.markdown_calls as u64, summary.markdown_bytes.div_ceil(64 * 1024));
+    assert_eq!(sink.asset_begin_calls, 1);
+    assert_eq!(sink.asset_end_calls, 1);
+    assert_eq!(summary.assets, 1);
 }
 
 struct StageListener(Arc<Mutex<Vec<ExecutionStage>>>);

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -1,5 +1,7 @@
 //! Deterministic registry and conversion pipeline orchestration.
 
+mod artifact_execution;
+mod artifact_output;
 mod collecting;
 mod fixed_alloc;
 mod nested;
@@ -13,7 +15,7 @@ pub use recovery::{RecoveryStore, RecoveryToken, TaskCheckpoint, TaskPhase};
 
 use fixed_alloc::{FixedSlots, try_clone_string};
 use into_markdown_core::{
-    AiMode, ArtifactSink, Asset, AssetStreamInfo, Block, BlockNode, ConversionError,
+    AiMode, ArtifactSink, ArtifactSinkCapabilities, Asset, Block, BlockNode, ConversionError,
     ConversionOptions, ConversionRequest, ConversionResult, ConversionSummary, Converter,
     ConverterOutput, ConverterStreamMode, DetectionRequest, DetectionResult, Diagnostic,
     DiagnosticSeverity, Document, EnrichmentPlan, ErrorPolicy, ExecutionContext, ExecutionStage,
@@ -24,10 +26,17 @@ use into_markdown_core::{
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-#[cfg(test)]
-use into_markdown_core::ConversionOutcome;
+/// Opaque, one-shot artifact conversion prepared against frozen sink capabilities.
+#[doc(hidden)]
+pub struct PreparedArtifactConversion {
+    inner: preparation::PreparedConversion,
+    capabilities: ArtifactSinkCapabilities,
+}
+
 #[cfg(test)]
 use into_markdown_core::ProbeOutcome;
+#[cfg(test)]
+use into_markdown_core::{AssetStreamInfo, ConversionOutcome};
 
 /// Explicit registry used by built-ins and future process-isolated plugins.
 #[derive(Default)]
@@ -295,11 +304,48 @@ impl Engine {
         context: ExecutionContext,
         sink: &mut dyn ArtifactSink,
     ) -> Result<ConversionSummary, ConversionError> {
-        let result = self.execute_aggregate_with_context(request, context.clone()).await?;
-        emit_conversion_result(&result, sink, &context)?;
-        let summary = result.into_summary();
-        context.report(ExecutionStage::Completed, Some(1), Some(1), None::<String>)?;
-        Ok(summary)
+        let capabilities = sink.capabilities();
+        let prepared = self.prepare_into_with_context(request, context, capabilities).await?;
+        self.execute_prepared_into(prepared, sink).await
+    }
+
+    /// Resolve, detect, probe, and admit one artifact conversion without
+    /// running its converter or renderer.
+    ///
+    /// # Errors
+    ///
+    /// Returns a typed preparation or policy failure. The returned value is
+    /// one-shot and bound to `capabilities`.
+    #[doc(hidden)]
+    pub async fn prepare_into_with_context(
+        &self,
+        request: ConversionRequest,
+        context: ExecutionContext,
+        capabilities: ArtifactSinkCapabilities,
+    ) -> Result<PreparedArtifactConversion, ConversionError> {
+        if !capabilities.has_output() {
+            return Err(ConversionError::Unsupported {
+                detail: "artifact sink accepts no conversion representation".into(),
+            });
+        }
+        let inner = preparation::prepare(self, request, context).await?;
+        Ok(PreparedArtifactConversion { inner, capabilities })
+    }
+
+    /// Execute one prepared artifact conversion and finalize its sink.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first converter, renderer, sink, cancellation, or
+    /// finalization failure. Completion is reported only after every sink call
+    /// succeeds.
+    #[doc(hidden)]
+    pub async fn execute_prepared_into(
+        &self,
+        prepared: PreparedArtifactConversion,
+        sink: &mut dyn ArtifactSink,
+    ) -> Result<ConversionSummary, ConversionError> {
+        artifact_execution::execute(self, prepared, sink).await
     }
 
     /// Convert using an independently controlled context backed by a caller-owned
@@ -418,41 +464,6 @@ impl Engine {
     ) -> Result<Vec<FormatCandidate>, ConversionError> {
         nested::detect_formats(&self.format_detectors, input, hint, context).await
     }
-}
-
-fn emit_conversion_result(
-    result: &ConversionResult,
-    sink: &mut dyn ArtifactSink,
-    context: &ExecutionContext,
-) -> Result<(), ConversionError> {
-    for chunk in result.markdown.as_bytes().chunks(64 * 1024) {
-        context.checkpoint()?;
-        sink.write_markdown(chunk)?;
-    }
-    for asset in &result.assets {
-        let size =
-            u64::try_from(asset.bytes.len()).map_err(|_| ConversionError::ResourceLimit {
-                limit: "max_asset_bytes",
-                detail: "asset byte length cannot be represented".into(),
-            })?;
-        context.checkpoint()?;
-        let info = AssetStreamInfo {
-            id: asset.id.clone(),
-            filename: asset.filename.clone(),
-            media_type: asset.media_type.clone(),
-            size,
-            external_uri: asset.external_uri.clone(),
-        };
-        context.checkpoint()?;
-        sink.begin_asset(&info)?;
-        for chunk in asset.bytes.chunks(64 * 1024) {
-            context.checkpoint()?;
-            sink.write_asset(chunk)?;
-        }
-        context.checkpoint()?;
-        sink.end_asset()?;
-    }
-    Ok(())
 }
 
 fn preserve_utf8_markdown(

--- a/crates/engine/src/rendering.rs
+++ b/crates/engine/src/rendering.rs
@@ -19,34 +19,26 @@ pub(crate) struct RenderRequest<'a> {
     pub(crate) context: &'a ExecutionContext,
 }
 
+pub(crate) struct RenderedArtifacts {
+    pub(crate) output: ConverterOutput,
+    pub(crate) markdown: String,
+    pub(crate) provenance: Vec<into_markdown_core::Provenance>,
+    pub(crate) markdown_memory: into_markdown_core::ResourceReservation,
+    pub(crate) provenance_memory: into_markdown_core::ResourceReservation,
+}
+
 pub(crate) async fn render(
     request: RenderRequest<'_>,
 ) -> Result<ConversionResult, ConversionError> {
-    let RenderRequest { renderer, output, source, format, options, context } = request;
-    validate_asset_limits(&output, options)?;
-    context.report(
-        into_markdown_core::ExecutionStage::Rendering,
-        None,
-        None,
-        Some(renderer.id()),
-    )?;
-    let (markdown, markdown_memory) = if format == InputFormat::Markdown
-        && options.ai.markdown_postprocess == AiMode::Off
-        && options.text.charset.is_none()
-        && options.text.decoding_mode == TextDecodingMode::Strict
-    {
-        preserve_utf8_markdown(source, context)?
-    } else {
-        invoke_renderer_preflighted(renderer, &output.document, &output.assets, options, context)
-            .await?
-    };
+    let format = request.format;
+    let context = request.context;
+    let RenderedArtifacts { output, markdown, provenance, markdown_memory, provenance_memory } =
+        render_artifacts(request).await?;
     let markdown_bytes =
         u64::try_from(markdown.capacity()).map_err(|_| ConversionError::ResourceLimit {
             limit: "max_memory_bytes",
             detail: "rendered Markdown capacity cannot be represented as u64".into(),
         })?;
-    let (provenance, provenance_memory) =
-        collect_provenance_preflighted(&output.document.blocks, context)?;
     let final_required = estimate_retained_result(
         &output.document,
         &markdown,
@@ -69,6 +61,32 @@ pub(crate) async fn render(
     )?;
     result.set_detected_format(format);
     Ok(result)
+}
+
+pub(crate) async fn render_artifacts(
+    request: RenderRequest<'_>,
+) -> Result<RenderedArtifacts, ConversionError> {
+    let RenderRequest { renderer, output, source, format, options, context } = request;
+    validate_asset_limits(&output, options)?;
+    context.report(
+        into_markdown_core::ExecutionStage::Rendering,
+        None,
+        None,
+        Some(renderer.id()),
+    )?;
+    let (markdown, markdown_memory) = if format == InputFormat::Markdown
+        && options.ai.markdown_postprocess == AiMode::Off
+        && options.text.charset.is_none()
+        && options.text.decoding_mode == TextDecodingMode::Strict
+    {
+        preserve_utf8_markdown(source, context)?
+    } else {
+        invoke_renderer_preflighted(renderer, &output.document, &output.assets, options, context)
+            .await?
+    };
+    let (provenance, provenance_memory) =
+        collect_provenance_preflighted(&output.document.blocks, context)?;
+    Ok(RenderedArtifacts { output, markdown, provenance, markdown_memory, provenance_memory })
 }
 
 fn validate_asset_limits(

--- a/crates/engine/src/stream_execution.rs
+++ b/crates/engine/src/stream_execution.rs
@@ -18,13 +18,48 @@ pub(crate) async fn invoke_native_collecting(
     services: &Services,
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
-    let plan = converter.planned_stream_bytes(
+    invoke_native(
+        converter,
         input,
         candidate,
         options,
+        services,
         context,
         StreamConsumerKind::Collecting,
-    )?;
+    )
+    .await
+}
+
+pub(crate) async fn invoke_native_immediate(
+    converter: &dyn ConverterStream,
+    input: &ResolvedInput,
+    candidate: &FormatCandidate,
+    options: &ConversionOptions,
+    services: &Services,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    invoke_native(
+        converter,
+        input,
+        candidate,
+        options,
+        services,
+        context,
+        StreamConsumerKind::Immediate,
+    )
+    .await
+}
+
+async fn invoke_native(
+    converter: &dyn ConverterStream,
+    input: &ResolvedInput,
+    candidate: &FormatCandidate,
+    options: &ConversionOptions,
+    services: &Services,
+    context: &ExecutionContext,
+    consumer: StreamConsumerKind,
+) -> Result<ConverterOutput, ConversionError> {
+    let plan = converter.planned_stream_bytes(input, candidate, options, context, consumer)?;
     let mut admission = context.reserve_memory(plan)?;
     let credited = context.with_memory_credit(&mut admission)?;
     let mut sink = CollectingArtifactSink::new(&credited);

--- a/crates/render-markdown/src/lib.rs
+++ b/crates/render-markdown/src/lib.rs
@@ -197,15 +197,11 @@ pub fn plan_assets(
 
     let mut entries = groups
         .into_iter()
-        .map(|(sha256, (source_index, media_type, extension, mut asset_ids))| {
+        .map(|(sha256, (source_index, media_type, _extension, mut asset_ids))| {
             asset_ids.sort();
-            let mut filename = format!("asset-{sha256}");
-            if let Some(extension) = extension {
-                filename.push('.');
-                filename.push_str(&extension);
-            }
+            let filename = asset_filename_from_sha256(&sha256, &media_type)?;
             let uri = join_uri_prefix(options.output.asset_uri_prefix.as_deref(), &filename);
-            PlannedAsset {
+            Ok(PlannedAsset {
                 asset_ids,
                 source_index,
                 filename,
@@ -213,9 +209,9 @@ pub fn plan_assets(
                 media_type,
                 size: u64::try_from(assets[source_index].bytes.len()).unwrap_or(u64::MAX),
                 sha256,
-            }
+            })
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, ConversionError>>()?;
     entries.sort_by(|left, right| left.filename.cmp(&right.filename));
     for (entry_index, entry) in entries.iter().enumerate() {
         for id in &entry.asset_ids {
@@ -247,6 +243,34 @@ pub fn plan_assets(
         }
     }
     Ok(plan)
+}
+
+/// Build the stable content-addressed filename for a validated SHA-256 digest
+/// and media type.
+///
+/// # Errors
+///
+/// Returns a rendering error when the digest is not 64 lowercase hexadecimal
+/// bytes or the media type is invalid.
+pub fn asset_filename_from_sha256(
+    sha256: &str,
+    media_type: &str,
+) -> Result<String, ConversionError> {
+    if sha256.len() != 64
+        || !sha256.bytes().all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err(render_error("asset SHA-256 digest is not canonical lowercase hexadecimal"));
+    }
+    let media_type = normalize_media_type(media_type)?;
+    let extension = media_type_extension(&media_type);
+    let mut filename = String::with_capacity(6 + sha256.len() + 17);
+    filename.push_str("asset-");
+    filename.push_str(sha256);
+    if let Some(extension) = extension {
+        filename.push('.');
+        filename.push_str(&extension);
+    }
+    Ok(filename)
 }
 
 impl MarkdownRenderer for GfmRenderer {

--- a/docs/cli-streaming-output.md
+++ b/docs/cli-streaming-output.md
@@ -40,10 +40,12 @@ buffer.
 
 For stdout, the complete primary artifact remains in an accounted temporary
 file until conversion and serialization succeed. Only then is it copied to the
-pipe. Broken pipe is a terminal consumer condition: staged companion files are
-rolled back, temporary files are dropped, and no output transaction is left
-behind. File output uses the same staged artifact and the existing atomic
-publication boundary.
+pipe. Broken pipe is a terminal consumer condition: copying stops, the primary
+temporary file is dropped, and fully staged companion assets retain the existing
+CLI behavior of committing after successful conversion and serialization.
+Serialization, cancellation, and non-pipe I/O failures abort companions. File
+output uses the same staged artifact and the existing atomic publication
+boundary.
 
 ## State and failure rules
 

--- a/docs/cli-streaming-output.md
+++ b/docs/cli-streaming-output.md
@@ -9,13 +9,16 @@ before #273.
 
 ## Responsibilities
 
-- `output/stream.rs` owns the spool state machine and compact asset index;
-  `output/stream/json.rs` performs incremental JSON string escaping.
+- `output/stream.rs` owns the spool state machine and compact indexes;
+  `output/stream/document.rs` writes semantic IR, `output/stream/sink.rs`
+  handles engine callbacks and asset payloads, and `output/stream/io.rs` owns
+  accounted replay buffers.
+- `output/stream/json.rs` performs incremental JSON string escaping.
 - `output/stream/result.rs` composes result JSON and streams Base64;
   `output/stream/bundle.rs` writes the deterministic ZIP entry contract and streams
   asset payloads without constructing Base64 or ZIP-entry buffers.
-- `output/serialization.rs` retains the compatibility encoder used by existing
-  call sites and byte-for-byte regression tests until the #272 adapter lands.
+- `output/serialization.rs` retains the compatibility encoder only for
+  byte-for-byte regression tests; production CLI conversion uses the sink.
 - `output/assets.rs` plans and stages companion asset files.
 - `output/commit.rs` publishes the primary artifact and companions atomically.
 
@@ -86,5 +89,5 @@ successful serialization and fsync.
 - Large Markdown, IR, and asset tests record peak RSS, shared memory leases,
   temporary bytes, and spool write calls. Payload growth must not increase
   retained memory proportionally and must not create a second payload copy.
-- Asset lookup and deduplication use a digest index and bounded byte comparison,
-  avoiding pairwise scans and repeated serialization.
+- Asset lookup and deduplication use an authoritative SHA-256 index plus streamed
+  digest verification, avoiding pairwise scans and repeated serialization.

--- a/docs/cli-streaming-output.md
+++ b/docs/cli-streaming-output.md
@@ -56,8 +56,25 @@ while an asset is open or when the semantic document is incomplete.
 
 Cancellation is checked before every spool write, replay chunk, Base64 chunk,
 ZIP entry, stdout write, and commit. Serialization, disk-full, cancellation,
-and pipe errors all use the same idempotent abort path. File targets are never
-visible before successful serialization and fsync.
+and non-pipe I/O errors use the same idempotent abort path; broken pipe follows
+the terminal-consumer rule above. File targets are never visible before
+successful serialization and fsync.
+
+## Engine seam invariants
+
+- Preparation resolves, probes, plans admission, and freezes sink capabilities;
+  it does not execute a converter, render Markdown, or create a result object.
+- A prepared conversion is consumed exactly once. Execution rejects a different
+  capability set instead of silently selecting another converter path.
+- Semantic events are protocol-validated while they are written. Document
+  finalization succeeds exactly once and precedes the successful summary and
+  terminal `Completed` progress event.
+- Native and compatibility converter paths move their outputs through the same
+  event adapter. A compatibility adapter may drain a converter-owned document
+  and assets, but it must not assemble a `ConversionResult` before spooling.
+- The selected primary representation is serialized exactly once after the
+  conversion sink is finalized. Sink, finalization, and serialization failures
+  cannot publish a primary file or report completion.
 
 ## Compatibility and performance gates
 

--- a/docs/cli-streaming-output.md
+++ b/docs/cli-streaming-output.md
@@ -10,6 +10,7 @@ before #273.
 ## Responsibilities
 
 - `output/stream.rs` owns the spool state machine and compact indexes;
+  `output/stream/plan.rs` freezes the emit and asset-mode representation set;
   `output/stream/document.rs` writes semantic IR, `output/stream/sink.rs`
   handles engine callbacks and asset payloads, and `output/stream/io.rs` owns
   accounted replay buffers.
@@ -35,11 +36,21 @@ budget before the underlying write. The only retained memory is a compact
 asset index and fixed-size copy buffers; index capacity and cloned metadata are
 reserved from the shared memory budget before allocation.
 
-The document spool is written in stable JSON order while semantic events
-arrive. Markdown and asset bytes have separate spools. Result JSON streams JSON
-escaping and Base64 directly to the final stage. Bundle output streams the
-same spools through `ZipWriter`. Neither path creates a second payload-sized
-buffer.
+Only representations selected by the frozen plan have temporary files:
+
+| Emit | Raw Markdown | Escaped Markdown | IR | Diagnostics/provenance | Asset payload |
+| --- | --- | --- | --- | --- | --- |
+| Markdown | yes | no | no | no | extract only |
+| IR JSON | no | no | yes | no | extract only |
+| Result JSON | no | yes | yes | yes | yes |
+| Bundle | yes | no | yes | yes | yes |
+
+`omit` and `embed` therefore do not stage companion payloads for Markdown or
+IR JSON. Result JSON and bundle retain asset payloads because their existing
+wire formats contain them. Result JSON streams JSON escaping and Base64 from
+its selected spools. Bundle streams its selected spools through `ZipWriter`.
+Construction, callbacks, finalization, and serialization reject a missing or
+mismatched representation rather than silently creating it later.
 
 For stdout, the complete primary artifact remains in an accounted temporary
 file until conversion and serialization succeed. Only then is it copied to the

--- a/docs/cli-streaming-output.md
+++ b/docs/cli-streaming-output.md
@@ -1,0 +1,69 @@
+# CLI bounded structured output
+
+Issue #273 is stacked on #272. The lower change owns the engine transaction and
+semantic event contract (`prepare_into` / `execute_prepared_into`), including
+the existing Markdown file sink. This change owns only the CLI consumers of
+that contract. Merge #272 before #273.
+
+## Responsibilities
+
+- `output/stream.rs` owns the spool state machine and compact asset index;
+  `output/stream/json.rs` performs incremental JSON string escaping.
+- `output/stream/result.rs` composes result JSON and streams Base64;
+  `output/stream/bundle.rs` writes the deterministic ZIP entry contract and streams
+  asset payloads without constructing Base64 or ZIP-entry buffers.
+- `output/serialization.rs` retains the compatibility encoder used by existing
+  call sites and byte-for-byte regression tests until the #272 adapter lands.
+- `output/assets.rs` plans and stages companion asset files.
+- `output/commit.rs` publishes the primary artifact and companions atomically.
+
+No layer may reconstruct a `ConversionResult`. A conversion is prepared once,
+executed once, and its selected primary representation is serialized once.
+Compatibility helpers for tests may feed an existing small `ConversionResult`
+into the same sink, but production conversion never uses that helper.
+
+## Bounded staging model
+
+The sink writes variable-sized payloads to `ExecutionContext::temporary_file`
+instances. Every byte therefore consumes the request's shared temporary-space
+budget before the underlying write. The only retained memory is a compact
+asset index and fixed-size copy buffers; index capacity and cloned metadata are
+reserved from the shared memory budget before allocation.
+
+The document spool is written in stable JSON order while semantic events
+arrive. Markdown and asset bytes have separate spools. Result JSON streams JSON
+escaping and Base64 directly to the final stage. Bundle output streams the
+same spools through `ZipWriter`. Neither path creates a second payload-sized
+buffer.
+
+For stdout, the complete primary artifact remains in an accounted temporary
+file until conversion and serialization succeed. Only then is it copied to the
+pipe. Broken pipe is a terminal consumer condition: staged companion files are
+rolled back, temporary files are dropped, and no output transaction is left
+behind. File output uses the same staged artifact and the existing atomic
+publication boundary.
+
+## State and failure rules
+
+The sink state is `ready -> receiving -> finalized -> committed`; any failure
+transitions to `aborted`. Begin/end asset calls must be balanced and the
+observed byte count must equal the announced size. Finalization is rejected
+while an asset is open or when the semantic document is incomplete.
+
+Cancellation is checked before every spool write, replay chunk, Base64 chunk,
+ZIP entry, stdout write, and commit. Serialization, disk-full, cancellation,
+and pipe errors all use the same idempotent abort path. File targets are never
+visible before successful serialization and fsync.
+
+## Compatibility and performance gates
+
+- Four emit modes must match the legacy encoder byte-for-byte for small
+  fixtures, including ZIP entry order, modes, timestamps, JSON whitespace,
+  trailing newlines, asset names, and Base64 padding.
+- Tests count conversion execution and primary serialization calls; both must
+  be exactly one.
+- Large Markdown, IR, and asset tests record peak RSS, shared memory leases,
+  temporary bytes, and spool write calls. Payload growth must not increase
+  retained memory proportionally and must not create a second payload copy.
+- Asset lookup and deduplication use a digest index and bounded byte comparison,
+  avoiding pairwise scans and repeated serialization.

--- a/docs/cli-streaming-output.md
+++ b/docs/cli-streaming-output.md
@@ -1,9 +1,11 @@
 # CLI bounded structured output
 
-Issue #273 is stacked on #272. The lower change owns the engine transaction and
-semantic event contract (`prepare_into` / `execute_prepared_into`), including
-the existing Markdown file sink. This change owns only the CLI consumers of
-that contract. Merge #272 before #273.
+Issue #273 is stacked on #272. The lower change owns collecting conversion's
+single-execution boundary. This change owns the structured-output sink contract,
+semantic document events and finalization, plus the smallest practical
+`prepare_into` / `execute_prepared_into` seam needed by the CLI. Those seams
+remain crate-private unless another crate must implement the sink. Merge #272
+before #273.
 
 ## Responsibilities
 


### PR DESCRIPTION
## 依赖与范围

- Closes #273
- 本 PR 按 stacked 关系依赖 #272；#272 已合入，最终顺序仍是 **#272 → #273**。
- 已 rebase 到最新 `main` `8e19d85`。
- 只包含 structured streaming / sink 契约与 CLI 接线；不包含 #274 的恢复或事务语义改动。

## 实现

- 增加冻结 capabilities 的一次性 `prepare_into_with_context` / `execute_prepared_into` seam；生产路径不构造完整 `ConversionResult`。
- 新增不可变 `emit × asset_mode` representation plan，只创建 wire 真正需要的 spool：
  - Markdown：raw Markdown；仅 extract 接收 companion asset payload。
  - IR JSON：semantic IR；仅 extract 接收 companion asset payload。
  - result JSON：escaped Markdown + IR + diagnostics/provenance + asset payload；不写 raw Markdown。
  - bundle：raw Markdown + IR + diagnostics/provenance + asset payload；不写 escaped Markdown。
- 构造、sink callback、finish 与 serialize 均 fail-closed；emit 不匹配或所需表示缺失时，在 destination 写入及 serialization call 计数前失败。
- result JSON 流式 JSON escaping/Base64；bundle 从 spool 写确定性 ZIP entry；资产按 SHA-256 去重并校验摘要。
- `ConversionSummary.outcome` 贯穿 stdout 与单/多文件 batch；Info diagnostics 不再被重新推断为 degraded，CLI rename warning 只会把 complete 提升为 degraded。
- timeout 在 semantic、Markdown、asset sink callback 中保持 `errorCode=timeout` 和 policy exit，不再降级为 internal。
- stdout broken-pipe 与文件原子发布沿用既有语义；未修改 transaction/recovery。

## 正确性与资源测试

- 四种 emit 与旧编码逐字节一致，包括 JSON 空白/换行、Base64、ZIP entry 顺序/模式/时间戳。
- sink/call 计数证明 prepare converter=0、execute native converter=1 / aggregate=0、primary serialization=1。
- 覆盖 representation 存在性、12 组 emit/asset_mode temp 计费、缺失表示/emit mismatch fail-closed、Info outcome、三阶段 deadline、stdout broken pipe、序列化中途失败、取消、UTF-8 分片、重复资产、limit/limit-1、原子主文件+资产发布。
- 4 MiB Markdown + 2 MiB IR + 4 MiB 去重资产（staged temp / serialize peak temp）：

| Representation | 旧 SHA | 修复后 | staged 变化 | 修复后 peak |
|---|---:|---:|---:|---:|
| Markdown omit/embed | 14,681,197 B | 4,194,306 B | -71.4% | 8,388,612 B |
| Markdown extract | 14,681,197 B | 8,388,610 B | -42.9% | 12,582,916 B |
| IR omit | 14,681,197 B | 2,097,906 B | -85.7% | 4,195,812 B |
| IR extract | 14,681,197 B | 6,292,210 B | -57.1% | 8,390,116 B |
| result JSON | 14,681,197 B | 10,486,891 B | -28.6% | 27,964,821 B |
| bundle | 14,681,197 B | 10,486,887 B | -28.6% | 10,529,406 B |

Markdown omit/embed staged memory lease 为 0 B，serialize copy buffer peak 65,536 B；所有矩阵项 drop 后 memory/temp 均为 0。

## 验证

- `cargo fmt --all -- --check`、`git diff --check`
- `cargo clippy --locked -p into-markdown-core -p into-markdown-engine -p into-markdown-render-markdown -p into-markdown --lib --no-deps -- -D warnings`
- `cargo test --locked -p into-markdown-core -p into-markdown-engine -p into-markdown-render-markdown -p into-markdown`
  - API 42 passed / 2 PDFium-only ignored；collecting parity 4；core 99；engine 36；renderer 28。
- `cargo test --locked -p into-markdown-cli`
  - CLI 229；exit contract 15；plugin lifecycle 2，全部通过。
- 完整 all-targets `clippy -D warnings` 已运行，仍被 `main` 既有告警阻断（API test 的 4 处 `u32 as f32`，以及 CLI/测试既有 pedantic 告警）。本 PR 未新增 lint 豁免；本次 stream/plan/outcome 触及区域的严格扫描无告警。

## Markdown 文件性能

Windows release、OCR off，每项 warm-up 后 3 次平均；对比被 P1 审核冻结的旧 SHA `2ecc88c`，发布字节逐项一致。

| 样本 / asset mode | 旧 SHA | 修复后 | 耗时变化 | peak RSS（旧 → 新） | 发布字节 |
|---|---:|---:|---:|---:|---:|
| 普通 DOCX / extract | 139.5 ms | 129.5 ms | -7.2% | 16.70 → 18.41 MB | 76 B |
| 22 MB 图片 PPTX / omit | 1,463.4 ms | 1,016.1 ms | -30.6% | 59.93 → 57.52 MB | 13,563 B |
| 22 MB 图片 PPTX / extract | 1,658.6 ms | 1,294.4 ms | -22.0% | 60.13 → 57.49 MB | 20,445,793 B |
| 22 MB 图片 PPTX / embed | 3,433.1 ms | 2,783.7 ms | -18.9% | 239.19 → 224.93 MB | 110,391,685 B |

无耗时回退；普通样本 RSS 波动约 +10.2%，远低于 50% 门禁；三个大样本 RSS 均下降。

## 风险

- converter/renderer 仍遵循既有受 memory lease 约束的 IR、asset 与 Markdown 所有权模型；本 PR 消除的是未请求表示和结构化编码阶段的额外 spool。
- stdout 为保证单一完整产物仍使用受 `max_temporary_bytes` 约束的 primary spool；大 result JSON 的 temp 峰值随最终 wire 增长，但内存为固定缓冲。
- broken pipe 在转换与序列化成功后仍提交已完全 staged 的 companion assets，这是现有 CLI 兼容语义。