### PR TITLE
Add auditable per-file and batch timings

### DIFF
--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -4237,6 +4237,7 @@ fn run_conversion(
     json_log: bool,
     context: &mut RunContext<'_>,
 ) -> Result<(), CliError> {
+    let batch_timer = crate::timing::ItemTimer::start();
     apply_conversion_overrides(&arguments, &mut loaded)?;
     let includes = build_globset(&arguments.include)?;
     let excludes = build_globset(&arguments.exclude)?;
@@ -4308,45 +4309,91 @@ fn run_conversion(
         assets_dir: arguments.assets_dir,
         working_directory: context.cwd.clone(),
     };
-    let reports = if plans.len() == 1 && plans[0].output.is_none() {
-        vec![match process_stdout(&plans[0], &policy, catalog, json_log, context) {
-            Ok(report) => report,
-            Err(error) if arguments.report.is_some() => {
-                failed_item_report(&plans[0], &policy, &error)
+    let reports = execute_plans(
+        plans,
+        &policy,
+        arguments.jobs.map_or(loaded.jobs, std::num::NonZero::get),
+        arguments.report.is_some(),
+        catalog,
+        json_log,
+        context,
+    )?;
+    finish_reports(
+        reports,
+        FinishReportsContext {
+            report_path: arguments.report.as_deref(),
+            global,
+            catalog,
+            json_log,
+            stderr: context.stderr,
+            output_context: &policy.output_context,
+            wall_duration_ms: batch_timer.elapsed_ms(),
+        },
+    )
+}
+
+fn execute_plans(
+    plans: Vec<WorkPlan>,
+    policy: &ExecutionPolicy,
+    jobs: usize,
+    report_requested: bool,
+    catalog: Catalog,
+    json_log: bool,
+    context: &mut RunContext<'_>,
+) -> Result<Vec<BatchItemReport>, CliError> {
+    if plans.len() == 1 && plans[0].output.is_none() {
+        let item_timer = crate::timing::ItemTimer::start();
+        Ok(vec![match process_stdout(&plans[0], policy, catalog, json_log, context) {
+            Ok(mut report) => {
+                report.duration_ms = Some(item_timer.elapsed_ms());
+                report
+            }
+            Err(error) if report_requested => {
+                failed_item_report(&plans[0], policy, &error, Some(item_timer.elapsed_ms()))
             }
             Err(error) => return Err(error),
-        }]
+        }])
     } else if plans.len() == 1 {
         let plan = &plans[0];
         let output_phase = Mutex::new(());
-        vec![match process_file_task_inner(plan, &policy, &output_phase) {
-            Ok(completed) => completed_item_report(plan.item.display.clone(), completed),
-            Err(error) if arguments.report.is_some() => failed_item_report(plan, &policy, &error),
+        let item_timer = crate::timing::ItemTimer::start();
+        Ok(vec![match process_file_task_inner(plan, policy, &output_phase) {
+            Ok(completed) => {
+                completed_item_report(plan.item.display.clone(), completed, item_timer.elapsed_ms())
+            }
+            Err(error) if report_requested => {
+                failed_item_report(plan, policy, &error, Some(item_timer.elapsed_ms()))
+            }
             Err(error) => return Err(error),
-        }]
+        }])
     } else {
-        process_batch(plans, &policy, arguments.jobs.map_or(loaded.jobs, std::num::NonZero::get))?
-    };
-    finish_reports(
-        reports,
-        arguments.report.as_deref(),
-        global,
-        catalog,
-        json_log,
-        context.stderr,
-        &policy.output_context,
-    )
+        process_batch(plans, policy, jobs)
+    }
+}
+
+struct FinishReportsContext<'a> {
+    report_path: Option<&'a Path>,
+    global: &'a crate::args::GlobalArgs,
+    catalog: Catalog,
+    json_log: bool,
+    stderr: &'a mut dyn Write,
+    output_context: &'a into_markdown::ExecutionContext,
+    wall_duration_ms: f64,
 }
 
 fn finish_reports(
     reports: Vec<BatchItemReport>,
-    report_path: Option<&Path>,
-    global: &crate::args::GlobalArgs,
-    catalog: Catalog,
-    json_log: bool,
-    stderr: &mut dyn Write,
-    output_context: &into_markdown::ExecutionContext,
+    context: FinishReportsContext<'_>,
 ) -> Result<(), CliError> {
+    let FinishReportsContext {
+        report_path,
+        global,
+        catalog,
+        json_log,
+        stderr,
+        output_context,
+        wall_duration_ms,
+    } = context;
     for report in &reports {
         for warning in &report.warnings {
             if !global.quiet {
@@ -4378,7 +4425,10 @@ fn finish_reports(
             )?;
         }
     }
-    let report = BatchReport::try_new(reports)
+    if !global.quiet {
+        crate::timing::write_summary(stderr, &reports, wall_duration_ms, catalog, json_log)?;
+    }
+    let report = BatchReport::try_new_with_wall_duration(reports, Some(wall_duration_ms))
         .map_err(|error| CliError::internal(format!("build batch report DTO: {error}")))?;
     if let Some(path) = report_path {
         output::write_report(path, &report, output_context)?;
@@ -4939,51 +4989,57 @@ fn process_stdout(
         &policy.working_directory,
     )?;
     let (mut spool, summary) = convert_item_into(&plan.item, policy, asset_output.uri_prefix)?;
-    crate::result_policy::validate_for_emit(&summary, policy.emit, policy.asset_mode)?;
-    spool.finish()?;
-    let mut encoded =
-        policy.output_context.temporary_file("into-md-stdout").map_err(CliError::from)?;
-    spool.serialize(policy.emit, &mut encoded)?;
-    encoded.sync_all().map_err(CliError::from)?;
-    let staged_assets = if let Some(assets_dir) = asset_output.external_directory {
-        spool
-            .has_payloads()
-            .then(|| {
-                output::stage_spooled_assets(
-                    &spool,
-                    &assets_dir,
-                    policy.asset_mode,
-                    policy.conflict,
-                    &policy.output_context,
-                )
-            })
-            .transpose()?
-    } else if policy.asset_mode == AssetModeArg::Extract
-        && policy.emit != EmitKind::Bundle
-        && spool.has_payloads()
-    {
-        return Err(CliError::usage(
-            "stdin and URI inputs with extracted assets require --assets-dir",
-        ));
-    } else {
-        None
-    };
-    output::publish_stdout(&encoded, context.stdout, staged_assets, &policy.output_context)?;
-    Ok(BatchItemReport {
-        input: plan.item.display.clone(),
-        output: None,
-        format: summary.format.map(|format| format.as_str().into()),
-        status: BatchItemStatus::Success,
-        outcome: crate::result_policy::batch_outcome(summary.outcome),
-        diagnostics: summary.diagnostics.iter().map(Into::into).collect(),
-        error_code: None,
-        reason_code: summary.reason_code().map(str::to_owned),
-        component: None,
-        part: None,
-        limit: None,
-        message: None,
-        warnings: vec![],
-    })
+    let processing_duration_ms = summary.processing_duration_ms;
+    (|| -> Result<BatchItemReport, CliError> {
+        crate::result_policy::validate_for_emit(&summary, policy.emit, policy.asset_mode)?;
+        spool.finish()?;
+        let mut encoded =
+            policy.output_context.temporary_file("into-md-stdout").map_err(CliError::from)?;
+        spool.serialize(policy.emit, &mut encoded)?;
+        encoded.sync_all().map_err(CliError::from)?;
+        let staged_assets = if let Some(assets_dir) = asset_output.external_directory {
+            spool
+                .has_payloads()
+                .then(|| {
+                    output::stage_spooled_assets(
+                        &spool,
+                        &assets_dir,
+                        policy.asset_mode,
+                        policy.conflict,
+                        &policy.output_context,
+                    )
+                })
+                .transpose()?
+        } else if policy.asset_mode == AssetModeArg::Extract
+            && policy.emit != EmitKind::Bundle
+            && spool.has_payloads()
+        {
+            return Err(CliError::usage(
+                "stdin and URI inputs with extracted assets require --assets-dir",
+            ));
+        } else {
+            None
+        };
+        output::publish_stdout(&encoded, context.stdout, staged_assets, &policy.output_context)?;
+        Ok(BatchItemReport {
+            input: plan.item.display.clone(),
+            output: None,
+            format: summary.format.map(|format| format.as_str().into()),
+            status: BatchItemStatus::Success,
+            outcome: crate::result_policy::batch_outcome(summary.outcome),
+            diagnostics: summary.diagnostics.iter().map(Into::into).collect(),
+            error_code: None,
+            reason_code: summary.reason_code().map(str::to_owned),
+            component: None,
+            part: None,
+            limit: None,
+            message: None,
+            warnings: vec![],
+            duration_ms: None,
+            processing_duration_ms,
+        })
+    })()
+    .map_err(|error| error.with_processing_duration(processing_duration_ms))
 }
 
 fn process_batch(
@@ -5046,15 +5102,19 @@ fn process_file_task(
     memory_phase: &Mutex<()>,
 ) -> BatchItemReport {
     let _memory_guard = memory_phase.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let item_timer = crate::timing::ItemTimer::start();
     match process_file_task_inner(&plan, policy, output_phase) {
-        Ok(completed) => completed_item_report(plan.item.display, completed),
-        Err(error) => failed_item_report(&plan, policy, &error),
+        Ok(completed) => {
+            completed_item_report(plan.item.display, completed, item_timer.elapsed_ms())
+        }
+        Err(error) => failed_item_report(&plan, policy, &error, Some(item_timer.elapsed_ms())),
     }
 }
 
 fn completed_item_report(
     input: String,
     completed: crate::result_policy::CommittedOutput,
+    duration_ms: f64,
 ) -> BatchItemReport {
     let reason_code = completed.summary.reason_code().map(str::to_owned);
     BatchItemReport {
@@ -5071,6 +5131,8 @@ fn completed_item_report(
         limit: None,
         message: None,
         warnings: completed.warnings,
+        duration_ms: Some(duration_ms),
+        processing_duration_ms: completed.summary.processing_duration_ms,
     }
 }
 
@@ -5078,6 +5140,7 @@ fn failed_item_report(
     plan: &WorkPlan,
     policy: &ExecutionPolicy,
     error: &CliError,
+    duration_ms: Option<f64>,
 ) -> BatchItemReport {
     BatchItemReport {
         input: plan.item.display.clone(),
@@ -5095,6 +5158,8 @@ fn failed_item_report(
             .map(|(name, detail)| BatchLimitDto { name: name.into(), detail: Some(detail.into()) }),
         message: Some(error.to_string()),
         warnings: vec![],
+        duration_ms,
+        processing_duration_ms: error.processing_duration_ms(),
     }
 }
 
@@ -5118,38 +5183,43 @@ fn process_file_task_inner(
         &policy.working_directory,
     )?;
     let (mut spool, summary) = convert_item_into(&plan.item, policy, asset_output.uri_prefix)?;
-    crate::result_policy::validate_for_emit(&summary, policy.emit, policy.asset_mode)?;
-    spool.finish()?;
-    let output_parent = output_path
-        .parent()
-        .ok_or_else(|| CliError::internal("batch output has no parent directory"))?;
-    let mut encoded = policy
-        .output_context
-        .temporary_file_in(output_parent, "into-md-encoded")
-        .map_err(CliError::from)?;
-    spool.serialize(policy.emit, &mut encoded)?;
-    encoded.sync_all().map_err(CliError::from)?;
-    let write_outcome = {
-        let _guard =
-            output_phase.lock().map_err(|_| CliError::internal("batch output lock is poisoned"))?;
-        output::write_spooled_output_set_file(
-            &output_path,
-            encoded.as_file().map_err(CliError::from)?,
-            &spool,
-            asset_output.external_directory.as_deref(),
-            policy.asset_mode,
-            policy.conflict,
-            &policy.output_context,
-        )?
-    };
-    let mut warnings = Vec::new();
-    if write_outcome.renamed || output_path != requested {
-        warnings.push(format!(
-            "output renamed to {} because the requested path existed",
-            write_outcome.path.display()
-        ));
-    }
-    Ok(crate::result_policy::CommittedOutput { path: write_outcome.path, summary, warnings })
+    let processing_duration_ms = summary.processing_duration_ms;
+    (|| -> Result<crate::result_policy::CommittedOutput, CliError> {
+        crate::result_policy::validate_for_emit(&summary, policy.emit, policy.asset_mode)?;
+        spool.finish()?;
+        let output_parent = output_path
+            .parent()
+            .ok_or_else(|| CliError::internal("batch output has no parent directory"))?;
+        let mut encoded = policy
+            .output_context
+            .temporary_file_in(output_parent, "into-md-encoded")
+            .map_err(CliError::from)?;
+        spool.serialize(policy.emit, &mut encoded)?;
+        encoded.sync_all().map_err(CliError::from)?;
+        let write_outcome = {
+            let _guard = output_phase
+                .lock()
+                .map_err(|_| CliError::internal("batch output lock is poisoned"))?;
+            output::write_spooled_output_set_file(
+                &output_path,
+                encoded.as_file().map_err(CliError::from)?,
+                &spool,
+                asset_output.external_directory.as_deref(),
+                policy.asset_mode,
+                policy.conflict,
+                &policy.output_context,
+            )?
+        };
+        let mut warnings = Vec::new();
+        if write_outcome.renamed || output_path != requested {
+            warnings.push(format!(
+                "output renamed to {} because the requested path existed",
+                write_outcome.path.display()
+            ));
+        }
+        Ok(crate::result_policy::CommittedOutput { path: write_outcome.path, summary, warnings })
+    })()
+    .map_err(|error| error.with_processing_duration(processing_duration_ms))
 }
 
 fn report_path(path: &Path) -> String {
@@ -5780,6 +5850,10 @@ fn redact_parsed_url(mut parsed: url::Url) -> String {
     parsed.set_fragment(None);
     parsed.to_string()
 }
+
+#[cfg(test)]
+#[path = "app/timing_tests.rs"]
+mod timing_tests;
 
 #[cfg(test)]
 mod tests {
@@ -7204,7 +7278,10 @@ mod tests {
         .unwrap();
         server.join().unwrap();
         assert_eq!(String::from_utf8(stdout).unwrap(), "hello\n");
-        assert!(stderr.is_empty());
+        let timing = String::from_utf8(stderr).unwrap();
+        assert!(timing.contains("timing: total "));
+        assert!(timing.contains("timing: batch wall "));
+        assert!(!timing.contains(&address.to_string()));
         fs::remove_dir_all(root).unwrap();
     }
 
@@ -7264,6 +7341,8 @@ mod tests {
             limit: None,
             message: None,
             warnings: Vec::new(),
+            duration_ms: Some(0.0),
+            processing_duration_ms: None,
         };
         let report_json = BatchReport::try_new(vec![report]).unwrap().to_pretty_json().unwrap();
         assert!(!report_json.contains(CANARY));

--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -4317,7 +4317,8 @@ fn run_conversion(
         catalog,
         json_log,
         context,
-    )?;
+    )
+    .map_err(|error| error.with_wall_duration(batch_timer.elapsed_ms()))?;
     finish_reports(
         reports,
         FinishReportsContext {
@@ -4351,7 +4352,7 @@ fn execute_plans(
             Err(error) if report_requested => {
                 failed_item_report(&plans[0], policy, &error, Some(item_timer.elapsed_ms()))
             }
-            Err(error) => return Err(error),
+            Err(error) => return Err(error.with_duration(item_timer.elapsed_ms())),
         }])
     } else if plans.len() == 1 {
         let plan = &plans[0];
@@ -4364,7 +4365,7 @@ fn execute_plans(
             Err(error) if report_requested => {
                 failed_item_report(plan, policy, &error, Some(item_timer.elapsed_ms()))
             }
-            Err(error) => return Err(error),
+            Err(error) => return Err(error.with_duration(item_timer.elapsed_ms())),
         }])
     } else {
         process_batch(plans, policy, jobs)

--- a/apps/cli/src/app/timing_tests.rs
+++ b/apps/cli/src/app/timing_tests.rs
@@ -98,52 +98,141 @@ fn failures_remain_auditable_with_elapsed_time() {
 }
 
 #[test]
-fn cancelled_worker_item_records_elapsed_time_without_a_fake_processing_stage() {
+fn malformed_without_report_renders_text_and_json_timings() {
     let temporary = tempfile::tempdir().unwrap();
     let root = temporary.path().canonicalize().unwrap();
-    let input = root.join("cancelled.txt");
-    let output = root.join("cancelled.md");
-    fs::write(&input, b"cancel me\n").unwrap();
+    let invalid = root.join("invalid.epub");
+    fs::write(&invalid, b"PK\x03\x04broken ZIP archive").unwrap();
+
+    for json_log in [false, true] {
+        let mut arguments = vec![
+            OsString::from("--no-config"),
+            invalid.clone().into_os_string(),
+            OsString::from("--output"),
+            root.join(if json_log { "json.md" } else { "text.md" }).into_os_string(),
+        ];
+        if json_log {
+            arguments.extend([OsString::from("--log-format"), OsString::from("json")]);
+        }
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let error = run(
+            arguments,
+            RunContext {
+                user_data_anchor: Some(root.join(".test-user-data")),
+                stdout: &mut stdout,
+                stderr: &mut stderr,
+                stdin_is_terminal: true,
+                cwd: root.clone(),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "malformed");
+        assert!(error.duration_ms().is_some_and(|value| value >= 0.0));
+        assert!(error.wall_duration_ms().is_some_and(|value| value >= 0.0));
+        assert!(error.wall_duration_ms().unwrap() >= error.duration_ms().unwrap());
+        assert_eq!(error.processing_duration_ms(), None);
+
+        crate::write_error(&mut stderr, &error, Catalog::new(crate::args::Language::En), json_log)
+            .unwrap();
+        if json_log {
+            let event: serde_json::Value = serde_json::from_slice(&stderr).unwrap();
+            assert!(event["durationMs"].as_f64().is_some_and(|value| value >= 0.0));
+            assert!(event["wallDurationMs"].as_f64().is_some_and(|value| value >= 0.0));
+            assert!(event.get("processingDurationMs").is_none());
+        } else {
+            let output = String::from_utf8(stderr).unwrap();
+            assert!(output.contains("timing: total "));
+            assert!(output.contains("timing: batch wall "));
+        }
+    }
+}
+
+#[test]
+fn cancelled_and_timed_out_workers_return_no_report_timings_without_fake_processing() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = temporary.path().canonicalize().unwrap();
     let cancellation = into_markdown::CancellationToken::new();
     cancellation.cancel();
-    let execution = into_markdown::ExecutionOptions {
-        cancellation,
-        ..into_markdown::ExecutionOptions::default()
-    };
-    let options = ConversionOptions::default();
-    let policy = ExecutionPolicy {
-        output_context: into_markdown::ExecutionContext::new(
-            execution.clone(),
-            options.limits.clone(),
+    let cases = [
+        (
+            "cancelled",
+            into_markdown::ExecutionOptions {
+                cancellation,
+                ..into_markdown::ExecutionOptions::default()
+            },
         ),
-        options,
-        execution,
-        services: into_markdown::Services::default(),
-        hint: FormatHint::default(),
-        emit: EmitKind::Markdown,
-        asset_mode: AssetModeArg::Extract,
-        conflict: ConflictPolicy::Error,
-        assets_dir: None,
-        working_directory: root.clone(),
-    };
-    let plan = WorkPlan {
-        item: WorkItem {
-            input: InputRef::Path(input.clone()),
-            display: input.display().to_string(),
-            relative: PathBuf::from("cancelled.txt"),
-            root_label: "cancelled".into(),
-            input_root: root.clone(),
-            from_directory: false,
-            local_path: Some(input),
-        },
-        output: Some(output),
-        output_root: Some(root),
-    };
+        (
+            "timeout",
+            into_markdown::ExecutionOptions {
+                timeout: Some(std::time::Duration::ZERO),
+                ..into_markdown::ExecutionOptions::default()
+            },
+        ),
+    ];
 
-    let report = process_file_task(plan, &policy, &Mutex::new(()), &Mutex::new(()));
+    for (expected_code, execution) in cases {
+        let input = root.join(format!("{expected_code}.txt"));
+        fs::write(&input, b"stop me\n").unwrap();
+        let options = ConversionOptions::default();
+        let policy = ExecutionPolicy {
+            output_context: into_markdown::ExecutionContext::new(
+                execution.clone(),
+                options.limits.clone(),
+            ),
+            options,
+            execution,
+            services: into_markdown::Services::default(),
+            hint: FormatHint::default(),
+            emit: EmitKind::Markdown,
+            asset_mode: AssetModeArg::Extract,
+            conflict: ConflictPolicy::Error,
+            assets_dir: None,
+            working_directory: root.clone(),
+        };
+        let plan = WorkPlan {
+            item: WorkItem {
+                input: InputRef::Path(input.clone()),
+                display: input.display().to_string(),
+                relative: PathBuf::from(format!("{expected_code}.txt")),
+                root_label: expected_code.into(),
+                input_root: root.clone(),
+                from_directory: false,
+                local_path: Some(input),
+            },
+            output: Some(root.join(format!("{expected_code}.md"))),
+            output_root: Some(root.clone()),
+        };
+        let batch_timer = crate::timing::ItemTimer::start();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut context = RunContext {
+            user_data_anchor: Some(root.join(".test-user-data")),
+            stdout: &mut stdout,
+            stderr: &mut stderr,
+            stdin_is_terminal: true,
+            cwd: root.clone(),
+        };
+        let error = execute_plans(
+            vec![plan],
+            &policy,
+            1,
+            false,
+            Catalog::new(crate::args::Language::En),
+            true,
+            &mut context,
+        )
+        .unwrap_err()
+        .with_wall_duration(batch_timer.elapsed_ms());
 
-    assert_eq!(report.status, BatchItemStatus::Failed);
-    assert_eq!(report.error_code.as_deref(), Some("cancelled"));
-    assert!(report.duration_ms.is_some_and(|value| value >= 0.0));
-    assert_eq!(report.processing_duration_ms, None);
+        assert_eq!(error.code(), expected_code);
+        assert!(error.duration_ms().is_some_and(|value| value >= 0.0));
+        assert!(error.wall_duration_ms().unwrap() >= error.duration_ms().unwrap());
+        assert_eq!(error.processing_duration_ms(), None);
+        crate::write_error(&mut stderr, &error, Catalog::new(crate::args::Language::En), true)
+            .unwrap();
+        let event: serde_json::Value = serde_json::from_slice(&stderr).unwrap();
+        assert!(event["durationMs"].is_number());
+        assert!(event["wallDurationMs"].is_number());
+    }
 }

--- a/apps/cli/src/app/timing_tests.rs
+++ b/apps/cli/src/app/timing_tests.rs
@@ -1,0 +1,149 @@
+use super::*;
+
+#[test]
+fn single_and_parallel_reports_publish_real_timing_boundaries() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = temporary.path().canonicalize().unwrap();
+    let first = root.join("first.txt");
+    let second = root.join("second.txt");
+    fs::write(&first, b"first\n").unwrap();
+    fs::write(&second, b"second\n").unwrap();
+
+    for (inputs, jobs, name) in [
+        (vec![first.clone()], "1", "single"),
+        (vec![first.clone(), second.clone()], "2", "parallel"),
+    ] {
+        let output_dir = root.join(format!("{name}-output"));
+        let report_path = root.join(format!("{name}-report.json"));
+        let mut arguments = vec![OsString::from("--no-config")];
+        arguments.extend(inputs.into_iter().map(PathBuf::into_os_string));
+        arguments.extend([
+            OsString::from("--output-dir"),
+            output_dir.into_os_string(),
+            OsString::from("--report"),
+            report_path.clone().into_os_string(),
+            OsString::from("--jobs"),
+            OsString::from(jobs),
+        ]);
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        run(
+            arguments,
+            RunContext {
+                user_data_anchor: Some(root.join(".test-user-data")),
+                stdout: &mut stdout,
+                stderr: &mut stderr,
+                stdin_is_terminal: true,
+                cwd: root.clone(),
+            },
+        )
+        .unwrap();
+
+        let report: serde_json::Value =
+            serde_json::from_slice(&fs::read(report_path).unwrap()).unwrap();
+        let wall = report["wallDurationMs"].as_f64().unwrap();
+        assert_eq!(report["items"].as_array().unwrap().len(), usize::from(jobs == "2") + 1);
+        for item in report["items"].as_array().unwrap() {
+            let duration = item["durationMs"].as_f64().unwrap();
+            let processing = item["processingDurationMs"].as_f64().unwrap();
+            assert!(wall >= duration);
+            assert!(duration >= processing);
+            assert!(processing >= 0.0);
+            assert!(!item["output"].as_str().unwrap().contains('\\'));
+        }
+        let stderr = String::from_utf8(stderr).unwrap();
+        assert!(stderr.contains("timing: "));
+        assert!(stderr.contains("timing: batch wall "));
+    }
+}
+
+#[test]
+fn failures_remain_auditable_with_elapsed_time() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = temporary.path().canonicalize().unwrap();
+    let invalid = root.join("invalid.epub");
+    fs::write(&invalid, b"PK\x03\x04broken ZIP archive").unwrap();
+    let report_path = root.join("failure-report.json");
+    let arguments = vec![
+        OsString::from("--no-config"),
+        invalid.into_os_string(),
+        OsString::from("--output"),
+        root.join("failure.md").into_os_string(),
+        OsString::from("--report"),
+        report_path.clone().into_os_string(),
+    ];
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let error = run(
+        arguments,
+        RunContext {
+            user_data_anchor: Some(root.join(".test-user-data")),
+            stdout: &mut stdout,
+            stderr: &mut stderr,
+            stdin_is_terminal: true,
+            cwd: root,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(error.code(), "partialFailure");
+    let report: serde_json::Value =
+        serde_json::from_slice(&fs::read(report_path).unwrap()).unwrap();
+    assert_eq!(report["items"][0]["status"], "failed");
+    assert!(report["items"][0]["durationMs"].as_f64().is_some_and(|value| value >= 0.0));
+    assert!(report["items"][0].get("processingDurationMs").is_none());
+    assert!(
+        report["wallDurationMs"].as_f64().unwrap()
+            >= report["items"][0]["durationMs"].as_f64().unwrap()
+    );
+}
+
+#[test]
+fn cancelled_worker_item_records_elapsed_time_without_a_fake_processing_stage() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = temporary.path().canonicalize().unwrap();
+    let input = root.join("cancelled.txt");
+    let output = root.join("cancelled.md");
+    fs::write(&input, b"cancel me\n").unwrap();
+    let cancellation = into_markdown::CancellationToken::new();
+    cancellation.cancel();
+    let execution = into_markdown::ExecutionOptions {
+        cancellation,
+        ..into_markdown::ExecutionOptions::default()
+    };
+    let options = ConversionOptions::default();
+    let policy = ExecutionPolicy {
+        output_context: into_markdown::ExecutionContext::new(
+            execution.clone(),
+            options.limits.clone(),
+        ),
+        options,
+        execution,
+        services: into_markdown::Services::default(),
+        hint: FormatHint::default(),
+        emit: EmitKind::Markdown,
+        asset_mode: AssetModeArg::Extract,
+        conflict: ConflictPolicy::Error,
+        assets_dir: None,
+        working_directory: root.clone(),
+    };
+    let plan = WorkPlan {
+        item: WorkItem {
+            input: InputRef::Path(input.clone()),
+            display: input.display().to_string(),
+            relative: PathBuf::from("cancelled.txt"),
+            root_label: "cancelled".into(),
+            input_root: root.clone(),
+            from_directory: false,
+            local_path: Some(input),
+        },
+        output: Some(output),
+        output_root: Some(root),
+    };
+
+    let report = process_file_task(plan, &policy, &Mutex::new(()), &Mutex::new(()));
+
+    assert_eq!(report.status, BatchItemStatus::Failed);
+    assert_eq!(report.error_code.as_deref(), Some("cancelled"));
+    assert!(report.duration_ms.is_some_and(|value| value >= 0.0));
+    assert_eq!(report.processing_duration_ms, None);
+}

--- a/apps/cli/src/error.rs
+++ b/apps/cli/src/error.rs
@@ -50,7 +50,9 @@ pub struct CliError {
     broken_pipe: bool,
     language: Option<Language>,
     json_log: bool,
+    duration_ms: Option<f64>,
     processing_duration_ms: Option<f64>,
+    wall_duration_ms: Option<f64>,
 }
 
 #[derive(Debug)]
@@ -72,7 +74,9 @@ impl CliError {
             broken_pipe: false,
             language: None,
             json_log: false,
+            duration_ms: None,
             processing_duration_ms: None,
+            wall_duration_ms: None,
         }
     }
 
@@ -136,8 +140,26 @@ impl CliError {
         self.processing_duration_ms
     }
 
+    pub const fn duration_ms(&self) -> Option<f64> {
+        self.duration_ms
+    }
+
+    pub const fn wall_duration_ms(&self) -> Option<f64> {
+        self.wall_duration_ms
+    }
+
+    pub fn with_duration(mut self, duration_ms: f64) -> Self {
+        self.duration_ms = Some(duration_ms);
+        self
+    }
+
     pub fn with_processing_duration(mut self, duration_ms: Option<f64>) -> Self {
         self.processing_duration_ms = duration_ms;
+        self
+    }
+
+    pub fn with_wall_duration(mut self, duration_ms: f64) -> Self {
+        self.wall_duration_ms = Some(duration_ms);
         self
     }
 
@@ -205,7 +227,9 @@ impl From<std::io::Error> for CliError {
                 broken_pipe: true,
                 language: None,
                 json_log: false,
+                duration_ms: None,
                 processing_duration_ms: None,
+                wall_duration_ms: None,
             }
         } else {
             Self::new(ExitClass::Io, "io", error.to_string())

--- a/apps/cli/src/error.rs
+++ b/apps/cli/src/error.rs
@@ -50,6 +50,7 @@ pub struct CliError {
     broken_pipe: bool,
     language: Option<Language>,
     json_log: bool,
+    processing_duration_ms: Option<f64>,
 }
 
 #[derive(Debug)]
@@ -71,6 +72,7 @@ impl CliError {
             broken_pipe: false,
             language: None,
             json_log: false,
+            processing_duration_ms: None,
         }
     }
 
@@ -128,6 +130,15 @@ impl CliError {
 
     pub fn detected_format(&self) -> Option<InputFormat> {
         self.metadata.as_ref().and_then(|metadata| metadata.detected_format)
+    }
+
+    pub const fn processing_duration_ms(&self) -> Option<f64> {
+        self.processing_duration_ms
+    }
+
+    pub fn with_processing_duration(mut self, duration_ms: Option<f64>) -> Self {
+        self.processing_duration_ms = duration_ms;
+        self
     }
 
     pub fn with_detected_format(mut self, format: Option<InputFormat>) -> Self {
@@ -194,6 +205,7 @@ impl From<std::io::Error> for CliError {
                 broken_pipe: true,
                 language: None,
                 json_log: false,
+                processing_duration_ms: None,
             }
         } else {
             Self::new(ExitClass::Io, "io", error.to_string())

--- a/apps/cli/src/i18n.rs
+++ b/apps/cli/src/i18n.rs
@@ -61,6 +61,41 @@ impl Catalog {
             Language::ZhCn => "警告",
         }
     }
+
+    pub const fn timing_prefix(self) -> &'static str {
+        match self.language {
+            Language::En => "timing",
+            Language::ZhCn => "计时",
+        }
+    }
+
+    pub const fn total_duration_label(self) -> &'static str {
+        match self.language {
+            Language::En => "total",
+            Language::ZhCn => "总耗时",
+        }
+    }
+
+    pub const fn processing_duration_label(self) -> &'static str {
+        match self.language {
+            Language::En => "conversion",
+            Language::ZhCn => "转换",
+        }
+    }
+
+    pub const fn batch_wall_duration_label(self) -> &'static str {
+        match self.language {
+            Language::En => "batch wall",
+            Language::ZhCn => "整批墙钟",
+        }
+    }
+
+    pub const fn unavailable_label(self) -> &'static str {
+        match self.language {
+            Language::En => "unavailable",
+            Language::ZhCn => "不可用",
+        }
+    }
 }
 
 /// Return localized help when Chinese was explicitly selected.

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -11,6 +11,7 @@ mod output;
 mod proxy_env;
 mod result_policy;
 mod services;
+mod timing;
 mod transaction;
 mod ui;
 mod ui_assets;

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -71,14 +71,45 @@ fn write_error(
     json_log: bool,
 ) -> std::io::Result<()> {
     if json_log {
-        let event = serde_json::json!({
+        let mut event = serde_json::json!({
             "code": error.code(),
             "message": error.message(),
             "exitCode": error.exit_code(),
         });
+        if let Some(duration_ms) = error.duration_ms() {
+            event["durationMs"] = duration_ms.into();
+        }
+        if let Some(duration_ms) = error.processing_duration_ms() {
+            event["processingDurationMs"] = duration_ms.into();
+        }
+        if let Some(duration_ms) = error.wall_duration_ms() {
+            event["wallDurationMs"] = duration_ms.into();
+        }
         writeln!(stderr, "{event}")
     } else {
-        writeln!(stderr, "{}: {}", catalog.error_prefix(), error)
+        writeln!(stderr, "{}: {}", catalog.error_prefix(), error)?;
+        if let Some(duration_ms) = error.duration_ms() {
+            let processing = error.processing_duration_ms().map_or_else(
+                || catalog.unavailable_label().to_owned(),
+                |value| format!("{value:.2} ms"),
+            );
+            writeln!(
+                stderr,
+                "{}: {} {duration_ms:.2} ms, {} {processing}",
+                catalog.timing_prefix(),
+                catalog.total_duration_label(),
+                catalog.processing_duration_label(),
+            )?;
+        }
+        if let Some(duration_ms) = error.wall_duration_ms() {
+            writeln!(
+                stderr,
+                "{}: {} {duration_ms:.2} ms",
+                catalog.timing_prefix(),
+                catalog.batch_wall_duration_label(),
+            )?;
+        }
+        Ok(())
     }
 }
 
@@ -95,5 +126,22 @@ mod tests {
         assert_eq!(value["code"], "componentUnavailable");
         assert_eq!(value["exitCode"], 9);
         assert_eq!(value["message"], "model runtime missing");
+        assert!(value.get("durationMs").is_none());
+        assert!(value.get("processingDurationMs").is_none());
+        assert!(value.get("wallDurationMs").is_none());
+    }
+
+    #[test]
+    fn json_errors_add_timing_fields_when_one_execution_started() {
+        let error = error::CliError::component("late output failure")
+            .with_duration(12.5)
+            .with_processing_duration(Some(8.25))
+            .with_wall_duration(14.0);
+        let mut bytes = Vec::new();
+        write_error(&mut bytes, &error, i18n::Catalog::new(args::Language::En), true).unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value["durationMs"], 12.5);
+        assert_eq!(value["processingDurationMs"], 8.25);
+        assert_eq!(value["wallDurationMs"], 14.0);
     }
 }

--- a/apps/cli/src/output.rs
+++ b/apps/cli/src/output.rs
@@ -301,6 +301,8 @@ mod tests {
             limit: None,
             message: None,
             warnings: vec![],
+            duration_ms: None,
+            processing_duration_ms: None,
         }])
         .unwrap();
         write_report(&path, &report, &output_context()).unwrap();

--- a/apps/cli/src/timing.rs
+++ b/apps/cli/src/timing.rs
@@ -1,0 +1,192 @@
+//! Monotonic CLI timing and presentation, kept separate from conversion orchestration.
+
+use crate::error::CliError;
+use crate::i18n::Catalog;
+use into_markdown::BatchItemDto;
+use serde::Serialize;
+use std::io::Write;
+use std::time::Instant;
+
+pub(crate) struct ItemTimer(Instant);
+
+impl ItemTimer {
+    pub(crate) fn start() -> Self {
+        Self(Instant::now())
+    }
+
+    pub(crate) fn elapsed_ms(&self) -> f64 {
+        elapsed_ms(self.0)
+    }
+}
+
+pub(crate) fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1_000.0
+}
+
+pub(crate) fn write_summary(
+    stderr: &mut dyn Write,
+    reports: &[BatchItemDto],
+    wall_duration_ms: f64,
+    catalog: Catalog,
+    json_log: bool,
+) -> Result<(), CliError> {
+    if json_log {
+        write_json_summary(stderr, reports, wall_duration_ms)
+    } else {
+        write_human_summary(stderr, reports, wall_duration_ms, catalog)
+    }
+}
+
+fn write_human_summary(
+    stderr: &mut dyn Write,
+    reports: &[BatchItemDto],
+    wall_duration_ms: f64,
+    catalog: Catalog,
+) -> Result<(), CliError> {
+    let include_input = reports.len() > 1;
+    for report in reports {
+        let total = display_duration(report.duration_ms, catalog);
+        let processing = display_duration(report.processing_duration_ms, catalog);
+        if include_input {
+            writeln!(
+                stderr,
+                "{}: {}: {} {total}, {} {processing}",
+                catalog.timing_prefix(),
+                safe_input_label(&report.input),
+                catalog.total_duration_label(),
+                catalog.processing_duration_label(),
+            )?;
+        } else {
+            writeln!(
+                stderr,
+                "{}: {} {total}, {} {processing}",
+                catalog.timing_prefix(),
+                catalog.total_duration_label(),
+                catalog.processing_duration_label(),
+            )?;
+        }
+    }
+    writeln!(
+        stderr,
+        "{}: {} {wall_duration_ms:.2} ms",
+        catalog.timing_prefix(),
+        catalog.batch_wall_duration_label(),
+    )?;
+    Ok(())
+}
+
+fn display_duration(value: Option<f64>, catalog: Catalog) -> String {
+    value.map_or_else(
+        || catalog.unavailable_label().to_owned(),
+        |duration| format!("{duration:.2} ms"),
+    )
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ItemTimingEvent<'a> {
+    level: &'static str,
+    code: &'static str,
+    message: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    input: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    processing_duration_ms: Option<f64>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BatchTimingEvent {
+    level: &'static str,
+    code: &'static str,
+    message: &'static str,
+    wall_duration_ms: f64,
+}
+
+fn write_json_summary(
+    stderr: &mut dyn Write,
+    reports: &[BatchItemDto],
+    wall_duration_ms: f64,
+) -> Result<(), CliError> {
+    let include_input = reports.len() > 1;
+    for report in reports {
+        serde_json::to_writer(
+            &mut *stderr,
+            &ItemTimingEvent {
+                level: "info",
+                code: "itemTiming",
+                message: "conversion item timing",
+                input: include_input.then(|| safe_input_label(&report.input)),
+                duration_ms: report.duration_ms,
+                processing_duration_ms: report.processing_duration_ms,
+            },
+        )
+        .map_err(|error| CliError::internal(format!("serialize timing event: {error}")))?;
+        writeln!(stderr)?;
+    }
+    serde_json::to_writer(
+        &mut *stderr,
+        &BatchTimingEvent {
+            level: "info",
+            code: "batchTiming",
+            message: "conversion batch timing",
+            wall_duration_ms,
+        },
+    )
+    .map_err(|error| CliError::internal(format!("serialize timing event: {error}")))?;
+    writeln!(stderr)?;
+    Ok(())
+}
+
+fn safe_input_label(input: &str) -> &str {
+    if input.contains("://") { "remote input" } else { input }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown::{BatchItemOutcome, BatchItemStatus};
+
+    fn item() -> BatchItemDto {
+        BatchItemDto {
+            input: r"C:\work\input.txt".into(),
+            output: Some("C:/work/output.md".into()),
+            format: Some("text".into()),
+            status: BatchItemStatus::Success,
+            outcome: BatchItemOutcome::Complete,
+            diagnostics: vec![],
+            error_code: None,
+            reason_code: None,
+            component: None,
+            part: None,
+            limit: None,
+            message: None,
+            warnings: vec![],
+            duration_ms: Some(12.5),
+            processing_duration_ms: Some(8.25),
+        }
+    }
+
+    #[test]
+    fn json_summary_is_structured_and_hides_single_input() {
+        let mut output = Vec::new();
+        write_summary(&mut output, &[item()], 13.0, Catalog::new(crate::args::Language::En), true)
+            .unwrap();
+        let lines = String::from_utf8(output).unwrap();
+        let events = lines
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(events[0]["code"], "itemTiming");
+        assert!(events[0].get("input").is_none());
+        assert_eq!(events[1]["wallDurationMs"], 13.0);
+    }
+
+    #[test]
+    fn batch_labels_keep_windows_paths_and_hide_remote_queries() {
+        assert_eq!(safe_input_label(r"C:\work\input.txt"), r"C:\work\input.txt");
+        assert_eq!(safe_input_label("https://example.test/a?secret=x"), "remote input");
+    }
+}

--- a/crates/core/src/dto.rs
+++ b/crates/core/src/dto.rs
@@ -353,6 +353,10 @@ pub struct BatchItemDto {
     pub message: Option<String>,
     /// Human-readable warnings produced by output handling.
     pub warnings: Vec<String>,
+    /// End-to-end time from worker admission through output commit or failure cleanup.
+    pub duration_ms: Option<f64>,
+    /// Engine processing time through rendering, excluding output sink and persistence work.
+    pub processing_duration_ms: Option<f64>,
 }
 
 /// Versioned machine-readable batch report.
@@ -366,6 +370,8 @@ pub struct BatchReportDto {
     pub failed: u64,
     /// Input-order report items.
     pub items: Vec<BatchItemDto>,
+    /// Independent batch wall-clock time; this is never derived by summing item durations.
+    pub wall_duration_ms: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -512,6 +518,10 @@ struct RawBatchItemDto {
     limit: Option<RawBatchLimitDto>,
     message: Option<String>,
     warnings: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    processing_duration_ms: Option<f64>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -521,6 +531,8 @@ struct RawBatchReportDto {
     succeeded: u64,
     failed: u64,
     items: Vec<RawBatchItemDto>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    wall_duration_ms: Option<f64>,
 }
 
 #[derive(Serialize)]
@@ -809,6 +821,7 @@ fn encode_batch_report(value: &BatchReportDto) -> RawBatchReportDto {
         schema_version: value.schema_version,
         succeeded: value.succeeded,
         failed: value.failed,
+        wall_duration_ms: value.wall_duration_ms,
         items: value
             .items
             .iter()
@@ -836,6 +849,8 @@ fn encode_batch_report(value: &BatchReportDto) -> RawBatchReportDto {
                 }),
                 message: item.message.clone(),
                 warnings: item.warnings.clone(),
+                duration_ms: item.duration_ms,
+                processing_duration_ms: item.processing_duration_ms,
             })
             .collect(),
     }
@@ -848,6 +863,19 @@ impl BatchReportDto {
     ///
     /// Returns [`DtoErrorCode::ResourceLimit`] if counts cannot be represented.
     pub fn try_new(items: Vec<BatchItemDto>) -> Result<Self, DtoError> {
+        Self::try_new_with_wall_duration(items, None)
+    }
+
+    /// Build a report with derived totals and an independently measured batch duration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DtoErrorCode::ResourceLimit`] if counts cannot be represented, or
+    /// [`DtoErrorCode::InvalidField`] for a non-finite or negative duration.
+    pub fn try_new_with_wall_duration(
+        items: Vec<BatchItemDto>,
+        wall_duration_ms: Option<f64>,
+    ) -> Result<Self, DtoError> {
         let succeeded = items.iter().filter(|item| item.status == BatchItemStatus::Success).count();
         let failed = items.len().saturating_sub(succeeded);
         let report = Self {
@@ -867,6 +895,7 @@ impl BatchReportDto {
                 )
             })?,
             items,
+            wall_duration_ms,
         };
         report.validate(&DtoLimits::default())?;
         Ok(report)
@@ -1010,6 +1039,7 @@ impl TryFrom<ResultDto> for crate::ConversionResult {
                 .map(Provenance::try_from)
                 .collect::<Result<_, _>>()?,
             detected_format: None,
+            processing_duration_ms: None,
             memory_lease: crate::spi::OutputMemoryLease::default(),
         })
     }
@@ -1461,6 +1491,7 @@ impl BundleManifestDto {
 impl BatchReportDto {
     fn validate(&self, limits: &DtoLimits) -> Result<(), DtoError> {
         validate_version(self.schema_version)?;
+        validate_duration(self.wall_duration_ms, "$.wallDurationMs")?;
         if self.items.len() > limits.max_batch_items {
             return limit("$.items", "batchItems", limits.max_batch_items);
         }
@@ -1489,6 +1520,11 @@ impl BatchReportDto {
             ));
         }
         for (index, item) in self.items.iter().enumerate() {
+            validate_duration(item.duration_ms, &format!("$.items[{index}].durationMs"))?;
+            validate_duration(
+                item.processing_duration_ms,
+                &format!("$.items[{index}].processingDurationMs"),
+            )?;
             validate_diagnostics(
                 &item.diagnostics,
                 limits,
@@ -1845,6 +1881,7 @@ fn decode_batch_report(value: serde_json::Value) -> Result<BatchReportDto, DtoEr
         schema_version: raw.schema_version,
         succeeded: raw.succeeded,
         failed: raw.failed,
+        wall_duration_ms: raw.wall_duration_ms,
         items: raw
             .items
             .into_iter()
@@ -1875,9 +1912,23 @@ fn decode_batch_report(value: serde_json::Value) -> Result<BatchReportDto, DtoEr
                     .map(|limit| BatchLimitDto { name: limit.name, detail: limit.detail }),
                 message: item.message,
                 warnings: item.warnings,
+                duration_ms: item.duration_ms,
+                processing_duration_ms: item.processing_duration_ms,
             })
             .collect(),
     })
+}
+
+fn validate_duration(value: Option<f64>, path: &str) -> Result<(), DtoError> {
+    if value.is_some_and(|duration| !duration.is_finite() || duration < 0.0) {
+        Err(DtoError::new(
+            DtoErrorCode::InvalidField,
+            path,
+            "duration must be finite and non-negative",
+        ))
+    } else {
+        Ok(())
+    }
 }
 
 fn validate_version(version: u32) -> Result<(), DtoError> {
@@ -2597,6 +2648,7 @@ mod tests {
                 confidence: Some(1.0),
             }],
             detected_format: None,
+            processing_duration_ms: None,
             memory_lease: crate::spi::OutputMemoryLease::default(),
         };
         ResultDto::from_json(&ResultDto::json_from_result(&result, DtoJsonStyle::Compact).unwrap())
@@ -2660,6 +2712,7 @@ mod tests {
             diagnostics: Vec::new(),
             provenance: Vec::new(),
             detected_format: None,
+            processing_duration_ms: None,
             memory_lease: crate::spi::OutputMemoryLease::default(),
         };
         let json = ResultDto::json_from_result(&result, DtoJsonStyle::Compact).unwrap();
@@ -2800,6 +2853,7 @@ mod tests {
             diagnostics: vec![],
             provenance: vec![],
             detected_format: None,
+            processing_duration_ms: None,
             memory_lease: crate::spi::OutputMemoryLease::default(),
         };
         ASSET_BASE64_ENCODE_CALLS.set(0);
@@ -2826,6 +2880,7 @@ mod tests {
             diagnostics: vec![],
             provenance: vec![],
             detected_format: None,
+            processing_duration_ms: None,
             memory_lease: crate::spi::OutputMemoryLease::default(),
         };
         ASSET_BASE64_ENCODE_CALLS.set(0);
@@ -2899,6 +2954,7 @@ mod tests {
             diagnostics: vec![],
             provenance,
             detected_format: None,
+            processing_duration_ms: None,
             memory_lease: crate::spi::OutputMemoryLease::default(),
         };
         let limits = DtoLimits::default();
@@ -2965,6 +3021,7 @@ mod tests {
             diagnostics: vec![],
             provenance: vec![],
             detected_format: None,
+            processing_duration_ms: None,
             memory_lease: crate::spi::OutputMemoryLease::default(),
         };
         ASSET_BASE64_ENCODE_CALLS.set(0);
@@ -2998,6 +3055,7 @@ mod tests {
             }],
             provenance: vec![],
             detected_format: None,
+            processing_duration_ms: None,
             memory_lease: crate::spi::OutputMemoryLease::default(),
         };
         for style in [DtoJsonStyle::Compact, DtoJsonStyle::Pretty] {
@@ -3060,6 +3118,8 @@ mod tests {
             limit: None,
             message: None,
             warnings: vec![],
+            duration_ms: None,
+            processing_duration_ms: None,
         }])
         .unwrap();
         assert_eq!(
@@ -3075,6 +3135,70 @@ mod tests {
         value["assets"][0].as_object_mut().unwrap().insert("futureAssetField".into(), true.into());
         let decoded = ResultDto::from_json(&value.to_string()).unwrap();
         assert_eq!(decoded.assets[0].id, "image-1");
+    }
+
+    #[test]
+    fn batch_timing_fields_round_trip_and_legacy_reports_remain_readable() {
+        let item = BatchItemDto {
+            input: r"C:\work\report.pdf".into(),
+            output: Some("C:/work/report.md".into()),
+            format: Some("pdf".into()),
+            status: BatchItemStatus::Success,
+            outcome: BatchItemOutcome::Complete,
+            diagnostics: vec![],
+            error_code: None,
+            reason_code: None,
+            component: None,
+            part: None,
+            limit: None,
+            message: None,
+            warnings: vec![],
+            duration_ms: Some(12.34),
+            processing_duration_ms: Some(9.81),
+        };
+        let report = BatchReportDto::try_new_with_wall_duration(vec![item], Some(15.72)).unwrap();
+        let json = report.to_json().unwrap();
+        assert!(json.contains(r#""durationMs":12.34"#));
+        assert!(json.contains(r#""processingDurationMs":9.81"#));
+        assert!(json.contains(r#""wallDurationMs":15.72"#));
+        assert_eq!(BatchReportDto::from_json(&json).unwrap(), report);
+
+        let legacy = r#"{"schemaVersion":1,"succeeded":1,"failed":0,"items":[{"input":"old.txt","output":"old.md","format":"text","status":"success","diagnostics":[],"errorCode":null,"message":null,"warnings":[]}]}"#;
+        let decoded = BatchReportDto::from_json(legacy).unwrap();
+        assert_eq!(decoded.wall_duration_ms, None);
+        assert_eq!(decoded.items[0].duration_ms, None);
+        assert_eq!(decoded.items[0].processing_duration_ms, None);
+    }
+
+    #[test]
+    fn batch_timing_rejects_negative_and_non_finite_values() {
+        let item = BatchItemDto {
+            input: "input.txt".into(),
+            output: Some("output.md".into()),
+            format: Some("text".into()),
+            status: BatchItemStatus::Success,
+            outcome: BatchItemOutcome::Complete,
+            diagnostics: vec![],
+            error_code: None,
+            reason_code: None,
+            component: None,
+            part: None,
+            limit: None,
+            message: None,
+            warnings: vec![],
+            duration_ms: Some(-1.0),
+            processing_duration_ms: None,
+        };
+        let error = BatchReportDto::try_new(vec![item.clone()]).unwrap_err();
+        assert_eq!(error.code, DtoErrorCode::InvalidField);
+        assert_eq!(error.path, "$.items[0].durationMs");
+
+        let mut valid_item = item;
+        valid_item.duration_ms = Some(0.0);
+        let error = BatchReportDto::try_new_with_wall_duration(vec![valid_item], Some(f64::NAN))
+            .unwrap_err();
+        assert_eq!(error.code, DtoErrorCode::InvalidField);
+        assert_eq!(error.path, "$.wallDurationMs");
     }
 
     #[test]
@@ -3149,6 +3273,7 @@ mod tests {
                 diagnostics: vec![],
                 provenance: vec![],
                 detected_format: None,
+                processing_duration_ms: None,
                 memory_lease: crate::spi::OutputMemoryLease::default(),
             },
             DtoJsonStyle::Compact,
@@ -3429,6 +3554,8 @@ mod tests {
             limit: None,
             message: Some("failed".into()),
             warnings: vec![],
+            duration_ms: None,
+            processing_duration_ms: None,
         }])
         .unwrap_err();
         assert_eq!(error.code, DtoErrorCode::InvalidField);
@@ -3467,6 +3594,8 @@ mod tests {
             limit: None,
             message: None,
             warnings: vec![],
+            duration_ms: None,
+            processing_duration_ms: None,
         }])
         .unwrap();
         let json = report.to_json().unwrap();

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -112,6 +112,8 @@ pub struct ConversionResult {
     pub provenance: Vec<Provenance>,
     /// Format selected after detection and converter probing, when available.
     pub(crate) detected_format: Option<InputFormat>,
+    /// Monotonic engine processing time, excluding downstream artifact sinks.
+    pub(crate) processing_duration_ms: Option<f64>,
     /// Live request-memory charges for retained IR and assets.
     pub(crate) memory_lease: OutputMemoryLease,
 }
@@ -156,6 +158,8 @@ pub struct ConversionSummary {
     pub markdown_bytes: u64,
     /// Number of assets written.
     pub assets: u64,
+    /// Monotonic engine processing time, excluding artifact sink writes.
+    pub processing_duration_ms: Option<f64>,
     pub(crate) content: Option<crate::ResultContent>,
     pub(crate) payload_only_assets: u64,
     pub(crate) external_only_assets: u64,
@@ -322,6 +326,7 @@ impl ConversionResult {
             diagnostics,
             provenance,
             detected_format: None,
+            processing_duration_ms: None,
             memory_lease,
         }
     }
@@ -360,6 +365,18 @@ impl ConversionResult {
     #[must_use]
     pub fn has_memory_lease(&self) -> bool {
         !self.memory_lease.leases.is_empty()
+    }
+
+    /// Engine processing time through rendering, excluding downstream sink work.
+    #[must_use]
+    pub const fn processing_duration_ms(&self) -> Option<f64> {
+        self.processing_duration_ms
+    }
+
+    /// Attach an engine-owned processing measurement before crossing the result boundary.
+    #[doc(hidden)]
+    pub fn set_processing_duration_ms(&mut self, value: f64) {
+        self.processing_duration_ms = Some(value);
     }
 
     /// Format selected after detection and converter probing.
@@ -679,6 +696,7 @@ impl ConverterOutput {
             diagnostics,
             markdown_bytes,
             assets: u64::try_from(assets.len()).unwrap_or(u64::MAX),
+            processing_duration_ms: None,
             content: Some(content),
             payload_only_assets: u64::try_from(payload_only_assets).unwrap_or(u64::MAX),
             external_only_assets: u64::try_from(external_only_assets).unwrap_or(u64::MAX),

--- a/crates/core/src/summary.rs
+++ b/crates/core/src/summary.rs
@@ -11,6 +11,7 @@ impl Clone for ConversionSummary {
             diagnostics: self.diagnostics.clone(),
             markdown_bytes: self.markdown_bytes,
             assets: self.assets,
+            processing_duration_ms: self.processing_duration_ms,
             content: self.content,
             payload_only_assets: self.payload_only_assets,
             external_only_assets: self.external_only_assets,
@@ -27,6 +28,7 @@ impl PartialEq for ConversionSummary {
             && self.diagnostics == other.diagnostics
             && self.markdown_bytes == other.markdown_bytes
             && self.assets == other.assets
+            && self.processing_duration_ms == other.processing_duration_ms
             && self.content == other.content
             && self.payload_only_assets == other.payload_only_assets
             && self.external_only_assets == other.external_only_assets
@@ -65,6 +67,7 @@ impl ConversionResult {
             diagnostics: self.diagnostics,
             markdown_bytes: u64::try_from(self.markdown.len()).unwrap_or(u64::MAX),
             assets: u64::try_from(self.assets.len()).unwrap_or(u64::MAX),
+            processing_duration_ms: self.processing_duration_ms,
             content,
             payload_only_assets: u64::try_from(payload_only_assets).unwrap_or(u64::MAX),
             external_only_assets: u64::try_from(external_only_assets).unwrap_or(u64::MAX),

--- a/crates/engine/src/artifact_execution.rs
+++ b/crates/engine/src/artifact_execution.rs
@@ -20,7 +20,14 @@ pub(crate) async fn execute(
         });
     }
     let PreparedArtifactConversion { inner, capabilities } = prepared;
-    let crate::preparation::PreparedConversion { request, context, source, attempt } = inner;
+    let crate::preparation::PreparedConversion {
+        request,
+        context,
+        source,
+        attempt,
+        preparation_duration,
+    } = inner;
+    let execution_timer = crate::timing::ProcessingTimer::start();
     context.report(ExecutionStage::Converting, None, None, Some(attempt.converter.id()))?;
     let native = attempt.converter.stream_support().filter(|stream| {
         stream.stream_mode_for(
@@ -75,8 +82,10 @@ pub(crate) async fn execute(
         context: &context,
     })
     .await?;
-    let summary =
+    let processing_duration = preparation_duration.saturating_add(execution_timer.elapsed());
+    let mut summary =
         artifact_output::emit(artifacts, attempt.candidate.format, capabilities, sink, &context)?;
+    summary.processing_duration_ms = Some(processing_duration.as_secs_f64() * 1_000.0);
     drop(source);
     context.report(ExecutionStage::Completed, Some(1), Some(1), None::<String>)?;
     Ok(summary)

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -11,6 +11,7 @@ mod rendering;
 mod result_policy;
 mod result_sink;
 mod stream_execution;
+mod timing;
 
 pub use recovery::{RecoveryStore, RecoveryToken, TaskCheckpoint, TaskPhase};
 
@@ -375,8 +376,14 @@ impl Engine {
         request: ConversionRequest,
         context: ExecutionContext,
     ) -> Result<ConversionResult, ConversionError> {
-        let preparation::PreparedConversion { request, context, source, attempt } =
-            preparation::prepare(self, request, context).await?;
+        let preparation::PreparedConversion {
+            request,
+            context,
+            source,
+            attempt,
+            preparation_duration,
+        } = preparation::prepare(self, request, context).await?;
+        let execution_timer = timing::ProcessingTimer::start();
 
         // A successful probe makes conversion authoritative. Conversion errors
         // are returned immediately rather than being hidden by another parser.
@@ -425,7 +432,7 @@ impl Engine {
         let renderer = self.renderer.as_ref().ok_or_else(|| ConversionError::Internal {
             detail: "no Markdown renderer is registered".into(),
         })?;
-        let result = rendering::render(rendering::RenderRequest {
+        let mut result = rendering::render(rendering::RenderRequest {
             renderer: renderer.as_ref(),
             output,
             source: source.input(),
@@ -434,6 +441,8 @@ impl Engine {
             context: &context,
         })
         .await?;
+        let processing_duration = preparation_duration.saturating_add(execution_timer.elapsed());
+        result.set_processing_duration_ms(processing_duration.as_secs_f64() * 1_000.0);
         // Keep the resolver's source-memory lease through conversion,
         // rendering, and result assembly. The artifact boundary owns the
         // terminal event so sink/finalization failures cannot follow Completed.
@@ -1651,6 +1660,7 @@ mod tests {
         assert_eq!(summary.outcome, ConversionOutcome::Complete);
         assert_eq!(summary.markdown_bytes, 130 * 1024);
         assert_eq!(summary.assets, 0);
+        assert!(summary.processing_duration_ms.is_some_and(|value| value >= 0.0));
     }
 
     #[test]

--- a/crates/engine/src/preparation.rs
+++ b/crates/engine/src/preparation.rs
@@ -6,12 +6,14 @@ use into_markdown_core::{
     ResolvedSource,
 };
 use std::sync::Arc;
+use std::time::Duration;
 
 pub(crate) struct PreparedConversion {
     pub(crate) request: ConversionRequest,
     pub(crate) context: ExecutionContext,
     pub(crate) source: ResolvedSource,
     pub(crate) attempt: Attempt,
+    pub(crate) preparation_duration: Duration,
 }
 
 pub(crate) async fn prepare(
@@ -19,6 +21,7 @@ pub(crate) async fn prepare(
     mut request: ConversionRequest,
     context: ExecutionContext,
 ) -> Result<PreparedConversion, ConversionError> {
+    let timer = crate::timing::ProcessingTimer::start();
     if context.resource_limits() != &request.options.limits {
         return Err(ConversionError::Internal {
             detail: "shared execution context limits do not match conversion request".into(),
@@ -77,5 +80,11 @@ pub(crate) async fn prepare(
         return Err(ConversionError::NoConverter { format: formats });
     };
     context.record_detected_format(attempt.candidate.format);
-    Ok(PreparedConversion { request, context, source, attempt })
+    Ok(PreparedConversion {
+        request,
+        context,
+        source,
+        attempt,
+        preparation_duration: timer.elapsed(),
+    })
 }

--- a/crates/engine/src/timing.rs
+++ b/crates/engine/src/timing.rs
@@ -1,0 +1,79 @@
+//! Monotonic processing timers shared by the preparation and execution phases.
+
+use std::time::{Duration, Instant};
+
+pub(crate) trait MonotonicClock {
+    type Mark: Copy;
+
+    fn now(&self) -> Self::Mark;
+    fn elapsed(&self, start: Self::Mark, end: Self::Mark) -> Duration;
+}
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct SystemClock;
+
+impl MonotonicClock for SystemClock {
+    type Mark = Instant;
+
+    fn now(&self) -> Self::Mark {
+        Instant::now()
+    }
+
+    fn elapsed(&self, start: Self::Mark, end: Self::Mark) -> Duration {
+        end.saturating_duration_since(start)
+    }
+}
+
+pub(crate) struct ProcessingTimer<C: MonotonicClock = SystemClock> {
+    clock: C,
+    started: C::Mark,
+}
+
+impl ProcessingTimer<SystemClock> {
+    pub(crate) fn start() -> Self {
+        Self::start_with(SystemClock)
+    }
+}
+
+impl<C: MonotonicClock> ProcessingTimer<C> {
+    fn start_with(clock: C) -> Self {
+        let started = clock.now();
+        Self { clock, started }
+    }
+
+    pub(crate) fn elapsed(&self) -> Duration {
+        self.clock.elapsed(self.started, self.clock.now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::Cell;
+
+    struct FakeClock {
+        now_micros: Cell<u64>,
+    }
+
+    impl MonotonicClock for FakeClock {
+        type Mark = u64;
+
+        fn now(&self) -> Self::Mark {
+            let value = self.now_micros.get();
+            self.now_micros.set(value + 250);
+            value
+        }
+
+        fn elapsed(&self, start: Self::Mark, end: Self::Mark) -> Duration {
+            Duration::from_micros(end.saturating_sub(start))
+        }
+    }
+
+    #[test]
+    fn injected_monotonic_clock_controls_elapsed_time() {
+        let timer = ProcessingTimer::start_with(FakeClock { now_micros: Cell::new(1_000) });
+
+        assert_eq!(timer.elapsed(), Duration::from_micros(250));
+        assert_eq!(timer.elapsed(), Duration::from_micros(500));
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,7 +148,9 @@ into-md <INPUT...>
 - `--report` 写入带 `schemaVersion` 的 JSON 报告，包含逐项输入、输出、状态、
   `outcome`、格式、诊断、警告、错误码和细分 `reasonCode`。成功结果为 `complete` 或
   `degraded`，失败为 `failed`；真正空源使用 `complete` / `emptySource`，未证明可用的
-  空产物使用 `malformed` / `emptyContent`。
+  空产物使用 `malformed` / `emptyContent`。报告还包含逐项 `durationMs`、成功项的
+  `processingDurationMs` 和独立计量的整批 `wallDurationMs`；逐项耗时排除队列与批量
+  内存准入等待，整批墙钟时间不得由并发项耗时求和。
 - Engine 的空结果判定发生在 stdout 编码及文件事务 stage/commit 之前。除明确
   `emptySource` 外，成功或 degraded 的 Markdown 目标必须存在且非空；`emptyContent`
   不创建目标，并使批处理失败计数和退出码与报告一致。asset-only 结果只有在所选
@@ -268,7 +270,9 @@ markdown-postprocess
 ```
 
 `--log-format json` 将 stderr 事件编码为单行 JSON；错误对象固定包含 `code`、
-`message` 和 `exitCode`，字段名、错误码和状态值不随界面语言变化。
+`message` 和 `exitCode`，字段名、错误码和状态值不随界面语言变化。转换完成后，文本
+模式在 stderr 显示逐项总耗时、Engine 转换耗时和整批墙钟时间；JSON 模式使用
+`itemTiming`、`batchTiming` 事件。`--quiet` 只抑制这些显示，不移除报告中的计时字段。
 
 下游提前关闭管道产生 `EPIPE` 时按成功处理。`--quiet` 不会抑制主产物或失败退出码。
 

--- a/docs/dto.md
+++ b/docs/dto.md
@@ -48,7 +48,10 @@ DTO 解码错误为 `invalidField`、`invalidBase64`、`duplicateId` 和 `resour
   只有 `success`、`failed`。`outcome` 区分 `complete`、`degraded`、`failed`；
   `reasonCode` 细分 `emptySource`、`assetOnly`、`emptyContent` 或首个有损诊断。失败项
   必须有 `errorCode`，成功项不得有 `errorCode`。旧报告缺少 additive 的 `outcome` 或
-  `reasonCode` 时仍按原有 status 解码。
+  `reasonCode` 时仍按原有 status 解码。可选 `durationMs` 表示 worker 获得批量准入后到
+  输出提交或失败清理完成的逐项端到端耗时；可选 `processingDurationMs` 表示检测、解析、
+  IR 和渲染的 Engine 处理耗时，排除输出 sink 与持久化。顶层可选 `wallDurationMs` 从
+  命令开始独立计量到最后一次提交或回滚结束，并发执行时不能以逐项耗时之和替代。
 
 `ResultDto` 保持 schema 1，不新增重复 outcome 字段。显式 `emptySource` / `assetOnly`
 证据作为稳定 diagnostics code 随 Result JSON、Web diagnostics artifact 和 bundle
@@ -88,12 +91,16 @@ DTO 解码错误为 `invalidField`、`invalidBase64`、`duplicateId` 和 `resour
   "schemaVersion": 1,
   "succeeded": 1,
   "failed": 0,
+  "wallDurationMs": 15.72,
   "items": [
     {
       "input": "report.pdf",
       "output": "report.md",
       "format": "pdf",
       "status": "success",
+      "outcome": "complete",
+      "durationMs": 12.34,
+      "processingDurationMs": 9.81,
       "diagnostics": [],
       "errorCode": null,
       "message": null,


### PR DESCRIPTION
## Summary
- add backward-compatible `durationMs`, `processingDurationMs`, and independent `wallDurationMs` to schema-1 batch reports
- measure Engine processing from real preparation through rendering while excluding sink/persistence work
- measure each admitted worker through commit/failure cleanup and expose text/JSON timing events
- preserve real processing timing on post-conversion output failures; omit unavailable stages instead of synthesizing values

## Schema example
```json
{
  "schemaVersion": 1,
  "succeeded": 1,
  "failed": 0,
  "items": [{
    "input": "C:\\work\\input.txt",
    "output": "C:/work/output.md",
    "status": "success",
    "outcome": "complete",
    "durationMs": 12.34,
    "processingDurationMs": 9.81
  }],
  "wallDurationMs": 15.72
}
```

## Verification
- `cargo fmt --all -- --check`
- `cargo test --locked -p into-markdown-core -p into-markdown-engine --lib -j2` (151 passed)
- `cargo test --locked -p into-markdown-cli --bin into-md -j1 -- --test-threads=1` (238 passed)
- `cargo test --locked -p into-markdown-cli --test empty_result_contract --test exit_contract -j1 -- --test-threads=1` (21 passed)
- `cargo clippy --locked -p into-markdown-core -p into-markdown-engine --lib --no-deps -- -D warnings`
- CLI full-target clippy was also run; it reports existing unrelated lint debt on current `main`, with no diagnostic in the timing change locations
- Bazel docs check could not run locally because Bazel is not installed; hosted CI remains authoritative

## Performance evidence
Release binaries, Windows, 30 jointly successful 32 KiB text files, three warmups, alternating baseline/current order, external per-file wall time:

| revision | mean | P50 | P95 | peak RSS (10 samples) | temp residue |
|---|---:|---:|---:|---:|---:|
| `8d1d7d75` baseline (runtime code identical to current `main`) | 135.225 ms | 135.398 ms | 157.458 ms | 13.56 MiB | 0 files / 0 bytes |
| this PR | 143.730 ms | 143.732 ms | 178.061 ms | 13.25 MiB | 0 files / 0 bytes |

Common-success mean change: **+6.29%**, below the 50% ceiling. Timing adds monotonic reads only and does not re-run conversion.

Fixes #269