### PR TITLE
fix: reject unusable empty Markdown results

### DIFF
--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -4313,26 +4313,21 @@ fn run_conversion(
     } else if plans.len() == 1 {
         let plan = &plans[0];
         let output_phase = Mutex::new(());
-        let (output_path, detected_format, diagnostics, warnings) =
-            process_file_task_inner(plan, &policy, &output_phase)?;
+        let completed = process_file_task_inner(plan, &policy, &output_phase)?;
         vec![BatchItemReport {
             input: plan.item.display.clone(),
-            output: Some(report_path(&output_path)),
-            format: detected_format.map(|format| format.as_str().into()),
+            output: Some(report_path(&completed.path)),
+            format: completed.format.map(|format| format.as_str().into()),
             status: BatchItemStatus::Success,
-            outcome: if diagnostics.is_empty() && warnings.is_empty() {
-                BatchItemOutcome::Complete
-            } else {
-                BatchItemOutcome::Degraded
-            },
-            diagnostics: diagnostics.iter().map(Into::into).collect(),
+            outcome: crate::result_policy::batch_outcome(completed.outcome),
+            diagnostics: completed.diagnostics.iter().map(Into::into).collect(),
             error_code: None,
-            reason_code: None,
+            reason_code: completed.reason_code,
             component: None,
             part: None,
             limit: None,
             message: None,
-            warnings,
+            warnings: completed.warnings,
         }]
     } else {
         process_batch(plans, &policy, arguments.jobs.map_or(loaded.jobs, std::num::NonZero::get))?
@@ -4949,6 +4944,7 @@ fn process_stdout(
         &policy.working_directory,
     )?;
     let result = convert_item(&plan.item, policy, asset_output.uri_prefix)?;
+    crate::result_policy::validate_for_emit(&result, policy.emit, policy.asset_mode)?;
     let mut encoded =
         policy.output_context.temporary_file("into-md-stdout").map_err(CliError::from)?;
     output::encode_result_into(&result, policy.emit, &mut encoded)?;
@@ -5016,14 +5012,10 @@ fn process_stdout(
         output: None,
         format: result.detected_format().map(|format| format.as_str().into()),
         status: BatchItemStatus::Success,
-        outcome: if result.diagnostics.is_empty() {
-            BatchItemOutcome::Complete
-        } else {
-            BatchItemOutcome::Degraded
-        },
+        outcome: crate::result_policy::batch_outcome(result.outcome()),
         diagnostics: result.diagnostics.iter().map(Into::into).collect(),
         error_code: None,
-        reason_code: None,
+        reason_code: result.reason_code().map(str::to_owned),
         component: None,
         part: None,
         limit: None,
@@ -5093,24 +5085,20 @@ fn process_file_task(
 ) -> BatchItemReport {
     let _memory_guard = memory_phase.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     match process_file_task_inner(&plan, policy, output_phase) {
-        Ok((output_path, detected_format, diagnostics, warnings)) => BatchItemReport {
+        Ok(completed) => BatchItemReport {
             input: plan.item.display,
-            output: Some(report_path(&output_path)),
-            format: detected_format.map(|format| format.as_str().into()),
+            output: Some(report_path(&completed.path)),
+            format: completed.format.map(|format| format.as_str().into()),
             status: BatchItemStatus::Success,
-            outcome: if diagnostics.is_empty() && warnings.is_empty() {
-                BatchItemOutcome::Complete
-            } else {
-                BatchItemOutcome::Degraded
-            },
-            diagnostics: diagnostics.iter().map(Into::into).collect(),
+            outcome: crate::result_policy::batch_outcome(completed.outcome),
+            diagnostics: completed.diagnostics.iter().map(Into::into).collect(),
             error_code: None,
-            reason_code: None,
+            reason_code: completed.reason_code,
             component: None,
             part: None,
             limit: None,
             message: None,
-            warnings,
+            warnings: completed.warnings,
         },
         Err(error) => BatchItemReport {
             input: plan.item.display,
@@ -5140,7 +5128,7 @@ fn process_file_task_inner(
     plan: &WorkPlan,
     policy: &ExecutionPolicy,
     output_phase: &Mutex<()>,
-) -> Result<(PathBuf, Option<InputFormat>, Vec<into_markdown::Diagnostic>, Vec<String>), CliError> {
+) -> Result<crate::result_policy::CommittedOutput, CliError> {
     let requested =
         plan.output.as_deref().ok_or_else(|| CliError::internal("batch output path is absent"))?;
     let output_path = {
@@ -5156,6 +5144,9 @@ fn process_file_task_inner(
         &policy.working_directory,
     )?;
     let result = convert_item(&plan.item, policy, asset_output.uri_prefix)?;
+    crate::result_policy::validate_for_emit(&result, policy.emit, policy.asset_mode)?;
+    let content_outcome = result.outcome();
+    let reason_code = result.reason_code().map(str::to_owned);
     let output_parent = output_path
         .parent()
         .ok_or_else(|| CliError::internal("batch output has no parent directory"))?;
@@ -5185,7 +5176,14 @@ fn process_file_task_inner(
             outcome.path.display()
         ));
     }
-    Ok((outcome.path, result.detected_format(), result.diagnostics, warnings))
+    Ok(crate::result_policy::CommittedOutput {
+        path: outcome.path,
+        format: result.detected_format(),
+        diagnostics: result.diagnostics,
+        warnings,
+        outcome: content_outcome,
+        reason_code,
+    })
 }
 
 fn report_path(path: &Path) -> String {

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -9,6 +9,7 @@ mod error;
 mod i18n;
 mod output;
 mod proxy_env;
+mod result_policy;
 mod services;
 mod transaction;
 mod ui;

--- a/apps/cli/src/result_policy.rs
+++ b/apps/cli/src/result_policy.rs
@@ -1,0 +1,97 @@
+//! CLI delivery policy for exceptional usable conversion results.
+
+use crate::args::{AssetModeArg, EmitKind};
+use crate::error::CliError;
+use crate::output::BatchItemOutcome;
+use into_markdown::{
+    ConversionError, ConversionOutcome, ConversionResult, Diagnostic, InputFormat, ResultContent,
+};
+use std::path::PathBuf;
+
+pub(crate) struct CommittedOutput {
+    pub(crate) path: PathBuf,
+    pub(crate) format: Option<InputFormat>,
+    pub(crate) diagnostics: Vec<Diagnostic>,
+    pub(crate) warnings: Vec<String>,
+    pub(crate) outcome: ConversionOutcome,
+    pub(crate) reason_code: Option<String>,
+}
+
+pub(crate) fn validate_for_emit(
+    result: &ConversionResult,
+    emit: EmitKind,
+    asset_mode: AssetModeArg,
+) -> Result<(), CliError> {
+    match result.content().map_err(CliError::from)? {
+        ResultContent::Markdown | ResultContent::EmptySource => Ok(()),
+        ResultContent::AssetsOnly
+            if matches!(emit, EmitKind::Bundle | EmitKind::ResultJson)
+                || emit == EmitKind::IrJson && asset_mode == AssetModeArg::Extract =>
+        {
+            Ok(())
+        }
+        ResultContent::AssetsOnly => Err(CliError::from(ConversionError::EmptyContent)
+            .with_detected_format(result.detected_format())),
+    }
+}
+
+pub(crate) const fn batch_outcome(outcome: ConversionOutcome) -> BatchItemOutcome {
+    match outcome {
+        ConversionOutcome::Complete => BatchItemOutcome::Complete,
+        ConversionOutcome::Degraded => BatchItemOutcome::Degraded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown::{
+        ASSET_ONLY_REASON_CODE, Asset, AssetId, Block, BlockNode, Diagnostic, DiagnosticSeverity,
+        Document, NodeId, Provenance, ProvenanceKind, SourceLocator,
+    };
+
+    fn asset_only() -> ConversionResult {
+        let id = AssetId("asset".into());
+        ConversionResult::new(
+            Document {
+                blocks: vec![BlockNode {
+                    id: NodeId("image".into()),
+                    block: Block::Image { asset: id.clone(), alt: None },
+                    provenance: Provenance {
+                        kind: ProvenanceKind::NativeParser,
+                        provider: "test".into(),
+                        locator: SourceLocator::default(),
+                        confidence: None,
+                    },
+                }],
+                ..Document::default()
+            },
+            String::new(),
+            vec![Asset {
+                id,
+                filename: Some("asset.bin".into()),
+                media_type: "application/octet-stream".into(),
+                bytes: vec![1],
+                external_uri: None,
+            }],
+            vec![Diagnostic {
+                code: ASSET_ONLY_REASON_CODE.into(),
+                severity: DiagnosticSeverity::Info,
+                message: "asset only".into(),
+                locator: None,
+            }],
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn asset_only_delivery_requires_a_structured_or_extracted_target() {
+        let result = asset_only();
+        assert!(validate_for_emit(&result, EmitKind::ResultJson, AssetModeArg::Omit).is_ok());
+        assert!(validate_for_emit(&result, EmitKind::Bundle, AssetModeArg::Omit).is_ok());
+        assert!(validate_for_emit(&result, EmitKind::IrJson, AssetModeArg::Extract).is_ok());
+        let error =
+            validate_for_emit(&result, EmitKind::Markdown, AssetModeArg::Extract).unwrap_err();
+        assert_eq!(error.reason_code(), "emptyContent");
+    }
+}

--- a/apps/cli/src/web_tasks.rs
+++ b/apps/cli/src/web_tasks.rs
@@ -77,7 +77,7 @@ pub enum WebTaskError {
     #[error("backend I/O failed: {0}")]
     Io(String),
     #[error("conversion failed during {stage}: {code}")]
-    Conversion { code: String, stage: String },
+    Conversion { code: String, reason_code: Option<String>, stage: String },
 }
 
 /// One-time grants accompanying a Web upload. Grants are checked before task
@@ -348,6 +348,8 @@ pub(crate) struct WebTaskRecord {
 pub(crate) struct WebTaskFailure {
     schema_version: u32,
     pub(crate) code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) reason_code: Option<String>,
     pub(crate) stage: String,
     pub(crate) retryable: bool,
 }
@@ -2727,12 +2729,14 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
             let services = shared.media_services.assemble(&persisted.options).map_err(|error| {
                 WebTaskError::Conversion {
                     code: error.code().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "capabilityRouting".into(),
                 }
             })?;
             Some(into_markdown::default_engine_with_services(services).map_err(|error| {
                 WebTaskError::Conversion {
                     code: error.code().as_str().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "conversionSetup".into(),
                 }
             })?)
@@ -2742,12 +2746,14 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
                 .assemble_conversion(&persisted.options, web_invocation_capabilities(&persisted))
                 .map_err(|error| WebTaskError::Conversion {
                     code: error.code().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "capabilityRouting".into(),
                 })?
                 .map(into_markdown::default_engine_with_services)
                 .transpose()
                 .map_err(|error| WebTaskError::Conversion {
                     code: error.code().as_str().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "conversionSetup".into(),
                 })?
         };
@@ -2770,6 +2776,7 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
             } else {
                 WebTaskError::Conversion {
                     code: error.code().as_str().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "conversion".into(),
                 }
             }
@@ -4162,23 +4169,25 @@ fn load_persisted_request(task: &SafeDir) -> Result<Option<PersistedRequest>, We
 }
 
 fn failure_from_error(error: &WebTaskError) -> WebTaskFailure {
-    let (code, stage, retryable) = match error {
-        WebTaskError::Conversion { code, stage } => {
+    let (code, reason_code, stage, retryable) = match error {
+        WebTaskError::Conversion { code, reason_code, stage } => {
             let retryable = matches!(
                 code.as_str(),
                 "network" | "networkDenied" | "timeout" | "componentUnavailable" | "ai"
             );
-            (code.clone(), stage.clone(), retryable)
+            (code.clone(), reason_code.clone(), stage.clone(), retryable)
         }
-        WebTaskError::Limit(_) => ("resourceLimit".into(), "storage".into(), false),
-        WebTaskError::Unsafe(_) => ("unsafeStorage".into(), "storage".into(), false),
-        WebTaskError::Cancelled => ("cancelled".into(), "conversion".into(), true),
-        WebTaskError::NotFound => ("notFound".into(), "storage".into(), false),
-        WebTaskError::Conflict(_) => ("taskConflict".into(), "storage".into(), true),
-        WebTaskError::Invalid(_) => ("invalidTaskOptions".into(), "conversionSetup".into(), false),
-        WebTaskError::Io(_) => ("backendIo".into(), "storage".into(), true),
+        WebTaskError::Limit(_) => ("resourceLimit".into(), None, "storage".into(), false),
+        WebTaskError::Unsafe(_) => ("unsafeStorage".into(), None, "storage".into(), false),
+        WebTaskError::Cancelled => ("cancelled".into(), None, "conversion".into(), true),
+        WebTaskError::NotFound => ("notFound".into(), None, "storage".into(), false),
+        WebTaskError::Conflict(_) => ("taskConflict".into(), None, "storage".into(), true),
+        WebTaskError::Invalid(_) => {
+            ("invalidTaskOptions".into(), None, "conversionSetup".into(), false)
+        }
+        WebTaskError::Io(_) => ("backendIo".into(), None, "storage".into(), true),
     };
-    WebTaskFailure { schema_version: 1, code, stage, retryable }
+    WebTaskFailure { schema_version: 1, code, reason_code, stage, retryable }
 }
 
 fn persist_task_failure(
@@ -4212,8 +4221,13 @@ fn load_task_failure(shared: &Shared, id: &TaskId) -> Result<Option<WebTaskFailu
         .map_err(|_| WebTaskError::Unsafe("task failure record is invalid".into()))?;
     if failure.schema_version != 1
         || failure.code.len() > 64
+        || failure.reason_code.as_ref().is_some_and(|value| value.len() > 64)
         || failure.stage.len() > 64
         || !failure.code.bytes().all(|byte| byte.is_ascii_alphanumeric())
+        || failure
+            .reason_code
+            .as_ref()
+            .is_some_and(|value| !value.bytes().all(|byte| byte.is_ascii_alphanumeric()))
         || !failure.stage.bytes().all(|byte| byte.is_ascii_alphanumeric())
     {
         return Err(WebTaskError::Unsafe("task failure record is incompatible".into()));
@@ -5204,6 +5218,9 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[path = "empty_result_tests.rs"]
+    mod empty_result_tests;
 
     #[test]
     fn durable_web_requests_assemble_capabilities_from_options_and_filename() {

--- a/apps/cli/src/web_tasks/tests/empty_result_tests.rs
+++ b/apps/cli/src/web_tasks/tests/empty_result_tests.rs
@@ -1,0 +1,69 @@
+use super::*;
+use std::io::Cursor;
+use zip::write::SimpleFileOptions;
+
+#[test]
+fn empty_source_and_empty_content_share_the_web_terminal_contract() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = WebTaskBackend::open(temporary.path().join("backend")).unwrap();
+
+    let mut empty_request =
+        WebTaskRequest { format: Some(InputFormat::Text), ..WebTaskRequest::default() };
+    empty_request.options.error_policy = into_markdown::ErrorPolicy::BestEffort;
+    let mut upload = backend.begin_upload_configured("empty.txt", Some(3), empty_request).unwrap();
+    upload.write_chunk(b" \n").unwrap();
+    let empty = upload.finish().unwrap();
+    let empty = wait_terminal(&backend, &empty.id);
+    assert_eq!(empty.status, TaskStatus::Succeeded);
+    let markdown =
+        empty.artifacts.iter().find(|artifact| artifact.kind == ArtifactKind::Markdown).unwrap();
+    assert_eq!(markdown.byte_len, 0);
+    let diagnostics =
+        empty.artifacts.iter().find(|artifact| artifact.kind == ArtifactKind::Diagnostics).unwrap();
+    let (mut diagnostics_file, _) = backend.artifact(&empty.id, &diagnostics.storage_key).unwrap();
+    let mut diagnostics_json = String::new();
+    diagnostics_file.read_to_string(&mut diagnostics_json).unwrap();
+    assert!(diagnostics_json.contains("emptySource"), "{diagnostics_json}");
+    assert!(backend.web_record(empty).unwrap().failure.is_none());
+
+    let docx = alt_chunk_only_docx();
+    let request = WebTaskRequest { format: Some(InputFormat::Docx), ..WebTaskRequest::default() };
+    let mut upload = backend
+        .begin_upload_configured("omitted.docx", Some(u64::try_from(docx.len()).unwrap()), request)
+        .unwrap();
+    upload.write_chunk(&docx).unwrap();
+    let omitted = upload.finish().unwrap();
+    let omitted = wait_terminal(&backend, &omitted.id);
+    assert_eq!(omitted.status, TaskStatus::Failed);
+    assert!(omitted.artifacts.is_empty());
+    let failure = backend.web_record(omitted).unwrap().failure.unwrap();
+    assert_eq!(failure.code, "malformed");
+    assert_eq!(failure.reason_code.as_deref(), Some("emptyContent"));
+}
+
+fn alt_chunk_only_docx() -> Vec<u8> {
+    let parts = [
+        (
+            "[Content_Types].xml",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#,
+        ),
+        (
+            "_rels/.rels",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rDocument" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+        ),
+        (
+            "word/document.xml",
+            r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:altChunk/></w:body></w:document>"#,
+        ),
+    ];
+    let mut output = Cursor::new(Vec::new());
+    {
+        let mut archive = zip::ZipWriter::new(&mut output);
+        for (name, bytes) in parts {
+            archive.start_file(name, SimpleFileOptions::default()).unwrap();
+            archive.write_all(bytes.as_bytes()).unwrap();
+        }
+        archive.finish().unwrap();
+    }
+    output.into_inner()
+}

--- a/apps/cli/tests/empty_result_contract.rs
+++ b/apps/cli/tests/empty_result_contract.rs
@@ -1,0 +1,221 @@
+//! Real-process contracts for exceptional empty conversion results.
+
+use std::io::{Cursor, Write};
+use std::path::PathBuf;
+use std::process::Command;
+use zip::write::SimpleFileOptions;
+
+fn binary() -> PathBuf {
+    option_env!("CARGO_BIN_EXE_into-md")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("INTO_MD_BIN").map(PathBuf::from))
+        .expect("Cargo or Bazel must provide the into-md binary")
+}
+
+#[test]
+fn genuine_empty_sources_commit_existing_targets_with_complete_reports() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = temporary.path().join("input");
+    let output = temporary.path().join("output");
+    let report = temporary.path().join("report.json");
+    std::fs::create_dir(&input).unwrap();
+    let text = input.join("empty.txt");
+    let markdown = input.join("empty.md");
+    let docx = input.join("empty.docx");
+    let xlsx = input.join("empty.xlsx");
+    std::fs::write(&text, b" \r\n").unwrap();
+    std::fs::write(&markdown, b"\xef\xbb\xbf\n").unwrap();
+    std::fs::write(&docx, empty_docx()).unwrap();
+    std::fs::write(&xlsx, empty_xlsx()).unwrap();
+
+    let result = Command::new(binary())
+        .args(["--no-config", "--output-dir"])
+        .arg(&output)
+        .args(["--report"])
+        .arg(&report)
+        .args([&text, &markdown, &docx, &xlsx])
+        .output()
+        .unwrap();
+
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(result.stdout.is_empty());
+    let report: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).unwrap()).unwrap();
+    assert_eq!(report["succeeded"], 4);
+    assert_eq!(report["failed"], 0);
+    for item in report["items"].as_array().unwrap() {
+        assert_eq!(item["status"], "success");
+        assert_eq!(item["outcome"], "complete");
+        assert_eq!(item["reasonCode"], "emptySource");
+        let target = PathBuf::from(item["output"].as_str().unwrap());
+        assert!(target.is_file(), "missing committed target {target:?}");
+    }
+}
+
+#[test]
+fn empty_stdout_is_explicit_in_reports_and_structured_output() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = temporary.path().join("empty.txt");
+    let report = temporary.path().join("stdout-report.json");
+    std::fs::write(&input, b"\n").unwrap();
+
+    let markdown = Command::new(binary())
+        .args(["--no-config", "--report"])
+        .arg(&report)
+        .arg(&input)
+        .output()
+        .unwrap();
+    assert!(markdown.status.success());
+    assert!(markdown.stdout.is_empty());
+    let report: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).unwrap()).unwrap();
+    assert_eq!(report["items"][0]["outcome"], "complete");
+    assert_eq!(report["items"][0]["reasonCode"], "emptySource");
+
+    let structured = Command::new(binary())
+        .args(["--no-config", "--emit", "result-json"])
+        .arg(&input)
+        .output()
+        .unwrap();
+    assert!(structured.status.success());
+    let result: serde_json::Value = serde_json::from_slice(&structured.stdout).unwrap();
+    assert_eq!(result["markdown"], "");
+    assert!(
+        result["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "emptySource")
+    );
+}
+
+#[test]
+fn empty_content_fails_batch_without_committing_a_false_success_target() {
+    let temporary = tempfile::tempdir().unwrap();
+    let good = temporary.path().join("good.txt");
+    let omitted = temporary.path().join("omitted.docx");
+    let output = temporary.path().join("output");
+    let report = temporary.path().join("report.json");
+    std::fs::write(&good, b"usable").unwrap();
+    std::fs::write(&omitted, alt_chunk_only_docx()).unwrap();
+
+    let result = Command::new(binary())
+        .args(["--no-config", "--output-dir"])
+        .arg(&output)
+        .args(["--report"])
+        .arg(&report)
+        .args([&good, &omitted])
+        .output()
+        .unwrap();
+
+    assert_eq!(result.status.code(), Some(10), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(output.join("good.md").is_file());
+    assert!(!std::fs::read(output.join("good.md")).unwrap().is_empty());
+    assert!(!output.join("omitted.md").exists());
+    let report: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).unwrap()).unwrap();
+    assert_eq!(report["succeeded"], 1);
+    assert_eq!(report["failed"], 1);
+    let failed =
+        report["items"].as_array().unwrap().iter().find(|item| item["status"] == "failed").unwrap();
+    assert_eq!(failed["outcome"], "failed");
+    assert_eq!(failed["errorCode"], "malformed");
+    assert_eq!(failed["reasonCode"], "emptyContent");
+    assert!(failed["output"].as_str().unwrap().ends_with("omitted.md"));
+}
+
+#[test]
+fn recoverable_omission_commits_nonempty_degraded_output() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = temporary.path().join("recovered.rtf");
+    let output = temporary.path().join("output");
+    let report = temporary.path().join("report.json");
+    std::fs::write(&input, br"{\rtf1\ansi visible \unknowncontrol42 text}").unwrap();
+
+    let result = Command::new(binary())
+        .args(["--no-config", "--output-dir"])
+        .arg(&output)
+        .args(["--report"])
+        .arg(&report)
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(!std::fs::read(output.join("recovered.md")).unwrap().is_empty());
+    let report: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).unwrap()).unwrap();
+    assert_eq!(report["succeeded"], 1);
+    assert_eq!(report["failed"], 0);
+    assert_eq!(report["items"][0]["status"], "success");
+    assert_eq!(report["items"][0]["outcome"], "degraded");
+    assert_eq!(report["items"][0]["reasonCode"], "rtf.unknownControlIgnored");
+}
+
+fn empty_docx() -> Vec<u8> {
+    docx(
+        r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body></w:body></w:document>"#,
+    )
+}
+
+fn alt_chunk_only_docx() -> Vec<u8> {
+    docx(
+        r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:altChunk/></w:body></w:document>"#,
+    )
+}
+
+fn docx(document: &str) -> Vec<u8> {
+    zip(&[
+        (
+            "[Content_Types].xml",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#,
+        ),
+        (
+            "_rels/.rels",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rDocument" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+        ),
+        ("word/document.xml", document),
+    ])
+}
+
+fn empty_xlsx() -> Vec<u8> {
+    zip(&[
+        (
+            "[Content_Types].xml",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/></Types>"#,
+        ),
+        (
+            "_rels/.rels",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+        ),
+        (
+            "xl/workbook.xml",
+            r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Empty" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+        ),
+        (
+            "xl/_rels/workbook.xml.rels",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#,
+        ),
+        (
+            "xl/styles.xml",
+            r#"<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><numFmts count="0"/><fonts count="1"><font/></fonts><fills count="1"><fill><patternFill patternType="none"/></fill></fills><borders count="1"><border/></borders><cellStyleXfs count="1"><xf numFmtId="0"/></cellStyleXfs><cellXfs count="1"><xf numFmtId="0"/></cellXfs></styleSheet>"#,
+        ),
+        (
+            "xl/worksheets/sheet1.xml",
+            r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>"#,
+        ),
+    ])
+}
+
+fn zip(parts: &[(&str, &str)]) -> Vec<u8> {
+    let mut output = Cursor::new(Vec::new());
+    {
+        let mut archive = zip::ZipWriter::new(&mut output);
+        for (name, bytes) in parts {
+            archive.start_file(*name, SimpleFileOptions::default()).unwrap();
+            archive.write_all(bytes.as_bytes()).unwrap();
+        }
+        archive.finish().unwrap();
+    }
+    output.into_inner()
+}

--- a/crates/api/src/zip_recursive_tests.rs
+++ b/crates/api/src/zip_recursive_tests.rs
@@ -1,6 +1,7 @@
 use crate::{
-    Block, BlockNode, CancellationToken, ConversionError, ConversionOptions, ConversionRequest,
-    ErrorCode, ExecutionOptions, FormatHint, Inline, InputFormat, InputRef, default_engine,
+    Block, BlockNode, CancellationToken, ConversionError, ConversionOptions, ConversionOutcome,
+    ConversionRequest, ErrorCode, ExecutionOptions, FormatHint, Inline, InputFormat, InputRef,
+    ResultContent, default_engine,
 };
 use std::future::Future;
 use std::io::{Cursor, Write as _};
@@ -153,7 +154,11 @@ fn empty_is_valid_but_all_failed_members_are_not_pseudo_success() {
     let empty = archive(&[], false);
     let result = convert(empty, ConversionOptions::default(), ExecutionOptions::default()).unwrap();
     assert!(result.document.blocks.is_empty());
-    assert!(result.diagnostics.is_empty());
+    assert_eq!(result.content().unwrap(), ResultContent::EmptySource);
+    assert_eq!(result.outcome(), ConversionOutcome::Complete);
+    assert_eq!(result.reason_code(), Some("emptySource"));
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(result.diagnostics[0].code, "emptySource");
 
     let unsupported = archive(&[("unknown.bin", b"\0\x01\x02")], false);
     assert!(matches!(

--- a/crates/converters/src/docx.rs
+++ b/crates/converters/src/docx.rs
@@ -6,7 +6,7 @@ use into_markdown_core::{
     Converter, ConverterOutput, Diagnostic, DiagnosticSeverity, Document, ExecutionContext,
     FormatCandidate, Inline, InlineMark, InputFormat, ListItem, ListKind, MAX_DOCUMENT_INLINES,
     MAX_DOCUMENT_NODES, MAX_TABLE_COLUMNS, NodeId, ProbeOutcome, Provenance, ProvenanceKind,
-    ResolvedInput, Services, SourceLocator, TableAlignment, TableRow,
+    ResolvedInput, Services, SourceContentEvidence, SourceLocator, TableAlignment, TableRow,
 };
 use quick_xml::events::{BytesCData, BytesRef, BytesStart, BytesText, Event};
 use quick_xml::name::ResolveResult;
@@ -721,7 +721,16 @@ fn convert_docx(
             error.detail
         ),
     })?;
-    Ok(ConverterOutput::new(state.document, state.assets, state.diagnostics))
+    let evidence = if state.document.blocks.is_empty()
+        && state.assets.is_empty()
+        && state.diagnostics.is_empty()
+    {
+        SourceContentEvidence::Empty
+    } else {
+        SourceContentEvidence::Unknown
+    };
+    Ok(ConverterOutput::new(state.document, state.assets, state.diagnostics)
+        .with_source_content_evidence(evidence))
 }
 
 fn relationship_target(

--- a/crates/converters/src/epub/merge.rs
+++ b/crates/converters/src/epub/merge.rs
@@ -69,20 +69,12 @@ pub(super) fn assemble(
         ));
     }
     if spine.skipped_non_linear > 0 {
-        output.diagnostics.push(diagnostic(
-            "epub.spine.nonLinearSkipped",
-            DiagnosticSeverity::Info,
-            format!("skipped {} non-linear spine item(s)", spine.skipped_non_linear),
-            Some(&package.path),
-        ));
+        output
+            .diagnostics
+            .push(non_linear_spine_diagnostic(spine.skipped_non_linear, &package.path));
     }
     if rights_metadata {
-        output.diagnostics.push(diagnostic(
-            "epub.rightsMetadataIgnored",
-            DiagnosticSeverity::Info,
-            "META-INF/rights.xml was retained as inert metadata and not interpreted".into(),
-            Some("META-INF/rights.xml"),
-        ));
+        output.diagnostics.push(rights_metadata_diagnostic());
     }
     for path in encryption.unavailable_fonts {
         output.diagnostics.push(diagnostic(
@@ -177,6 +169,28 @@ pub(super) fn assemble(
     })?;
     output.account_retained(context)
 }
+
+fn non_linear_spine_diagnostic(skipped: usize, package_path: &str) -> Diagnostic {
+    diagnostic(
+        "epub.spine.nonLinearSkipped",
+        DiagnosticSeverity::Warning,
+        format!("skipped {skipped} non-linear spine item(s)"),
+        Some(package_path),
+    )
+}
+
+fn rights_metadata_diagnostic() -> Diagnostic {
+    diagnostic(
+        "epub.rightsMetadataIgnored",
+        DiagnosticSeverity::Info,
+        "META-INF/rights.xml was retained as inert metadata and not interpreted".into(),
+        Some("META-INF/rights.xml"),
+    )
+}
+
+#[cfg(test)]
+#[path = "merge_tests.rs"]
+mod tests;
 
 fn append_navigation(
     blocks: &mut Vec<BlockNode>,
@@ -420,15 +434,24 @@ fn append_omitted_resource_diagnostic(output: &mut ConverterOutput, package: &Pa
         }
     }
     if css + fonts + media > 0 {
-        output.diagnostics.push(diagnostic(
-            "epub.unreferencedResourcesOmitted",
-            DiagnosticSeverity::Info,
-            format!(
-                "omitted {css} CSS, {fonts} font, and {media} audio/video manifest resource(s) without an IR reference contract"
-            ),
-            Some(&package.path),
-        ));
+        output.diagnostics.push(omitted_resources_diagnostic(css, fonts, media, &package.path));
     }
+}
+
+fn omitted_resources_diagnostic(
+    css: usize,
+    fonts: usize,
+    media: usize,
+    package_path: &str,
+) -> Diagnostic {
+    diagnostic(
+        "epub.unreferencedResourcesOmitted",
+        DiagnosticSeverity::Warning,
+        format!(
+            "omitted {css} CSS, {fonts} font, and {media} audio/video manifest resource(s) without a proven lossless IR mapping"
+        ),
+        Some(package_path),
+    )
 }
 
 fn node(id: String, block: Block, part: &str, kind: ProvenanceKind) -> BlockNode {

--- a/crates/converters/src/epub/merge_tests.rs
+++ b/crates/converters/src/epub/merge_tests.rs
@@ -1,0 +1,19 @@
+use super::{
+    non_linear_spine_diagnostic, omitted_resources_diagnostic, rights_metadata_diagnostic,
+};
+use into_markdown_core::{ConversionOutcome, DiagnosticSeverity, conversion_outcome};
+
+#[test]
+fn compatibility_audit_is_complete_but_omitted_chapter_is_degraded() {
+    let compatibility = rights_metadata_diagnostic();
+    assert_eq!(compatibility.severity, DiagnosticSeverity::Info);
+    assert_eq!(conversion_outcome(&[compatibility]), ConversionOutcome::Complete);
+
+    let omitted_chapter = non_linear_spine_diagnostic(1, "OPS/package.opf");
+    assert_eq!(omitted_chapter.severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&[omitted_chapter]), ConversionOutcome::Degraded);
+
+    let omitted_resources = omitted_resources_diagnostic(1, 1, 1, "OPS/package.opf");
+    assert_eq!(omitted_resources.severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&[omitted_resources]), ConversionOutcome::Degraded);
+}

--- a/crates/converters/src/image_converter/ocr.rs
+++ b/crates/converters/src/image_converter/ocr.rs
@@ -310,7 +310,7 @@ fn materialize_nodes(
         {
             diagnostics.push(Diagnostic {
                 code: "ocr.lowConfidence".into(),
-                severity: DiagnosticSeverity::Info,
+                severity: DiagnosticSeverity::Warning,
                 message: format!("OCR region {index} was omitted below the configured confidence"),
                 locator: Some(page_locator(
                     materialize.page,

--- a/crates/converters/src/image_converter/tests.rs
+++ b/crates/converters/src/image_converter/tests.rs
@@ -2,8 +2,9 @@ use super::*;
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 use into_markdown_core::{
     AiCapability, AiInput, AiOutput, AiProvider, AiRequest, BoundOcrResult, BoxFuture,
-    ExecutionOptions, Inline, OcrEngine, OcrEvidenceStage, OcrEvidenceStep, OcrOutputPlan,
-    OcrPolicy, OcrRecognition, OcrRegion, OcrRequest, OcrResult, ResourceLimits, SourceMetadata,
+    ConversionOutcome, ExecutionOptions, Inline, OcrEngine, OcrEvidenceStage, OcrEvidenceStep,
+    OcrOutputPlan, OcrPolicy, OcrRecognition, OcrRegion, OcrRequest, OcrResult, ResourceLimits,
+    SourceMetadata, conversion_outcome,
 };
 use std::collections::BTreeSet;
 use std::future::Future;
@@ -769,6 +770,28 @@ fn bound_ocr_emits_exact_geometry_confidence_and_chain() {
     assert!((evidence.regions[0].detection_confidence - 0.98).abs() < f32::EPSILON);
     assert_eq!(evidence.chain.len(), 3);
     assert_eq!(evidence.chain[2].stage, OcrEvidenceStage::Merge);
+}
+
+#[test]
+fn low_confidence_ocr_omission_is_degraded() {
+    let mut options = options();
+    options.ocr.policy = OcrPolicy::Always;
+    options.ocr.minimum_confidence = 0.99;
+    let services = Services { ocr: Some(Arc::new(BoundOcr)), ..Services::default() };
+    let output = block_on(convert_image(
+        &input(encoded(ImageFormat::Png), "low-confidence.png"),
+        &options,
+        &services,
+        &context(&options),
+    ))
+    .unwrap();
+    let diagnostic = output
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "ocr.lowConfidence")
+        .unwrap();
+    assert_eq!(diagnostic.severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&output.diagnostics), ConversionOutcome::Degraded);
 }
 
 struct LegacyOcr;

--- a/crates/converters/src/markdown.rs
+++ b/crates/converters/src/markdown.rs
@@ -6,7 +6,7 @@ use into_markdown_core::{
     Converter, ConverterOutput, Diagnostic, DiagnosticSeverity, Document, ExecutionContext,
     FormatCandidate, Inline, InlineMark, InputFormat, ListItem, ListKind, MAX_DOCUMENT_INLINES,
     MAX_DOCUMENT_NODES, NodeId, ProbeOutcome, Provenance, ProvenanceKind, ResolvedInput, Services,
-    SourceLocator, TableAlignment, TableRow, canonical_external_asset_uri,
+    SourceContentEvidence, SourceLocator, TableAlignment, TableRow, canonical_external_asset_uri,
 };
 use pulldown_cmark::{
     Alignment, CodeBlockKind, CowStr, Event, HeadingLevel, Options, Parser, Tag, TagEnd,
@@ -169,6 +169,10 @@ pub(crate) fn convert_markdown(
     }
     let (mut decoded, mut diagnostics) =
         text::decode_source(&input.bytes, Some("utf-8"), options.text.decoding_mode, context)?;
+    if diagnostics.is_empty() && decoded.text.chars().all(char::is_whitespace) {
+        return Ok(ConverterOutput::new(Document::default(), Vec::new(), diagnostics)
+            .with_source_content_evidence(SourceContentEvidence::Empty));
+    }
     scan_duplicate_definitions(&mut decoded, &mut diagnostics, context)?;
     let mut builder = Builder::new(&decoded, options, context, diagnostics)?;
     builder.parse()?;

--- a/crates/converters/src/presentation/mod.rs
+++ b/crates/converters/src/presentation/mod.rs
@@ -34,8 +34,9 @@ use into_markdown_core::{
     Block, BoxFuture, ConversionError, ConversionOptions, Converter, ConverterEventSink,
     ConverterOutput, ConverterStream, ConverterStreamCompletion, ConverterStreamMode, Diagnostic,
     DiagnosticSeverity, ExecutionContext, FormatCandidate, Inline, InputFormat, LocalBoxFuture,
-    ProbeOutcome, ResolvedInput, Services, SourceLocator, StreamConsumerKind,
-    estimate_retained_output, estimate_validation_working_set, stream_converter_output,
+    ProbeOutcome, ResolvedInput, Services, SourceContentEvidence, SourceLocator,
+    StreamConsumerKind, document_is_empty, estimate_retained_output,
+    estimate_validation_working_set, stream_converter_output,
 };
 use model::{Package, ParseState};
 use output::shapes_to_blocks;
@@ -278,7 +279,7 @@ fn convert_presentation(
             })?;
             state.diagnostics.push(Diagnostic {
                 code: "presentation.hiddenSlideSkipped".into(),
-                severity: DiagnosticSeverity::Info,
+                severity: DiagnosticSeverity::Warning,
                 message: format!("hidden slide {slide_number} was deterministically omitted"),
                 locator: Some(SourceLocator {
                     slide: Some(slide_number),
@@ -464,7 +465,16 @@ fn convert_presentation(
     if package.memory_bytes < retained {
         package.grow_memory(retained - package.memory_bytes)?;
     }
-    let output = ConverterOutput::new(state.document, state.assets, state.diagnostics);
+    let evidence = if document_is_empty(&state.document)
+        && state.assets.is_empty()
+        && state.diagnostics.is_empty()
+    {
+        SourceContentEvidence::Empty
+    } else {
+        SourceContentEvidence::Unknown
+    };
+    let output = ConverterOutput::new(state.document, state.assets, state.diagnostics)
+        .with_source_content_evidence(evidence);
     let Package { memory, .. } = package;
     output.certify_preflight_reservation(context, memory)
 }

--- a/crates/converters/src/presentation/tests/conversion.rs
+++ b/crates/converters/src/presentation/tests/conversion.rs
@@ -2,8 +2,9 @@ use super::super::relationships::resolve_target;
 use super::super::schema::{A_NS, LAYOUT_REL, P_NS, R_NS, REL_NS, REL_PREFIX, SLIDE_REL};
 use super::support::{block_on, convert, fixture, rewrite_part, zip};
 use into_markdown_core::{
-    Block, ConversionError, ConversionOptions, ExecutionContext, ExecutionOptions, FormatDetector,
-    FormatHint, InputFormat, ResolvedInput, SourceMetadata,
+    Block, ConversionError, ConversionOptions, ConversionOutcome, DiagnosticSeverity,
+    ExecutionContext, ExecutionOptions, FormatDetector, FormatHint, InputFormat, ResolvedInput,
+    SourceMetadata, conversion_outcome,
 };
 use into_markdown_render_markdown::render;
 use std::io::{Cursor, Read};
@@ -122,6 +123,8 @@ fn multiple_slide_boundaries_and_hidden_slide_order_are_deterministic() {
     assert_eq!(output.document.blocks.len(), 1);
     assert!(matches!(output.document.blocks[0].block, Block::Slide { number: 2, .. }));
     assert_eq!(output.diagnostics[0].code, "presentation.hiddenSlideSkipped");
+    assert_eq!(output.diagnostics[0].severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&output.diagnostics), ConversionOutcome::Degraded);
     assert_eq!(output.diagnostics[0].locator.as_ref().unwrap().slide, Some(1));
 }
 

--- a/crates/converters/src/rtf/control.rs
+++ b/crates/converters/src/rtf/control.rs
@@ -271,7 +271,7 @@ impl Parser<'_> {
             _ if is_known_non_destination_control(name) => {}
             _ => self.add_diagnostic(
                 "rtf.unknownControlIgnored",
-                DiagnosticSeverity::Info,
+                DiagnosticSeverity::Warning,
                 "unknown non-destination control word was ignored",
                 Some(locator(start, end)),
             )?,
@@ -309,7 +309,7 @@ impl Parser<'_> {
             _ => {
                 self.add_diagnostic(
                     "rtf.unknownControlSymbolIgnored",
-                    DiagnosticSeverity::Info,
+                    DiagnosticSeverity::Warning,
                     "unknown control symbol was ignored",
                     Some(locator(start, end)),
                 )?;

--- a/crates/converters/src/rtf/parser.rs
+++ b/crates/converters/src/rtf/parser.rs
@@ -265,7 +265,9 @@ impl<'a> Parser<'a> {
         }
         self.flush_pending_surrogate()?;
         self.finish_table_or_paragraph(self.bytes.len())?;
-        if self.blocks.is_empty() && self.assets.is_empty() {
+        let source_is_empty =
+            self.blocks.is_empty() && self.assets.is_empty() && self.diagnostics.is_empty();
+        if source_is_empty {
             self.add_diagnostic(
                 "rtf.emptyDocument",
                 DiagnosticSeverity::Info,
@@ -294,7 +296,18 @@ impl<'a> Parser<'a> {
         // table, and decode buffer has been dropped. Only then may the retained-output
         // authority shrink the same authenticated reservation to the live IR/assets.
         drop(self);
-        ConverterOutput::new_with_memory_reservation(document, assets, diagnostics, context, memory)
+        let output = ConverterOutput::new_with_memory_reservation(
+            document,
+            assets,
+            diagnostics,
+            context,
+            memory,
+        )?;
+        Ok(if source_is_empty {
+            output.with_source_content_evidence(into_markdown_core::SourceContentEvidence::Empty)
+        } else {
+            output
+        })
     }
 
     pub(super) fn state(&self) -> &State {

--- a/crates/converters/src/rtf/tests.rs
+++ b/crates/converters/src/rtf/tests.rs
@@ -382,9 +382,22 @@ fn table_list_and_safe_field_map_to_structured_ir() {
         !link.diagnostics.iter().any(|diagnostic| diagnostic.code == "rtf.unknownControlIgnored")
     );
     let unknown = convert(b"{\\rtf1\\ansi\\definitelyunknown text}").unwrap();
-    assert!(
-        unknown.diagnostics.iter().any(|diagnostic| diagnostic.code == "rtf.unknownControlIgnored")
-    );
+    let diagnostic = unknown
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "rtf.unknownControlIgnored")
+        .unwrap();
+    assert_eq!(diagnostic.severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&unknown.diagnostics), ConversionOutcome::Degraded);
+}
+
+#[test]
+fn empty_rtf_is_certified_without_degrading_its_audit_diagnostic() {
+    let output = convert(b"{\\rtf1\\ansi}").unwrap();
+    assert_eq!(output.source_content_evidence(), SourceContentEvidence::Empty);
+    assert_eq!(output.diagnostics[0].code, "rtf.emptyDocument");
+    assert_eq!(output.diagnostics[0].severity, DiagnosticSeverity::Info);
+    assert_eq!(conversion_outcome(&output.diagnostics), ConversionOutcome::Complete);
 }
 
 #[test]

--- a/crates/converters/src/text.rs
+++ b/crates/converters/src/text.rs
@@ -7,7 +7,8 @@ use into_markdown_core::{
     Block, BlockNode, BoxFuture, ConversionError, ConversionOptions, Converter, ConverterOutput,
     Diagnostic, DiagnosticSeverity, Document, ExecutionContext, FormatCandidate, Inline,
     InputFormat, MAX_DOCUMENT_INLINES, MAX_DOCUMENT_NODES, NodeId, ProbeOutcome, Provenance,
-    ProvenanceKind, ResolvedInput, ResourceReservation, Services, SourceLocator, TextDecodingMode,
+    ProvenanceKind, ResolvedInput, ResourceReservation, Services, SourceContentEvidence,
+    SourceLocator, TextDecodingMode,
 };
 use std::mem::size_of;
 
@@ -805,6 +806,11 @@ fn convert_text(
         options.text.decoding_mode,
         context,
     )?;
+    let source_is_empty = diagnostics.is_empty() && decoded.text.chars().all(char::is_whitespace);
+    if source_is_empty {
+        return Ok(ConverterOutput::new(Document::default(), Vec::new(), diagnostics)
+            .with_source_content_evidence(SourceContentEvidence::Empty));
+    }
     let max_decoded_text_bytes =
         size.checked_mul(3).ok_or_else(|| ConversionError::ResourceLimit {
             limit: "max_text_decoded_bytes",

--- a/crates/converters/src/workbook/mod.rs
+++ b/crates/converters/src/workbook/mod.rs
@@ -27,7 +27,7 @@ use into_markdown_core::{
     BoxFuture, ConversionError, ConversionOptions, Converter, ConverterEventSink, ConverterOutput,
     ConverterStream, ConverterStreamCompletion, ConverterStreamMode, ExecutionContext,
     FormatCandidate, InputFormat, LocalBoxFuture, ProbeOutcome, ResolvedInput, Services,
-    StreamConsumerKind, stream_converter_output,
+    SourceContentEvidence, StreamConsumerKind, document_is_empty, stream_converter_output,
 };
 
 const FORMATS: &[InputFormat] = &[InputFormat::Xlsx];
@@ -43,7 +43,15 @@ pub(crate) fn convert_legacy_xls(
     options: &ConversionOptions,
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
-    calamine_adapter::convert_xls(bytes, options, context)
+    let output = calamine_adapter::convert_xls(bytes, options, context)?;
+    if document_is_empty(&output.document)
+        && output.assets.is_empty()
+        && output.diagnostics.is_empty()
+    {
+        Ok(output.with_source_content_evidence(SourceContentEvidence::Empty))
+    } else {
+        Ok(output)
+    }
 }
 
 impl Converter for WorkbookConverter {

--- a/crates/converters/src/workbook/orchestrator.rs
+++ b/crates/converters/src/workbook/orchestrator.rs
@@ -4,7 +4,8 @@ use crate::workbook::model::WorkbookKind;
 use crate::workbook::preflight::preflight_package;
 use into_markdown_core::{
     Block, BlockNode, ConversionError, ConversionOptions, ConverterOutput, ExecutionContext,
-    estimate_retained_output, estimate_validation_working_set,
+    SourceContentEvidence, document_is_empty, estimate_retained_output,
+    estimate_validation_working_set,
 };
 
 pub(super) fn convert_workbook(
@@ -87,6 +88,12 @@ pub(super) fn convert_workbook(
             .metadata
             .properties
             .insert(format!("spreadsheet.preflight.{name}"), value.to_string());
+    }
+    if document_is_empty(&output.document)
+        && output.assets.is_empty()
+        && output.diagnostics.is_empty()
+    {
+        output = output.with_source_content_evidence(SourceContentEvidence::Empty);
     }
     output.document.validate().map_err(|error| ConversionError::Internal {
         detail: format!("workbook converter produced invalid IR: {error}"),

--- a/crates/converters/src/zip/recursive.rs
+++ b/crates/converters/src/zip/recursive.rs
@@ -4,7 +4,7 @@ use super::entry_policy::EntryKind;
 use super::merge::MergeState;
 use into_markdown_core::{
     BoxFuture, ConversionError, ConversionOptions, ConverterOutput, ErrorCode, FormatHint,
-    NestedConversionRequest, ResolvedInput, Services, SourceMetadata,
+    NestedConversionRequest, ResolvedInput, Services, SourceContentEvidence, SourceMetadata,
 };
 use std::sync::Arc;
 
@@ -30,7 +30,13 @@ pub(super) async fn convert<'a>(
             ConversionError::Unsupported { detail: "ZIP contains no convertible members".into() }
         }));
     }
-    walker.merge.finish()
+    let has_leaf_content = walker.stats.leaves != 0;
+    let output = walker.merge.finish()?;
+    Ok(if has_leaf_content {
+        output
+    } else {
+        output.with_source_content_evidence(SourceContentEvidence::Empty)
+    })
 }
 
 struct RecursiveConverter<'a> {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -83,6 +83,10 @@ pub enum ConversionError {
         /// Human-readable structural failure.
         detail: String,
     },
+    /// Conversion completed structurally but produced no usable content and
+    /// the converter did not certify that the source itself was empty.
+    #[error("conversion produced no usable content")]
+    EmptyContent,
     /// The input cannot be opened without a password.
     #[error("input is encrypted or password protected")]
     Encrypted,
@@ -159,7 +163,7 @@ impl ConversionError {
         match self {
             Self::Unsupported { .. } => ErrorCode::Unsupported,
             Self::NoConverter { .. } => ErrorCode::NoConverter,
-            Self::Malformed { .. } => ErrorCode::Malformed,
+            Self::Malformed { .. } | Self::EmptyContent => ErrorCode::Malformed,
             Self::Encrypted => ErrorCode::Encrypted,
             Self::ResourceLimit { .. } => ErrorCode::ResourceLimit,
             Self::Ocr { .. } => ErrorCode::Ocr,
@@ -178,6 +182,7 @@ impl ConversionError {
     #[must_use]
     pub const fn reason_code(&self) -> &'static str {
         match self {
+            Self::EmptyContent => "emptyContent",
             Self::Recovery { reason, .. } => reason,
             Self::ResourceLimit { limit, .. } => limit,
             _ => self.code().as_str(),
@@ -229,6 +234,7 @@ mod tests {
             (ConversionError::Unsupported { detail: String::new() }, "unsupported"),
             (ConversionError::NoConverter { format: "pdf".into() }, "noConverter"),
             (ConversionError::Malformed { part: None, detail: String::new() }, "malformed"),
+            (ConversionError::EmptyContent, "malformed"),
             (ConversionError::Encrypted, "encrypted"),
             (
                 ConversionError::ResourceLimit { limit: "bytes", detail: String::new() },

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,6 +15,7 @@ mod media_checkpoint;
 mod nested;
 mod ocr_binding;
 mod options;
+mod result_policy;
 mod spi;
 mod stream;
 mod summary;
@@ -60,6 +61,12 @@ pub use options::{
     DelimitedTextOptions, DiarizationOptions, ErrorPolicy, NetworkOptions, OcrOptions, OcrPolicy,
     OutputOptions, RaggedRowsMode, ResourceLimits, TableHeaderMode, TextDecodingMode, TextOptions,
 };
+pub use result_policy::{
+    ASSET_ONLY_REASON_CODE, EMPTY_SOURCE_REASON_CODE, ResultContent, SourceContentEvidence,
+    classify_result, conversion_outcome, markdown_has_visible_content,
+};
+#[doc(hidden)]
+pub use result_policy::{document_is_asset_only, document_is_empty};
 pub use spi::{
     AiCapability, AiInput, AiOutput, AiProvider, AiRequest, ArtifactSink, AssetStreamInfo,
     BoxFuture, ConversionOutcome, ConversionRequest, ConversionResult, ConversionSummary,

--- a/crates/core/src/result_policy.rs
+++ b/crates/core/src/result_policy.rs
@@ -1,0 +1,363 @@
+//! Format-independent completion semantics for rendered conversion results.
+
+use crate::{
+    Asset, Block, ConversionError, ConversionOutcome, ConversionResult, Diagnostic,
+    DiagnosticSeverity, Document, Inline,
+};
+
+/// Stable diagnostic emitted when a converter proves that the source has no
+/// visible document content.
+pub const EMPTY_SOURCE_REASON_CODE: &str = "emptySource";
+
+/// Stable diagnostic emitted for useful asset-backed results whose Markdown
+/// representation is empty.
+pub const ASSET_ONLY_REASON_CODE: &str = "assetOnly";
+
+/// Converter-owned evidence used by the shared empty-result gate.
+///
+/// The default is fail-closed. `Empty` is valid only after the converter has
+/// scanned every visible-content domain it supports. `AssetsOnly` additionally
+/// requires retained IR references and a retained asset inventory.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SourceContentEvidence {
+    /// The converter cannot prove why a rendered result is empty.
+    #[default]
+    Unknown,
+    /// The converter proved that the source has no visible document content.
+    Empty,
+    /// The source contains only useful asset-backed document content.
+    AssetsOnly,
+}
+
+/// Usable content class of a completed result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResultContent {
+    /// Markdown contains a non-whitespace scalar.
+    Markdown,
+    /// The source was explicitly certified as empty.
+    EmptySource,
+    /// Structured IR and assets remain useful despite empty Markdown.
+    AssetsOnly,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum DocumentContent {
+    #[default]
+    Empty,
+    AssetsOnly,
+    Visible,
+}
+
+impl DocumentContent {
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Visible, _) | (_, Self::Visible) => Self::Visible,
+            (Self::AssetsOnly, _) | (_, Self::AssetsOnly) => Self::AssetsOnly,
+            _ => Self::Empty,
+        }
+    }
+}
+
+/// Classify the semantic content retained by a document independently of its
+/// format-specific container structure.
+#[must_use]
+pub(crate) fn document_content(document: &Document) -> DocumentContent {
+    document
+        .blocks
+        .iter()
+        .map(|node| block_content(&node.block))
+        .fold(DocumentContent::Empty, DocumentContent::merge)
+}
+
+/// Whether a converter result has no visible semantic body content.
+#[doc(hidden)]
+#[must_use]
+pub fn document_is_empty(document: &Document) -> bool {
+    document_content(document) == DocumentContent::Empty
+}
+
+/// Whether every visible semantic node is an asset reference.
+#[doc(hidden)]
+#[must_use]
+pub fn document_is_asset_only(document: &Document) -> bool {
+    document_content(document) == DocumentContent::AssetsOnly
+}
+
+/// Whether Markdown contains a usable non-whitespace scalar. A leading BOM is
+/// transport metadata and is not content by itself.
+#[must_use]
+pub fn markdown_has_visible_content(markdown: &str) -> bool {
+    markdown.chars().any(|value| !value.is_whitespace() && value != '\u{feff}')
+}
+
+/// Derive the stable success outcome without treating informational audit
+/// diagnostics as content loss.
+#[must_use]
+pub fn conversion_outcome(diagnostics: &[Diagnostic]) -> ConversionOutcome {
+    if diagnostics.iter().any(|value| value.severity != DiagnosticSeverity::Info) {
+        ConversionOutcome::Degraded
+    } else {
+        ConversionOutcome::Complete
+    }
+}
+
+/// Validate and classify a completed result.
+///
+/// # Errors
+///
+/// Returns `emptyContent` for an unusable empty result and `internal` for
+/// contradictory engine-reserved evidence.
+pub fn classify_result(
+    document: &Document,
+    markdown: &str,
+    assets: &[Asset],
+    diagnostics: &[Diagnostic],
+) -> Result<ResultContent, ConversionError> {
+    let empty_source = has_reason(diagnostics, EMPTY_SOURCE_REASON_CODE);
+    let asset_only = has_reason(diagnostics, ASSET_ONLY_REASON_CODE);
+    if empty_source && asset_only {
+        return Err(ConversionError::Internal {
+            detail: "result carries conflicting empty-source and asset-only evidence".into(),
+        });
+    }
+    let content = document_content(document);
+    if empty_source {
+        if content != DocumentContent::Empty || !assets.is_empty() {
+            return Err(ConversionError::Internal {
+                detail: "empty-source evidence conflicts with retained document content".into(),
+            });
+        }
+        if markdown_has_visible_content(markdown) {
+            return Ok(ResultContent::Markdown);
+        }
+        return Ok(ResultContent::EmptySource);
+    }
+    if asset_only {
+        if content != DocumentContent::AssetsOnly || assets.is_empty() {
+            return Err(ConversionError::Internal {
+                detail: "asset-only evidence requires asset-only IR and retained assets".into(),
+            });
+        }
+        if markdown_has_visible_content(markdown) {
+            return Ok(ResultContent::Markdown);
+        }
+        return Ok(ResultContent::AssetsOnly);
+    }
+    if markdown_has_visible_content(markdown) {
+        Ok(ResultContent::Markdown)
+    } else {
+        Err(ConversionError::EmptyContent)
+    }
+}
+
+impl ConversionResult {
+    /// Validate and return this result's usable content class.
+    ///
+    /// # Errors
+    ///
+    /// Returns the shared empty-result failure when the result is unusable.
+    pub fn content(&self) -> Result<ResultContent, ConversionError> {
+        classify_result(&self.document, &self.markdown, &self.assets, &self.diagnostics)
+    }
+
+    /// Stable success outcome derived from diagnostic severity.
+    #[must_use]
+    pub fn outcome(&self) -> ConversionOutcome {
+        conversion_outcome(&self.diagnostics)
+    }
+
+    /// Stable success reason for exceptional usable results.
+    #[must_use]
+    pub fn reason_code(&self) -> Option<&str> {
+        if let Some(diagnostic) =
+            self.diagnostics.iter().find(|value| value.severity != DiagnosticSeverity::Info)
+        {
+            Some(diagnostic.code.as_str())
+        } else if has_reason(&self.diagnostics, EMPTY_SOURCE_REASON_CODE) {
+            Some(EMPTY_SOURCE_REASON_CODE)
+        } else if has_reason(&self.diagnostics, ASSET_ONLY_REASON_CODE) {
+            Some(ASSET_ONLY_REASON_CODE)
+        } else {
+            None
+        }
+    }
+}
+
+impl crate::ConversionSummary {
+    /// Stable reason for an exceptional successful completion.
+    #[must_use]
+    pub fn reason_code(&self) -> Option<&str> {
+        if let Some(diagnostic) =
+            self.diagnostics.iter().find(|value| value.severity != DiagnosticSeverity::Info)
+        {
+            Some(diagnostic.code.as_str())
+        } else if has_reason(&self.diagnostics, EMPTY_SOURCE_REASON_CODE) {
+            Some(EMPTY_SOURCE_REASON_CODE)
+        } else if has_reason(&self.diagnostics, ASSET_ONLY_REASON_CODE) {
+            Some(ASSET_ONLY_REASON_CODE)
+        } else {
+            None
+        }
+    }
+}
+
+fn has_reason(diagnostics: &[Diagnostic], code: &str) -> bool {
+    diagnostics.iter().any(|value| value.code == code)
+}
+
+fn block_content(block: &Block) -> DocumentContent {
+    match block {
+        Block::Paragraph(values) => inline_content(values),
+        Block::Heading { content, .. } | Block::TimedSegment { content, .. } => {
+            inline_content(content)
+        }
+        Block::List { items, .. } => items
+            .iter()
+            .flat_map(|item| &item.blocks)
+            .map(|node| block_content(&node.block))
+            .fold(DocumentContent::Empty, DocumentContent::merge),
+        Block::Table { rows, .. } => {
+            if rows.is_empty() {
+                DocumentContent::Empty
+            } else {
+                DocumentContent::Visible
+            }
+        }
+        Block::Code { text, .. } | Block::Formula(text) => {
+            if text.is_empty() {
+                DocumentContent::Empty
+            } else {
+                DocumentContent::Visible
+            }
+        }
+        Block::Footnote { blocks, .. }
+        | Block::Page { blocks, .. }
+        | Block::Sheet { blocks, .. } => blocks
+            .iter()
+            .map(|node| block_content(&node.block))
+            .fold(DocumentContent::Empty, DocumentContent::merge),
+        Block::Slide { title, blocks, .. } => {
+            let title = title.as_deref().is_some_and(|value| !value.trim().is_empty());
+            if title {
+                DocumentContent::Visible
+            } else {
+                blocks
+                    .iter()
+                    .map(|node| block_content(&node.block))
+                    .fold(DocumentContent::Empty, DocumentContent::merge)
+            }
+        }
+        Block::Image { .. } => DocumentContent::AssetsOnly,
+        Block::Rule => DocumentContent::Visible,
+    }
+}
+
+fn inline_content(values: &[Inline]) -> DocumentContent {
+    if values.iter().any(inline_is_visible) {
+        DocumentContent::Visible
+    } else {
+        DocumentContent::Empty
+    }
+}
+
+fn inline_is_visible(value: &Inline) -> bool {
+    match value {
+        Inline::Text { value, .. }
+        | Inline::SourceText { value, .. }
+        | Inline::OcrText { value, .. }
+        | Inline::Code(value)
+        | Inline::Formula(value) => markdown_has_visible_content(value),
+        Inline::Link { content, .. } => content.iter().any(inline_is_visible),
+        Inline::FootnoteReference(_) => true,
+        Inline::LineBreak => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Diagnostic, Document};
+
+    fn diagnostic(code: &str, severity: DiagnosticSeverity) -> Diagnostic {
+        Diagnostic { code: code.into(), severity, message: code.into(), locator: None }
+    }
+
+    #[test]
+    fn empty_results_require_explicit_evidence() {
+        let document = Document::default();
+        assert!(matches!(
+            classify_result(&document, "", &[], &[]),
+            Err(ConversionError::EmptyContent)
+        ));
+        assert_eq!(
+            classify_result(
+                &document,
+                "",
+                &[],
+                &[diagnostic(EMPTY_SOURCE_REASON_CODE, DiagnosticSeverity::Info)]
+            )
+            .unwrap(),
+            ResultContent::EmptySource
+        );
+    }
+
+    #[test]
+    fn informational_evidence_does_not_degrade_success() {
+        assert_eq!(
+            conversion_outcome(&[diagnostic(EMPTY_SOURCE_REASON_CODE, DiagnosticSeverity::Info)]),
+            ConversionOutcome::Complete
+        );
+        assert_eq!(
+            conversion_outcome(&[diagnostic("omitted", DiagnosticSeverity::Warning)]),
+            ConversionOutcome::Degraded
+        );
+    }
+
+    #[test]
+    fn visible_recovery_is_degraded_and_uses_the_first_loss_reason() {
+        let result = ConversionResult::new(
+            Document::default(),
+            "[Unsupported media]".into(),
+            Vec::new(),
+            vec![diagnostic("media.omitted", DiagnosticSeverity::Warning)],
+            Vec::new(),
+        );
+        assert_eq!(result.content().unwrap(), ResultContent::Markdown);
+        assert_eq!(result.outcome(), ConversionOutcome::Degraded);
+        assert_eq!(result.reason_code(), Some("media.omitted"));
+    }
+
+    #[test]
+    fn asset_only_evidence_does_not_override_visible_markdown() {
+        let id = crate::AssetId("asset".into());
+        let document = Document {
+            blocks: vec![crate::BlockNode {
+                id: crate::NodeId("image".into()),
+                block: Block::Image { asset: id.clone(), alt: None },
+                provenance: crate::Provenance {
+                    kind: crate::ProvenanceKind::NativeParser,
+                    provider: "test".into(),
+                    locator: crate::SourceLocator::default(),
+                    confidence: None,
+                },
+            }],
+            ..Document::default()
+        };
+        let assets = vec![Asset {
+            id,
+            filename: None,
+            media_type: "image/png".into(),
+            bytes: vec![1],
+            external_uri: None,
+        }];
+        let diagnostics = vec![diagnostic(ASSET_ONLY_REASON_CODE, DiagnosticSeverity::Info)];
+        assert_eq!(
+            classify_result(&document, "![image](asset.png)", &assets, &diagnostics).unwrap(),
+            ResultContent::Markdown
+        );
+        assert_eq!(
+            classify_result(&document, "", &assets, &diagnostics).unwrap(),
+            ResultContent::AssetsOnly
+        );
+    }
+}

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -134,9 +134,10 @@ pub struct AssetStreamInfo {
 /// Semantic result of a completed streaming conversion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConversionOutcome {
-    /// No recoverable content was omitted or sanitized.
+    /// No recoverable content was omitted, replaced, or sanitized.
     Complete,
-    /// Conversion completed with one or more diagnostics.
+    /// Conversion completed with usable output after a recoverable omission,
+    /// replacement, or sanitization.
     Degraded,
 }
 
@@ -408,6 +409,8 @@ pub struct ConverterOutput {
     pub assets: Vec<Asset>,
     /// Recoveries and scoped failures.
     pub diagnostics: Vec<Diagnostic>,
+    /// Converter-owned evidence consumed by the shared empty-result policy.
+    source_content_evidence: crate::SourceContentEvidence,
     /// Live memory charges transferred with the output until the engine has assembled its result.
     memory_lease: OutputMemoryLease,
 }
@@ -416,7 +419,13 @@ impl ConverterOutput {
     /// Construct an output without transferred charges.
     #[must_use]
     pub fn new(document: Document, assets: Vec<Asset>, diagnostics: Vec<Diagnostic>) -> Self {
-        Self { document, assets, diagnostics, memory_lease: OutputMemoryLease::default() }
+        Self {
+            document,
+            assets,
+            diagnostics,
+            source_content_evidence: crate::SourceContentEvidence::Unknown,
+            memory_lease: OutputMemoryLease::default(),
+        }
     }
 
     /// Construct converter output with reservations attached exactly once.
@@ -433,6 +442,7 @@ impl ConverterOutput {
             document,
             assets,
             diagnostics,
+            source_content_evidence: crate::SourceContentEvidence::Unknown,
             memory_lease: OutputMemoryLease::from_reservations(leases),
         }
     }
@@ -451,7 +461,27 @@ impl ConverterOutput {
         certify_recovered_reservation(context, &mut lease, retained)?;
         let mut memory_lease = OutputMemoryLease::from_reservation(lease)?;
         memory_lease.accounted_bytes = retained;
-        Ok(Self { document, assets, diagnostics, memory_lease })
+        Ok(Self {
+            document,
+            assets,
+            diagnostics,
+            source_content_evidence: crate::SourceContentEvidence::Unknown,
+            memory_lease,
+        })
+    }
+
+    /// Attach converter-owned source-content evidence.
+    #[must_use]
+    pub fn with_source_content_evidence(mut self, evidence: crate::SourceContentEvidence) -> Self {
+        self.source_content_evidence = evidence;
+        self
+    }
+
+    /// Read converter-owned source-content evidence at the engine boundary.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn source_content_evidence(&self) -> crate::SourceContentEvidence {
+        self.source_content_evidence
     }
 
     /// Bind live reservations to this output using the central retained-size
@@ -560,7 +590,8 @@ impl ConverterOutput {
         provenance: Vec<Provenance>,
         reservations: [Option<ResourceReservation>; 3],
     ) -> Result<ConversionResult, ConversionError> {
-        let Self { document, assets, diagnostics, mut memory_lease } = self;
+        let Self { document, assets, diagnostics, source_content_evidence: _, mut memory_lease } =
+            self;
         for reservation in reservations.into_iter().flatten() {
             memory_lease.push(reservation)?;
         }

--- a/crates/core/src/summary.rs
+++ b/crates/core/src/summary.rs
@@ -1,7 +1,7 @@
 //! Completion-summary ownership and accounting.
 
 use crate::spi::OutputMemoryLease;
-use crate::{ConversionOutcome, ConversionResult, ConversionSummary};
+use crate::{ConversionResult, ConversionSummary};
 
 impl Clone for ConversionSummary {
     fn clone(&self) -> Self {
@@ -34,11 +34,7 @@ impl ConversionResult {
     #[doc(hidden)]
     #[must_use]
     pub fn into_summary(self) -> ConversionSummary {
-        let outcome = if self.diagnostics.is_empty() {
-            ConversionOutcome::Complete
-        } else {
-            ConversionOutcome::Degraded
-        };
+        let outcome = self.outcome();
         ConversionSummary {
             format: self.detected_format,
             outcome,

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -6,6 +6,7 @@ mod nested;
 mod preparation;
 mod recovery;
 mod rendering;
+mod result_policy;
 mod result_sink;
 mod stream_execution;
 
@@ -374,6 +375,12 @@ impl Engine {
             &context,
         )
         .await?;
+        let output = result_policy::attach_evidence(
+            output,
+            source.input(),
+            attempt.candidate.format,
+            &context,
+        )?;
         let renderer = self.renderer.as_ref().ok_or_else(|| ConversionError::Internal {
             detail: "no Markdown renderer is registered".into(),
         })?;
@@ -1344,8 +1351,8 @@ mod tests {
         }
     }
 
-    struct EmptyRenderer;
-    impl MarkdownRenderer for EmptyRenderer {
+    struct TitleRenderer;
+    impl MarkdownRenderer for TitleRenderer {
         fn id(&self) -> &'static str {
             "test.renderer"
         }
@@ -1360,12 +1367,12 @@ mod tests {
         }
         fn render<'a>(
             &'a self,
-            _: &'a Document,
+            document: &'a Document,
             _: &'a [Asset],
             _: &'a ConversionOptions,
             _: &'a ExecutionContext,
         ) -> BoxFuture<'a, Result<String, ConversionError>> {
-            Box::pin(async { Ok(String::new()) })
+            Box::pin(async move { Ok(document.metadata.title.clone().unwrap_or_default()) })
         }
     }
 
@@ -1663,7 +1670,7 @@ mod tests {
     #[test]
     fn output_enrichers_run_in_registration_order_before_rendering() {
         let mut builder = EngineBuilder::new()
-            .renderer(Arc::new(EmptyRenderer))
+            .renderer(Arc::new(TitleRenderer))
             .enricher(Arc::new(TitleEnricher { id: "first.enricher", suffix: ":one" }))
             .enricher(Arc::new(TitleEnricher { id: "second.enricher", suffix: ":two" }));
         builder
@@ -1770,7 +1777,7 @@ mod tests {
 
     #[test]
     fn stable_id_breaks_equal_confidence_and_priority_ties() {
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(BytesResolver))
@@ -1785,7 +1792,7 @@ mod tests {
 
     #[test]
     fn invalid_converter_ir_is_rejected_before_rendering() {
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(BytesResolver))
@@ -1800,7 +1807,7 @@ mod tests {
 
     #[test]
     fn overdeep_converter_ir_is_bounded_before_retained_estimation() {
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(BytesResolver))
@@ -1859,7 +1866,7 @@ mod tests {
     fn converter_credit_requires_each_coexisting_owner_before_allocation() {
         let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let observed = Arc::new(Mutex::new(None));
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(TrackingBytesResolver {
@@ -1891,7 +1898,7 @@ mod tests {
     fn engine_accounts_large_ir_capacity_with_and_without_assets() {
         for (title_capacity, asset_capacity) in [(80_000, 0), (40_000, 40_000)] {
             let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-            let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+            let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
             builder
                 .registry_mut()
                 .register_source_resolver(Arc::new(BytesResolver))
@@ -2043,7 +2050,7 @@ mod tests {
 
     #[test]
     fn explicit_format_attempt_precedes_higher_combined_inferred_attempt() {
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(BytesResolver))

--- a/crates/engine/src/recovery.rs
+++ b/crates/engine/src/recovery.rs
@@ -602,6 +602,12 @@ pub(super) async fn convert(
             &context,
         )
         .await?;
+        let output = crate::result_policy::attach_evidence(
+            output,
+            source.input(),
+            attempt.candidate.format,
+            &context,
+        )?;
         validate_asset_inventory(&output.document, &output.assets, &request)?;
         validate_diagnostics(&output.diagnostics)?;
         store.commit(
@@ -659,6 +665,7 @@ pub(super) async fn convert(
         provenance,
         [Some(markdown_memory), Some(provenance_memory), Some(final_memory)],
     )?;
+    result.content()?;
     store.commit(
         token,
         &context,
@@ -892,6 +899,9 @@ async fn validate_recovered_success(
             "checkpoint Markdown does not match its document and assets",
         ));
     }
+    result.content().map_err(|error| {
+        recovery_error("corrupt", format!("checkpoint result fails content validation: {error}"))
+    })?;
     Ok(result)
 }
 

--- a/crates/engine/src/rendering.rs
+++ b/crates/engine/src/rendering.rs
@@ -68,6 +68,7 @@ pub(crate) async fn render(
         [Some(markdown_memory), Some(provenance_memory), Some(final_memory)],
     )?;
     result.set_detected_format(format);
+    result.content()?;
     Ok(result)
 }
 

--- a/crates/engine/src/result_policy.rs
+++ b/crates/engine/src/result_policy.rs
@@ -1,0 +1,147 @@
+//! Engine-side source evidence attachment and terminal result validation.
+
+use into_markdown_core::{
+    ASSET_ONLY_REASON_CODE, ConversionError, ConverterOutput, Diagnostic, DiagnosticSeverity,
+    EMPTY_SOURCE_REASON_CODE, ExecutionContext, InputFormat, ResolvedInput, SourceContentEvidence,
+    document_is_asset_only, document_is_empty,
+};
+
+const EVIDENCE_DIAGNOSTIC_PEAK_BYTES: u64 = 512;
+
+pub(crate) fn attach_evidence(
+    mut output: ConverterOutput,
+    source: &ResolvedInput,
+    format: InputFormat,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    if output.diagnostics.iter().any(|diagnostic| {
+        matches!(diagnostic.code.as_str(), EMPTY_SOURCE_REASON_CODE | ASSET_ONLY_REASON_CODE)
+    }) {
+        return Err(ConversionError::Internal {
+            detail: "converter emitted an engine-reserved result diagnostic".into(),
+        });
+    }
+    let evidence = match output.source_content_evidence() {
+        SourceContentEvidence::Unknown
+            if format == InputFormat::Markdown
+                && document_is_empty(&output.document)
+                && output.assets.is_empty()
+                && utf8_source_is_blank(&source.bytes) =>
+        {
+            SourceContentEvidence::Empty
+        }
+        SourceContentEvidence::Unknown
+            if document_is_asset_only(&output.document) && !output.assets.is_empty() =>
+        {
+            SourceContentEvidence::AssetsOnly
+        }
+        evidence => evidence,
+    };
+    let (code, message) = match evidence {
+        SourceContentEvidence::Unknown => return Ok(output),
+        SourceContentEvidence::Empty => {
+            if !document_is_empty(&output.document) || !output.assets.is_empty() {
+                return Err(ConversionError::Internal {
+                    detail: "empty-source evidence conflicts with retained document content".into(),
+                });
+            }
+            (EMPTY_SOURCE_REASON_CODE, "source was fully scanned and contains no visible content")
+        }
+        SourceContentEvidence::AssetsOnly => {
+            if !document_is_asset_only(&output.document) || output.assets.is_empty() {
+                return Err(ConversionError::Internal {
+                    detail: "asset-only evidence requires asset-only IR and retained assets".into(),
+                });
+            }
+            (ASSET_ONLY_REASON_CODE, "source contains only asset-backed structured content")
+        }
+    };
+
+    // Hold a conservative peak before allocating the small audit diagnostic;
+    // `account_retained` then transfers the exact retained charge to output.
+    let allocation_guard = context.reserve_memory(EVIDENCE_DIAGNOSTIC_PEAK_BYTES)?;
+    output.diagnostics.try_reserve(1).map_err(|error| ConversionError::ResourceLimit {
+        limit: "max_memory_bytes",
+        detail: format!("cannot reserve source-content diagnostic: {error}"),
+    })?;
+    output.diagnostics.push(Diagnostic {
+        code: code.into(),
+        severity: DiagnosticSeverity::Info,
+        message: message.into(),
+        locator: None,
+    });
+    output = output.account_retained(context)?;
+    drop(allocation_guard);
+    Ok(output)
+}
+
+fn utf8_source_is_blank(bytes: &[u8]) -> bool {
+    let bytes = bytes.strip_prefix(&[0xef, 0xbb, 0xbf]).unwrap_or(bytes);
+    std::str::from_utf8(bytes).is_ok_and(|text| text.chars().all(char::is_whitespace))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown_core::{
+        Asset, AssetId, Block, BlockNode, Document, ExecutionOptions, NodeId, Provenance,
+        ProvenanceKind, ResourceLimits, SourceLocator, SourceMetadata,
+    };
+    use std::sync::Arc;
+
+    fn context() -> ExecutionContext {
+        ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default())
+    }
+
+    fn source(bytes: &'static [u8]) -> ResolvedInput {
+        ResolvedInput { metadata: SourceMetadata::default(), bytes: Arc::from(bytes) }
+    }
+
+    #[test]
+    fn blank_markdown_gets_complete_audit_evidence() {
+        let output = attach_evidence(
+            ConverterOutput::default(),
+            &source(b"\xef\xbb\xbf \r\n"),
+            InputFormat::Markdown,
+            &context(),
+        )
+        .unwrap();
+        assert_eq!(output.diagnostics[0].code, EMPTY_SOURCE_REASON_CODE);
+        assert_eq!(output.diagnostics[0].severity, DiagnosticSeverity::Info);
+    }
+
+    #[test]
+    fn asset_only_ir_is_certified_without_format_special_cases() {
+        let id = AssetId("asset".into());
+        let output = ConverterOutput::new(
+            Document {
+                blocks: vec![BlockNode {
+                    id: NodeId("image".into()),
+                    block: Block::Image { asset: id.clone(), alt: None },
+                    provenance: Provenance {
+                        kind: ProvenanceKind::NativeParser,
+                        provider: "test".into(),
+                        locator: SourceLocator::default(),
+                        confidence: None,
+                    },
+                }],
+                ..Document::default()
+            },
+            vec![Asset {
+                id,
+                filename: Some("asset.bin".into()),
+                media_type: "application/octet-stream".into(),
+                bytes: vec![1],
+                external_uri: None,
+            }],
+            Vec::new(),
+        );
+        let output =
+            attach_evidence(output, &source(b"asset"), InputFormat::Text, &context()).unwrap();
+        assert_eq!(output.diagnostics[0].code, ASSET_ONLY_REASON_CODE);
+    }
+}
+
+#[cfg(test)]
+#[path = "result_policy/integration_tests.rs"]
+mod integration_tests;

--- a/crates/engine/src/result_policy/integration_tests.rs
+++ b/crates/engine/src/result_policy/integration_tests.rs
@@ -1,0 +1,325 @@
+use crate::{EngineBuilder, RegistryBuilder};
+use into_markdown_core::{
+    ArtifactSink, Asset, AssetId, AssetStreamInfo, Block, BlockNode, BoxFuture, ConversionError,
+    ConversionOptions, ConversionOutcome, ConversionRequest, Converter, ConverterOutput, Document,
+    ErrorPolicy, ExecutionContext, FormatCandidate, FormatDetector, FormatHint, InputFormat,
+    InputRef, MarkdownRenderer, NodeId, ProbeOutcome, Provenance, ProvenanceKind, ResolvedInput,
+    ResultContent, Services, SourceContentEvidence, SourceLocator, SourceMetadata, SourceResolver,
+};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct BytesResolver;
+
+impl SourceResolver for BytesResolver {
+    fn id(&self) -> &'static str {
+        "empty-policy.bytes"
+    }
+
+    fn supports(&self, input: &InputRef) -> bool {
+        matches!(input, InputRef::Bytes { .. })
+    }
+
+    fn resolve<'a>(
+        &'a self,
+        input: &'a InputRef,
+        _: &'a ConversionOptions,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ResolvedInput, ConversionError>> {
+        Box::pin(async move {
+            let InputRef::Bytes { data, name } = input else {
+                return Err(ConversionError::Unsupported { detail: "expected bytes".into() });
+            };
+            Ok(ResolvedInput {
+                bytes: Arc::clone(data),
+                metadata: SourceMetadata {
+                    name: name.clone(),
+                    size: u64::try_from(data.len()).unwrap_or(u64::MAX),
+                    ..SourceMetadata::default()
+                },
+            })
+        })
+    }
+}
+
+struct TextDetector;
+
+impl FormatDetector for TextDetector {
+    fn id(&self) -> &'static str {
+        "empty-policy.text"
+    }
+
+    fn detect<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatHint,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<Vec<FormatCandidate>, ConversionError>> {
+        Box::pin(async {
+            Ok(vec![FormatCandidate::new(InputFormat::Text, 1.0, "empty-result policy test")])
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+enum OutputKind {
+    UnknownEmpty,
+    CertifiedEmpty,
+    ExternalAssetOnly,
+}
+
+struct CountingConverter {
+    calls: Arc<AtomicUsize>,
+    output: OutputKind,
+}
+
+impl Converter for CountingConverter {
+    fn id(&self) -> &'static str {
+        "empty-policy.converter"
+    }
+
+    fn supported_formats(&self) -> &'static [InputFormat] {
+        &[InputFormat::Text]
+    }
+
+    fn probe<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ProbeOutcome, ConversionError>> {
+        Box::pin(async { Ok(ProbeOutcome::Match { confidence: 1.0 }) })
+    }
+
+    fn planned_output_bytes(
+        &self,
+        _: &ResolvedInput,
+        _: &FormatCandidate,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        Ok(64 * 1024)
+    }
+
+    fn convert<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        _: &'a ConversionOptions,
+        _: &'a Services,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        let calls = Arc::clone(&self.calls);
+        let output = self.output;
+        Box::pin(async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(match output {
+                OutputKind::UnknownEmpty => ConverterOutput::default(),
+                OutputKind::CertifiedEmpty => ConverterOutput::default()
+                    .with_source_content_evidence(SourceContentEvidence::Empty),
+                OutputKind::ExternalAssetOnly => external_asset_only_output(),
+            })
+        })
+    }
+}
+
+fn external_asset_only_output() -> ConverterOutput {
+    let id = AssetId("external-image".into());
+    ConverterOutput::new(
+        Document {
+            blocks: vec![BlockNode {
+                id: NodeId("image".into()),
+                block: Block::Image { asset: id.clone(), alt: None },
+                provenance: Provenance {
+                    kind: ProvenanceKind::NativeParser,
+                    provider: "empty-policy.converter".into(),
+                    locator: SourceLocator::default(),
+                    confidence: None,
+                },
+            }],
+            ..Document::default()
+        },
+        vec![Asset {
+            id,
+            filename: Some("external.png".into()),
+            media_type: "image/png".into(),
+            bytes: Vec::new(),
+            external_uri: Some("https://example.invalid/external.png".into()),
+        }],
+        Vec::new(),
+    )
+}
+
+struct CountingEmptyRenderer(Arc<AtomicUsize>);
+
+impl MarkdownRenderer for CountingEmptyRenderer {
+    fn id(&self) -> &'static str {
+        "empty-policy.renderer"
+    }
+
+    fn planned_markdown_bytes(
+        &self,
+        _: &Document,
+        _: &[Asset],
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        Ok(64 * 1024)
+    }
+
+    fn render<'a>(
+        &'a self,
+        _: &'a Document,
+        _: &'a [Asset],
+        _: &'a ConversionOptions,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<String, ConversionError>> {
+        let calls = Arc::clone(&self.0);
+        Box::pin(async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(String::new())
+        })
+    }
+}
+
+#[derive(Default)]
+struct RecordingSink {
+    markdown_writes: usize,
+    asset_starts: usize,
+}
+
+impl ArtifactSink for RecordingSink {
+    fn write_markdown(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        self.markdown_writes += 1;
+        Ok(())
+    }
+
+    fn begin_asset(&mut self, _: &AssetStreamInfo) -> Result<(), ConversionError> {
+        self.asset_starts += 1;
+        Ok(())
+    }
+
+    fn write_asset(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        Ok(())
+    }
+
+    fn end_asset(&mut self) -> Result<(), ConversionError> {
+        Ok(())
+    }
+}
+
+fn engine(
+    output: OutputKind,
+    converter_calls: &Arc<AtomicUsize>,
+    renderer_calls: &Arc<AtomicUsize>,
+) -> crate::Engine {
+    let mut registry = RegistryBuilder::new();
+    registry
+        .register_source_resolver(Arc::new(BytesResolver))
+        .register_format_detector(Arc::new(TextDetector))
+        .register_converter(Arc::new(CountingConverter {
+            calls: Arc::clone(converter_calls),
+            output,
+        }));
+    let mut builder =
+        EngineBuilder::new().renderer(Arc::new(CountingEmptyRenderer(Arc::clone(renderer_calls))));
+    *builder.registry_mut() = registry;
+    builder.build().unwrap()
+}
+
+fn request(bytes: &'static [u8]) -> ConversionRequest {
+    ConversionRequest::new(InputRef::bytes(bytes, Some("input.txt")))
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = std::pin::pin!(future);
+    let waker = std::task::Waker::noop();
+    let mut context = std::task::Context::from_waker(waker);
+    loop {
+        match future.as_mut().poll(&mut context) {
+            std::task::Poll::Ready(output) => return output,
+            std::task::Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
+#[test]
+fn unusable_empty_result_fails_before_sink_and_never_reexecutes() {
+    let converter_calls = Arc::new(AtomicUsize::new(0));
+    let renderer_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(OutputKind::UnknownEmpty, &converter_calls, &renderer_calls);
+    let mut sink = RecordingSink::default();
+
+    let error = block_on(engine.convert_into(request(b"visible"), &mut sink)).unwrap_err();
+
+    assert_eq!(error.reason_code(), "emptyContent");
+    assert_eq!(sink.markdown_writes, 0);
+    assert_eq!(sink.asset_starts, 0);
+    assert_eq!(converter_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(renderer_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn certified_empty_source_is_complete_with_a_stable_reason() {
+    let converter_calls = Arc::new(AtomicUsize::new(0));
+    let renderer_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(OutputKind::CertifiedEmpty, &converter_calls, &renderer_calls);
+
+    let result = block_on(engine.convert(request(b""))).unwrap();
+
+    assert_eq!(result.content().unwrap(), ResultContent::EmptySource);
+    assert_eq!(result.outcome(), ConversionOutcome::Complete);
+    assert_eq!(result.reason_code(), Some("emptySource"));
+    assert_eq!(converter_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(renderer_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn external_asset_only_result_remains_usable_for_structured_consumers() {
+    let converter_calls = Arc::new(AtomicUsize::new(0));
+    let renderer_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(OutputKind::ExternalAssetOnly, &converter_calls, &renderer_calls);
+
+    let result = block_on(engine.convert(request(b"external"))).unwrap();
+
+    assert_eq!(result.content().unwrap(), ResultContent::AssetsOnly);
+    assert_eq!(result.outcome(), ConversionOutcome::Complete);
+    assert_eq!(result.reason_code(), Some("assetOnly"));
+    assert_eq!(result.assets.len(), 1);
+}
+
+#[test]
+fn empty_content_is_failed_in_best_effort_and_strict_modes() {
+    for policy in [ErrorPolicy::BestEffort, ErrorPolicy::Strict] {
+        let converter_calls = Arc::new(AtomicUsize::new(0));
+        let renderer_calls = Arc::new(AtomicUsize::new(0));
+        let engine = engine(OutputKind::UnknownEmpty, &converter_calls, &renderer_calls);
+        let mut request = request(b"visible");
+        request.options.error_policy = policy;
+
+        let error = block_on(engine.convert(request)).unwrap_err();
+
+        assert_eq!(error.reason_code(), "emptyContent");
+        assert_eq!(converter_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(renderer_calls.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn recoverable_resume_reuses_conversion_and_reapplies_the_terminal_gate() {
+    let converter_calls = Arc::new(AtomicUsize::new(0));
+    let renderer_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(OutputKind::UnknownEmpty, &converter_calls, &renderer_calls);
+    let temporary = tempfile::tempdir().unwrap();
+    let store = crate::RecoveryStore::open(temporary.path().join("recovery")).unwrap();
+    let token = store.create_token().unwrap();
+
+    for _ in 0..2 {
+        let error =
+            block_on(engine.convert_recoverable(request(b"visible"), &store, &token)).unwrap_err();
+        assert_eq!(error.reason_code(), "emptyContent");
+    }
+
+    assert_eq!(converter_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(renderer_calls.load(Ordering::SeqCst), 2);
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -146,7 +146,13 @@ into-md <INPUT...>
 - 多输入输出保留相对于各输入根的目录结构；不同输入根产生同名输出时先加输入根名
   前缀，仍冲突时再使用稳定数字后缀，所有消歧均在调度前完成。
 - `--report` 写入带 `schemaVersion` 的 JSON 报告，包含逐项输入、输出、状态、
-  格式、诊断、警告和错误码。
+  `outcome`、格式、诊断、警告、错误码和细分 `reasonCode`。成功结果为 `complete` 或
+  `degraded`，失败为 `failed`；真正空源使用 `complete` / `emptySource`，未证明可用的
+  空产物使用 `malformed` / `emptyContent`。
+- Engine 的空结果判定发生在 stdout 编码及文件事务 stage/commit 之前。除明确
+  `emptySource` 外，成功或 degraded 的 Markdown 目标必须存在且非空；`emptyContent`
+  不创建目标，并使批处理失败计数和退出码与报告一致。asset-only 结果只允许
+  `result-json`、bundle，或带 `--asset-mode extract` 的 `ir-json`。
 - `--dry-run` 只展开输入、验证配置和计算输出路径，不转换、不联网、不写任何文件。
 
 ### OCR 与 AI

--- a/docs/dto.md
+++ b/docs/dto.md
@@ -45,7 +45,14 @@ DTO 解码错误为 `invalidField`、`invalidBase64`、`duplicateId` 和 `resour
   非空、唯一、按字节序排列的完整别名集合。schema 1 输入归一为 `[id]`，写出端生成
   schema 2。
 - `BatchReportDto`：包含派生的 `succeeded`、`failed` 和输入稳定顺序的 `items`；状态
-  只有 `success`、`failed`。失败项必须有 `errorCode`，成功项不得有 `errorCode`。
+  只有 `success`、`failed`。`outcome` 区分 `complete`、`degraded`、`failed`；
+  `reasonCode` 细分 `emptySource`、`assetOnly`、`emptyContent` 或首个有损诊断。失败项
+  必须有 `errorCode`，成功项不得有 `errorCode`。旧报告缺少 additive 的 `outcome` 或
+  `reasonCode` 时仍按原有 status 解码。
+
+`ResultDto` 保持 schema 1，不新增重复 outcome 字段。`emptySource` 与 `assetOnly` 作为
+稳定 diagnostics code 随 Result JSON、Web diagnostics artifact 和 bundle 传播；Engine
+返回前已经执行共享终态校验，因此结构化消费者不会收到未证明可用的空成功结果。
 
 结果示例：
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -78,6 +78,23 @@ HTTP(S) URI，并拒绝非法 percent escape。它只验证并保留审计引用
 SPI 不允许渲染器写资源、追加诊断或改写 provenance。转换器诊断和引擎按深度优先
 阅读顺序收集的 provenance 原样保留在 `ConversionResult` 中。
 
+Engine 在渲染后、任何 sink 写入或成功 checkpoint 提交前执行统一结果策略。Markdown
+含可见非空白字符时是普通成功；只有转换器完整扫描其可见内容域并附带私有
+`SourceContentEvidence::Empty`，空 Markdown 才能以 `complete` / `emptySource` 成功。
+未被证明为空、但最终 Markdown 为空且没有可用的 asset-only 结构时返回
+`ConversionError::EmptyContent`；为保持既有错误分类兼容，它的 `ErrorCode` 仍是
+`malformed`，细分 `reasonCode` 是 `emptyContent`。只含受 IR 引用资源的结果使用
+`assetOnly`：结构化 Result/IR、bundle 或资源抽取目标可以成功，不能承载该结果的纯
+Markdown 目标失败。普通执行、`convert_into`、可恢复 checkpoint fresh/resume、CLI
+stdout、文件事务和 Web 发布共用这项判定，判空不会再次调用 converter。
+
+`ConversionOutcome` 的诊断严重度契约可审计且不使用诊断码白名单：`Info` 只能描述无
+正文内容损失的审计事实，全部诊断均为 `Info` 时仍是 `complete`；任何省略、替代或净化
+必须由生产端发出 `Warning` 或 `Error`，结果为 `degraded`。例如 OCR 低置信区域、隐藏
+slide、未知 RTF 控制、非线性 EPUB spine 章节，以及未证明无损映射的 EPUB manifest
+资源省略均为 `Warning`；feed 源顺序、PDF 扫描页识别、MediaWiki 标题重定向以及 EPUB
+inert rights 元数据保留 `Info`。
+
 资源模式只决定 Markdown 表示：统一规划器在渲染前生成并冻结与资源写出层共享的
 `asset-<完整 SHA-256(bytes)>.<MIME 权威扩展名>` 有界 ASCII 文件名，
 `embed` 生成 base64 data URI，`omit` 保留 alt 而不生成悬空链接。资源写出层必须


### PR DESCRIPTION
## Summary

- integrate with #273's single-execution streaming pipeline and authoritative `ConversionSummary.outcome`; the terminal gate runs after conversion/rendering and before any semantic, Markdown, asset, stdout, file, Web, or recovery-success publication
- add one format-independent Core result policy that classifies rendered results as usable Markdown, proven `emptySource`, proven `assetOnly`, or failed `emptyContent`
- keep converter-specific code limited to evidence production; the shared gate owns validation and outcome semantics, with converter and renderer call-count tests preventing a second conversion for emptiness checks
- derive `complete`/`degraded` only from diagnostic severity: `Info` is lossless audit, while omission/replacement/sanitization is `Warning` and therefore degraded
- certify genuinely empty TXT, Markdown, DOCX, PPTX, XLS/XLSX, RTF, and ZIP sources; retain asset-only structured results; conservatively classify EPUB manifest resources without a proven lossless IR mapping as degraded
- apply the same result to API, CLI stdout, batch reports, atomic file transactions, Web task history, strict/best-effort execution, and recovery replay

## Terminal semantics

| Rendered/evidenced result | Terminal state | outcome | reasonCode | Publication contract |
| --- | --- | --- | --- | --- |
| visible Markdown, Info-only diagnostics | success | complete | none | non-empty Markdown is emitted/committed |
| visible Markdown after omission/replacement | success | degraded | first non-Info diagnostic | usable non-empty output is emitted/committed |
| converter-proven empty source | success | complete | `emptySource` | an existing 0-byte Markdown target is the documented exception |
| asset-backed IR with retained assets | success for bundle/result JSON/IR+extract | complete or degraded by severity | `assetOnly` or first non-Info diagnostic | structured/asset output remains usable |
| asset-only result requested as plain Markdown | failed | failed | `emptyContent` | no misleading empty target/stdout success |
| unproven empty result, strict or best-effort | failed | failed | `emptyContent` | fails before the first sink write or transaction staging |
| sink or atomic commit failure | failed | failed | existing typed failure reason | no success record and no partial target set |

## Compatibility

- `EmptyContent` intentionally remains public `errorCode=malformed`; `reasonCode=emptyContent` is additive, so existing error-class switches continue to work.
- Successful Result DTO schema stays unchanged. Empty-source and asset-only evidence uses diagnostics plus `ConversionSummary` accessors; older Web schema-1 records without `reasonCode` still deserialize.
- `ConversionSummary.outcome` from #273 remains authoritative. CLI rename/output warnings stay in `warnings` and do not rewrite content outcome.
- Previously accepted unproven empty outputs now fail. Proven empty sources remain successful and may intentionally commit a 0-byte target with `emptySource`.
- Legacy recovery checkpoints containing an unproven empty success are rejected instead of replayed as false success.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- strict `clippy -D warnings`:
  - Core + Engine + Converters, all targets, no deps: passed
  - API lib: passed
  - new CLI empty-result integration target: passed
- tests:
  - Core: 103 passed; doc tests: 8 passed
  - Engine: 43 passed, including single converter/renderer execution, pre-sink failure, streaming summaries, recovery, strict/best-effort
  - Converters: 455 passed, 1 ignored; real repository fixture corpus passed
  - API: 42 passed, 2 ignored; collecting parity: 4 passed
  - CLI unit/Web/transaction: 231 passed
  - CLI empty-result contract: 4 passed
  - CLI exit contract: 15 passed
  - full CLI `--tests` reached `plugin_lifecycle`: all preceding suites passed; 1 test failed only because the CI-provided `INTO_MD_PLUGIN_PROCESS_FIXTURE` was absent (the other plugin lifecycle test passed)

The all-target API/CLI clippy command also reproduces unchanged warnings already present on `origin/main` under Rust 1.97 (plugin test size/arguments, OCR test float casts, CLI admin redundant `else`, exit-test pass-by-value). This PR adds no lint exemptions; all changed libraries and the new CLI contract target pass strict clippy.

## Performance

Release binaries from latest main `387e6db306269304a36af3d55a225b649be44363` and this commit were warmed up, then run in alternating order 15 times per common successful small fixture with `--no-config --emit markdown --asset-mode embed`.

| Fixture | main elapsed ms | PR elapsed ms | change | main RSS MiB | PR RSS MiB | max temp bytes (main / PR) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| TXT | 96.372 | 99.828 | +3.59% | 9.995 | 10.166 | 64 / 64 |
| Markdown | 57.800 | 81.736 | +41.41% | 9.489 | 8.405 | 58 / 29 |
| DOCX | 34.454 | 36.056 | +4.65% | 8.136 | 9.717 | 20 / 40 |
| XLSX | 42.275 | 41.156 | -2.65% | 6.888 | 7.603 | 417 / 417 |
| **Mean (60 runs/version)** | **57.725** | **64.694** | **+12.07%** | **8.627** | **8.973** | **417 / 417** |

The ordinary-case mean elapsed regression is below the +50% ceiling. Mean peak RSS changed +4.01%; every run produced non-empty stdout, and both versions left 0 temporary bytes after exit. The small-file per-format timing is process-start dominated, so the 60-run aggregate is the acceptance metric.

## Risk

- Conservative severity corrections can reclassify OCR low confidence, hidden slides, unknown RTF controls, non-linear EPUB chapters, and EPUB resources without proven lossless mapping from complete to degraded. This is the intended content-loss contract.
- Empty-source evidence is converter-owned and fail-closed; unsupported/new formats that return empty without proof fail until they provide evidence.
- Asset-only plain-Markdown callers that previously accepted an unusable empty artifact now receive `emptyContent`; structured and extraction-capable callers remain supported.
- Scope is limited to #268 and #273 integration; it does not copy or implement #267, #269, or #270 behavior.

Fixes #268
