### PR TITLE
fix: reject unusable empty Markdown results

### DIFF
--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -4309,26 +4309,20 @@ fn run_conversion(
         working_directory: context.cwd.clone(),
     };
     let reports = if plans.len() == 1 && plans[0].output.is_none() {
-        vec![process_stdout(&plans[0], &policy, catalog, json_log, context)?]
+        vec![match process_stdout(&plans[0], &policy, catalog, json_log, context) {
+            Ok(report) => report,
+            Err(error) if arguments.report.is_some() => {
+                failed_item_report(&plans[0], &policy, &error)
+            }
+            Err(error) => return Err(error),
+        }]
     } else if plans.len() == 1 {
         let plan = &plans[0];
         let output_phase = Mutex::new(());
-        let completed = process_file_task_inner(plan, &policy, &output_phase)?;
-        let reason_code = completed.summary.reason_code().map(str::to_owned);
-        vec![BatchItemReport {
-            input: plan.item.display.clone(),
-            output: Some(report_path(&completed.path)),
-            format: completed.summary.format.map(|format| format.as_str().into()),
-            status: BatchItemStatus::Success,
-            outcome: crate::result_policy::batch_outcome(completed.summary.outcome),
-            diagnostics: completed.summary.diagnostics.iter().map(Into::into).collect(),
-            error_code: None,
-            reason_code,
-            component: None,
-            part: None,
-            limit: None,
-            message: None,
-            warnings: completed.warnings,
+        vec![match process_file_task_inner(plan, &policy, &output_phase) {
+            Ok(completed) => completed_item_report(plan.item.display.clone(), completed),
+            Err(error) if arguments.report.is_some() => failed_item_report(plan, &policy, &error),
+            Err(error) => return Err(error),
         }]
     } else {
         process_batch(plans, &policy, arguments.jobs.map_or(loaded.jobs, std::num::NonZero::get))?
@@ -5053,45 +5047,54 @@ fn process_file_task(
 ) -> BatchItemReport {
     let _memory_guard = memory_phase.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     match process_file_task_inner(&plan, policy, output_phase) {
-        Ok(completed) => {
-            let reason_code = completed.summary.reason_code().map(str::to_owned);
-            BatchItemReport {
-                input: plan.item.display,
-                output: Some(report_path(&completed.path)),
-                format: completed.summary.format.map(|format| format.as_str().into()),
-                status: BatchItemStatus::Success,
-                outcome: crate::result_policy::batch_outcome(completed.summary.outcome),
-                diagnostics: completed.summary.diagnostics.iter().map(Into::into).collect(),
-                error_code: None,
-                reason_code,
-                component: None,
-                part: None,
-                limit: None,
-                message: None,
-                warnings: completed.warnings,
-            }
-        }
-        Err(error) => BatchItemReport {
-            input: plan.item.display,
-            output: plan.output.as_deref().map(report_path),
-            format: error
-                .detected_format()
-                .or(policy.hint.format)
-                .map(|format| format.as_str().into()),
-            status: BatchItemStatus::Failed,
-            outcome: BatchItemOutcome::Failed,
-            diagnostics: vec![],
-            error_code: Some(error.code().into()),
-            reason_code: Some(error.reason_code().into()),
-            component: error.component_name().map(str::to_owned),
-            part: error.part().map(str::to_owned),
-            limit: error.limit().map(|(name, detail)| BatchLimitDto {
-                name: name.into(),
-                detail: Some(detail.into()),
-            }),
-            message: Some(error.to_string()),
-            warnings: vec![],
-        },
+        Ok(completed) => completed_item_report(plan.item.display, completed),
+        Err(error) => failed_item_report(&plan, policy, &error),
+    }
+}
+
+fn completed_item_report(
+    input: String,
+    completed: crate::result_policy::CommittedOutput,
+) -> BatchItemReport {
+    let reason_code = completed.summary.reason_code().map(str::to_owned);
+    BatchItemReport {
+        input,
+        output: Some(report_path(&completed.path)),
+        format: completed.summary.format.map(|format| format.as_str().into()),
+        status: BatchItemStatus::Success,
+        outcome: crate::result_policy::batch_outcome(completed.summary.outcome),
+        diagnostics: completed.summary.diagnostics.iter().map(Into::into).collect(),
+        error_code: None,
+        reason_code,
+        component: None,
+        part: None,
+        limit: None,
+        message: None,
+        warnings: completed.warnings,
+    }
+}
+
+fn failed_item_report(
+    plan: &WorkPlan,
+    policy: &ExecutionPolicy,
+    error: &CliError,
+) -> BatchItemReport {
+    BatchItemReport {
+        input: plan.item.display.clone(),
+        output: plan.output.as_deref().map(report_path),
+        format: error.detected_format().or(policy.hint.format).map(|format| format.as_str().into()),
+        status: BatchItemStatus::Failed,
+        outcome: BatchItemOutcome::Failed,
+        diagnostics: vec![],
+        error_code: Some(error.code().into()),
+        reason_code: Some(error.reason_code().into()),
+        component: error.component_name().map(str::to_owned),
+        part: error.part().map(str::to_owned),
+        limit: error
+            .limit()
+            .map(|(name, detail)| BatchLimitDto { name: name.into(), detail: Some(detail.into()) }),
+        message: Some(error.to_string()),
+        warnings: vec![],
     }
 }
 
@@ -6872,7 +6875,7 @@ mod tests {
         let lines = output.lines().collect::<Vec<_>>();
         assert_eq!(lines[0], "FORMAT\tCONFIDENCE\tEXPLICIT\tDETECTOR\tREASON\tDIAGNOSTICS");
         assert_eq!(lines[1], "pdf\t0.990\tfalse\tbuiltin.detector.content\tPDF magic bytes\t");
-        assert_eq!(lines[2], "docx\t0.550\tfalse\tbuiltin.detector.hints\tfilename extension\t");
+        assert_eq!(lines[2], "docx\t0.910\tfalse\tbuiltin.detector.hints\tfilename extension\t");
     }
 
     #[test]

--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -16,8 +16,8 @@ use crate::output::{
 use clap::{CommandFactory, Parser};
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use into_markdown::{
-    AiMode, ArtifactSink, AssetMode, ConversionOptions, ConversionOutcome, ConversionRequest,
-    ConversionSummary, DetectionRequest, ErrorPolicy, FormatHint, InputFormat, InputRef, OcrPolicy,
+    AiMode, ArtifactSink, AssetMode, ConversionOptions, ConversionRequest, ConversionSummary,
+    DetectionRequest, ErrorPolicy, FormatHint, InputFormat, InputRef, OcrPolicy,
     OpenAiCompatibleClient, ProviderConfig as TransportProviderConfig, ProviderNetworkPolicy,
     RaggedRowsMode, TableHeaderMode, TextDecodingMode,
 };
@@ -4313,22 +4313,22 @@ fn run_conversion(
     } else if plans.len() == 1 {
         let plan = &plans[0];
         let output_phase = Mutex::new(());
-        let (output_path, detected_format, conversion_outcome, diagnostics, warnings) =
-            process_file_task_inner(plan, &policy, &output_phase)?;
+        let completed = process_file_task_inner(plan, &policy, &output_phase)?;
+        let reason_code = completed.summary.reason_code().map(str::to_owned);
         vec![BatchItemReport {
             input: plan.item.display.clone(),
-            output: Some(report_path(&output_path)),
-            format: detected_format.map(|format| format.as_str().into()),
+            output: Some(report_path(&completed.path)),
+            format: completed.summary.format.map(|format| format.as_str().into()),
             status: BatchItemStatus::Success,
-            outcome: batch_outcome(conversion_outcome, !warnings.is_empty()),
-            diagnostics: diagnostics.iter().map(Into::into).collect(),
+            outcome: crate::result_policy::batch_outcome(completed.summary.outcome),
+            diagnostics: completed.summary.diagnostics.iter().map(Into::into).collect(),
             error_code: None,
-            reason_code: None,
+            reason_code,
             component: None,
             part: None,
             limit: None,
             message: None,
-            warnings,
+            warnings: completed.warnings,
         }]
     } else {
         process_batch(plans, &policy, arguments.jobs.map_or(loaded.jobs, std::num::NonZero::get))?
@@ -4945,6 +4945,7 @@ fn process_stdout(
         &policy.working_directory,
     )?;
     let (mut spool, summary) = convert_item_into(&plan.item, policy, asset_output.uri_prefix)?;
+    crate::result_policy::validate_for_emit(&summary, policy.emit, policy.asset_mode)?;
     spool.finish()?;
     let mut encoded =
         policy.output_context.temporary_file("into-md-stdout").map_err(CliError::from)?;
@@ -4979,10 +4980,10 @@ fn process_stdout(
         output: None,
         format: summary.format.map(|format| format.as_str().into()),
         status: BatchItemStatus::Success,
-        outcome: batch_outcome(summary.outcome, false),
+        outcome: crate::result_policy::batch_outcome(summary.outcome),
         diagnostics: summary.diagnostics.iter().map(Into::into).collect(),
         error_code: None,
-        reason_code: None,
+        reason_code: summary.reason_code().map(str::to_owned),
         component: None,
         part: None,
         limit: None,
@@ -5052,21 +5053,22 @@ fn process_file_task(
 ) -> BatchItemReport {
     let _memory_guard = memory_phase.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     match process_file_task_inner(&plan, policy, output_phase) {
-        Ok((output_path, detected_format, conversion_outcome, diagnostics, warnings)) => {
+        Ok(completed) => {
+            let reason_code = completed.summary.reason_code().map(str::to_owned);
             BatchItemReport {
                 input: plan.item.display,
-                output: Some(report_path(&output_path)),
-                format: detected_format.map(|format| format.as_str().into()),
+                output: Some(report_path(&completed.path)),
+                format: completed.summary.format.map(|format| format.as_str().into()),
                 status: BatchItemStatus::Success,
-                outcome: batch_outcome(conversion_outcome, !warnings.is_empty()),
-                diagnostics: diagnostics.iter().map(Into::into).collect(),
+                outcome: crate::result_policy::batch_outcome(completed.summary.outcome),
+                diagnostics: completed.summary.diagnostics.iter().map(Into::into).collect(),
                 error_code: None,
-                reason_code: None,
+                reason_code,
                 component: None,
                 part: None,
                 limit: None,
                 message: None,
-                warnings,
+                warnings: completed.warnings,
             }
         }
         Err(error) => BatchItemReport {
@@ -5093,14 +5095,11 @@ fn process_file_task(
     }
 }
 
-type FileTaskOutput =
-    (PathBuf, Option<InputFormat>, ConversionOutcome, Vec<into_markdown::Diagnostic>, Vec<String>);
-
 fn process_file_task_inner(
     plan: &WorkPlan,
     policy: &ExecutionPolicy,
     output_phase: &Mutex<()>,
-) -> Result<FileTaskOutput, CliError> {
+) -> Result<crate::result_policy::CommittedOutput, CliError> {
     let requested =
         plan.output.as_deref().ok_or_else(|| CliError::internal("batch output path is absent"))?;
     let output_path = {
@@ -5116,6 +5115,7 @@ fn process_file_task_inner(
         &policy.working_directory,
     )?;
     let (mut spool, summary) = convert_item_into(&plan.item, policy, asset_output.uri_prefix)?;
+    crate::result_policy::validate_for_emit(&summary, policy.emit, policy.asset_mode)?;
     spool.finish()?;
     let output_parent = output_path
         .parent()
@@ -5146,15 +5146,7 @@ fn process_file_task_inner(
             write_outcome.path.display()
         ));
     }
-    Ok((write_outcome.path, summary.format, summary.outcome, summary.diagnostics, warnings))
-}
-
-fn batch_outcome(outcome: ConversionOutcome, has_cli_warnings: bool) -> BatchItemOutcome {
-    match (outcome, has_cli_warnings) {
-        (ConversionOutcome::Complete, false) => BatchItemOutcome::Complete,
-        (ConversionOutcome::Complete | ConversionOutcome::Degraded, true)
-        | (ConversionOutcome::Degraded, false) => BatchItemOutcome::Degraded,
-    }
+    Ok(crate::result_policy::CommittedOutput { path: write_outcome.path, summary, warnings })
 }
 
 fn report_path(path: &Path) -> String {
@@ -5807,19 +5799,26 @@ mod tests {
             message: "lossless note".into(),
             locator: None,
         }];
-        assert!(!informational_diagnostics.is_empty());
+        let degrading_diagnostics = [into_markdown::Diagnostic {
+            code: "contentOmitted".into(),
+            severity: into_markdown::DiagnosticSeverity::Warning,
+            message: "content was omitted".into(),
+            locator: None,
+        }];
         assert_eq!(
-            batch_outcome(ConversionOutcome::Complete, false),
+            crate::result_policy::batch_outcome(into_markdown::conversion_outcome(
+                &informational_diagnostics,
+            )),
             BatchItemOutcome::Complete,
             "stdout and batch must not infer degradation from informational diagnostics"
         );
-        assert_eq!(batch_outcome(ConversionOutcome::Degraded, false), BatchItemOutcome::Degraded);
         assert_eq!(
-            batch_outcome(ConversionOutcome::Complete, true),
+            crate::result_policy::batch_outcome(into_markdown::conversion_outcome(
+                &degrading_diagnostics,
+            )),
             BatchItemOutcome::Degraded,
-            "a CLI output warning may only promote complete to degraded"
+            "recoverable content loss must remain degraded"
         );
-        assert_eq!(batch_outcome(ConversionOutcome::Degraded, true), BatchItemOutcome::Degraded);
     }
 
     fn controlled_test_secret_environment() -> &'static str {

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -9,6 +9,7 @@ mod error;
 mod i18n;
 mod output;
 mod proxy_env;
+mod result_policy;
 mod services;
 mod transaction;
 mod ui;

--- a/apps/cli/src/result_policy.rs
+++ b/apps/cli/src/result_policy.rs
@@ -1,0 +1,93 @@
+//! CLI delivery policy for exceptional usable conversion results.
+
+use crate::args::{AssetModeArg, EmitKind};
+use crate::error::CliError;
+use crate::output::BatchItemOutcome;
+use into_markdown::{ConversionError, ConversionOutcome, ConversionSummary, ResultContent};
+use std::path::PathBuf;
+
+pub(crate) struct CommittedOutput {
+    pub(crate) path: PathBuf,
+    pub(crate) summary: ConversionSummary,
+    pub(crate) warnings: Vec<String>,
+}
+
+pub(crate) fn validate_for_emit(
+    summary: &ConversionSummary,
+    emit: EmitKind,
+    asset_mode: AssetModeArg,
+) -> Result<(), CliError> {
+    match summary.content().map_err(CliError::from)? {
+        ResultContent::Markdown | ResultContent::EmptySource => Ok(()),
+        ResultContent::AssetsOnly
+            if matches!(emit, EmitKind::Bundle | EmitKind::ResultJson)
+                || emit == EmitKind::IrJson && asset_mode == AssetModeArg::Extract =>
+        {
+            Ok(())
+        }
+        ResultContent::AssetsOnly => {
+            Err(CliError::from(ConversionError::EmptyContent).with_detected_format(summary.format))
+        }
+    }
+}
+
+pub(crate) const fn batch_outcome(outcome: ConversionOutcome) -> BatchItemOutcome {
+    match outcome {
+        ConversionOutcome::Complete => BatchItemOutcome::Complete,
+        ConversionOutcome::Degraded => BatchItemOutcome::Degraded,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown::{
+        ASSET_ONLY_REASON_CODE, Asset, AssetId, Block, BlockNode, ConversionResult, Diagnostic,
+        DiagnosticSeverity, Document, NodeId, Provenance, ProvenanceKind, SourceLocator,
+    };
+
+    fn asset_only() -> ConversionResult {
+        let id = AssetId("asset".into());
+        ConversionResult::new(
+            Document {
+                blocks: vec![BlockNode {
+                    id: NodeId("image".into()),
+                    block: Block::Image { asset: id.clone(), alt: None },
+                    provenance: Provenance {
+                        kind: ProvenanceKind::NativeParser,
+                        provider: "test".into(),
+                        locator: SourceLocator::default(),
+                        confidence: None,
+                    },
+                }],
+                ..Document::default()
+            },
+            String::new(),
+            vec![Asset {
+                id,
+                filename: Some("asset.bin".into()),
+                media_type: "application/octet-stream".into(),
+                bytes: vec![1],
+                external_uri: None,
+            }],
+            vec![Diagnostic {
+                code: ASSET_ONLY_REASON_CODE.into(),
+                severity: DiagnosticSeverity::Info,
+                message: "asset only".into(),
+                locator: None,
+            }],
+            Vec::new(),
+        )
+    }
+
+    #[test]
+    fn asset_only_delivery_requires_a_structured_or_extracted_target() {
+        let summary = asset_only().into_summary();
+        assert!(validate_for_emit(&summary, EmitKind::ResultJson, AssetModeArg::Omit).is_ok());
+        assert!(validate_for_emit(&summary, EmitKind::Bundle, AssetModeArg::Omit).is_ok());
+        assert!(validate_for_emit(&summary, EmitKind::IrJson, AssetModeArg::Extract).is_ok());
+        let error =
+            validate_for_emit(&summary, EmitKind::Markdown, AssetModeArg::Extract).unwrap_err();
+        assert_eq!(error.reason_code(), "emptyContent");
+    }
+}

--- a/apps/cli/src/result_policy.rs
+++ b/apps/cli/src/result_policy.rs
@@ -19,14 +19,19 @@ pub(crate) fn validate_for_emit(
 ) -> Result<(), CliError> {
     match summary.content().map_err(CliError::from)? {
         ResultContent::Markdown | ResultContent::EmptySource => Ok(()),
-        ResultContent::AssetsOnly
-            if matches!(emit, EmitKind::Bundle | EmitKind::ResultJson)
-                || emit == EmitKind::IrJson && asset_mode == AssetModeArg::Extract =>
-        {
-            Ok(())
-        }
         ResultContent::AssetsOnly => {
-            Err(CliError::from(ConversionError::EmptyContent).with_detected_format(summary.format))
+            let (payloads, external_references) = match emit {
+                EmitKind::Markdown => (false, false),
+                EmitKind::IrJson => (asset_mode == AssetModeArg::Extract, false),
+                EmitKind::ResultJson => (true, true),
+                EmitKind::Bundle => (true, false),
+            };
+            if summary.assets_are_deliverable(payloads, external_references) {
+                Ok(())
+            } else {
+                Err(CliError::from(ConversionError::EmptyContent)
+                    .with_detected_format(summary.format))
+            }
         }
     }
 }
@@ -46,7 +51,7 @@ mod tests {
         DiagnosticSeverity, Document, NodeId, Provenance, ProvenanceKind, SourceLocator,
     };
 
-    fn asset_only() -> ConversionResult {
+    fn asset_only(external: bool) -> ConversionResult {
         let id = AssetId("asset".into());
         ConversionResult::new(
             Document {
@@ -67,8 +72,8 @@ mod tests {
                 id,
                 filename: Some("asset.bin".into()),
                 media_type: "application/octet-stream".into(),
-                bytes: vec![1],
-                external_uri: None,
+                bytes: if external { Vec::new() } else { vec![1] },
+                external_uri: external.then(|| "https://example.invalid/asset.bin".into()),
             }],
             vec![Diagnostic {
                 code: ASSET_ONLY_REASON_CODE.into(),
@@ -82,12 +87,28 @@ mod tests {
 
     #[test]
     fn asset_only_delivery_requires_a_structured_or_extracted_target() {
-        let summary = asset_only().into_summary();
+        let summary = asset_only(false).into_summary();
         assert!(validate_for_emit(&summary, EmitKind::ResultJson, AssetModeArg::Omit).is_ok());
         assert!(validate_for_emit(&summary, EmitKind::Bundle, AssetModeArg::Omit).is_ok());
         assert!(validate_for_emit(&summary, EmitKind::IrJson, AssetModeArg::Extract).is_ok());
         let error =
             validate_for_emit(&summary, EmitKind::Markdown, AssetModeArg::Extract).unwrap_err();
         assert_eq!(error.reason_code(), "emptyContent");
+    }
+
+    #[test]
+    fn external_only_assets_require_external_metadata_in_the_selected_wire_format() {
+        let summary = asset_only(true).into_summary();
+        assert!(validate_for_emit(&summary, EmitKind::ResultJson, AssetModeArg::Omit).is_ok());
+        for (emit, mode) in [
+            (EmitKind::Markdown, AssetModeArg::Omit),
+            (EmitKind::IrJson, AssetModeArg::Extract),
+            (EmitKind::Bundle, AssetModeArg::Omit),
+        ] {
+            assert_eq!(
+                validate_for_emit(&summary, emit, mode).unwrap_err().reason_code(),
+                "emptyContent"
+            );
+        }
     }
 }

--- a/apps/cli/src/web_tasks.rs
+++ b/apps/cli/src/web_tasks.rs
@@ -77,7 +77,7 @@ pub enum WebTaskError {
     #[error("backend I/O failed: {0}")]
     Io(String),
     #[error("conversion failed during {stage}: {code}")]
-    Conversion { code: String, stage: String },
+    Conversion { code: String, reason_code: Option<String>, stage: String },
 }
 
 /// One-time grants accompanying a Web upload. Grants are checked before task
@@ -348,6 +348,8 @@ pub(crate) struct WebTaskRecord {
 pub(crate) struct WebTaskFailure {
     schema_version: u32,
     pub(crate) code: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) reason_code: Option<String>,
     pub(crate) stage: String,
     pub(crate) retryable: bool,
 }
@@ -2727,12 +2729,14 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
             let services = shared.media_services.assemble(&persisted.options).map_err(|error| {
                 WebTaskError::Conversion {
                     code: error.code().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "capabilityRouting".into(),
                 }
             })?;
             Some(into_markdown::default_engine_with_services(services).map_err(|error| {
                 WebTaskError::Conversion {
                     code: error.code().as_str().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "conversionSetup".into(),
                 }
             })?)
@@ -2742,12 +2746,14 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
                 .assemble_conversion(&persisted.options, web_invocation_capabilities(&persisted))
                 .map_err(|error| WebTaskError::Conversion {
                     code: error.code().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "capabilityRouting".into(),
                 })?
                 .map(into_markdown::default_engine_with_services)
                 .transpose()
                 .map_err(|error| WebTaskError::Conversion {
                     code: error.code().as_str().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "conversionSetup".into(),
                 })?
         };
@@ -2770,6 +2776,7 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
             } else {
                 WebTaskError::Conversion {
                     code: error.code().as_str().into(),
+                    reason_code: Some(error.reason_code().into()),
                     stage: "conversion".into(),
                 }
             }
@@ -4162,23 +4169,25 @@ fn load_persisted_request(task: &SafeDir) -> Result<Option<PersistedRequest>, We
 }
 
 fn failure_from_error(error: &WebTaskError) -> WebTaskFailure {
-    let (code, stage, retryable) = match error {
-        WebTaskError::Conversion { code, stage } => {
+    let (code, reason_code, stage, retryable) = match error {
+        WebTaskError::Conversion { code, reason_code, stage } => {
             let retryable = matches!(
                 code.as_str(),
                 "network" | "networkDenied" | "timeout" | "componentUnavailable" | "ai"
             );
-            (code.clone(), stage.clone(), retryable)
+            (code.clone(), reason_code.clone(), stage.clone(), retryable)
         }
-        WebTaskError::Limit(_) => ("resourceLimit".into(), "storage".into(), false),
-        WebTaskError::Unsafe(_) => ("unsafeStorage".into(), "storage".into(), false),
-        WebTaskError::Cancelled => ("cancelled".into(), "conversion".into(), true),
-        WebTaskError::NotFound => ("notFound".into(), "storage".into(), false),
-        WebTaskError::Conflict(_) => ("taskConflict".into(), "storage".into(), true),
-        WebTaskError::Invalid(_) => ("invalidTaskOptions".into(), "conversionSetup".into(), false),
-        WebTaskError::Io(_) => ("backendIo".into(), "storage".into(), true),
+        WebTaskError::Limit(_) => ("resourceLimit".into(), None, "storage".into(), false),
+        WebTaskError::Unsafe(_) => ("unsafeStorage".into(), None, "storage".into(), false),
+        WebTaskError::Cancelled => ("cancelled".into(), None, "conversion".into(), true),
+        WebTaskError::NotFound => ("notFound".into(), None, "storage".into(), false),
+        WebTaskError::Conflict(_) => ("taskConflict".into(), None, "storage".into(), true),
+        WebTaskError::Invalid(_) => {
+            ("invalidTaskOptions".into(), None, "conversionSetup".into(), false)
+        }
+        WebTaskError::Io(_) => ("backendIo".into(), None, "storage".into(), true),
     };
-    WebTaskFailure { schema_version: 1, code, stage, retryable }
+    WebTaskFailure { schema_version: 1, code, reason_code, stage, retryable }
 }
 
 fn persist_task_failure(
@@ -4212,8 +4221,13 @@ fn load_task_failure(shared: &Shared, id: &TaskId) -> Result<Option<WebTaskFailu
         .map_err(|_| WebTaskError::Unsafe("task failure record is invalid".into()))?;
     if failure.schema_version != 1
         || failure.code.len() > 64
+        || failure.reason_code.as_ref().is_some_and(|value| value.len() > 64)
         || failure.stage.len() > 64
         || !failure.code.bytes().all(|byte| byte.is_ascii_alphanumeric())
+        || failure
+            .reason_code
+            .as_ref()
+            .is_some_and(|value| !value.bytes().all(|byte| byte.is_ascii_alphanumeric()))
         || !failure.stage.bytes().all(|byte| byte.is_ascii_alphanumeric())
     {
         return Err(WebTaskError::Unsafe("task failure record is incompatible".into()));
@@ -5204,6 +5218,9 @@ fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[path = "empty_result_tests.rs"]
+    mod empty_result_tests;
 
     #[test]
     fn durable_web_requests_assemble_capabilities_from_options_and_filename() {

--- a/apps/cli/src/web_tasks.rs
+++ b/apps/cli/src/web_tasks.rs
@@ -2781,6 +2781,7 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
                 }
             }
         })?;
+        validate_web_result_delivery(&converted)?;
         let current = lock(&shared.task_store).get(&job.id)?.ok_or(WebTaskError::NotFound)?;
         if current.status == TaskStatus::Running {
             let converted_record = lock(&shared.task_store).transition(
@@ -2836,6 +2837,26 @@ fn run_job(shared: &Arc<Shared>, job: &Job) {
             finish_terminal_or_stop(shared, &job.id, false);
         }
     }
+}
+
+fn validate_web_result_delivery(
+    result: &into_markdown::ConversionResult,
+) -> Result<(), WebTaskError> {
+    let content = result.content().map_err(|error| WebTaskError::Conversion {
+        code: error.code().as_str().into(),
+        reason_code: Some(error.reason_code().into()),
+        stage: "resultDelivery".into(),
+    })?;
+    if content == into_markdown::ResultContent::AssetsOnly
+        && !result.assets_are_deliverable(true, false)
+    {
+        return Err(WebTaskError::Conversion {
+            code: "malformed".into(),
+            reason_code: Some("emptyContent".into()),
+            stage: "resultDelivery".into(),
+        });
+    }
+    Ok(())
 }
 
 fn web_invocation_capabilities(

--- a/apps/cli/src/web_tasks/tests/empty_result_tests.rs
+++ b/apps/cli/src/web_tasks/tests/empty_result_tests.rs
@@ -1,4 +1,8 @@
 use super::*;
+use into_markdown::{
+    Asset, AssetId, Block, BlockNode, ConversionResult, Document, NodeId, Provenance,
+    ProvenanceKind, SourceLocator,
+};
 use std::io::Cursor;
 use zip::write::SimpleFileOptions;
 
@@ -39,6 +43,46 @@ fn empty_source_and_empty_content_share_the_web_terminal_contract() {
     let failure = backend.web_record(omitted).unwrap().failure.unwrap();
     assert_eq!(failure.code, "malformed");
     assert_eq!(failure.reason_code.as_deref(), Some("emptyContent"));
+}
+
+#[test]
+fn web_rejects_external_uri_only_asset_results_it_cannot_publish() {
+    let id = AssetId("external".into());
+    let result = ConversionResult::new(
+        Document {
+            blocks: vec![BlockNode {
+                id: NodeId("image".into()),
+                block: Block::Image { asset: id.clone(), alt: None },
+                provenance: Provenance {
+                    kind: ProvenanceKind::NativeParser,
+                    provider: "test".into(),
+                    locator: SourceLocator::default(),
+                    confidence: None,
+                },
+            }],
+            ..Document::default()
+        },
+        String::new(),
+        vec![Asset {
+            id,
+            filename: Some("external.png".into()),
+            media_type: "image/png".into(),
+            bytes: Vec::new(),
+            external_uri: Some("https://example.invalid/external.png".into()),
+        }],
+        Vec::new(),
+        Vec::new(),
+    );
+
+    let error = validate_web_result_delivery(&result).unwrap_err();
+    assert!(matches!(
+        error,
+        WebTaskError::Conversion {
+            ref code,
+            reason_code: Some(ref reason_code),
+            ref stage,
+        } if code == "malformed" && reason_code == "emptyContent" && stage == "resultDelivery"
+    ));
 }
 
 fn alt_chunk_only_docx() -> Vec<u8> {

--- a/apps/cli/src/web_tasks/tests/empty_result_tests.rs
+++ b/apps/cli/src/web_tasks/tests/empty_result_tests.rs
@@ -1,0 +1,69 @@
+use super::*;
+use std::io::Cursor;
+use zip::write::SimpleFileOptions;
+
+#[test]
+fn empty_source_and_empty_content_share_the_web_terminal_contract() {
+    let temporary = tempfile::tempdir().unwrap();
+    let backend = WebTaskBackend::open(temporary.path().join("backend")).unwrap();
+
+    let mut empty_request =
+        WebTaskRequest { format: Some(InputFormat::Text), ..WebTaskRequest::default() };
+    empty_request.options.error_policy = into_markdown::ErrorPolicy::BestEffort;
+    let mut upload = backend.begin_upload_configured("empty.txt", Some(3), empty_request).unwrap();
+    upload.write_chunk(b" \n").unwrap();
+    let empty = upload.finish().unwrap();
+    let empty = wait_terminal(&backend, &empty.id);
+    assert_eq!(empty.status, TaskStatus::Succeeded);
+    let markdown =
+        empty.artifacts.iter().find(|artifact| artifact.kind == ArtifactKind::Markdown).unwrap();
+    assert_eq!(markdown.byte_len, 0);
+    let diagnostics =
+        empty.artifacts.iter().find(|artifact| artifact.kind == ArtifactKind::Diagnostics).unwrap();
+    let (mut diagnostics_file, _) = backend.artifact(&empty.id, &diagnostics.storage_key).unwrap();
+    let mut diagnostics_json = String::new();
+    diagnostics_file.read_to_string(&mut diagnostics_json).unwrap();
+    assert!(diagnostics_json.contains("emptySource"), "{diagnostics_json}");
+    assert!(backend.web_record(empty).unwrap().failure.is_none());
+
+    let docx = alt_chunk_only_docx();
+    let request = WebTaskRequest { format: Some(InputFormat::Docx), ..WebTaskRequest::default() };
+    let mut upload = backend
+        .begin_upload_configured("omitted.docx", Some(u64::try_from(docx.len()).unwrap()), request)
+        .unwrap();
+    upload.write_chunk(&docx).unwrap();
+    let omitted = upload.finish().unwrap();
+    let omitted = wait_terminal(&backend, &omitted.id);
+    assert_eq!(omitted.status, TaskStatus::Failed);
+    assert!(omitted.artifacts.is_empty());
+    let failure = backend.web_record(omitted).unwrap().failure.unwrap();
+    assert_eq!(failure.code, "malformed");
+    assert_eq!(failure.reason_code.as_deref(), Some("emptyContent"));
+}
+
+fn alt_chunk_only_docx() -> Vec<u8> {
+    let parts = [
+        (
+            "[Content_Types].xml",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#,
+        ),
+        (
+            "_rels/.rels",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rDocument" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+        ),
+        (
+            "word/document.xml",
+            r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:altChunk/></w:body></w:document>"#,
+        ),
+    ];
+    let mut output = Cursor::new(Vec::new());
+    {
+        let mut archive = zip::ZipWriter::new(&mut output);
+        for (name, bytes) in parts {
+            archive.start_file(name, SimpleFileOptions::default()).unwrap();
+            archive.write_all(bytes.as_bytes()).unwrap();
+        }
+        archive.finish().unwrap();
+    }
+    output.into_inner()
+}

--- a/apps/cli/tests/empty_result_contract.rs
+++ b/apps/cli/tests/empty_result_contract.rs
@@ -1,0 +1,221 @@
+//! Real-process contracts for exceptional empty conversion results.
+
+use std::io::{Cursor, Write};
+use std::path::PathBuf;
+use std::process::Command;
+use zip::write::SimpleFileOptions;
+
+fn binary() -> PathBuf {
+    option_env!("CARGO_BIN_EXE_into-md")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("INTO_MD_BIN").map(PathBuf::from))
+        .expect("Cargo or Bazel must provide the into-md binary")
+}
+
+#[test]
+fn genuine_empty_sources_commit_existing_targets_with_complete_reports() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = temporary.path().join("input");
+    let output = temporary.path().join("output");
+    let report = temporary.path().join("report.json");
+    std::fs::create_dir(&input).unwrap();
+    let text = input.join("empty.txt");
+    let markdown = input.join("empty.md");
+    let docx = input.join("empty.docx");
+    let xlsx = input.join("empty.xlsx");
+    std::fs::write(&text, b" \r\n").unwrap();
+    std::fs::write(&markdown, b"\xef\xbb\xbf\n").unwrap();
+    std::fs::write(&docx, empty_docx()).unwrap();
+    std::fs::write(&xlsx, empty_xlsx()).unwrap();
+
+    let result = Command::new(binary())
+        .args(["--no-config", "--output-dir"])
+        .arg(&output)
+        .args(["--report"])
+        .arg(&report)
+        .args([&text, &markdown, &docx, &xlsx])
+        .output()
+        .unwrap();
+
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(result.stdout.is_empty());
+    let report: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).unwrap()).unwrap();
+    assert_eq!(report["succeeded"], 4);
+    assert_eq!(report["failed"], 0);
+    for item in report["items"].as_array().unwrap() {
+        assert_eq!(item["status"], "success");
+        assert_eq!(item["outcome"], "complete");
+        assert_eq!(item["reasonCode"], "emptySource");
+        let target = PathBuf::from(item["output"].as_str().unwrap());
+        assert!(target.is_file(), "missing committed target {target:?}");
+    }
+}
+
+#[test]
+fn empty_stdout_is_explicit_in_reports_and_structured_output() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = temporary.path().join("empty.txt");
+    let report = temporary.path().join("stdout-report.json");
+    std::fs::write(&input, b"\n").unwrap();
+
+    let markdown = Command::new(binary())
+        .args(["--no-config", "--report"])
+        .arg(&report)
+        .arg(&input)
+        .output()
+        .unwrap();
+    assert!(markdown.status.success());
+    assert!(markdown.stdout.is_empty());
+    let report: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).unwrap()).unwrap();
+    assert_eq!(report["items"][0]["outcome"], "complete");
+    assert_eq!(report["items"][0]["reasonCode"], "emptySource");
+
+    let structured = Command::new(binary())
+        .args(["--no-config", "--emit", "result-json"])
+        .arg(&input)
+        .output()
+        .unwrap();
+    assert!(structured.status.success());
+    let result: serde_json::Value = serde_json::from_slice(&structured.stdout).unwrap();
+    assert_eq!(result["markdown"], "");
+    assert!(
+        result["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "emptySource")
+    );
+}
+
+#[test]
+fn empty_content_fails_batch_without_committing_a_false_success_target() {
+    let temporary = tempfile::tempdir().unwrap();
+    let good = temporary.path().join("good.txt");
+    let omitted = temporary.path().join("omitted.docx");
+    let output = temporary.path().join("output");
+    let report = temporary.path().join("report.json");
+    std::fs::write(&good, b"usable").unwrap();
+    std::fs::write(&omitted, alt_chunk_only_docx()).unwrap();
+
+    let result = Command::new(binary())
+        .args(["--no-config", "--output-dir"])
+        .arg(&output)
+        .args(["--report"])
+        .arg(&report)
+        .args([&good, &omitted])
+        .output()
+        .unwrap();
+
+    assert_eq!(result.status.code(), Some(10), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(output.join("good.md").is_file());
+    assert!(!std::fs::read(output.join("good.md")).unwrap().is_empty());
+    assert!(!output.join("omitted.md").exists());
+    let report: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).unwrap()).unwrap();
+    assert_eq!(report["succeeded"], 1);
+    assert_eq!(report["failed"], 1);
+    let failed =
+        report["items"].as_array().unwrap().iter().find(|item| item["status"] == "failed").unwrap();
+    assert_eq!(failed["outcome"], "failed");
+    assert_eq!(failed["errorCode"], "malformed");
+    assert_eq!(failed["reasonCode"], "emptyContent");
+    assert!(failed["output"].as_str().unwrap().ends_with("omitted.md"));
+}
+
+#[test]
+fn recoverable_omission_commits_nonempty_degraded_output() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = temporary.path().join("recovered.rtf");
+    let output = temporary.path().join("output");
+    let report = temporary.path().join("report.json");
+    std::fs::write(&input, br"{\rtf1\ansi visible \unknowncontrol42 text}").unwrap();
+
+    let result = Command::new(binary())
+        .args(["--no-config", "--output-dir"])
+        .arg(&output)
+        .args(["--report"])
+        .arg(&report)
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert!(result.status.success(), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(!std::fs::read(output.join("recovered.md")).unwrap().is_empty());
+    let report: serde_json::Value =
+        serde_json::from_slice(&std::fs::read(&report).unwrap()).unwrap();
+    assert_eq!(report["succeeded"], 1);
+    assert_eq!(report["failed"], 0);
+    assert_eq!(report["items"][0]["status"], "success");
+    assert_eq!(report["items"][0]["outcome"], "degraded");
+    assert_eq!(report["items"][0]["reasonCode"], "rtf.unknownControlIgnored");
+}
+
+fn empty_docx() -> Vec<u8> {
+    docx(
+        r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body></w:body></w:document>"#,
+    )
+}
+
+fn alt_chunk_only_docx() -> Vec<u8> {
+    docx(
+        r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:altChunk/></w:body></w:document>"#,
+    )
+}
+
+fn docx(document: &str) -> Vec<u8> {
+    zip(&[
+        (
+            "[Content_Types].xml",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#,
+        ),
+        (
+            "_rels/.rels",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rDocument" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+        ),
+        ("word/document.xml", document),
+    ])
+}
+
+fn empty_xlsx() -> Vec<u8> {
+    zip(&[
+        (
+            "[Content_Types].xml",
+            r#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/><Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/></Types>"#,
+        ),
+        (
+            "_rels/.rels",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+        ),
+        (
+            "xl/workbook.xml",
+            r#"<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Empty" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+        ),
+        (
+            "xl/_rels/workbook.xml.rels",
+            r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/><Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#,
+        ),
+        (
+            "xl/styles.xml",
+            r#"<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><numFmts count="0"/><fonts count="1"><font/></fonts><fills count="1"><fill><patternFill patternType="none"/></fill></fills><borders count="1"><border/></borders><cellStyleXfs count="1"><xf numFmtId="0"/></cellStyleXfs><cellXfs count="1"><xf numFmtId="0"/></cellXfs></styleSheet>"#,
+        ),
+        (
+            "xl/worksheets/sheet1.xml",
+            r#"<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>"#,
+        ),
+    ])
+}
+
+fn zip(parts: &[(&str, &str)]) -> Vec<u8> {
+    let mut output = Cursor::new(Vec::new());
+    {
+        let mut archive = zip::ZipWriter::new(&mut output);
+        for (name, bytes) in parts {
+            archive.start_file(*name, SimpleFileOptions::default()).unwrap();
+            archive.write_all(bytes.as_bytes()).unwrap();
+        }
+        archive.finish().unwrap();
+    }
+    output.into_inner()
+}

--- a/apps/cli/tests/empty_result_contract.rs
+++ b/apps/cli/tests/empty_result_contract.rs
@@ -125,6 +125,56 @@ fn empty_content_fails_batch_without_committing_a_false_success_target() {
 }
 
 #[test]
+fn empty_content_single_file_still_writes_a_failed_report_and_no_target() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = temporary.path().join("omitted.docx");
+    let output = temporary.path().join("omitted.md");
+    let report = temporary.path().join("report.json");
+    std::fs::write(&input, alt_chunk_only_docx()).unwrap();
+
+    let result = Command::new(binary())
+        .args(["--no-config", "--output"])
+        .arg(&output)
+        .args(["--report"])
+        .arg(&report)
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert_eq!(result.status.code(), Some(10), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(!output.exists());
+    assert_failed_empty_content_report(&report);
+}
+
+#[test]
+fn empty_content_stdout_still_writes_a_failed_report_and_no_stdout() {
+    let temporary = tempfile::tempdir().unwrap();
+    let input = temporary.path().join("omitted.docx");
+    let report = temporary.path().join("report.json");
+    std::fs::write(&input, alt_chunk_only_docx()).unwrap();
+
+    let result = Command::new(binary())
+        .args(["--no-config", "--report"])
+        .arg(&report)
+        .arg(&input)
+        .output()
+        .unwrap();
+
+    assert_eq!(result.status.code(), Some(10), "{}", String::from_utf8_lossy(&result.stderr));
+    assert!(result.stdout.is_empty());
+    assert_failed_empty_content_report(&report);
+}
+
+fn assert_failed_empty_content_report(path: &std::path::Path) {
+    let report: serde_json::Value = serde_json::from_slice(&std::fs::read(path).unwrap()).unwrap();
+    assert_eq!(report["succeeded"], 0);
+    assert_eq!(report["failed"], 1);
+    assert_eq!(report["items"][0]["status"], "failed");
+    assert_eq!(report["items"][0]["outcome"], "failed");
+    assert_eq!(report["items"][0]["reasonCode"], "emptyContent");
+}
+
+#[test]
 fn recoverable_omission_commits_nonempty_degraded_output() {
     let temporary = tempfile::tempdir().unwrap();
     let input = temporary.path().join("recovered.rtf");

--- a/crates/api/src/epub_tests.rs
+++ b/crates/api/src/epub_tests.rs
@@ -198,7 +198,7 @@ fn epub3_spine_navigation_links_footnotes_and_referenced_image_are_stable() {
     assert_eq!(result.assets[0].media_type, "image/png");
     assert!(result.assets[0].external_uri.is_none());
     assert!(result.diagnostics.iter().any(|item| item.code == "epub.spine.nonLinearSkipped"));
-    assert!(result.diagnostics.iter().any(|item| item.code == "epub.unreferencedResourcesOmitted"));
+    assert!(!result.diagnostics.iter().any(|item| item.code == "epub.linkedResourcesOmitted"));
 
     let mut link_targets = Vec::new();
     let mut footnote_references = Vec::new();
@@ -212,6 +212,41 @@ fn epub3_spine_navigation_links_footnotes_and_referenced_image_are_stable() {
         .filter(|node| matches!(&node.block, Block::Footnote { label, .. } if label == "epub-footnote-000001"))
         .count(), 1);
     assert!(has_nested_list(&result.document.blocks));
+}
+
+#[test]
+fn only_reachable_styles_and_their_css_dependencies_are_reported_as_omitted() {
+    let package = std::str::from_utf8(epub3_package()).unwrap().replace(
+        "</manifest>",
+        r#"<item id="font" href="fonts/book.woff2" media-type="font/woff2"/></manifest>"#,
+    );
+    let chapter = std::str::from_utf8(chapter_one()).unwrap().replace(
+        "<title>Chapter One</title>",
+        r#"<title>Chapter One</title><link rel="stylesheet" href="../styles/book.css"/>"#,
+    );
+    let bytes = epub(&[
+        ("META-INF/container.xml", container()),
+        ("OPS/content.opf", package.as_bytes()),
+        ("OPS/nav.xhtml", nav3()),
+        ("OPS/text/one.xhtml", chapter.as_bytes()),
+        ("OPS/text/two.xhtml", chapter_two()),
+        (
+            "OPS/text/extra.xhtml",
+            b"<html xmlns='http://www.w3.org/1999/xhtml'><body><p>skip me</p></body></html>",
+        ),
+        ("OPS/images/cover.png", PNG),
+        ("OPS/styles/book.css", b"@font-face{src:url('../fonts/book.woff2')}"),
+        ("OPS/fonts/book.woff2", b"font"),
+    ]);
+
+    let result = convert(bytes).unwrap();
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|item| item.code == "epub.linkedResourcesOmitted")
+        .expect("linked resources must be disclosed");
+    assert!(diagnostic.message.contains("1 reachable CSS"));
+    assert!(diagnostic.message.contains("1 reachable font"));
 }
 
 #[test]

--- a/crates/api/src/zip_recursive_tests.rs
+++ b/crates/api/src/zip_recursive_tests.rs
@@ -1,6 +1,7 @@
 use crate::{
-    Block, BlockNode, CancellationToken, ConversionError, ConversionOptions, ConversionRequest,
-    ErrorCode, ExecutionOptions, FormatHint, Inline, InputFormat, InputRef, default_engine,
+    Block, BlockNode, CancellationToken, ConversionError, ConversionOptions, ConversionOutcome,
+    ConversionRequest, ErrorCode, ExecutionOptions, FormatHint, Inline, InputFormat, InputRef,
+    ResultContent, default_engine,
 };
 use std::future::Future;
 use std::io::{Cursor, Write as _};
@@ -153,7 +154,11 @@ fn empty_is_valid_but_all_failed_members_are_not_pseudo_success() {
     let empty = archive(&[], false);
     let result = convert(empty, ConversionOptions::default(), ExecutionOptions::default()).unwrap();
     assert!(result.document.blocks.is_empty());
-    assert!(result.diagnostics.is_empty());
+    assert_eq!(result.content().unwrap(), ResultContent::EmptySource);
+    assert_eq!(result.outcome(), ConversionOutcome::Complete);
+    assert_eq!(result.reason_code(), Some("emptySource"));
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(result.diagnostics[0].code, "emptySource");
 
     let unsupported = archive(&[("unknown.bin", b"\0\x01\x02")], false);
     assert!(matches!(

--- a/crates/api/src/zip_recursive_tests.rs
+++ b/crates/api/src/zip_recursive_tests.rs
@@ -168,6 +168,73 @@ fn empty_is_valid_but_all_failed_members_are_not_pseudo_success() {
 }
 
 #[test]
+fn empty_zip_bytes_named_as_xlsx_never_fall_back_to_generic_zip_success() {
+    let invalid_xlsx = archive(&[], false);
+    for policy in [crate::ErrorPolicy::BestEffort, crate::ErrorPolicy::Strict] {
+        let mut request =
+            ConversionRequest::new(InputRef::bytes(invalid_xlsx.clone(), Some("invalid.xlsx")));
+        request.options.error_policy = policy;
+        let error = block_on(default_engine().unwrap().convert(request)).unwrap_err();
+        assert_eq!(error.code(), ErrorCode::Malformed);
+    }
+
+    let nested = archive(&[("invalid.xlsx", &invalid_xlsx)], false);
+    let error =
+        convert(nested, ConversionOptions::default(), ExecutionOptions::default()).unwrap_err();
+    assert!(matches!(
+        error,
+        ConversionError::Malformed { .. }
+            | ConversionError::Unsupported { .. }
+            | ConversionError::NoConverter { .. }
+    ));
+}
+
+#[test]
+fn empty_zip_bytes_with_six_package_extensions_never_become_empty_zip_successes() {
+    let bytes = archive(&[], false);
+    for name in [
+        "invalid.docx",
+        "invalid.pptx",
+        "invalid.xlsx",
+        "invalid.odt",
+        "invalid.ods",
+        "invalid.odp",
+    ] {
+        let request = ConversionRequest::new(InputRef::bytes(bytes.clone(), Some(name)));
+        let error = block_on(default_engine().unwrap().convert(request)).unwrap_err();
+        assert_ne!(error.reason_code(), "emptySource", "{name} was washed into an empty ZIP");
+    }
+}
+
+#[test]
+fn empty_text_members_empty_nested_zip_and_failed_siblings_have_stable_outcomes() {
+    let empty_text = archive(&[("empty.txt", b" \n"), ("empty.md", b"\xef\xbb\xbf\n")], false);
+    let result =
+        convert(empty_text, ConversionOptions::default(), ExecutionOptions::default()).unwrap();
+    assert_eq!(result.content().unwrap(), ResultContent::Markdown);
+    assert!(result.markdown.contains("empty\\.txt"));
+    assert!(result.markdown.contains("empty\\.md"));
+    assert_eq!(result.outcome(), ConversionOutcome::Complete);
+
+    let empty_nested = archive(&[("nested.zip", &archive(&[], false))], false);
+    let result =
+        convert(empty_nested, ConversionOptions::default(), ExecutionOptions::default()).unwrap();
+    assert_eq!(result.content().unwrap(), ResultContent::EmptySource);
+    assert_eq!(result.outcome(), ConversionOutcome::Complete);
+
+    let mixed = archive(&[("empty.txt", b"\n"), ("failed.bin", b"\0\x01\x02")], false);
+    let result = convert(mixed, ConversionOptions::default(), ExecutionOptions::default()).unwrap();
+    assert_eq!(result.content().unwrap(), ResultContent::Markdown);
+    assert!(result.markdown.contains("empty\\.txt"));
+    assert_eq!(result.outcome(), ConversionOutcome::Degraded);
+    assert!(result.diagnostics.iter().any(|diagnostic| {
+        diagnostic.code == "zip.entry.failed"
+            && diagnostic.locator.as_ref().and_then(|locator| locator.part.as_deref())
+                == Some("failed.bin")
+    }));
+}
+
+#[test]
 fn recursive_identity_footnotes_and_character_provenance_are_namespaced() {
     let footnotes = archive(
         &[

--- a/crates/converters/src/docx.rs
+++ b/crates/converters/src/docx.rs
@@ -595,6 +595,15 @@ fn convert_docx(
         options,
         context,
     )?;
+    let glossary_part = relationship_target(&relationships, "glossaryDocument", &main_part)?;
+    if let Some(part) = glossary_part.as_deref() {
+        require_content_type(
+            &package,
+            part,
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document.glossary+xml",
+        )?;
+        package.required(part)?;
+    }
     let styles_part = relationship_target(&relationships, "styles", &main_part)?;
     let styles = if let Some(part) = styles_part.as_deref() {
         require_content_type(
@@ -618,6 +627,13 @@ fn convert_docx(
         BTreeMap::new()
     };
     let mut state = ParseState::default();
+    if let Some(part) = glossary_part.as_deref() {
+        state.warning(
+            "word.glossaryContentOmitted",
+            "authenticated glossary document content is not represented in the Markdown output",
+            part,
+        );
+    }
     if package.macro_present {
         state.warning(
             "docx.macrosIgnored",
@@ -4176,6 +4192,9 @@ mod tests {
                 "word/endnotes.xml" => Some(
                     "application/vnd.openxmlformats-officedocument.wordprocessingml.endnotes+xml",
                 ),
+                "word/glossary/document.xml" => Some(
+                    "application/vnd.openxmlformats-officedocument.wordprocessingml.document.glossary+xml",
+                ),
                 "word/header1.xml" => Some(
                     "application/vnd.openxmlformats-officedocument.wordprocessingml.header+xml",
                 ),
@@ -4238,6 +4257,36 @@ mod tests {
             ("word/_rels/document.xml.rels".into(), relationships.into_bytes()),
             (part.into(), bytes.to_vec()),
         ])
+    }
+
+    #[test]
+    fn authenticated_glossary_content_is_omitted_with_unknown_evidence() {
+        let document =
+            format!(r#"<w:document xmlns:w="{WORD}"><w:body><w:p/></w:body></w:document>"#);
+        let relationships = format!(
+            r#"<Relationships xmlns="{PACKAGE_REL}"><Relationship Id="rGlossary" Type="{REL_TYPE_PREFIX}glossaryDocument" Target="glossary/document.xml"/></Relationships>"#
+        );
+        let glossary = format!(
+            r#"<w:glossaryDocument xmlns:w="{WORD}"><w:docParts><w:docPart><w:docPartBody><w:sdt><w:sdtContent><w:p><w:r><w:t>Building block</w:t></w:r></w:p></w:sdtContent></w:sdt></w:docPartBody></w:docPart></w:docParts></w:glossaryDocument>"#
+        );
+        let bytes = base(
+            document.as_bytes(),
+            &[
+                ("word/_rels/document.xml.rels", relationships.as_bytes()),
+                ("word/glossary/document.xml", glossary.as_bytes()),
+            ],
+        );
+
+        let output = convert_docx(&bytes, &ConversionOptions::default(), &context()).unwrap();
+
+        assert_eq!(output.source_content_evidence(), SourceContentEvidence::Unknown);
+        assert!(output.document.blocks.is_empty());
+        assert!(
+            output
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == "word.glossaryContentOmitted")
+        );
     }
 
     #[test]

--- a/crates/converters/src/docx.rs
+++ b/crates/converters/src/docx.rs
@@ -6,7 +6,7 @@ use into_markdown_core::{
     Converter, ConverterOutput, Diagnostic, DiagnosticSeverity, Document, ExecutionContext,
     FormatCandidate, Inline, InlineMark, InputFormat, ListItem, ListKind, MAX_DOCUMENT_INLINES,
     MAX_DOCUMENT_NODES, MAX_TABLE_COLUMNS, NodeId, ProbeOutcome, Provenance, ProvenanceKind,
-    ResolvedInput, Services, SourceLocator, TableAlignment, TableRow,
+    ResolvedInput, Services, SourceContentEvidence, SourceLocator, TableAlignment, TableRow,
 };
 use quick_xml::events::{BytesCData, BytesRef, BytesStart, BytesText, Event};
 use quick_xml::name::ResolveResult;
@@ -721,7 +721,16 @@ fn convert_docx(
             error.detail
         ),
     })?;
-    Ok(ConverterOutput::new(state.document, state.assets, state.diagnostics))
+    let evidence = if state.document.blocks.is_empty()
+        && state.assets.is_empty()
+        && state.diagnostics.is_empty()
+    {
+        SourceContentEvidence::Empty
+    } else {
+        SourceContentEvidence::Unknown
+    };
+    Ok(ConverterOutput::new(state.document, state.assets, state.diagnostics)
+        .with_source_content_evidence(evidence))
 }
 
 fn relationship_target(

--- a/crates/converters/src/epub/merge.rs
+++ b/crates/converters/src/epub/merge.rs
@@ -3,6 +3,7 @@
 use super::encryption::EncryptionPolicy;
 use super::navigation::{NavEntry, Navigation};
 use super::package::Package;
+use super::reachability::OmittedResources;
 use super::resources::{CoverResource, ResourceStore};
 use super::spine::SpineResult;
 use into_markdown_core::{
@@ -24,6 +25,7 @@ pub(super) fn assemble(
     cover: Option<CoverResource>,
     encryption: EncryptionPolicy,
     rights_metadata: bool,
+    omitted: OmittedResources,
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
     context.checkpoint()?;
@@ -84,7 +86,7 @@ pub(super) fn assemble(
             Some(&path),
         ));
     }
-    append_omitted_resource_diagnostic(&mut output, &package);
+    append_omitted_resource_diagnostic(&mut output, omitted, &package.path);
 
     for (index, chapter) in spine.chapters.iter_mut().enumerate() {
         let sequence = index + 1;
@@ -196,7 +198,7 @@ fn append_navigation(
     blocks: &mut Vec<BlockNode>,
     navigation: Navigation,
 ) -> Result<(), ConversionError> {
-    let Navigation { source_path, entries } = navigation;
+    let Navigation { source_path, entries, .. } = navigation;
     if entries.iter().any(|entry| entry.depth.saturating_add(2) > MAX_DOCUMENT_DEPTH) {
         return Err(ConversionError::ResourceLimit {
             limit: "documentDepth",
@@ -421,20 +423,18 @@ fn chapter_title(chapter: &super::spine::Chapter, package: &Package, sequence: u
         .unwrap_or_else(|| chapter.path.rsplit('/').next().unwrap_or(&chapter.path).to_owned())
 }
 
-fn append_omitted_resource_diagnostic(output: &mut ConverterOutput, package: &Package) {
-    let mut css = 0;
-    let mut fonts = 0;
-    let mut media = 0;
-    for item in package.manifest.values() {
-        match item.media_type.as_str() {
-            "text/css" => css += 1,
-            value if value.starts_with("font/") || value.contains("font") => fonts += 1,
-            value if value.starts_with("audio/") || value.starts_with("video/") => media += 1,
-            _ => {}
-        }
-    }
-    if css + fonts + media > 0 {
-        output.diagnostics.push(omitted_resources_diagnostic(css, fonts, media, &package.path));
+fn append_omitted_resource_diagnostic(
+    output: &mut ConverterOutput,
+    omitted: OmittedResources,
+    package_path: &str,
+) {
+    if omitted.css + omitted.fonts + omitted.media > 0 {
+        output.diagnostics.push(omitted_resources_diagnostic(
+            omitted.css,
+            omitted.fonts,
+            omitted.media,
+            package_path,
+        ));
     }
 }
 
@@ -445,10 +445,10 @@ fn omitted_resources_diagnostic(
     package_path: &str,
 ) -> Diagnostic {
     diagnostic(
-        "epub.unreferencedResourcesOmitted",
+        "epub.linkedResourcesOmitted",
         DiagnosticSeverity::Warning,
         format!(
-            "omitted {css} CSS, {fonts} font, and {media} audio/video manifest resource(s) without a proven lossless IR mapping"
+            "omitted {css} reachable CSS, {fonts} reachable font, and {media} reachable audio/video resource(s) without a proven lossless IR mapping"
         ),
         Some(package_path),
     )

--- a/crates/converters/src/epub/merge.rs
+++ b/crates/converters/src/epub/merge.rs
@@ -69,20 +69,12 @@ pub(super) fn assemble(
         ));
     }
     if spine.skipped_non_linear > 0 {
-        output.diagnostics.push(diagnostic(
-            "epub.spine.nonLinearSkipped",
-            DiagnosticSeverity::Info,
-            format!("skipped {} non-linear spine item(s)", spine.skipped_non_linear),
-            Some(&package.path),
-        ));
+        output
+            .diagnostics
+            .push(non_linear_spine_diagnostic(spine.skipped_non_linear, &package.path));
     }
     if rights_metadata {
-        output.diagnostics.push(diagnostic(
-            "epub.rightsMetadataIgnored",
-            DiagnosticSeverity::Info,
-            "META-INF/rights.xml was retained as inert metadata and not interpreted".into(),
-            Some("META-INF/rights.xml"),
-        ));
+        output.diagnostics.push(rights_metadata_diagnostic());
     }
     for path in encryption.unavailable_fonts {
         output.diagnostics.push(diagnostic(
@@ -177,6 +169,28 @@ pub(super) fn assemble(
     })?;
     output.account_retained(context)
 }
+
+fn non_linear_spine_diagnostic(skipped: usize, package_path: &str) -> Diagnostic {
+    diagnostic(
+        "epub.spine.nonLinearSkipped",
+        DiagnosticSeverity::Warning,
+        format!("skipped {skipped} non-linear spine item(s)"),
+        Some(package_path),
+    )
+}
+
+fn rights_metadata_diagnostic() -> Diagnostic {
+    diagnostic(
+        "epub.rightsMetadataIgnored",
+        DiagnosticSeverity::Info,
+        "META-INF/rights.xml was retained as inert metadata and not interpreted".into(),
+        Some("META-INF/rights.xml"),
+    )
+}
+
+#[cfg(test)]
+#[path = "merge_tests.rs"]
+mod tests;
 
 fn append_navigation(
     blocks: &mut Vec<BlockNode>,
@@ -420,15 +434,24 @@ fn append_omitted_resource_diagnostic(output: &mut ConverterOutput, package: &Pa
         }
     }
     if css + fonts + media > 0 {
-        output.diagnostics.push(diagnostic(
-            "epub.unreferencedResourcesOmitted",
-            DiagnosticSeverity::Info,
-            format!(
-                "omitted {css} CSS, {fonts} font, and {media} audio/video manifest resource(s) without an IR reference contract"
-            ),
-            Some(&package.path),
-        ));
+        output.diagnostics.push(omitted_resources_diagnostic(css, fonts, media, &package.path));
     }
+}
+
+fn omitted_resources_diagnostic(
+    css: usize,
+    fonts: usize,
+    media: usize,
+    package_path: &str,
+) -> Diagnostic {
+    diagnostic(
+        "epub.unreferencedResourcesOmitted",
+        DiagnosticSeverity::Warning,
+        format!(
+            "omitted {css} CSS, {fonts} font, and {media} audio/video manifest resource(s) without a proven lossless IR mapping"
+        ),
+        Some(package_path),
+    )
 }
 
 fn node(id: String, block: Block, part: &str, kind: ProvenanceKind) -> BlockNode {

--- a/crates/converters/src/epub/merge_tests.rs
+++ b/crates/converters/src/epub/merge_tests.rs
@@ -1,0 +1,19 @@
+use super::{
+    non_linear_spine_diagnostic, omitted_resources_diagnostic, rights_metadata_diagnostic,
+};
+use into_markdown_core::{ConversionOutcome, DiagnosticSeverity, conversion_outcome};
+
+#[test]
+fn compatibility_audit_is_complete_but_omitted_chapter_is_degraded() {
+    let compatibility = rights_metadata_diagnostic();
+    assert_eq!(compatibility.severity, DiagnosticSeverity::Info);
+    assert_eq!(conversion_outcome(&[compatibility]), ConversionOutcome::Complete);
+
+    let omitted_chapter = non_linear_spine_diagnostic(1, "OPS/package.opf");
+    assert_eq!(omitted_chapter.severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&[omitted_chapter]), ConversionOutcome::Degraded);
+
+    let omitted_resources = omitted_resources_diagnostic(1, 1, 1, "OPS/package.opf");
+    assert_eq!(omitted_resources.severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&[omitted_resources]), ConversionOutcome::Degraded);
+}

--- a/crates/converters/src/epub/mod.rs
+++ b/crates/converters/src/epub/mod.rs
@@ -10,6 +10,7 @@ mod merge;
 mod navigation;
 mod package;
 mod path;
+mod reachability;
 mod resources;
 mod spine;
 mod xhtml;
@@ -127,6 +128,13 @@ async fn convert_epub(
     let navigation = read_navigation(&package, &mut archive, &mut budget)?;
     let mut spine =
         spine::convert(&package, &mut archive, options, services, &mut budget, context).await?;
+    let omitted = reachability::omitted_resources(
+        &package,
+        navigation.as_ref(),
+        &spine,
+        &mut archive,
+        context,
+    )?;
     let mut resources = ResourceStore::new(options);
     for chapter in &mut spine.chapters {
         resources.bind_chapter_images(
@@ -146,6 +154,7 @@ async fn convert_epub(
         cover,
         encryption,
         rights_metadata,
+        omitted,
         context,
     )
 }

--- a/crates/converters/src/epub/navigation.rs
+++ b/crates/converters/src/epub/navigation.rs
@@ -26,6 +26,7 @@ pub(super) struct NavEntry {
 pub(super) struct Navigation {
     pub(super) source_path: String,
     pub(super) entries: Vec<NavEntry>,
+    pub(super) resource_paths: BTreeSet<String>,
 }
 
 #[allow(clippy::struct_excessive_bools)] // Streaming XHTML context is explicit and non-recursive.
@@ -64,6 +65,7 @@ pub(super) fn parse_nav(
     let mut root_seen = false;
     let mut toc_seen = false;
     let mut entries = Vec::new();
+    let mut resource_paths = BTreeSet::new();
     let mut document_events = xml::DocumentEvents::default();
     loop {
         let event = reader.read_event().map_err(|error| xml::malformed(error.to_string()))?;
@@ -92,6 +94,13 @@ pub(super) fn parse_nav(
                 }
                 if !label_policy::is_known_namespace(name.namespace.as_deref()) {
                     return Err(xml::malformed("navigation contains an unsupported namespace"));
+                }
+                if name.matches(Some(XHTML_NS), b"link")
+                    && let Some(href) = xml::optional(&attributes, None, b"href")
+                    && let Reference::Internal { path, .. } =
+                        base.resolve(href)?.require_existing(archive)?
+                {
+                    resource_paths.insert(path);
                 }
                 let parent_in_toc = stack.last().is_some_and(|frame| frame.in_toc);
                 let declared_toc = name.matches(Some(XHTML_NS), b"nav")
@@ -278,7 +287,7 @@ pub(super) fn parse_nav(
         return Err(xml::malformed("EPUB navigation toc is missing or incomplete"));
     }
     budget.items("navigation", entries.len())?;
-    Ok(Navigation { source_path: path.into(), entries })
+    Ok(Navigation { source_path: path.into(), entries, resource_paths })
 }
 
 fn close_nav_frame(
@@ -528,7 +537,7 @@ pub(super) fn parse_ncx(
         }
     }
     budget.items("NCX navigation", entries.len())?;
-    Ok(Navigation { source_path: path.into(), entries })
+    Ok(Navigation { source_path: path.into(), entries, resource_paths: BTreeSet::new() })
 }
 
 fn normalize(value: &str) -> String {

--- a/crates/converters/src/epub/reachability.rs
+++ b/crates/converters/src/epub/reachability.rs
@@ -1,0 +1,150 @@
+//! Reachability of EPUB resources that have no lossless document-IR mapping.
+
+use super::navigation::Navigation;
+use super::package::Package;
+use super::path::{BasePath, Reference};
+use super::spine::SpineResult;
+use crate::zip_converter::archive_api::SafeArchive;
+use into_markdown_core::{ConversionError, ExecutionContext};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(super) struct OmittedResources {
+    pub(super) css: usize,
+    pub(super) fonts: usize,
+    pub(super) media: usize,
+}
+
+pub(super) fn omitted_resources(
+    package: &Package,
+    navigation: Option<&Navigation>,
+    spine: &SpineResult,
+    archive: &mut SafeArchive<'_, '_>,
+    context: &ExecutionContext,
+) -> Result<OmittedResources, ConversionError> {
+    let by_path = package
+        .manifest
+        .values()
+        .map(|item| (item.path.as_str(), item))
+        .collect::<BTreeMap<_, _>>();
+    let mut queue = spine
+        .chapters
+        .iter()
+        .flat_map(|chapter| chapter.resource_paths.iter().cloned())
+        .collect::<VecDeque<_>>();
+    if let Some(navigation) = navigation {
+        queue.extend(navigation.resource_paths.iter().cloned());
+    }
+    let mut reached = BTreeSet::new();
+    let mut omitted = OmittedResources::default();
+    while let Some(path) = queue.pop_front() {
+        context.checkpoint()?;
+        if !reached.insert(path.clone()) {
+            continue;
+        }
+        let Some(item) = by_path.get(path.as_str()) else { continue };
+        match item.media_type.as_str() {
+            "text/css" => {
+                omitted.css += 1;
+                let entry = archive.read(&path)?;
+                let references = css_references(&path, &entry.bytes, archive)?;
+                drop(entry);
+                queue.extend(references);
+            }
+            value if value.starts_with("font/") || value.contains("font") => omitted.fonts += 1,
+            value if value.starts_with("audio/") || value.starts_with("video/") => {
+                omitted.media += 1;
+            }
+            _ => {}
+        }
+    }
+    Ok(omitted)
+}
+
+fn css_references(
+    path: &str,
+    bytes: &[u8],
+    archive: &SafeArchive<'_, '_>,
+) -> Result<BTreeSet<String>, ConversionError> {
+    let text = std::str::from_utf8(bytes).map_err(|_| ConversionError::Malformed {
+        part: Some(path.into()),
+        detail: "reachable CSS resource is not UTF-8".into(),
+    })?;
+    let without_comments = strip_comments(text);
+    let lower = without_comments.to_ascii_lowercase();
+    let base = BasePath::document(path)?;
+    let mut values = Vec::new();
+    let mut cursor = 0;
+    while let Some(relative) = lower[cursor..].find("url(") {
+        let start = cursor + relative + 4;
+        let end =
+            without_comments[start..].find(')').ok_or_else(|| ConversionError::Malformed {
+                part: Some(path.into()),
+                detail: "reachable CSS contains an unterminated url()".into(),
+            })? + start;
+        values.push(trim_css_url(&without_comments[start..end])?);
+        cursor = end + 1;
+    }
+    cursor = 0;
+    while let Some(relative) = lower[cursor..].find("@import") {
+        let start = cursor + relative + "@import".len();
+        let tail = without_comments[start..].trim_start();
+        if let Some(quote @ ('\'' | '"')) = tail.chars().next() {
+            let value = &tail[quote.len_utf8()..];
+            let end = value.find(quote).ok_or_else(|| ConversionError::Malformed {
+                part: Some(path.into()),
+                detail: "reachable CSS contains an unterminated @import".into(),
+            })?;
+            values.push(value[..end].trim());
+        }
+        cursor = start;
+    }
+    let mut output = BTreeSet::new();
+    for value in values {
+        if value.is_empty() || value.starts_with('#') || value.starts_with("data:") {
+            continue;
+        }
+        let reference = base.resolve(value)?.require_existing(archive)?;
+        if let Reference::Internal { path, .. } = reference {
+            output.insert(path);
+        }
+    }
+    Ok(output)
+}
+
+fn trim_css_url(value: &str) -> Result<&str, ConversionError> {
+    let value = value.trim();
+    if let Some(quote @ ('\'' | '"')) = value.chars().next() {
+        return value
+            .strip_prefix(quote)
+            .and_then(|value| value.strip_suffix(quote))
+            .map(str::trim)
+            .ok_or_else(|| ConversionError::Malformed {
+                part: None,
+                detail: "reachable CSS contains mismatched url() quotes".into(),
+            });
+    }
+    Ok(value)
+}
+
+fn strip_comments(value: &str) -> String {
+    let mut output = String::with_capacity(value.len());
+    let mut remaining = value;
+    while let Some(start) = remaining.find("/*") {
+        output.push_str(&remaining[..start]);
+        let Some(end) = remaining[start + 2..].find("*/") else { return output };
+        remaining = &remaining[start + 2 + end + 2..];
+    }
+    output.push_str(remaining);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_comments;
+
+    #[test]
+    fn comments_do_not_create_resource_edges() {
+        assert_eq!(strip_comments("a{/* url(orphan.woff) */color:red}"), "a{color:red}");
+    }
+}

--- a/crates/converters/src/epub/spine.rs
+++ b/crates/converters/src/epub/spine.rs
@@ -22,6 +22,7 @@ pub(super) struct Chapter {
     pub(super) internal_targets: BTreeSet<String>,
     pub(super) anchors: BTreeSet<String>,
     pub(super) footnotes: Vec<Footnote>,
+    pub(super) resource_paths: BTreeSet<String>,
 }
 
 pub(super) struct SpineResult {
@@ -107,6 +108,7 @@ pub(super) async fn convert(
             internal_targets: prepared.internal_targets,
             anchors: prepared.anchors,
             footnotes: prepared.footnotes,
+            resource_paths: prepared.resource_paths,
         });
     }
     if chapters.is_empty() {

--- a/crates/converters/src/epub/xhtml.rs
+++ b/crates/converters/src/epub/xhtml.rs
@@ -25,6 +25,7 @@ pub(super) struct PreparedXhtml {
     pub(super) internal_targets: BTreeSet<String>,
     pub(super) anchors: BTreeSet<String>,
     pub(super) footnotes: Vec<Footnote>,
+    pub(super) resource_paths: BTreeSet<String>,
     pub(super) _memory: ResourceReservation,
 }
 
@@ -39,6 +40,13 @@ struct Frame {
 struct FootnoteBuilder {
     target: String,
     text: String,
+}
+
+#[derive(Default)]
+struct RewriteInventory {
+    references: BTreeMap<String, String>,
+    internal_targets: BTreeSet<String>,
+    resource_paths: BTreeSet<String>,
 }
 
 #[allow(clippy::too_many_lines)] // Rewriting and footnote extraction share the namespace stack.
@@ -76,8 +84,7 @@ pub(super) fn prepare(
     let mut stack = Vec::<Frame>::new();
     let mut root_seen = false;
     let mut document_events = xml::DocumentEvents::default();
-    let mut references = BTreeMap::new();
-    let mut internal_targets = BTreeSet::new();
+    let mut inventory = RewriteInventory::default();
     let mut anchors = BTreeSet::new();
     let mut footnotes = Vec::new();
     loop {
@@ -140,15 +147,8 @@ pub(super) fn prepare(
                 let suppressed_output =
                     is_footnote || stack.last().is_some_and(|frame| frame.suppressed_output);
                 if !suppressed_output {
-                    let rewritten = rewrite_element(
-                        &reader,
-                        &element,
-                        &name,
-                        &base,
-                        archive,
-                        &mut references,
-                        &mut internal_targets,
-                    )?;
+                    let rewritten =
+                        rewrite_element(&reader, &element, &name, &base, archive, &mut inventory)?;
                     writer
                         .write_event(if empty {
                             Event::Empty(rewritten)
@@ -222,10 +222,11 @@ pub(super) fn prepare(
     }
     Ok(PreparedXhtml {
         bytes: output,
-        references,
-        internal_targets,
+        references: inventory.references,
+        internal_targets: inventory.internal_targets,
         anchors,
         footnotes,
+        resource_paths: inventory.resource_paths,
         _memory: memory,
     })
 }
@@ -236,8 +237,7 @@ fn rewrite_element(
     name: &Name,
     base: &BasePath,
     archive: &SafeArchive<'_, '_>,
-    references: &mut BTreeMap<String, String>,
-    internal_targets: &mut BTreeSet<String>,
+    inventory: &mut RewriteInventory,
 ) -> Result<BytesStart<'static>, ConversionError> {
     let element_name = element.name();
     let qname = std::str::from_utf8(element_name.as_ref())
@@ -266,17 +266,33 @@ fn rewrite_element(
             && (name.local == b"a" && local.as_ref() == b"href"
                 || name.local == b"img" && local.as_ref() == b"src")
             && matches!(namespace, ResolveResult::Unbound);
+        let resource = name.namespace.as_deref() == Some(XHTML_NS)
+            && matches!(namespace, ResolveResult::Unbound)
+            && matches!(
+                (name.local.as_slice(), local.as_ref()),
+                (b"link", b"href")
+                    | (b"audio" | b"video" | b"source" | b"track" | b"iframe", b"src")
+                    | (b"video", b"poster")
+                    | (b"object", b"data")
+            );
+        if resource {
+            let reference = base.resolve(&value)?.require_existing(archive)?;
+            if let super::path::Reference::Internal { path, .. } = reference {
+                inventory.resource_paths.insert(path);
+            }
+        }
         if rewrite {
             let reference = base.resolve(&value)?.require_existing(archive)?;
             if let Some(synthetic) = reference.synthetic_url()? {
                 let canonical = reference.canonical_target();
-                if references
+                if inventory
+                    .references
                     .insert(synthetic.clone(), canonical.clone())
                     .is_some_and(|old| old != canonical)
                 {
                     return Err(xml::malformed("synthetic XHTML reference alias collision"));
                 }
-                internal_targets.insert(canonical);
+                inventory.internal_targets.insert(canonical);
                 value = synthetic;
             }
         }

--- a/crates/converters/src/image_converter/ocr.rs
+++ b/crates/converters/src/image_converter/ocr.rs
@@ -310,7 +310,7 @@ fn materialize_nodes(
         {
             diagnostics.push(Diagnostic {
                 code: "ocr.lowConfidence".into(),
-                severity: DiagnosticSeverity::Info,
+                severity: DiagnosticSeverity::Warning,
                 message: format!("OCR region {index} was omitted below the configured confidence"),
                 locator: Some(page_locator(
                     materialize.page,

--- a/crates/converters/src/image_converter/tests.rs
+++ b/crates/converters/src/image_converter/tests.rs
@@ -2,8 +2,9 @@ use super::*;
 use image::{DynamicImage, ImageFormat, Rgba, RgbaImage};
 use into_markdown_core::{
     AiCapability, AiInput, AiOutput, AiProvider, AiRequest, BoundOcrResult, BoxFuture,
-    ExecutionOptions, Inline, OcrEngine, OcrEvidenceStage, OcrEvidenceStep, OcrOutputPlan,
-    OcrPolicy, OcrRecognition, OcrRegion, OcrRequest, OcrResult, ResourceLimits, SourceMetadata,
+    ConversionOutcome, ExecutionOptions, Inline, OcrEngine, OcrEvidenceStage, OcrEvidenceStep,
+    OcrOutputPlan, OcrPolicy, OcrRecognition, OcrRegion, OcrRequest, OcrResult, ResourceLimits,
+    SourceMetadata, conversion_outcome,
 };
 use std::collections::BTreeSet;
 use std::future::Future;
@@ -769,6 +770,28 @@ fn bound_ocr_emits_exact_geometry_confidence_and_chain() {
     assert!((evidence.regions[0].detection_confidence - 0.98).abs() < f32::EPSILON);
     assert_eq!(evidence.chain.len(), 3);
     assert_eq!(evidence.chain[2].stage, OcrEvidenceStage::Merge);
+}
+
+#[test]
+fn low_confidence_ocr_omission_is_degraded() {
+    let mut options = options();
+    options.ocr.policy = OcrPolicy::Always;
+    options.ocr.minimum_confidence = 0.99;
+    let services = Services { ocr: Some(Arc::new(BoundOcr)), ..Services::default() };
+    let output = block_on(convert_image(
+        &input(encoded(ImageFormat::Png), "low-confidence.png"),
+        &options,
+        &services,
+        &context(&options),
+    ))
+    .unwrap();
+    let diagnostic = output
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "ocr.lowConfidence")
+        .unwrap();
+    assert_eq!(diagnostic.severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&output.diagnostics), ConversionOutcome::Degraded);
 }
 
 struct LegacyOcr;

--- a/crates/converters/src/lib.rs
+++ b/crates/converters/src/lib.rs
@@ -781,14 +781,27 @@ impl FormatDetector for HintFormatDetector {
             Ok(evidence
                 .into_iter()
                 .map(|(format, reasons)| {
-                    let confidence = if matches!(
-                        format,
-                        InputFormat::Markdown
-                            | InputFormat::Csv
-                            | InputFormat::Tsv
-                            | InputFormat::Wikipedia
-                    ) {
-                        0.99
+                    let strong_package_hint = !conflict
+                        && reasons.contains(&"filename extension")
+                        && matches!(
+                            format,
+                            InputFormat::Docx
+                                | InputFormat::Pptx
+                                | InputFormat::Xlsx
+                                | InputFormat::Odt
+                                | InputFormat::Ods
+                                | InputFormat::Odp
+                                | InputFormat::Epub
+                        );
+                    let confidence = if strong_package_hint
+                        || matches!(
+                            format,
+                            InputFormat::Markdown
+                                | InputFormat::Csv
+                                | InputFormat::Tsv
+                                | InputFormat::Wikipedia
+                        ) {
+                        if strong_package_hint { 0.91 } else { 0.99 }
                     } else if reasons.len() > 1 {
                         0.68
                     } else if reasons[0] == "media type" {
@@ -3422,6 +3435,26 @@ mod tests {
         let candidates = block_on(detector.detect(&input, &hint, &execution_context())).unwrap();
         assert_eq!(candidates.len(), 2);
         assert!(candidates.iter().all(|candidate| !candidate.diagnostics.is_empty()));
+    }
+
+    #[test]
+    fn package_extension_is_stronger_than_generic_zip_content() {
+        let input = resolved([b"PK\x05\x06".as_slice(), &[0_u8; 18]].concat(), "invalid.xlsx");
+        let hints = block_on(HintFormatDetector.detect(
+            &input,
+            &FormatHint::default(),
+            &execution_context(),
+        ))
+        .unwrap();
+        let content = block_on(ContentFormatDetector.detect(
+            &input,
+            &FormatHint::default(),
+            &execution_context(),
+        ))
+        .unwrap();
+        let xlsx = hints.iter().find(|candidate| candidate.format == InputFormat::Xlsx).unwrap();
+        let zip = content.iter().find(|candidate| candidate.format == InputFormat::Zip).unwrap();
+        assert!(xlsx.confidence > zip.confidence);
     }
 
     #[test]

--- a/crates/converters/src/markdown.rs
+++ b/crates/converters/src/markdown.rs
@@ -6,7 +6,7 @@ use into_markdown_core::{
     Converter, ConverterOutput, Diagnostic, DiagnosticSeverity, Document, ExecutionContext,
     FormatCandidate, Inline, InlineMark, InputFormat, ListItem, ListKind, MAX_DOCUMENT_INLINES,
     MAX_DOCUMENT_NODES, NodeId, ProbeOutcome, Provenance, ProvenanceKind, ResolvedInput, Services,
-    SourceLocator, TableAlignment, TableRow, canonical_external_asset_uri,
+    SourceContentEvidence, SourceLocator, TableAlignment, TableRow, canonical_external_asset_uri,
 };
 use pulldown_cmark::{
     Alignment, CodeBlockKind, CowStr, Event, HeadingLevel, Options, Parser, Tag, TagEnd,
@@ -169,6 +169,10 @@ pub(crate) fn convert_markdown(
     }
     let (mut decoded, mut diagnostics) =
         text::decode_source(&input.bytes, Some("utf-8"), options.text.decoding_mode, context)?;
+    if diagnostics.is_empty() && decoded.text.chars().all(char::is_whitespace) {
+        return Ok(ConverterOutput::new(Document::default(), Vec::new(), diagnostics)
+            .with_source_content_evidence(SourceContentEvidence::Empty));
+    }
     scan_duplicate_definitions(&mut decoded, &mut diagnostics, context)?;
     let mut builder = Builder::new(&decoded, options, context, diagnostics)?;
     builder.parse()?;

--- a/crates/converters/src/presentation/mod.rs
+++ b/crates/converters/src/presentation/mod.rs
@@ -34,8 +34,9 @@ use into_markdown_core::{
     Block, BoxFuture, ConversionError, ConversionOptions, Converter, ConverterEventSink,
     ConverterOutput, ConverterStream, ConverterStreamCompletion, ConverterStreamMode, Diagnostic,
     DiagnosticSeverity, ExecutionContext, FormatCandidate, Inline, InputFormat, LocalBoxFuture,
-    ProbeOutcome, ResolvedInput, Services, SourceLocator, StreamConsumerKind,
-    estimate_retained_output, estimate_validation_working_set, stream_converter_output,
+    ProbeOutcome, ResolvedInput, Services, SourceContentEvidence, SourceLocator,
+    StreamConsumerKind, document_is_empty, estimate_retained_output,
+    estimate_validation_working_set, stream_converter_output,
 };
 use model::{Package, ParseState};
 use output::shapes_to_blocks;
@@ -278,7 +279,7 @@ fn convert_presentation(
             })?;
             state.diagnostics.push(Diagnostic {
                 code: "presentation.hiddenSlideSkipped".into(),
-                severity: DiagnosticSeverity::Info,
+                severity: DiagnosticSeverity::Warning,
                 message: format!("hidden slide {slide_number} was deterministically omitted"),
                 locator: Some(SourceLocator {
                     slide: Some(slide_number),
@@ -464,7 +465,16 @@ fn convert_presentation(
     if package.memory_bytes < retained {
         package.grow_memory(retained - package.memory_bytes)?;
     }
-    let output = ConverterOutput::new(state.document, state.assets, state.diagnostics);
+    let evidence = if document_is_empty(&state.document)
+        && state.assets.is_empty()
+        && state.diagnostics.is_empty()
+    {
+        SourceContentEvidence::Empty
+    } else {
+        SourceContentEvidence::Unknown
+    };
+    let output = ConverterOutput::new(state.document, state.assets, state.diagnostics)
+        .with_source_content_evidence(evidence);
     let Package { memory, .. } = package;
     output.certify_preflight_reservation(context, memory)
 }

--- a/crates/converters/src/presentation/tests/conversion.rs
+++ b/crates/converters/src/presentation/tests/conversion.rs
@@ -2,8 +2,9 @@ use super::super::relationships::resolve_target;
 use super::super::schema::{A_NS, LAYOUT_REL, P_NS, R_NS, REL_NS, REL_PREFIX, SLIDE_REL};
 use super::support::{block_on, convert, fixture, rewrite_part, zip};
 use into_markdown_core::{
-    Block, ConversionError, ConversionOptions, ExecutionContext, ExecutionOptions, FormatDetector,
-    FormatHint, InputFormat, ResolvedInput, SourceMetadata,
+    Block, ConversionError, ConversionOptions, ConversionOutcome, DiagnosticSeverity,
+    ExecutionContext, ExecutionOptions, FormatDetector, FormatHint, InputFormat, ResolvedInput,
+    SourceMetadata, conversion_outcome,
 };
 use into_markdown_render_markdown::render;
 use std::io::{Cursor, Read};
@@ -122,6 +123,8 @@ fn multiple_slide_boundaries_and_hidden_slide_order_are_deterministic() {
     assert_eq!(output.document.blocks.len(), 1);
     assert!(matches!(output.document.blocks[0].block, Block::Slide { number: 2, .. }));
     assert_eq!(output.diagnostics[0].code, "presentation.hiddenSlideSkipped");
+    assert_eq!(output.diagnostics[0].severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&output.diagnostics), ConversionOutcome::Degraded);
     assert_eq!(output.diagnostics[0].locator.as_ref().unwrap().slide, Some(1));
 }
 

--- a/crates/converters/src/rtf/control.rs
+++ b/crates/converters/src/rtf/control.rs
@@ -271,7 +271,7 @@ impl Parser<'_> {
             _ if is_known_non_destination_control(name) => {}
             _ => self.add_diagnostic(
                 "rtf.unknownControlIgnored",
-                DiagnosticSeverity::Info,
+                DiagnosticSeverity::Warning,
                 "unknown non-destination control word was ignored",
                 Some(locator(start, end)),
             )?,
@@ -309,7 +309,7 @@ impl Parser<'_> {
             _ => {
                 self.add_diagnostic(
                     "rtf.unknownControlSymbolIgnored",
-                    DiagnosticSeverity::Info,
+                    DiagnosticSeverity::Warning,
                     "unknown control symbol was ignored",
                     Some(locator(start, end)),
                 )?;

--- a/crates/converters/src/rtf/parser.rs
+++ b/crates/converters/src/rtf/parser.rs
@@ -265,7 +265,9 @@ impl<'a> Parser<'a> {
         }
         self.flush_pending_surrogate()?;
         self.finish_table_or_paragraph(self.bytes.len())?;
-        if self.blocks.is_empty() && self.assets.is_empty() {
+        let source_is_empty =
+            self.blocks.is_empty() && self.assets.is_empty() && self.diagnostics.is_empty();
+        if source_is_empty {
             self.add_diagnostic(
                 "rtf.emptyDocument",
                 DiagnosticSeverity::Info,
@@ -294,7 +296,18 @@ impl<'a> Parser<'a> {
         // table, and decode buffer has been dropped. Only then may the retained-output
         // authority shrink the same authenticated reservation to the live IR/assets.
         drop(self);
-        ConverterOutput::new_with_memory_reservation(document, assets, diagnostics, context, memory)
+        let output = ConverterOutput::new_with_memory_reservation(
+            document,
+            assets,
+            diagnostics,
+            context,
+            memory,
+        )?;
+        Ok(if source_is_empty {
+            output.with_source_content_evidence(into_markdown_core::SourceContentEvidence::Empty)
+        } else {
+            output
+        })
     }
 
     pub(super) fn state(&self) -> &State {

--- a/crates/converters/src/rtf/tests.rs
+++ b/crates/converters/src/rtf/tests.rs
@@ -382,9 +382,22 @@ fn table_list_and_safe_field_map_to_structured_ir() {
         !link.diagnostics.iter().any(|diagnostic| diagnostic.code == "rtf.unknownControlIgnored")
     );
     let unknown = convert(b"{\\rtf1\\ansi\\definitelyunknown text}").unwrap();
-    assert!(
-        unknown.diagnostics.iter().any(|diagnostic| diagnostic.code == "rtf.unknownControlIgnored")
-    );
+    let diagnostic = unknown
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == "rtf.unknownControlIgnored")
+        .unwrap();
+    assert_eq!(diagnostic.severity, DiagnosticSeverity::Warning);
+    assert_eq!(conversion_outcome(&unknown.diagnostics), ConversionOutcome::Degraded);
+}
+
+#[test]
+fn empty_rtf_is_certified_without_degrading_its_audit_diagnostic() {
+    let output = convert(b"{\\rtf1\\ansi}").unwrap();
+    assert_eq!(output.source_content_evidence(), SourceContentEvidence::Empty);
+    assert_eq!(output.diagnostics[0].code, "rtf.emptyDocument");
+    assert_eq!(output.diagnostics[0].severity, DiagnosticSeverity::Info);
+    assert_eq!(conversion_outcome(&output.diagnostics), ConversionOutcome::Complete);
 }
 
 #[test]

--- a/crates/converters/src/text.rs
+++ b/crates/converters/src/text.rs
@@ -7,7 +7,8 @@ use into_markdown_core::{
     Block, BlockNode, BoxFuture, ConversionError, ConversionOptions, Converter, ConverterOutput,
     Diagnostic, DiagnosticSeverity, Document, ExecutionContext, FormatCandidate, Inline,
     InputFormat, MAX_DOCUMENT_INLINES, MAX_DOCUMENT_NODES, NodeId, ProbeOutcome, Provenance,
-    ProvenanceKind, ResolvedInput, ResourceReservation, Services, SourceLocator, TextDecodingMode,
+    ProvenanceKind, ResolvedInput, ResourceReservation, Services, SourceContentEvidence,
+    SourceLocator, TextDecodingMode,
 };
 use std::mem::size_of;
 
@@ -805,6 +806,11 @@ fn convert_text(
         options.text.decoding_mode,
         context,
     )?;
+    let source_is_empty = diagnostics.is_empty() && decoded.text.chars().all(char::is_whitespace);
+    if source_is_empty {
+        return Ok(ConverterOutput::new(Document::default(), Vec::new(), diagnostics)
+            .with_source_content_evidence(SourceContentEvidence::Empty));
+    }
     let max_decoded_text_bytes =
         size.checked_mul(3).ok_or_else(|| ConversionError::ResourceLimit {
             limit: "max_text_decoded_bytes",

--- a/crates/converters/src/workbook/mod.rs
+++ b/crates/converters/src/workbook/mod.rs
@@ -27,7 +27,7 @@ use into_markdown_core::{
     BoxFuture, ConversionError, ConversionOptions, Converter, ConverterEventSink, ConverterOutput,
     ConverterStream, ConverterStreamCompletion, ConverterStreamMode, ExecutionContext,
     FormatCandidate, InputFormat, LocalBoxFuture, ProbeOutcome, ResolvedInput, Services,
-    StreamConsumerKind, stream_converter_output,
+    SourceContentEvidence, StreamConsumerKind, document_is_empty, stream_converter_output,
 };
 
 const FORMATS: &[InputFormat] = &[InputFormat::Xlsx];
@@ -43,7 +43,15 @@ pub(crate) fn convert_legacy_xls(
     options: &ConversionOptions,
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
-    calamine_adapter::convert_xls(bytes, options, context)
+    let output = calamine_adapter::convert_xls(bytes, options, context)?;
+    if document_is_empty(&output.document)
+        && output.assets.is_empty()
+        && output.diagnostics.is_empty()
+    {
+        Ok(output.with_source_content_evidence(SourceContentEvidence::Empty))
+    } else {
+        Ok(output)
+    }
 }
 
 impl Converter for WorkbookConverter {

--- a/crates/converters/src/workbook/orchestrator.rs
+++ b/crates/converters/src/workbook/orchestrator.rs
@@ -4,7 +4,8 @@ use crate::workbook::model::WorkbookKind;
 use crate::workbook::preflight::preflight_package;
 use into_markdown_core::{
     Block, BlockNode, ConversionError, ConversionOptions, ConverterOutput, ExecutionContext,
-    estimate_retained_output, estimate_validation_working_set,
+    SourceContentEvidence, document_is_empty, estimate_retained_output,
+    estimate_validation_working_set,
 };
 
 pub(super) fn convert_workbook(
@@ -87,6 +88,12 @@ pub(super) fn convert_workbook(
             .metadata
             .properties
             .insert(format!("spreadsheet.preflight.{name}"), value.to_string());
+    }
+    if document_is_empty(&output.document)
+        && output.assets.is_empty()
+        && output.diagnostics.is_empty()
+    {
+        output = output.with_source_content_evidence(SourceContentEvidence::Empty);
     }
     output.document.validate().map_err(|error| ConversionError::Internal {
         detail: format!("workbook converter produced invalid IR: {error}"),

--- a/crates/converters/src/zip/recursive.rs
+++ b/crates/converters/src/zip/recursive.rs
@@ -4,7 +4,7 @@ use super::entry_policy::EntryKind;
 use super::merge::MergeState;
 use into_markdown_core::{
     BoxFuture, ConversionError, ConversionOptions, ConverterOutput, ErrorCode, FormatHint,
-    NestedConversionRequest, ResolvedInput, Services, SourceMetadata,
+    NestedConversionRequest, ResolvedInput, Services, SourceContentEvidence, SourceMetadata,
 };
 use std::sync::Arc;
 
@@ -30,7 +30,13 @@ pub(super) async fn convert<'a>(
             ConversionError::Unsupported { detail: "ZIP contains no convertible members".into() }
         }));
     }
-    walker.merge.finish()
+    let has_leaf_content = walker.stats.leaves != 0;
+    let output = walker.merge.finish()?;
+    Ok(if has_leaf_content {
+        output
+    } else {
+        output.with_source_content_evidence(SourceContentEvidence::Empty)
+    })
 }
 
 struct RecursiveConverter<'a> {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -83,6 +83,10 @@ pub enum ConversionError {
         /// Human-readable structural failure.
         detail: String,
     },
+    /// Conversion completed structurally but produced no usable content and
+    /// the converter did not certify that the source itself was empty.
+    #[error("conversion produced no usable content")]
+    EmptyContent,
     /// The input cannot be opened without a password.
     #[error("input is encrypted or password protected")]
     Encrypted,
@@ -159,7 +163,7 @@ impl ConversionError {
         match self {
             Self::Unsupported { .. } => ErrorCode::Unsupported,
             Self::NoConverter { .. } => ErrorCode::NoConverter,
-            Self::Malformed { .. } => ErrorCode::Malformed,
+            Self::Malformed { .. } | Self::EmptyContent => ErrorCode::Malformed,
             Self::Encrypted => ErrorCode::Encrypted,
             Self::ResourceLimit { .. } => ErrorCode::ResourceLimit,
             Self::Ocr { .. } => ErrorCode::Ocr,
@@ -178,6 +182,7 @@ impl ConversionError {
     #[must_use]
     pub const fn reason_code(&self) -> &'static str {
         match self {
+            Self::EmptyContent => "emptyContent",
             Self::Recovery { reason, .. } => reason,
             Self::ResourceLimit { limit, .. } => limit,
             _ => self.code().as_str(),
@@ -229,6 +234,7 @@ mod tests {
             (ConversionError::Unsupported { detail: String::new() }, "unsupported"),
             (ConversionError::NoConverter { format: "pdf".into() }, "noConverter"),
             (ConversionError::Malformed { part: None, detail: String::new() }, "malformed"),
+            (ConversionError::EmptyContent, "malformed"),
             (ConversionError::Encrypted, "encrypted"),
             (
                 ConversionError::ResourceLimit { limit: "bytes", detail: String::new() },

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,6 +16,7 @@ mod media_checkpoint;
 mod nested;
 mod ocr_binding;
 mod options;
+mod result_policy;
 mod spi;
 mod stream;
 mod summary;
@@ -62,6 +63,12 @@ pub use options::{
     DelimitedTextOptions, DiarizationOptions, ErrorPolicy, NetworkOptions, OcrOptions, OcrPolicy,
     OutputOptions, RaggedRowsMode, ResourceLimits, TableHeaderMode, TextDecodingMode, TextOptions,
 };
+pub use result_policy::{
+    ASSET_ONLY_REASON_CODE, EMPTY_SOURCE_REASON_CODE, ResultContent, SourceContentEvidence,
+    classify_result, conversion_outcome, markdown_has_visible_content,
+};
+#[doc(hidden)]
+pub use result_policy::{document_is_asset_only, document_is_empty};
 pub use spi::{
     AiCapability, AiInput, AiOutput, AiProvider, AiRequest, ArtifactSink, AssetStreamInfo,
     BoxFuture, ConversionOutcome, ConversionRequest, ConversionResult, ConversionSummary,

--- a/crates/core/src/result_policy.rs
+++ b/crates/core/src/result_policy.rs
@@ -49,11 +49,14 @@ pub(crate) enum DocumentContent {
 }
 
 impl DocumentContent {
-    fn merge(self, other: Self) -> Self {
-        match (self, other) {
-            (Self::Visible, _) | (_, Self::Visible) => Self::Visible,
-            (Self::AssetsOnly, _) | (_, Self::AssetsOnly) => Self::AssetsOnly,
-            _ => Self::Empty,
+    fn merge_non_visible(&mut self, other: Self) -> bool {
+        match other {
+            Self::Visible => true,
+            Self::AssetsOnly => {
+                *self = Self::AssetsOnly;
+                false
+            }
+            Self::Empty => false,
         }
     }
 }
@@ -62,11 +65,7 @@ impl DocumentContent {
 /// format-specific container structure.
 #[must_use]
 pub(crate) fn document_content(document: &Document) -> DocumentContent {
-    document
-        .blocks
-        .iter()
-        .map(|node| block_content(&node.block))
-        .fold(DocumentContent::Empty, DocumentContent::merge)
+    nodes_content(&document.blocks)
 }
 
 /// Whether a converter result has no visible semantic body content.
@@ -113,38 +112,37 @@ pub fn classify_result(
     assets: &[Asset],
     diagnostics: &[Diagnostic],
 ) -> Result<ResultContent, ConversionError> {
-    let empty_source = has_reason(diagnostics, EMPTY_SOURCE_REASON_CODE);
-    let asset_only = has_reason(diagnostics, ASSET_ONLY_REASON_CODE);
+    if markdown_has_visible_content(markdown) {
+        return Ok(ResultContent::Markdown);
+    }
+    let (empty_source, asset_only) = evidence_reasons(diagnostics);
     if empty_source && asset_only {
         return Err(ConversionError::Internal {
             detail: "result carries conflicting empty-source and asset-only evidence".into(),
         });
     }
-    let content = document_content(document);
     if empty_source {
-        if content != DocumentContent::Empty || !assets.is_empty() {
+        if !assets.is_empty() || document_content(document) != DocumentContent::Empty {
             return Err(ConversionError::Internal {
                 detail: "empty-source evidence conflicts with retained document content".into(),
             });
         }
-        if markdown_has_visible_content(markdown) {
-            return Ok(ResultContent::Markdown);
-        }
         return Ok(ResultContent::EmptySource);
     }
+    if assets.is_empty() {
+        return Err(ConversionError::EmptyContent);
+    }
+    let content = document_content(document);
     if asset_only {
         if content != DocumentContent::AssetsOnly || assets.is_empty() {
             return Err(ConversionError::Internal {
                 detail: "asset-only evidence requires asset-only IR and retained assets".into(),
             });
         }
-        if markdown_has_visible_content(markdown) {
-            return Ok(ResultContent::Markdown);
-        }
         return Ok(ResultContent::AssetsOnly);
     }
-    if markdown_has_visible_content(markdown) {
-        Ok(ResultContent::Markdown)
+    if content == DocumentContent::AssetsOnly {
+        Ok(ResultContent::AssetsOnly)
     } else {
         Err(ConversionError::EmptyContent)
     }
@@ -178,8 +176,18 @@ impl ConversionResult {
         } else if has_reason(&self.diagnostics, ASSET_ONLY_REASON_CODE) {
             Some(ASSET_ONLY_REASON_CODE)
         } else {
-            None
+            match self.content().ok()? {
+                ResultContent::AssetsOnly => Some(ASSET_ONLY_REASON_CODE),
+                ResultContent::Markdown | ResultContent::EmptySource => None,
+            }
         }
+    }
+
+    /// Whether every retained asset can be represented by a destination that
+    /// accepts local payloads and/or external URI metadata.
+    #[must_use]
+    pub fn assets_are_deliverable(&self, payloads: bool, external_references: bool) -> bool {
+        assets_are_deliverable(&self.assets, payloads, external_references)
     }
 }
 
@@ -206,9 +214,43 @@ impl crate::ConversionSummary {
         } else if has_reason(&self.diagnostics, ASSET_ONLY_REASON_CODE) {
             Some(ASSET_ONLY_REASON_CODE)
         } else {
-            None
+            match self.content? {
+                ResultContent::AssetsOnly => Some(ASSET_ONLY_REASON_CODE),
+                ResultContent::Markdown | ResultContent::EmptySource => None,
+            }
         }
     }
+
+    /// Whether every retained asset can be represented by a destination that
+    /// accepts local payloads and/or external URI metadata.
+    #[must_use]
+    pub const fn assets_are_deliverable(&self, payloads: bool, external_references: bool) -> bool {
+        (payloads || self.payload_only_assets == 0)
+            && (external_references || self.external_only_assets == 0)
+            && (payloads || external_references || self.dual_representation_assets == 0)
+    }
+}
+
+fn evidence_reasons(diagnostics: &[Diagnostic]) -> (bool, bool) {
+    let mut empty_source = false;
+    let mut asset_only = false;
+    for diagnostic in diagnostics {
+        match diagnostic.code.as_str() {
+            EMPTY_SOURCE_REASON_CODE => empty_source = true,
+            ASSET_ONLY_REASON_CODE => asset_only = true,
+            _ => {}
+        }
+        if empty_source && asset_only {
+            break;
+        }
+    }
+    (empty_source, asset_only)
+}
+
+fn assets_are_deliverable(assets: &[Asset], payloads: bool, external_references: bool) -> bool {
+    assets.iter().all(|asset| {
+        !asset.bytes.is_empty() && payloads || asset.external_uri.is_some() && external_references
+    })
 }
 
 fn has_reason(diagnostics: &[Diagnostic], code: &str) -> bool {
@@ -221,11 +263,15 @@ fn block_content(block: &Block) -> DocumentContent {
         Block::Heading { content, .. } | Block::TimedSegment { content, .. } => {
             inline_content(content)
         }
-        Block::List { items, .. } => items
-            .iter()
-            .flat_map(|item| &item.blocks)
-            .map(|node| block_content(&node.block))
-            .fold(DocumentContent::Empty, DocumentContent::merge),
+        Block::List { items, .. } => {
+            let mut content = DocumentContent::Empty;
+            for item in items {
+                if content.merge_non_visible(nodes_content(&item.blocks)) {
+                    return DocumentContent::Visible;
+                }
+            }
+            content
+        }
         Block::Table { rows, .. } => {
             if rows.is_empty() {
                 DocumentContent::Empty
@@ -242,24 +288,24 @@ fn block_content(block: &Block) -> DocumentContent {
         }
         Block::Footnote { blocks, .. }
         | Block::Page { blocks, .. }
-        | Block::Sheet { blocks, .. } => blocks
-            .iter()
-            .map(|node| block_content(&node.block))
-            .fold(DocumentContent::Empty, DocumentContent::merge),
+        | Block::Sheet { blocks, .. } => nodes_content(blocks),
         Block::Slide { title, blocks, .. } => {
             let title = title.as_deref().is_some_and(|value| !value.trim().is_empty());
-            if title {
-                DocumentContent::Visible
-            } else {
-                blocks
-                    .iter()
-                    .map(|node| block_content(&node.block))
-                    .fold(DocumentContent::Empty, DocumentContent::merge)
-            }
+            if title { DocumentContent::Visible } else { nodes_content(blocks) }
         }
         Block::Image { .. } => DocumentContent::AssetsOnly,
         Block::Rule => DocumentContent::Visible,
     }
+}
+
+fn nodes_content(nodes: &[crate::BlockNode]) -> DocumentContent {
+    let mut content = DocumentContent::Empty;
+    for node in nodes {
+        if content.merge_non_visible(block_content(&node.block)) {
+            return DocumentContent::Visible;
+        }
+    }
+    content
 }
 
 fn inline_content(values: &[Inline]) -> DocumentContent {
@@ -368,6 +414,26 @@ mod tests {
         assert_eq!(
             classify_result(&document, "", &assets, &diagnostics).unwrap(),
             ResultContent::AssetsOnly
+        );
+    }
+
+    #[test]
+    fn visible_markdown_short_circuits_a_large_ir_inventory() {
+        let prototype = crate::BlockNode {
+            id: crate::NodeId("empty".into()),
+            block: Block::Paragraph(Vec::new()),
+            provenance: crate::Provenance {
+                kind: crate::ProvenanceKind::NativeParser,
+                provider: "test".into(),
+                locator: crate::SourceLocator::default(),
+                confidence: None,
+            },
+        };
+        let document = Document { blocks: vec![prototype; 100_000], ..Document::default() };
+
+        assert_eq!(
+            classify_result(&document, "visible", &[], &[]).unwrap(),
+            ResultContent::Markdown
         );
     }
 }

--- a/crates/core/src/result_policy.rs
+++ b/crates/core/src/result_policy.rs
@@ -1,0 +1,373 @@
+//! Format-independent completion semantics for rendered conversion results.
+
+use crate::{
+    Asset, Block, ConversionError, ConversionOutcome, ConversionResult, Diagnostic,
+    DiagnosticSeverity, Document, Inline,
+};
+
+/// Stable diagnostic emitted when a converter proves that the source has no
+/// visible document content.
+pub const EMPTY_SOURCE_REASON_CODE: &str = "emptySource";
+
+/// Stable diagnostic emitted for useful asset-backed results whose Markdown
+/// representation is empty.
+pub const ASSET_ONLY_REASON_CODE: &str = "assetOnly";
+
+/// Converter-owned evidence used by the shared empty-result gate.
+///
+/// The default is fail-closed. `Empty` is valid only after the converter has
+/// scanned every visible-content domain it supports. `AssetsOnly` additionally
+/// requires retained IR references and a retained asset inventory.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SourceContentEvidence {
+    /// The converter cannot prove why a rendered result is empty.
+    #[default]
+    Unknown,
+    /// The converter proved that the source has no visible document content.
+    Empty,
+    /// The source contains only useful asset-backed document content.
+    AssetsOnly,
+}
+
+/// Usable content class of a completed result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResultContent {
+    /// Markdown contains a non-whitespace scalar.
+    Markdown,
+    /// The source was explicitly certified as empty.
+    EmptySource,
+    /// Structured IR and assets remain useful despite empty Markdown.
+    AssetsOnly,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum DocumentContent {
+    #[default]
+    Empty,
+    AssetsOnly,
+    Visible,
+}
+
+impl DocumentContent {
+    fn merge(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Visible, _) | (_, Self::Visible) => Self::Visible,
+            (Self::AssetsOnly, _) | (_, Self::AssetsOnly) => Self::AssetsOnly,
+            _ => Self::Empty,
+        }
+    }
+}
+
+/// Classify the semantic content retained by a document independently of its
+/// format-specific container structure.
+#[must_use]
+pub(crate) fn document_content(document: &Document) -> DocumentContent {
+    document
+        .blocks
+        .iter()
+        .map(|node| block_content(&node.block))
+        .fold(DocumentContent::Empty, DocumentContent::merge)
+}
+
+/// Whether a converter result has no visible semantic body content.
+#[doc(hidden)]
+#[must_use]
+pub fn document_is_empty(document: &Document) -> bool {
+    document_content(document) == DocumentContent::Empty
+}
+
+/// Whether every visible semantic node is an asset reference.
+#[doc(hidden)]
+#[must_use]
+pub fn document_is_asset_only(document: &Document) -> bool {
+    document_content(document) == DocumentContent::AssetsOnly
+}
+
+/// Whether Markdown contains a usable non-whitespace scalar. A leading BOM is
+/// transport metadata and is not content by itself.
+#[must_use]
+pub fn markdown_has_visible_content(markdown: &str) -> bool {
+    markdown.chars().any(|value| !value.is_whitespace() && value != '\u{feff}')
+}
+
+/// Derive the stable success outcome without treating informational audit
+/// diagnostics as content loss.
+#[must_use]
+pub fn conversion_outcome(diagnostics: &[Diagnostic]) -> ConversionOutcome {
+    if diagnostics.iter().any(|value| value.severity != DiagnosticSeverity::Info) {
+        ConversionOutcome::Degraded
+    } else {
+        ConversionOutcome::Complete
+    }
+}
+
+/// Validate and classify a completed result.
+///
+/// # Errors
+///
+/// Returns `emptyContent` for an unusable empty result and `internal` for
+/// contradictory engine-reserved evidence.
+pub fn classify_result(
+    document: &Document,
+    markdown: &str,
+    assets: &[Asset],
+    diagnostics: &[Diagnostic],
+) -> Result<ResultContent, ConversionError> {
+    let empty_source = has_reason(diagnostics, EMPTY_SOURCE_REASON_CODE);
+    let asset_only = has_reason(diagnostics, ASSET_ONLY_REASON_CODE);
+    if empty_source && asset_only {
+        return Err(ConversionError::Internal {
+            detail: "result carries conflicting empty-source and asset-only evidence".into(),
+        });
+    }
+    let content = document_content(document);
+    if empty_source {
+        if content != DocumentContent::Empty || !assets.is_empty() {
+            return Err(ConversionError::Internal {
+                detail: "empty-source evidence conflicts with retained document content".into(),
+            });
+        }
+        if markdown_has_visible_content(markdown) {
+            return Ok(ResultContent::Markdown);
+        }
+        return Ok(ResultContent::EmptySource);
+    }
+    if asset_only {
+        if content != DocumentContent::AssetsOnly || assets.is_empty() {
+            return Err(ConversionError::Internal {
+                detail: "asset-only evidence requires asset-only IR and retained assets".into(),
+            });
+        }
+        if markdown_has_visible_content(markdown) {
+            return Ok(ResultContent::Markdown);
+        }
+        return Ok(ResultContent::AssetsOnly);
+    }
+    if markdown_has_visible_content(markdown) {
+        Ok(ResultContent::Markdown)
+    } else {
+        Err(ConversionError::EmptyContent)
+    }
+}
+
+impl ConversionResult {
+    /// Validate and return this result's usable content class.
+    ///
+    /// # Errors
+    ///
+    /// Returns the shared empty-result failure when the result is unusable.
+    pub fn content(&self) -> Result<ResultContent, ConversionError> {
+        classify_result(&self.document, &self.markdown, &self.assets, &self.diagnostics)
+    }
+
+    /// Stable success outcome derived from diagnostic severity.
+    #[must_use]
+    pub fn outcome(&self) -> ConversionOutcome {
+        conversion_outcome(&self.diagnostics)
+    }
+
+    /// Stable success reason for exceptional usable results.
+    #[must_use]
+    pub fn reason_code(&self) -> Option<&str> {
+        if let Some(diagnostic) =
+            self.diagnostics.iter().find(|value| value.severity != DiagnosticSeverity::Info)
+        {
+            Some(diagnostic.code.as_str())
+        } else if has_reason(&self.diagnostics, EMPTY_SOURCE_REASON_CODE) {
+            Some(EMPTY_SOURCE_REASON_CODE)
+        } else if has_reason(&self.diagnostics, ASSET_ONLY_REASON_CODE) {
+            Some(ASSET_ONLY_REASON_CODE)
+        } else {
+            None
+        }
+    }
+}
+
+impl crate::ConversionSummary {
+    /// Return the usable content class validated before streaming emission.
+    ///
+    /// # Errors
+    ///
+    /// Returns `emptyContent` only for a summary derived from an externally
+    /// constructed result that never passed the Engine terminal gate.
+    pub fn content(&self) -> Result<ResultContent, ConversionError> {
+        self.content.ok_or(ConversionError::EmptyContent)
+    }
+
+    /// Stable reason for an exceptional successful completion.
+    #[must_use]
+    pub fn reason_code(&self) -> Option<&str> {
+        if let Some(diagnostic) =
+            self.diagnostics.iter().find(|value| value.severity != DiagnosticSeverity::Info)
+        {
+            Some(diagnostic.code.as_str())
+        } else if has_reason(&self.diagnostics, EMPTY_SOURCE_REASON_CODE) {
+            Some(EMPTY_SOURCE_REASON_CODE)
+        } else if has_reason(&self.diagnostics, ASSET_ONLY_REASON_CODE) {
+            Some(ASSET_ONLY_REASON_CODE)
+        } else {
+            None
+        }
+    }
+}
+
+fn has_reason(diagnostics: &[Diagnostic], code: &str) -> bool {
+    diagnostics.iter().any(|value| value.code == code)
+}
+
+fn block_content(block: &Block) -> DocumentContent {
+    match block {
+        Block::Paragraph(values) => inline_content(values),
+        Block::Heading { content, .. } | Block::TimedSegment { content, .. } => {
+            inline_content(content)
+        }
+        Block::List { items, .. } => items
+            .iter()
+            .flat_map(|item| &item.blocks)
+            .map(|node| block_content(&node.block))
+            .fold(DocumentContent::Empty, DocumentContent::merge),
+        Block::Table { rows, .. } => {
+            if rows.is_empty() {
+                DocumentContent::Empty
+            } else {
+                DocumentContent::Visible
+            }
+        }
+        Block::Code { text, .. } | Block::Formula(text) => {
+            if text.is_empty() {
+                DocumentContent::Empty
+            } else {
+                DocumentContent::Visible
+            }
+        }
+        Block::Footnote { blocks, .. }
+        | Block::Page { blocks, .. }
+        | Block::Sheet { blocks, .. } => blocks
+            .iter()
+            .map(|node| block_content(&node.block))
+            .fold(DocumentContent::Empty, DocumentContent::merge),
+        Block::Slide { title, blocks, .. } => {
+            let title = title.as_deref().is_some_and(|value| !value.trim().is_empty());
+            if title {
+                DocumentContent::Visible
+            } else {
+                blocks
+                    .iter()
+                    .map(|node| block_content(&node.block))
+                    .fold(DocumentContent::Empty, DocumentContent::merge)
+            }
+        }
+        Block::Image { .. } => DocumentContent::AssetsOnly,
+        Block::Rule => DocumentContent::Visible,
+    }
+}
+
+fn inline_content(values: &[Inline]) -> DocumentContent {
+    if values.iter().any(inline_is_visible) {
+        DocumentContent::Visible
+    } else {
+        DocumentContent::Empty
+    }
+}
+
+fn inline_is_visible(value: &Inline) -> bool {
+    match value {
+        Inline::Text { value, .. }
+        | Inline::SourceText { value, .. }
+        | Inline::OcrText { value, .. }
+        | Inline::Code(value)
+        | Inline::Formula(value) => markdown_has_visible_content(value),
+        Inline::Link { content, .. } => content.iter().any(inline_is_visible),
+        Inline::FootnoteReference(_) => true,
+        Inline::LineBreak => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Diagnostic, Document};
+
+    fn diagnostic(code: &str, severity: DiagnosticSeverity) -> Diagnostic {
+        Diagnostic { code: code.into(), severity, message: code.into(), locator: None }
+    }
+
+    #[test]
+    fn empty_results_require_explicit_evidence() {
+        let document = Document::default();
+        assert!(matches!(
+            classify_result(&document, "", &[], &[]),
+            Err(ConversionError::EmptyContent)
+        ));
+        assert_eq!(
+            classify_result(
+                &document,
+                "",
+                &[],
+                &[diagnostic(EMPTY_SOURCE_REASON_CODE, DiagnosticSeverity::Info)]
+            )
+            .unwrap(),
+            ResultContent::EmptySource
+        );
+    }
+
+    #[test]
+    fn informational_evidence_does_not_degrade_success() {
+        assert_eq!(
+            conversion_outcome(&[diagnostic(EMPTY_SOURCE_REASON_CODE, DiagnosticSeverity::Info)]),
+            ConversionOutcome::Complete
+        );
+        assert_eq!(
+            conversion_outcome(&[diagnostic("omitted", DiagnosticSeverity::Warning)]),
+            ConversionOutcome::Degraded
+        );
+    }
+
+    #[test]
+    fn visible_recovery_is_degraded_and_uses_the_first_loss_reason() {
+        let result = ConversionResult::new(
+            Document::default(),
+            "[Unsupported media]".into(),
+            Vec::new(),
+            vec![diagnostic("media.omitted", DiagnosticSeverity::Warning)],
+            Vec::new(),
+        );
+        assert_eq!(result.content().unwrap(), ResultContent::Markdown);
+        assert_eq!(result.outcome(), ConversionOutcome::Degraded);
+        assert_eq!(result.reason_code(), Some("media.omitted"));
+    }
+
+    #[test]
+    fn asset_only_evidence_does_not_override_visible_markdown() {
+        let id = crate::AssetId("asset".into());
+        let document = Document {
+            blocks: vec![crate::BlockNode {
+                id: crate::NodeId("image".into()),
+                block: Block::Image { asset: id.clone(), alt: None },
+                provenance: crate::Provenance {
+                    kind: crate::ProvenanceKind::NativeParser,
+                    provider: "test".into(),
+                    locator: crate::SourceLocator::default(),
+                    confidence: None,
+                },
+            }],
+            ..Document::default()
+        };
+        let assets = vec![Asset {
+            id,
+            filename: None,
+            media_type: "image/png".into(),
+            bytes: vec![1],
+            external_uri: None,
+        }];
+        let diagnostics = vec![diagnostic(ASSET_ONLY_REASON_CODE, DiagnosticSeverity::Info)];
+        assert_eq!(
+            classify_result(&document, "![image](asset.png)", &assets, &diagnostics).unwrap(),
+            ResultContent::Markdown
+        );
+        assert_eq!(
+            classify_result(&document, "", &assets, &diagnostics).unwrap(),
+            ResultContent::AssetsOnly
+        );
+    }
+}

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -136,9 +136,10 @@ pub struct AssetStreamInfo {
 /// Semantic result of a completed streaming conversion.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConversionOutcome {
-    /// No recoverable content was omitted or sanitized.
+    /// No recoverable content was omitted, replaced, or sanitized.
     Complete,
-    /// Conversion completed with one or more diagnostics.
+    /// Conversion completed with usable output after a recoverable omission,
+    /// replacement, or sanitization.
     Degraded,
 }
 
@@ -155,6 +156,7 @@ pub struct ConversionSummary {
     pub markdown_bytes: u64,
     /// Number of assets written.
     pub assets: u64,
+    pub(crate) content: Option<crate::ResultContent>,
     pub(crate) _memory_lease: OutputMemoryLease,
 }
 
@@ -445,6 +447,8 @@ pub struct ConverterOutput {
     pub assets: Vec<Asset>,
     /// Recoveries and scoped failures.
     pub diagnostics: Vec<Diagnostic>,
+    /// Converter-owned evidence consumed by the shared empty-result policy.
+    source_content_evidence: crate::SourceContentEvidence,
     /// Live memory charges transferred with the output until the engine has assembled its result.
     memory_lease: OutputMemoryLease,
 }
@@ -453,7 +457,13 @@ impl ConverterOutput {
     /// Construct an output without transferred charges.
     #[must_use]
     pub fn new(document: Document, assets: Vec<Asset>, diagnostics: Vec<Diagnostic>) -> Self {
-        Self { document, assets, diagnostics, memory_lease: OutputMemoryLease::default() }
+        Self {
+            document,
+            assets,
+            diagnostics,
+            source_content_evidence: crate::SourceContentEvidence::Unknown,
+            memory_lease: OutputMemoryLease::default(),
+        }
     }
 
     /// Construct converter output with reservations attached exactly once.
@@ -470,6 +480,7 @@ impl ConverterOutput {
             document,
             assets,
             diagnostics,
+            source_content_evidence: crate::SourceContentEvidence::Unknown,
             memory_lease: OutputMemoryLease::from_reservations(leases),
         }
     }
@@ -488,7 +499,27 @@ impl ConverterOutput {
         certify_recovered_reservation(context, &mut lease, retained)?;
         let mut memory_lease = OutputMemoryLease::from_reservation(lease)?;
         memory_lease.accounted_bytes = retained;
-        Ok(Self { document, assets, diagnostics, memory_lease })
+        Ok(Self {
+            document,
+            assets,
+            diagnostics,
+            source_content_evidence: crate::SourceContentEvidence::Unknown,
+            memory_lease,
+        })
+    }
+
+    /// Attach converter-owned source-content evidence.
+    #[must_use]
+    pub fn with_source_content_evidence(mut self, evidence: crate::SourceContentEvidence) -> Self {
+        self.source_content_evidence = evidence;
+        self
+    }
+
+    /// Read converter-owned source-content evidence at the engine boundary.
+    #[doc(hidden)]
+    #[must_use]
+    pub const fn source_content_evidence(&self) -> crate::SourceContentEvidence {
+        self.source_content_evidence
     }
 
     /// Bind live reservations to this output using the central retained-size
@@ -597,7 +628,8 @@ impl ConverterOutput {
         provenance: Vec<Provenance>,
         reservations: [Option<ResourceReservation>; 3],
     ) -> Result<ConversionResult, ConversionError> {
-        let Self { document, assets, diagnostics, mut memory_lease } = self;
+        let Self { document, assets, diagnostics, source_content_evidence: _, mut memory_lease } =
+            self;
         for reservation in reservations.into_iter().flatten() {
             memory_lease.push(reservation)?;
         }
@@ -619,19 +651,17 @@ impl ConverterOutput {
         self,
         format: InputFormat,
         markdown_bytes: u64,
+        content: crate::ResultContent,
     ) -> ConversionSummary {
         let Self { assets, diagnostics, memory_lease, .. } = self;
-        let outcome = if diagnostics.is_empty() {
-            ConversionOutcome::Complete
-        } else {
-            ConversionOutcome::Degraded
-        };
+        let outcome = crate::conversion_outcome(&diagnostics);
         ConversionSummary {
             format: Some(format),
             outcome,
             diagnostics,
             markdown_bytes,
             assets: u64::try_from(assets.len()).unwrap_or(u64::MAX),
+            content: Some(content),
             _memory_lease: memory_lease,
         }
     }

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -157,6 +157,9 @@ pub struct ConversionSummary {
     /// Number of assets written.
     pub assets: u64,
     pub(crate) content: Option<crate::ResultContent>,
+    pub(crate) payload_only_assets: u64,
+    pub(crate) external_only_assets: u64,
+    pub(crate) dual_representation_assets: u64,
     pub(crate) _memory_lease: OutputMemoryLease,
 }
 
@@ -653,6 +656,21 @@ impl ConverterOutput {
         markdown_bytes: u64,
         content: crate::ResultContent,
     ) -> ConversionSummary {
+        let payload_only_assets = self
+            .assets
+            .iter()
+            .filter(|asset| !asset.bytes.is_empty() && asset.external_uri.is_none())
+            .count();
+        let external_only_assets = self
+            .assets
+            .iter()
+            .filter(|asset| asset.bytes.is_empty() && asset.external_uri.is_some())
+            .count();
+        let dual_representation_assets = self
+            .assets
+            .iter()
+            .filter(|asset| !asset.bytes.is_empty() && asset.external_uri.is_some())
+            .count();
         let Self { assets, diagnostics, memory_lease, .. } = self;
         let outcome = crate::conversion_outcome(&diagnostics);
         ConversionSummary {
@@ -662,6 +680,10 @@ impl ConverterOutput {
             markdown_bytes,
             assets: u64::try_from(assets.len()).unwrap_or(u64::MAX),
             content: Some(content),
+            payload_only_assets: u64::try_from(payload_only_assets).unwrap_or(u64::MAX),
+            external_only_assets: u64::try_from(external_only_assets).unwrap_or(u64::MAX),
+            dual_representation_assets: u64::try_from(dual_representation_assets)
+                .unwrap_or(u64::MAX),
             _memory_lease: memory_lease,
         }
     }

--- a/crates/core/src/summary.rs
+++ b/crates/core/src/summary.rs
@@ -12,6 +12,9 @@ impl Clone for ConversionSummary {
             markdown_bytes: self.markdown_bytes,
             assets: self.assets,
             content: self.content,
+            payload_only_assets: self.payload_only_assets,
+            external_only_assets: self.external_only_assets,
+            dual_representation_assets: self.dual_representation_assets,
             _memory_lease: OutputMemoryLease::default(),
         }
     }
@@ -25,6 +28,9 @@ impl PartialEq for ConversionSummary {
             && self.markdown_bytes == other.markdown_bytes
             && self.assets == other.assets
             && self.content == other.content
+            && self.payload_only_assets == other.payload_only_assets
+            && self.external_only_assets == other.external_only_assets
+            && self.dual_representation_assets == other.dual_representation_assets
     }
 }
 
@@ -38,6 +44,21 @@ impl ConversionResult {
     pub fn into_summary(self) -> ConversionSummary {
         let outcome = self.outcome();
         let content = self.content().ok();
+        let payload_only_assets = self
+            .assets
+            .iter()
+            .filter(|asset| !asset.bytes.is_empty() && asset.external_uri.is_none())
+            .count();
+        let external_only_assets = self
+            .assets
+            .iter()
+            .filter(|asset| asset.bytes.is_empty() && asset.external_uri.is_some())
+            .count();
+        let dual_representation_assets = self
+            .assets
+            .iter()
+            .filter(|asset| !asset.bytes.is_empty() && asset.external_uri.is_some())
+            .count();
         ConversionSummary {
             format: self.detected_format,
             outcome,
@@ -45,6 +66,10 @@ impl ConversionResult {
             markdown_bytes: u64::try_from(self.markdown.len()).unwrap_or(u64::MAX),
             assets: u64::try_from(self.assets.len()).unwrap_or(u64::MAX),
             content,
+            payload_only_assets: u64::try_from(payload_only_assets).unwrap_or(u64::MAX),
+            external_only_assets: u64::try_from(external_only_assets).unwrap_or(u64::MAX),
+            dual_representation_assets: u64::try_from(dual_representation_assets)
+                .unwrap_or(u64::MAX),
             _memory_lease: self.memory_lease,
         }
     }

--- a/crates/core/src/summary.rs
+++ b/crates/core/src/summary.rs
@@ -1,7 +1,7 @@
 //! Completion-summary ownership and accounting.
 
 use crate::spi::OutputMemoryLease;
-use crate::{ConversionOutcome, ConversionResult, ConversionSummary};
+use crate::{ConversionResult, ConversionSummary};
 
 impl Clone for ConversionSummary {
     fn clone(&self) -> Self {
@@ -11,6 +11,7 @@ impl Clone for ConversionSummary {
             diagnostics: self.diagnostics.clone(),
             markdown_bytes: self.markdown_bytes,
             assets: self.assets,
+            content: self.content,
             _memory_lease: OutputMemoryLease::default(),
         }
     }
@@ -23,6 +24,7 @@ impl PartialEq for ConversionSummary {
             && self.diagnostics == other.diagnostics
             && self.markdown_bytes == other.markdown_bytes
             && self.assets == other.assets
+            && self.content == other.content
     }
 }
 
@@ -34,17 +36,15 @@ impl ConversionResult {
     #[doc(hidden)]
     #[must_use]
     pub fn into_summary(self) -> ConversionSummary {
-        let outcome = if self.diagnostics.is_empty() {
-            ConversionOutcome::Complete
-        } else {
-            ConversionOutcome::Degraded
-        };
+        let outcome = self.outcome();
+        let content = self.content().ok();
         ConversionSummary {
             format: self.detected_format,
             outcome,
             diagnostics: self.diagnostics,
             markdown_bytes: u64::try_from(self.markdown.len()).unwrap_or(u64::MAX),
             assets: u64::try_from(self.assets.len()).unwrap_or(u64::MAX),
+            content,
             _memory_lease: self.memory_lease,
         }
     }

--- a/crates/engine/src/artifact_execution.rs
+++ b/crates/engine/src/artifact_execution.rs
@@ -62,12 +62,7 @@ pub(crate) async fn execute(
         &context,
     )
     .await?;
-    let output = crate::result_policy::attach_evidence(
-        output,
-        source.input(),
-        attempt.candidate.format,
-        &context,
-    )?;
+    let output = crate::result_policy::attach_evidence(output, &context)?;
     let renderer = engine.renderer.as_ref().ok_or_else(|| ConversionError::Internal {
         detail: "no Markdown renderer is registered".into(),
     })?;

--- a/crates/engine/src/artifact_execution.rs
+++ b/crates/engine/src/artifact_execution.rs
@@ -62,6 +62,12 @@ pub(crate) async fn execute(
         &context,
     )
     .await?;
+    let output = crate::result_policy::attach_evidence(
+        output,
+        source.input(),
+        attempt.candidate.format,
+        &context,
+    )?;
     let renderer = engine.renderer.as_ref().ok_or_else(|| ConversionError::Internal {
         detail: "no Markdown renderer is registered".into(),
     })?;

--- a/crates/engine/src/artifact_output.rs
+++ b/crates/engine/src/artifact_output.rs
@@ -18,6 +18,12 @@ pub(crate) fn emit(
 ) -> Result<ConversionSummary, ConversionError> {
     let RenderedArtifacts { output, markdown, provenance, markdown_memory, provenance_memory } =
         rendered;
+    let result_content = into_markdown_core::classify_result(
+        &output.document,
+        &markdown,
+        &output.assets,
+        &output.diagnostics,
+    )?;
     if capabilities.semantic_events {
         emit_document(&output, &provenance, sink, context)?;
     }
@@ -38,7 +44,7 @@ pub(crate) fn emit(
     drop(provenance_memory);
     drop(markdown_memory);
     drop(markdown);
-    Ok(output.into_conversion_summary(format, markdown_bytes))
+    Ok(output.into_conversion_summary(format, markdown_bytes, result_content))
 }
 
 fn emit_document(

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -8,6 +8,7 @@ mod nested;
 mod preparation;
 mod recovery;
 mod rendering;
+mod result_policy;
 mod result_sink;
 mod stream_execution;
 
@@ -420,6 +421,12 @@ impl Engine {
             &context,
         )
         .await?;
+        let output = result_policy::attach_evidence(
+            output,
+            source.input(),
+            attempt.candidate.format,
+            &context,
+        )?;
         let renderer = self.renderer.as_ref().ok_or_else(|| ConversionError::Internal {
             detail: "no Markdown renderer is registered".into(),
         })?;
@@ -1355,8 +1362,8 @@ mod tests {
         }
     }
 
-    struct EmptyRenderer;
-    impl MarkdownRenderer for EmptyRenderer {
+    struct TitleRenderer;
+    impl MarkdownRenderer for TitleRenderer {
         fn id(&self) -> &'static str {
             "test.renderer"
         }
@@ -1371,12 +1378,12 @@ mod tests {
         }
         fn render<'a>(
             &'a self,
-            _: &'a Document,
+            document: &'a Document,
             _: &'a [Asset],
             _: &'a ConversionOptions,
             _: &'a ExecutionContext,
         ) -> BoxFuture<'a, Result<String, ConversionError>> {
-            Box::pin(async { Ok(String::new()) })
+            Box::pin(async move { Ok(document.metadata.title.clone().unwrap_or_default()) })
         }
     }
 
@@ -1674,7 +1681,7 @@ mod tests {
     #[test]
     fn output_enrichers_run_in_registration_order_before_rendering() {
         let mut builder = EngineBuilder::new()
-            .renderer(Arc::new(EmptyRenderer))
+            .renderer(Arc::new(TitleRenderer))
             .enricher(Arc::new(TitleEnricher { id: "first.enricher", suffix: ":one" }))
             .enricher(Arc::new(TitleEnricher { id: "second.enricher", suffix: ":two" }));
         builder
@@ -1781,7 +1788,7 @@ mod tests {
 
     #[test]
     fn stable_id_breaks_equal_confidence_and_priority_ties() {
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(BytesResolver))
@@ -1796,7 +1803,7 @@ mod tests {
 
     #[test]
     fn invalid_converter_ir_is_rejected_before_rendering() {
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(BytesResolver))
@@ -1811,7 +1818,7 @@ mod tests {
 
     #[test]
     fn overdeep_converter_ir_is_bounded_before_retained_estimation() {
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(BytesResolver))
@@ -1870,7 +1877,7 @@ mod tests {
     fn converter_credit_requires_each_coexisting_owner_before_allocation() {
         let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let observed = Arc::new(Mutex::new(None));
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(TrackingBytesResolver {
@@ -1902,7 +1909,7 @@ mod tests {
     fn engine_accounts_large_ir_capacity_with_and_without_assets() {
         for (title_capacity, asset_capacity) in [(80_000, 0), (40_000, 40_000)] {
             let calls = Arc::new(std::sync::atomic::AtomicUsize::new(0));
-            let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+            let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
             builder
                 .registry_mut()
                 .register_source_resolver(Arc::new(BytesResolver))
@@ -2054,7 +2061,7 @@ mod tests {
 
     #[test]
     fn explicit_format_attempt_precedes_higher_combined_inferred_attempt() {
-        let mut builder = EngineBuilder::new().renderer(Arc::new(EmptyRenderer));
+        let mut builder = EngineBuilder::new().renderer(Arc::new(TitleRenderer));
         builder
             .registry_mut()
             .register_source_resolver(Arc::new(BytesResolver))

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -421,12 +421,7 @@ impl Engine {
             &context,
         )
         .await?;
-        let output = result_policy::attach_evidence(
-            output,
-            source.input(),
-            attempt.candidate.format,
-            &context,
-        )?;
+        let output = result_policy::attach_evidence(output, &context)?;
         let renderer = self.renderer.as_ref().ok_or_else(|| ConversionError::Internal {
             detail: "no Markdown renderer is registered".into(),
         })?;

--- a/crates/engine/src/recovery.rs
+++ b/crates/engine/src/recovery.rs
@@ -602,6 +602,12 @@ pub(super) async fn convert(
             &context,
         )
         .await?;
+        let output = crate::result_policy::attach_evidence(
+            output,
+            source.input(),
+            attempt.candidate.format,
+            &context,
+        )?;
         validate_asset_inventory(&output.document, &output.assets, &request)?;
         validate_diagnostics(&output.diagnostics)?;
         store.commit(
@@ -659,6 +665,7 @@ pub(super) async fn convert(
         provenance,
         [Some(markdown_memory), Some(provenance_memory), Some(final_memory)],
     )?;
+    result.content()?;
     store.commit(
         token,
         &context,
@@ -892,6 +899,9 @@ async fn validate_recovered_success(
             "checkpoint Markdown does not match its document and assets",
         ));
     }
+    result.content().map_err(|error| {
+        recovery_error("corrupt", format!("checkpoint result fails content validation: {error}"))
+    })?;
     Ok(result)
 }
 

--- a/crates/engine/src/recovery.rs
+++ b/crates/engine/src/recovery.rs
@@ -602,12 +602,7 @@ pub(super) async fn convert(
             &context,
         )
         .await?;
-        let output = crate::result_policy::attach_evidence(
-            output,
-            source.input(),
-            attempt.candidate.format,
-            &context,
-        )?;
+        let output = crate::result_policy::attach_evidence(output, &context)?;
         validate_asset_inventory(&output.document, &output.assets, &request)?;
         validate_diagnostics(&output.diagnostics)?;
         store.commit(

--- a/crates/engine/src/rendering.rs
+++ b/crates/engine/src/rendering.rs
@@ -60,6 +60,7 @@ pub(crate) async fn render(
         [Some(markdown_memory), Some(provenance_memory), Some(final_memory)],
     )?;
     result.set_detected_format(format);
+    result.content()?;
     Ok(result)
 }
 

--- a/crates/engine/src/result_policy.rs
+++ b/crates/engine/src/result_policy.rs
@@ -1,0 +1,147 @@
+//! Engine-side source evidence attachment and terminal result validation.
+
+use into_markdown_core::{
+    ASSET_ONLY_REASON_CODE, ConversionError, ConverterOutput, Diagnostic, DiagnosticSeverity,
+    EMPTY_SOURCE_REASON_CODE, ExecutionContext, InputFormat, ResolvedInput, SourceContentEvidence,
+    document_is_asset_only, document_is_empty,
+};
+
+const EVIDENCE_DIAGNOSTIC_PEAK_BYTES: u64 = 512;
+
+pub(crate) fn attach_evidence(
+    mut output: ConverterOutput,
+    source: &ResolvedInput,
+    format: InputFormat,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    if output.diagnostics.iter().any(|diagnostic| {
+        matches!(diagnostic.code.as_str(), EMPTY_SOURCE_REASON_CODE | ASSET_ONLY_REASON_CODE)
+    }) {
+        return Err(ConversionError::Internal {
+            detail: "converter emitted an engine-reserved result diagnostic".into(),
+        });
+    }
+    let evidence = match output.source_content_evidence() {
+        SourceContentEvidence::Unknown
+            if format == InputFormat::Markdown
+                && document_is_empty(&output.document)
+                && output.assets.is_empty()
+                && utf8_source_is_blank(&source.bytes) =>
+        {
+            SourceContentEvidence::Empty
+        }
+        SourceContentEvidence::Unknown
+            if document_is_asset_only(&output.document) && !output.assets.is_empty() =>
+        {
+            SourceContentEvidence::AssetsOnly
+        }
+        evidence => evidence,
+    };
+    let (code, message) = match evidence {
+        SourceContentEvidence::Unknown => return Ok(output),
+        SourceContentEvidence::Empty => {
+            if !document_is_empty(&output.document) || !output.assets.is_empty() {
+                return Err(ConversionError::Internal {
+                    detail: "empty-source evidence conflicts with retained document content".into(),
+                });
+            }
+            (EMPTY_SOURCE_REASON_CODE, "source was fully scanned and contains no visible content")
+        }
+        SourceContentEvidence::AssetsOnly => {
+            if !document_is_asset_only(&output.document) || output.assets.is_empty() {
+                return Err(ConversionError::Internal {
+                    detail: "asset-only evidence requires asset-only IR and retained assets".into(),
+                });
+            }
+            (ASSET_ONLY_REASON_CODE, "source contains only asset-backed structured content")
+        }
+    };
+
+    // Hold a conservative peak before allocating the small audit diagnostic;
+    // `account_retained` then transfers the exact retained charge to output.
+    let allocation_guard = context.reserve_memory(EVIDENCE_DIAGNOSTIC_PEAK_BYTES)?;
+    output.diagnostics.try_reserve(1).map_err(|error| ConversionError::ResourceLimit {
+        limit: "max_memory_bytes",
+        detail: format!("cannot reserve source-content diagnostic: {error}"),
+    })?;
+    output.diagnostics.push(Diagnostic {
+        code: code.into(),
+        severity: DiagnosticSeverity::Info,
+        message: message.into(),
+        locator: None,
+    });
+    output = output.account_retained(context)?;
+    drop(allocation_guard);
+    Ok(output)
+}
+
+fn utf8_source_is_blank(bytes: &[u8]) -> bool {
+    let bytes = bytes.strip_prefix(&[0xef, 0xbb, 0xbf]).unwrap_or(bytes);
+    std::str::from_utf8(bytes).is_ok_and(|text| text.chars().all(char::is_whitespace))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown_core::{
+        Asset, AssetId, Block, BlockNode, Document, ExecutionOptions, NodeId, Provenance,
+        ProvenanceKind, ResourceLimits, SourceLocator, SourceMetadata,
+    };
+    use std::sync::Arc;
+
+    fn context() -> ExecutionContext {
+        ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default())
+    }
+
+    fn source(bytes: &'static [u8]) -> ResolvedInput {
+        ResolvedInput { metadata: SourceMetadata::default(), bytes: Arc::from(bytes) }
+    }
+
+    #[test]
+    fn blank_markdown_gets_complete_audit_evidence() {
+        let output = attach_evidence(
+            ConverterOutput::default(),
+            &source(b"\xef\xbb\xbf \r\n"),
+            InputFormat::Markdown,
+            &context(),
+        )
+        .unwrap();
+        assert_eq!(output.diagnostics[0].code, EMPTY_SOURCE_REASON_CODE);
+        assert_eq!(output.diagnostics[0].severity, DiagnosticSeverity::Info);
+    }
+
+    #[test]
+    fn asset_only_ir_is_certified_without_format_special_cases() {
+        let id = AssetId("asset".into());
+        let output = ConverterOutput::new(
+            Document {
+                blocks: vec![BlockNode {
+                    id: NodeId("image".into()),
+                    block: Block::Image { asset: id.clone(), alt: None },
+                    provenance: Provenance {
+                        kind: ProvenanceKind::NativeParser,
+                        provider: "test".into(),
+                        locator: SourceLocator::default(),
+                        confidence: None,
+                    },
+                }],
+                ..Document::default()
+            },
+            vec![Asset {
+                id,
+                filename: Some("asset.bin".into()),
+                media_type: "application/octet-stream".into(),
+                bytes: vec![1],
+                external_uri: None,
+            }],
+            Vec::new(),
+        );
+        let output =
+            attach_evidence(output, &source(b"asset"), InputFormat::Text, &context()).unwrap();
+        assert_eq!(output.diagnostics[0].code, ASSET_ONLY_REASON_CODE);
+    }
+}
+
+#[cfg(test)]
+#[path = "result_policy/integration_tests.rs"]
+mod integration_tests;

--- a/crates/engine/src/result_policy.rs
+++ b/crates/engine/src/result_policy.rs
@@ -2,16 +2,13 @@
 
 use into_markdown_core::{
     ASSET_ONLY_REASON_CODE, ConversionError, ConverterOutput, Diagnostic, DiagnosticSeverity,
-    EMPTY_SOURCE_REASON_CODE, ExecutionContext, InputFormat, ResolvedInput, SourceContentEvidence,
-    document_is_asset_only, document_is_empty,
+    EMPTY_SOURCE_REASON_CODE, ExecutionContext, SourceContentEvidence, estimate_retained_output,
 };
 
-const EVIDENCE_DIAGNOSTIC_PEAK_BYTES: u64 = 512;
+const EVIDENCE_DIAGNOSTIC_PEAK_BYTES: u64 = 1_280;
 
 pub(crate) fn attach_evidence(
     mut output: ConverterOutput,
-    source: &ResolvedInput,
-    format: InputFormat,
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
     if output.diagnostics.iter().any(|diagnostic| {
@@ -21,45 +18,20 @@ pub(crate) fn attach_evidence(
             detail: "converter emitted an engine-reserved result diagnostic".into(),
         });
     }
-    let evidence = match output.source_content_evidence() {
-        SourceContentEvidence::Unknown
-            if format == InputFormat::Markdown
-                && document_is_empty(&output.document)
-                && output.assets.is_empty()
-                && utf8_source_is_blank(&source.bytes) =>
-        {
-            SourceContentEvidence::Empty
-        }
-        SourceContentEvidence::Unknown
-            if document_is_asset_only(&output.document) && !output.assets.is_empty() =>
-        {
-            SourceContentEvidence::AssetsOnly
-        }
-        evidence => evidence,
-    };
+    let evidence = output.source_content_evidence();
     let (code, message) = match evidence {
         SourceContentEvidence::Unknown => return Ok(output),
         SourceContentEvidence::Empty => {
-            if !document_is_empty(&output.document) || !output.assets.is_empty() {
-                return Err(ConversionError::Internal {
-                    detail: "empty-source evidence conflicts with retained document content".into(),
-                });
-            }
             (EMPTY_SOURCE_REASON_CODE, "source was fully scanned and contains no visible content")
         }
         SourceContentEvidence::AssetsOnly => {
-            if !document_is_asset_only(&output.document) || output.assets.is_empty() {
-                return Err(ConversionError::Internal {
-                    detail: "asset-only evidence requires asset-only IR and retained assets".into(),
-                });
-            }
             (ASSET_ONLY_REASON_CODE, "source contains only asset-backed structured content")
         }
     };
 
-    // Hold a conservative peak before allocating the small audit diagnostic;
-    // `account_retained` then transfers the exact retained charge to output.
-    let allocation_guard = context.reserve_memory(EVIDENCE_DIAGNOSTIC_PEAK_BYTES)?;
+    let retained_before =
+        estimate_retained_output(&output.document, &output.assets, &output.diagnostics)?;
+    let mut allocation_guard = context.reserve_memory(EVIDENCE_DIAGNOSTIC_PEAK_BYTES)?;
     output.diagnostics.try_reserve(1).map_err(|error| ConversionError::ResourceLimit {
         limit: "max_memory_bytes",
         detail: format!("cannot reserve source-content diagnostic: {error}"),
@@ -70,39 +42,34 @@ pub(crate) fn attach_evidence(
         message: message.into(),
         locator: None,
     });
-    output = output.account_retained(context)?;
-    drop(allocation_guard);
+    let retained_after =
+        estimate_retained_output(&output.document, &output.assets, &output.diagnostics)?;
+    let retained_delta = retained_after.saturating_sub(retained_before);
+    if retained_delta > EVIDENCE_DIAGNOSTIC_PEAK_BYTES {
+        return Err(ConversionError::Internal {
+            detail: format!(
+                "source-content diagnostic retained {retained_delta} bytes beyond its {EVIDENCE_DIAGNOSTIC_PEAK_BYTES}-byte allocation plan"
+            ),
+        });
+    }
+    allocation_guard.shrink(EVIDENCE_DIAGNOSTIC_PEAK_BYTES - retained_delta)?;
+    output.attach_memory_reservation(context, allocation_guard)?;
     Ok(output)
-}
-
-fn utf8_source_is_blank(bytes: &[u8]) -> bool {
-    let bytes = bytes.strip_prefix(&[0xef, 0xbb, 0xbf]).unwrap_or(bytes);
-    std::str::from_utf8(bytes).is_ok_and(|text| text.chars().all(char::is_whitespace))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use into_markdown_core::{
-        Asset, AssetId, Block, BlockNode, Document, ExecutionOptions, NodeId, Provenance,
-        ProvenanceKind, ResourceLimits, SourceLocator, SourceMetadata,
-    };
-    use std::sync::Arc;
+    use into_markdown_core::{ExecutionOptions, ResourceLimits};
 
     fn context() -> ExecutionContext {
         ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default())
     }
 
-    fn source(bytes: &'static [u8]) -> ResolvedInput {
-        ResolvedInput { metadata: SourceMetadata::default(), bytes: Arc::from(bytes) }
-    }
-
     #[test]
-    fn blank_markdown_gets_complete_audit_evidence() {
+    fn certified_empty_source_gets_complete_audit_evidence() {
         let output = attach_evidence(
-            ConverterOutput::default(),
-            &source(b"\xef\xbb\xbf \r\n"),
-            InputFormat::Markdown,
+            ConverterOutput::default().with_source_content_evidence(SourceContentEvidence::Empty),
             &context(),
         )
         .unwrap();
@@ -111,34 +78,39 @@ mod tests {
     }
 
     #[test]
-    fn asset_only_ir_is_certified_without_format_special_cases() {
-        let id = AssetId("asset".into());
-        let output = ConverterOutput::new(
-            Document {
-                blocks: vec![BlockNode {
-                    id: NodeId("image".into()),
-                    block: Block::Image { asset: id.clone(), alt: None },
-                    provenance: Provenance {
-                        kind: ProvenanceKind::NativeParser,
-                        provider: "test".into(),
-                        locator: SourceLocator::default(),
-                        confidence: None,
-                    },
-                }],
-                ..Document::default()
-            },
-            vec![Asset {
-                id,
-                filename: Some("asset.bin".into()),
-                media_type: "application/octet-stream".into(),
-                bytes: vec![1],
-                external_uri: None,
-            }],
-            Vec::new(),
-        );
-        let output =
-            attach_evidence(output, &source(b"asset"), InputFormat::Text, &context()).unwrap();
-        assert_eq!(output.diagnostics[0].code, ASSET_ONLY_REASON_CODE);
+    fn evidence_peak_plan_succeeds_at_the_exact_limit_without_double_charging() {
+        let limits = ResourceLimits {
+            max_memory_bytes: EVIDENCE_DIAGNOSTIC_PEAK_BYTES,
+            ..ResourceLimits::default()
+        };
+        let context = ExecutionContext::new(ExecutionOptions::default(), limits);
+        let output = attach_evidence(
+            ConverterOutput::default().with_source_content_evidence(SourceContentEvidence::Empty),
+            &context,
+        )
+        .unwrap();
+
+        assert!(context.reserved_memory_bytes() > 0);
+        assert!(context.reserved_memory_bytes() < EVIDENCE_DIAGNOSTIC_PEAK_BYTES);
+        drop(output);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn evidence_peak_plan_fails_one_byte_below_the_exact_limit() {
+        let limits = ResourceLimits {
+            max_memory_bytes: EVIDENCE_DIAGNOSTIC_PEAK_BYTES - 1,
+            ..ResourceLimits::default()
+        };
+        let context = ExecutionContext::new(ExecutionOptions::default(), limits);
+        let error = attach_evidence(
+            ConverterOutput::default().with_source_content_evidence(SourceContentEvidence::Empty),
+            &context,
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, ConversionError::ResourceLimit { limit: "max_memory_bytes", .. }));
+        assert_eq!(context.reserved_memory_bytes(), 0);
     }
 }
 

--- a/crates/engine/src/result_policy/integration_tests.rs
+++ b/crates/engine/src/result_policy/integration_tests.rs
@@ -1,0 +1,331 @@
+use crate::{EngineBuilder, RegistryBuilder};
+use into_markdown_core::{
+    ArtifactSink, Asset, AssetId, AssetStreamInfo, Block, BlockNode, BoxFuture, ConversionError,
+    ConversionOptions, ConversionOutcome, ConversionRequest, Converter, ConverterOutput, Document,
+    ErrorPolicy, ExecutionContext, FormatCandidate, FormatDetector, FormatHint, InputFormat,
+    InputRef, MarkdownRenderer, NodeId, ProbeOutcome, Provenance, ProvenanceKind, ResolvedInput,
+    ResultContent, Services, SourceContentEvidence, SourceLocator, SourceMetadata, SourceResolver,
+};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct BytesResolver;
+
+impl SourceResolver for BytesResolver {
+    fn id(&self) -> &'static str {
+        "empty-policy.bytes"
+    }
+
+    fn supports(&self, input: &InputRef) -> bool {
+        matches!(input, InputRef::Bytes { .. })
+    }
+
+    fn resolve<'a>(
+        &'a self,
+        input: &'a InputRef,
+        _: &'a ConversionOptions,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ResolvedInput, ConversionError>> {
+        Box::pin(async move {
+            let InputRef::Bytes { data, name } = input else {
+                return Err(ConversionError::Unsupported { detail: "expected bytes".into() });
+            };
+            Ok(ResolvedInput {
+                bytes: Arc::clone(data),
+                metadata: SourceMetadata {
+                    name: name.clone(),
+                    size: u64::try_from(data.len()).unwrap_or(u64::MAX),
+                    ..SourceMetadata::default()
+                },
+            })
+        })
+    }
+}
+
+struct TextDetector;
+
+impl FormatDetector for TextDetector {
+    fn id(&self) -> &'static str {
+        "empty-policy.text"
+    }
+
+    fn detect<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatHint,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<Vec<FormatCandidate>, ConversionError>> {
+        Box::pin(async {
+            Ok(vec![FormatCandidate::new(InputFormat::Text, 1.0, "empty-result policy test")])
+        })
+    }
+}
+
+#[derive(Clone, Copy)]
+enum OutputKind {
+    UnknownEmpty,
+    CertifiedEmpty,
+    ExternalAssetOnly,
+}
+
+struct CountingConverter {
+    calls: Arc<AtomicUsize>,
+    output: OutputKind,
+}
+
+impl Converter for CountingConverter {
+    fn id(&self) -> &'static str {
+        "empty-policy.converter"
+    }
+
+    fn supported_formats(&self) -> &'static [InputFormat] {
+        &[InputFormat::Text]
+    }
+
+    fn probe<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ProbeOutcome, ConversionError>> {
+        Box::pin(async { Ok(ProbeOutcome::Match { confidence: 1.0 }) })
+    }
+
+    fn planned_output_bytes(
+        &self,
+        _: &ResolvedInput,
+        _: &FormatCandidate,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        Ok(64 * 1024)
+    }
+
+    fn convert<'a>(
+        &'a self,
+        _: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        _: &'a ConversionOptions,
+        _: &'a Services,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        let calls = Arc::clone(&self.calls);
+        let output = self.output;
+        Box::pin(async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(match output {
+                OutputKind::UnknownEmpty => ConverterOutput::default(),
+                OutputKind::CertifiedEmpty => ConverterOutput::default()
+                    .with_source_content_evidence(SourceContentEvidence::Empty),
+                OutputKind::ExternalAssetOnly => external_asset_only_output(),
+            })
+        })
+    }
+}
+
+fn external_asset_only_output() -> ConverterOutput {
+    let id = AssetId("external-image".into());
+    ConverterOutput::new(
+        Document {
+            blocks: vec![BlockNode {
+                id: NodeId("image".into()),
+                block: Block::Image { asset: id.clone(), alt: None },
+                provenance: Provenance {
+                    kind: ProvenanceKind::NativeParser,
+                    provider: "empty-policy.converter".into(),
+                    locator: SourceLocator::default(),
+                    confidence: None,
+                },
+            }],
+            ..Document::default()
+        },
+        vec![Asset {
+            id,
+            filename: Some("external.png".into()),
+            media_type: "image/png".into(),
+            bytes: Vec::new(),
+            external_uri: Some("https://example.invalid/external.png".into()),
+        }],
+        Vec::new(),
+    )
+}
+
+struct CountingEmptyRenderer(Arc<AtomicUsize>);
+
+impl MarkdownRenderer for CountingEmptyRenderer {
+    fn id(&self) -> &'static str {
+        "empty-policy.renderer"
+    }
+
+    fn planned_markdown_bytes(
+        &self,
+        _: &Document,
+        _: &[Asset],
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<u64, ConversionError> {
+        Ok(64 * 1024)
+    }
+
+    fn render<'a>(
+        &'a self,
+        _: &'a Document,
+        _: &'a [Asset],
+        _: &'a ConversionOptions,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<String, ConversionError>> {
+        let calls = Arc::clone(&self.0);
+        Box::pin(async move {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(String::new())
+        })
+    }
+}
+
+#[derive(Default)]
+struct RecordingSink {
+    markdown_writes: usize,
+    asset_starts: usize,
+}
+
+impl ArtifactSink for RecordingSink {
+    fn write_markdown(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        self.markdown_writes += 1;
+        Ok(())
+    }
+
+    fn begin_asset(&mut self, _: &AssetStreamInfo) -> Result<(), ConversionError> {
+        self.asset_starts += 1;
+        Ok(())
+    }
+
+    fn write_asset(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        Ok(())
+    }
+
+    fn end_asset(&mut self) -> Result<(), ConversionError> {
+        Ok(())
+    }
+}
+
+fn engine(
+    output: OutputKind,
+    converter_calls: &Arc<AtomicUsize>,
+    renderer_calls: &Arc<AtomicUsize>,
+) -> crate::Engine {
+    let mut registry = RegistryBuilder::new();
+    registry
+        .register_source_resolver(Arc::new(BytesResolver))
+        .register_format_detector(Arc::new(TextDetector))
+        .register_converter(Arc::new(CountingConverter {
+            calls: Arc::clone(converter_calls),
+            output,
+        }));
+    let mut builder =
+        EngineBuilder::new().renderer(Arc::new(CountingEmptyRenderer(Arc::clone(renderer_calls))));
+    *builder.registry_mut() = registry;
+    builder.build().unwrap()
+}
+
+fn request(bytes: &'static [u8]) -> ConversionRequest {
+    ConversionRequest::new(InputRef::bytes(bytes, Some("input.txt")))
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    let mut future = std::pin::pin!(future);
+    let waker = std::task::Waker::noop();
+    let mut context = std::task::Context::from_waker(waker);
+    loop {
+        match future.as_mut().poll(&mut context) {
+            std::task::Poll::Ready(output) => return output,
+            std::task::Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
+#[test]
+fn unusable_empty_result_fails_before_sink_and_never_reexecutes() {
+    let converter_calls = Arc::new(AtomicUsize::new(0));
+    let renderer_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(OutputKind::UnknownEmpty, &converter_calls, &renderer_calls);
+    let mut sink = RecordingSink::default();
+
+    let error = block_on(engine.convert_into(request(b"visible"), &mut sink)).unwrap_err();
+
+    assert_eq!(error.reason_code(), "emptyContent");
+    assert_eq!(sink.markdown_writes, 0);
+    assert_eq!(sink.asset_starts, 0);
+    assert_eq!(converter_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(renderer_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn certified_empty_source_is_complete_with_a_stable_reason() {
+    let converter_calls = Arc::new(AtomicUsize::new(0));
+    let renderer_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(OutputKind::CertifiedEmpty, &converter_calls, &renderer_calls);
+    let mut sink = RecordingSink::default();
+
+    let summary = block_on(engine.convert_into(request(b""), &mut sink)).unwrap();
+
+    assert_eq!(summary.content().unwrap(), ResultContent::EmptySource);
+    assert_eq!(summary.outcome, ConversionOutcome::Complete);
+    assert_eq!(summary.reason_code(), Some("emptySource"));
+    assert_eq!(sink.markdown_writes, 0);
+    assert_eq!(sink.asset_starts, 0);
+    assert_eq!(converter_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(renderer_calls.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn external_asset_only_result_remains_usable_for_structured_consumers() {
+    let converter_calls = Arc::new(AtomicUsize::new(0));
+    let renderer_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(OutputKind::ExternalAssetOnly, &converter_calls, &renderer_calls);
+    let mut sink = RecordingSink::default();
+
+    let summary = block_on(engine.convert_into(request(b"external"), &mut sink)).unwrap();
+
+    assert_eq!(summary.content().unwrap(), ResultContent::AssetsOnly);
+    assert_eq!(summary.outcome, ConversionOutcome::Complete);
+    assert_eq!(summary.reason_code(), Some("assetOnly"));
+    assert_eq!(summary.assets, 1);
+    assert_eq!(sink.markdown_writes, 0);
+    assert_eq!(sink.asset_starts, 1);
+}
+
+#[test]
+fn empty_content_is_failed_in_best_effort_and_strict_modes() {
+    for policy in [ErrorPolicy::BestEffort, ErrorPolicy::Strict] {
+        let converter_calls = Arc::new(AtomicUsize::new(0));
+        let renderer_calls = Arc::new(AtomicUsize::new(0));
+        let engine = engine(OutputKind::UnknownEmpty, &converter_calls, &renderer_calls);
+        let mut request = request(b"visible");
+        request.options.error_policy = policy;
+
+        let error = block_on(engine.convert(request)).unwrap_err();
+
+        assert_eq!(error.reason_code(), "emptyContent");
+        assert_eq!(converter_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(renderer_calls.load(Ordering::SeqCst), 1);
+    }
+}
+
+#[test]
+fn recoverable_resume_reuses_conversion_and_reapplies_the_terminal_gate() {
+    let converter_calls = Arc::new(AtomicUsize::new(0));
+    let renderer_calls = Arc::new(AtomicUsize::new(0));
+    let engine = engine(OutputKind::UnknownEmpty, &converter_calls, &renderer_calls);
+    let temporary = tempfile::tempdir().unwrap();
+    let store = crate::RecoveryStore::open(temporary.path().join("recovery")).unwrap();
+    let token = store.create_token().unwrap();
+
+    for _ in 0..2 {
+        let error =
+            block_on(engine.convert_recoverable(request(b"visible"), &store, &token)).unwrap_err();
+        assert_eq!(error.reason_code(), "emptyContent");
+    }
+
+    assert_eq!(converter_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(renderer_calls.load(Ordering::SeqCst), 2);
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -151,8 +151,9 @@ into-md <INPUT...>
   空产物使用 `malformed` / `emptyContent`。
 - Engine 的空结果判定发生在 stdout 编码及文件事务 stage/commit 之前。除明确
   `emptySource` 外，成功或 degraded 的 Markdown 目标必须存在且非空；`emptyContent`
-  不创建目标，并使批处理失败计数和退出码与报告一致。asset-only 结果只允许
-  `result-json`、bundle，或带 `--asset-mode extract` 的 `ir-json`。
+  不创建目标，并使批处理失败计数和退出码与报告一致。asset-only 结果只有在所选
+  输出能表示每项资源时成功：`result-json` 可保留 payload 或外部 URI；bundle 和带
+  `--asset-mode extract` 的 `ir-json` 要求本地 payload。
 - `--dry-run` 只展开输入、验证配置和计算输出路径，不转换、不联网、不写任何文件。
 
 ### OCR 与 AI

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -146,7 +146,13 @@ into-md <INPUT...>
 - 多输入输出保留相对于各输入根的目录结构；不同输入根产生同名输出时先加输入根名
   前缀，仍冲突时再使用稳定数字后缀，所有消歧均在调度前完成。
 - `--report` 写入带 `schemaVersion` 的 JSON 报告，包含逐项输入、输出、状态、
-  格式、诊断、警告和错误码。
+  `outcome`、格式、诊断、警告、错误码和细分 `reasonCode`。成功结果为 `complete` 或
+  `degraded`，失败为 `failed`；真正空源使用 `complete` / `emptySource`，未证明可用的
+  空产物使用 `malformed` / `emptyContent`。
+- Engine 的空结果判定发生在 stdout 编码及文件事务 stage/commit 之前。除明确
+  `emptySource` 外，成功或 degraded 的 Markdown 目标必须存在且非空；`emptyContent`
+  不创建目标，并使批处理失败计数和退出码与报告一致。asset-only 结果只允许
+  `result-json`、bundle，或带 `--asset-mode extract` 的 `ir-json`。
 - `--dry-run` 只展开输入、验证配置和计算输出路径，不转换、不联网、不写任何文件。
 
 ### OCR 与 AI

--- a/docs/dto.md
+++ b/docs/dto.md
@@ -45,7 +45,14 @@ DTO 解码错误为 `invalidField`、`invalidBase64`、`duplicateId` 和 `resour
   非空、唯一、按字节序排列的完整别名集合。schema 1 输入归一为 `[id]`，写出端生成
   schema 2。
 - `BatchReportDto`：包含派生的 `succeeded`、`failed` 和输入稳定顺序的 `items`；状态
-  只有 `success`、`failed`。失败项必须有 `errorCode`，成功项不得有 `errorCode`。
+  只有 `success`、`failed`。`outcome` 区分 `complete`、`degraded`、`failed`；
+  `reasonCode` 细分 `emptySource`、`assetOnly`、`emptyContent` 或首个有损诊断。失败项
+  必须有 `errorCode`，成功项不得有 `errorCode`。旧报告缺少 additive 的 `outcome` 或
+  `reasonCode` 时仍按原有 status 解码。
+
+`ResultDto` 保持 schema 1，不新增重复 outcome 字段。`emptySource` 与 `assetOnly` 作为
+稳定 diagnostics code 随 Result JSON、Web diagnostics artifact 和 bundle 传播；Engine
+返回前已经执行共享终态校验，因此结构化消费者不会收到未证明可用的空成功结果。
 
 结果示例：
 

--- a/docs/dto.md
+++ b/docs/dto.md
@@ -50,9 +50,11 @@ DTO 解码错误为 `invalidField`、`invalidBase64`、`duplicateId` 和 `resour
   必须有 `errorCode`，成功项不得有 `errorCode`。旧报告缺少 additive 的 `outcome` 或
   `reasonCode` 时仍按原有 status 解码。
 
-`ResultDto` 保持 schema 1，不新增重复 outcome 字段。`emptySource` 与 `assetOnly` 作为
-稳定 diagnostics code 随 Result JSON、Web diagnostics artifact 和 bundle 传播；Engine
-返回前已经执行共享终态校验，因此结构化消费者不会收到未证明可用的空成功结果。
+`ResultDto` 保持 schema 1，不新增重复 outcome 字段。显式 `emptySource` / `assetOnly`
+证据作为稳定 diagnostics code 随 Result JSON、Web diagnostics artifact 和 bundle
+传播；Engine 返回前已经执行共享终态校验，因此结构化消费者不会收到未证明可用的空
+成功结果。Web schema 1 历史记录仍只公开任务的 succeeded/failed 状态，不声称保存
+`ConversionOutcome`；完整诊断保存在成功任务的 diagnostics artifact 中。
 
 结果示例：
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -78,6 +78,23 @@ HTTP(S) URI，并拒绝非法 percent escape。它只验证并保留审计引用
 SPI 不允许渲染器写资源、追加诊断或改写 provenance。转换器诊断和引擎按深度优先
 阅读顺序收集的 provenance 原样保留在 `ConversionResult` 中。
 
+Engine 在渲染后、任何 sink 写入或成功 checkpoint 提交前执行统一结果策略。Markdown
+含可见非空白字符时是普通成功；只有转换器完整扫描其可见内容域并附带私有
+`SourceContentEvidence::Empty`，空 Markdown 才能以 `complete` / `emptySource` 成功。
+未被证明为空、但最终 Markdown 为空且没有可用的 asset-only 结构时返回
+`ConversionError::EmptyContent`；为保持既有错误分类兼容，它的 `ErrorCode` 仍是
+`malformed`，细分 `reasonCode` 是 `emptyContent`。只含受 IR 引用资源的结果使用
+`assetOnly`：结构化 Result/IR、bundle 或资源抽取目标可以成功，不能承载该结果的纯
+Markdown 目标失败。普通执行、`convert_into`、可恢复 checkpoint fresh/resume、CLI
+stdout、文件事务和 Web 发布共用这项判定，判空不会再次调用 converter。
+
+`ConversionOutcome` 的诊断严重度契约可审计且不使用诊断码白名单：`Info` 只能描述无
+正文内容损失的审计事实，全部诊断均为 `Info` 时仍是 `complete`；任何省略、替代或净化
+必须由生产端发出 `Warning` 或 `Error`，结果为 `degraded`。例如 OCR 低置信区域、隐藏
+slide、未知 RTF 控制、非线性 EPUB spine 章节，以及未证明无损映射的 EPUB manifest
+资源省略均为 `Warning`；feed 源顺序、PDF 扫描页识别、MediaWiki 标题重定向以及 EPUB
+inert rights 元数据保留 `Info`。
+
 资源模式只决定 Markdown 表示：统一规划器在渲染前生成并冻结与资源写出层共享的
 `asset-<完整 SHA-256(bytes)>.<MIME 权威扩展名>` 有界 ASCII 文件名，
 `embed` 生成 base64 data URI，`omit` 保留 alt 而不生成悬空链接。资源写出层必须

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -84,15 +84,16 @@ Engine 在渲染后、任何 sink 写入或成功 checkpoint 提交前执行统�
 未被证明为空、但最终 Markdown 为空且没有可用的 asset-only 结构时返回
 `ConversionError::EmptyContent`；为保持既有错误分类兼容，它的 `ErrorCode` 仍是
 `malformed`，细分 `reasonCode` 是 `emptyContent`。只含受 IR 引用资源的结果使用
-`assetOnly`：结构化 Result/IR、bundle 或资源抽取目标可以成功，不能承载该结果的纯
-Markdown 目标失败。普通执行、`convert_into`、可恢复 checkpoint fresh/resume、CLI
+`assetOnly`：只有能表示每个资源 payload 或外部 URI 的结构化/资源目标可以成功；纯
+Markdown、悬空 IR、以及缺少本地 payload 的 bundle 失败。普通执行、`convert_into`、可恢复 checkpoint fresh/resume、CLI
 stdout、文件事务和 Web 发布共用这项判定，判空不会再次调用 converter。
 
 `ConversionOutcome` 的诊断严重度契约可审计且不使用诊断码白名单：`Info` 只能描述无
 正文内容损失的审计事实，全部诊断均为 `Info` 时仍是 `complete`；任何省略、替代或净化
 必须由生产端发出 `Warning` 或 `Error`，结果为 `degraded`。例如 OCR 低置信区域、隐藏
-slide、未知 RTF 控制、非线性 EPUB spine 章节，以及未证明无损映射的 EPUB manifest
-资源省略均为 `Warning`；feed 源顺序、PDF 扫描页识别、MediaWiki 标题重定向以及 EPUB
+slide、未知 RTF 控制、非线性 EPUB spine 章节，以及从正文、导航或 CSS 依赖链可达但
+未证明无损映射的 EPUB 资源省略均为 `Warning`；孤立 manifest 项不表示内容损失。feed
+源顺序、PDF 扫描页识别、MediaWiki 标题重定向以及 EPUB
 inert rights 元数据保留 `Info`。
 
 资源模式只决定 Markdown 表示：统一规划器在渲染前生成并冻结与资源写出层共享的


### PR DESCRIPTION
## Summary

- build on #272's single-execution collecting boundary and #273's bounded structured-output pipeline; emptiness classification never converts a source a second time
- centralize format-independent terminal policy in Core: visible Markdown, proven `emptySource`, usable `assetOnly`, or failed `emptyContent`
- fail before stdout/file/transaction/Web publication when the selected destination cannot represent the result; preserve successful 0-byte output only for converter-certified empty sources
- derive `complete` / `degraded` only from diagnostic severity and retain `malformed` as the compatible public error class for additive `reasonCode=emptyContent`

## Review fixes in `b1be97a`

- authenticate DOCX `glossaryDocument` relationships and emit `word.glossaryContentOmitted` with Unknown evidence instead of falsely certifying glossary-backed content as empty
- make single-file and stdout failures flow through `--report`, while preserving the historic direct error/exit when no report was requested
- rank unconflicted OOXML/ODF filename hints above generic ZIP evidence but below authoritative file magic; cover top-level best-effort/strict, nested `.xlsx`, and all six OOXML/ODF package extensions
- validate asset-only delivery by actual payload/external-URI capability: Result JSON accepts either, IR+extract and bundle require payloads, Markdown accepts neither, and Web rejects external-only assets it cannot publish
- replace EPUB manifest enumeration with a container-confined reachability graph rooted at chapter/navigation resource references and followed through reachable CSS `url()` / `@import`; orphan resources are not loss evidence
- transfer and shrink one evidence-diagnostic reservation instead of double charging retained memory; exact-limit and one-byte-under are covered
- short-circuit visible Markdown before diagnostics/IR, scan evidence once, avoid asset-only traversal when no assets exist, and stop IR traversal at the first visible node

## Terminal semantics

| Rendered/evidenced result | Terminal state | outcome | reasonCode | Publication contract |
| --- | --- | --- | --- | --- |
| visible Markdown, Info-only diagnostics | success | complete | none | non-empty Markdown is emitted/committed |
| visible Markdown after omission/replacement | success | degraded | first non-Info diagnostic | usable non-empty output is emitted/committed |
| converter-proven empty source | success | complete | `emptySource` | an existing 0-byte Markdown target is the documented exception |
| asset-backed IR with representable assets | success | complete/degraded | `assetOnly` or first loss reason | only destinations able to carry each payload or external URI may publish |
| unrepresentable asset-only or unproven empty result | failed | failed | `emptyContent` | no misleading target/stdout/Web success |
| sink or atomic commit failure | failed | failed | existing typed reason | no success record and no partial target set |

Web schema-1 history intentionally remains succeeded/failed only; it does not claim to persist `ConversionOutcome`. Successful task diagnostics remain available in the diagnostics artifact. CLI batch reports expose complete/degraded/failed and reasonCode.

## Compatibility

- `EmptyContent` remains `errorCode=malformed`; `reasonCode=emptyContent` is additive.
- Result DTO stays schema 1. Older Web schema-1 records without reasonCode still deserialize.
- Direct single-input errors without `--report` retain their prior typed exit; `--report` now additionally records single-file/stdout failures.
- Previously accepted unproven empty outputs and destination-incompatible asset-only outputs now fail. Proven empty sources still succeed with `emptySource`.
- Legacy recovery checkpoints with unproven empty success are rejected. Converter and renderer call-count tests prevent emptiness checks from triggering another conversion.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- strict `clippy -D warnings`, no new exemptions:
  - Core + Engine + Converters, all targets, no deps: passed
  - API lib: passed
  - CLI empty-result integration target: passed
- Core: 104 passed; doc tests: 8 passed
- Engine: 44 passed
- Converters: 458 passed, 1 ignored; fixture corpus passed
- API: 45 passed, 2 ignored; collecting parity: 4 passed
- CLI unit/Web/transaction: 233 passed
- CLI empty-result real-process contract: 6 passed
- CLI exit contract: 15 passed
- full CLI tests reached the unrelated plugin lifecycle target: 1 passed; 1 could not run because `INTO_MD_PLUGIN_PROCESS_FIXTURE` is absent in this local environment

All-target API/CLI clippy also reproduces pre-existing Rust 1.97 warnings on `origin/main`; changed libraries and the new CLI target pass strict clippy.

## Performance

Release binaries from main `387e6db306269304a36af3d55a225b649be44363` and `b1be97a` were warmed up and run in alternating order 15 times per common successful small fixture with `--no-config --emit markdown --asset-mode embed`.

| Fixture | main elapsed ms | PR elapsed ms | change | main RSS MiB | PR RSS MiB | max temp bytes main / PR |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| TXT | 32.891 | 37.339 | +13.52% | 10.909 | 9.673 | 64 / 64 |
| Markdown | 31.386 | 32.959 | +5.01% | 9.598 | 8.798 | 58 / 58 |
| DOCX | 31.967 | 31.582 | -1.20% | 9.862 | 6.483 | 40 / 40 |
| XLSX | 32.273 | 33.062 | +2.44% | 11.550 | 9.208 | 834 / 417 |
| **Mean (60 runs/version)** | **32.129** | **33.736** | **+5.00%** | **10.480** | **8.540** | **834 / 417** |

Every run emitted non-empty stdout and left 0 temporary bytes after exit. The ordinary-case mean elapsed regression remains below the +50% ceiling.

For a release-mode in-process terminal-policy benchmark over 250,000 empty paragraph nodes, five runs measured the visible-Markdown fast path at 2–3 ns/call versus 1.793–1.862 ms/call for a forced complete IR walk. A permanent 100,000-node correctness regression locks the fast-path ordering without a timing assertion.

## Risk

- New formats remain fail-closed until their converters can certify truly empty input.
- Linked EPUB CSS/font/audio/video omissions now degrade; orphan manifest resources do not.
- Web rejects external-URI-only asset-only results because its artifact publication carries local payloads, while Result JSON remains the compatible external-reference destination.
- Scope is limited to #268 and integration with merged #272/#273 boundaries; it does not implement #267, #269, or #270.

Fixes #268
