### PR TITLE
Expose auditable batch resource and OCR telemetry

### DIFF
--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -4212,13 +4212,7 @@ fn invocation_capabilities(
         |format| matches!(format, InputFormat::Audio | InputFormat::Video | InputFormat::YouTube);
     let legacy_office =
         |format| matches!(format, InputFormat::Doc | InputFormat::Ppt | InputFormat::Xls);
-    let effective_ocr_policy = match options.ai.vision_ocr {
-        AiMode::Only => OcrPolicy::Always,
-        AiMode::Fallback | AiMode::Prefer if options.ocr.policy == OcrPolicy::Off => {
-            OcrPolicy::Auto
-        }
-        _ => options.ocr.policy,
-    };
+    let effective_ocr_policy = effective_ocr_policy(options);
     crate::services::InvocationCapabilities {
         ocr: formats.iter().copied().any(|format| {
             visual(format) && !(effective_ocr_policy == OcrPolicy::Auto && legacy_office(format))
@@ -4226,6 +4220,16 @@ fn invocation_capabilities(
         transcription: formats.iter().copied().any(media),
         diarization: formats.iter().copied().any(media),
         legacy_office: formats.iter().copied().any(legacy_office),
+    }
+}
+
+fn effective_ocr_policy(options: &ConversionOptions) -> OcrPolicy {
+    match options.ai.vision_ocr {
+        AiMode::Only => OcrPolicy::Always,
+        AiMode::Fallback | AiMode::Prefer if options.ocr.policy == OcrPolicy::Off => {
+            OcrPolicy::Auto
+        }
+        _ => options.ocr.policy,
     }
 }
 
@@ -4239,6 +4243,9 @@ fn run_conversion(
 ) -> Result<(), CliError> {
     let batch_timer = crate::timing::ItemTimer::start();
     apply_conversion_overrides(&arguments, &mut loaded)?;
+    if loaded.options.limits.max_memory_bytes == 0 {
+        return Err(CliError::usage("shared conversion memory budget must be greater than zero"));
+    }
     let includes = build_globset(&arguments.include)?;
     let excludes = build_globset(&arguments.exclude)?;
     let mut items = expand_inputs(&arguments, includes.as_ref(), excludes.as_ref())?;
@@ -4329,6 +4336,7 @@ fn run_conversion(
             stderr: context.stderr,
             output_context: &policy.output_context,
             wall_duration_ms: batch_timer.elapsed_ms(),
+            ocr_enabled: effective_ocr_policy(&policy.options) != OcrPolicy::Off,
         },
     )
 }
@@ -4380,6 +4388,7 @@ struct FinishReportsContext<'a> {
     stderr: &'a mut dyn Write,
     output_context: &'a into_markdown::ExecutionContext,
     wall_duration_ms: f64,
+    ocr_enabled: bool,
 }
 
 fn finish_reports(
@@ -4394,6 +4403,7 @@ fn finish_reports(
         stderr,
         output_context,
         wall_duration_ms,
+        ocr_enabled,
     } = context;
     for report in &reports {
         for warning in &report.warnings {
@@ -4429,10 +4439,25 @@ fn finish_reports(
     if !global.quiet {
         crate::timing::write_summary(stderr, &reports, wall_duration_ms, catalog, json_log)?;
     }
-    let report = BatchReport::try_new_with_wall_duration(reports, Some(wall_duration_ms))
-        .map_err(|error| CliError::internal(format!("build batch report DTO: {error}")))?;
+    let usage = output_context.resource_usage();
+    let resource_usage = into_markdown::BatchResourceUsageDto {
+        shared_lease_budget_bytes: usage.shared_lease_budget_bytes,
+        shared_lease_peak_bytes: usage.shared_lease_peak_bytes,
+        ocr: ocr_enabled.then_some(into_markdown::BatchOcrUsageDto {
+            recognized_regions: usage.ocr_recognized_regions,
+            recognized_chars: usage.ocr_recognized_chars,
+        }),
+    };
+    let report = BatchReport::try_new_with_resource_usage(
+        reports,
+        Some(wall_duration_ms),
+        Some(resource_usage),
+    )
+    .map_err(|error| CliError::internal(format!("build batch report DTO: {error}")))?;
     if let Some(path) = report_path {
-        output::write_report(path, &report, output_context)?;
+        let report_context =
+            output_context.fork_with_shared_resources(into_markdown::ExecutionOptions::default());
+        output::write_report(path, &report, &report_context)?;
     }
     if report.failed > 0 {
         Err(CliError::partial(format!(
@@ -5855,6 +5880,10 @@ fn redact_parsed_url(mut parsed: url::Url) -> String {
 #[cfg(test)]
 #[path = "app/timing_tests.rs"]
 mod timing_tests;
+
+#[cfg(test)]
+#[path = "app/resource_usage_tests.rs"]
+mod resource_usage_tests;
 
 #[cfg(test)]
 mod tests {

--- a/apps/cli/src/app/resource_usage_tests.rs
+++ b/apps/cli/src/app/resource_usage_tests.rs
@@ -1,0 +1,189 @@
+use super::*;
+
+fn read_report(path: &Path) -> serde_json::Value {
+    serde_json::from_slice(&fs::read(path).unwrap()).unwrap()
+}
+
+#[test]
+fn text_batches_publish_real_shared_budget_and_peak_without_job_multiplication() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = temporary.path().canonicalize().unwrap();
+    let first = root.join("first.txt");
+    let second = root.join("second.txt");
+    fs::write(&first, b"first\n").unwrap();
+    fs::write(&second, b"second\n").unwrap();
+
+    let explicit_report = root.join("explicit-report.json");
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    run(
+        vec![
+            OsString::from("--no-config"),
+            first.clone().into_os_string(),
+            second.clone().into_os_string(),
+            OsString::from("--output-dir"),
+            root.join("explicit-output").into_os_string(),
+            OsString::from("--report"),
+            explicit_report.clone().into_os_string(),
+            OsString::from("--jobs"),
+            OsString::from("2"),
+            OsString::from("--max-memory-size"),
+            OsString::from("16MiB"),
+            OsString::from("--ocr"),
+            OsString::from("off"),
+        ],
+        RunContext {
+            user_data_anchor: Some(root.join(".test-user-data")),
+            stdout: &mut stdout,
+            stderr: &mut stderr,
+            stdin_is_terminal: true,
+            cwd: root.clone(),
+        },
+    )
+    .unwrap();
+    let report = read_report(&explicit_report);
+    let usage = &report["resourceUsage"];
+    assert_eq!(usage["sharedLeaseBudgetBytes"], 16 * 1024 * 1024);
+    assert!(usage["sharedLeasePeakBytes"].as_u64().is_some_and(|peak| peak > 0));
+    assert!(usage["sharedLeasePeakBytes"].as_u64().unwrap() <= 16 * 1024 * 1024);
+    assert!(usage.get("ocr").is_none());
+
+    let automatic_report = root.join("automatic-report.json");
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    run(
+        vec![
+            OsString::from("--no-config"),
+            first.into_os_string(),
+            second.into_os_string(),
+            OsString::from("--output-dir"),
+            root.join("automatic-output").into_os_string(),
+            OsString::from("--report"),
+            automatic_report.clone().into_os_string(),
+            OsString::from("--jobs"),
+            OsString::from("2"),
+            OsString::from("--max-memory-size"),
+            OsString::from("auto"),
+            OsString::from("--ocr"),
+            OsString::from("auto"),
+        ],
+        RunContext {
+            user_data_anchor: Some(root.join(".test-user-data")),
+            stdout: &mut stdout,
+            stderr: &mut stderr,
+            stdin_is_terminal: true,
+            cwd: root,
+        },
+    )
+    .unwrap();
+    let report = read_report(&automatic_report);
+    let usage = &report["resourceUsage"];
+    assert_eq!(usage["sharedLeaseBudgetBytes"], config::adaptive_memory_budget());
+    assert!(usage["sharedLeasePeakBytes"].as_u64().unwrap() <= config::adaptive_memory_budget());
+    assert_eq!(usage["ocr"]["recognizedRegions"], 0);
+    assert_eq!(usage["ocr"]["recognizedChars"], 0);
+}
+
+fn stopped_plan(root: &Path, name: &str) -> WorkPlan {
+    let input = root.join(format!("{name}.txt"));
+    fs::write(&input, b"stop me\n").unwrap();
+    WorkPlan {
+        item: WorkItem {
+            input: InputRef::Path(input.clone()),
+            display: input.display().to_string(),
+            relative: PathBuf::from(format!("{name}.txt")),
+            root_label: name.into(),
+            input_root: root.to_path_buf(),
+            from_directory: false,
+            local_path: Some(input),
+        },
+        output: Some(root.join(format!("{name}.md"))),
+        output_root: Some(root.to_path_buf()),
+    }
+}
+
+#[test]
+fn cancellation_and_timeout_reports_keep_terminal_zero_ocr_and_resource_usage() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = temporary.path().canonicalize().unwrap();
+    let cancellation = into_markdown::CancellationToken::new();
+    cancellation.cancel();
+    for (name, execution) in [
+        (
+            "cancelled",
+            into_markdown::ExecutionOptions {
+                cancellation,
+                ..into_markdown::ExecutionOptions::default()
+            },
+        ),
+        (
+            "timeout",
+            into_markdown::ExecutionOptions {
+                timeout: Some(std::time::Duration::ZERO),
+                ..into_markdown::ExecutionOptions::default()
+            },
+        ),
+    ] {
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        options.limits.max_memory_bytes = 16 * 1024 * 1024;
+        let policy = ExecutionPolicy {
+            output_context: into_markdown::ExecutionContext::new(
+                execution.clone(),
+                options.limits.clone(),
+            ),
+            options,
+            execution,
+            services: into_markdown::Services::default(),
+            hint: FormatHint::default(),
+            emit: EmitKind::Markdown,
+            asset_mode: AssetModeArg::Extract,
+            conflict: ConflictPolicy::Error,
+            assets_dir: None,
+            working_directory: root.clone(),
+        };
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+        let mut run_context = RunContext {
+            user_data_anchor: Some(root.join(".test-user-data")),
+            stdout: &mut stdout,
+            stderr: &mut stderr,
+            stdin_is_terminal: true,
+            cwd: root.clone(),
+        };
+        let reports = execute_plans(
+            vec![stopped_plan(&root, name)],
+            &policy,
+            1,
+            true,
+            Catalog::new(crate::args::Language::En),
+            true,
+            &mut run_context,
+        )
+        .unwrap();
+        assert_eq!(reports[0].error_code.as_deref(), Some(name));
+
+        let report_path = root.join(format!("{name}-report.json"));
+        let error = finish_reports(
+            reports,
+            FinishReportsContext {
+                report_path: Some(&report_path),
+                global: &crate::args::GlobalArgs::default(),
+                catalog: Catalog::new(crate::args::Language::En),
+                json_log: true,
+                stderr: &mut stderr,
+                output_context: &policy.output_context,
+                wall_duration_ms: 0.0,
+                ocr_enabled: true,
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.code(), "partialFailure");
+        let report = read_report(&report_path);
+        assert_eq!(report["items"][0]["errorCode"], name);
+        assert_eq!(report["resourceUsage"]["sharedLeaseBudgetBytes"], 16 * 1024 * 1024);
+        assert_eq!(report["resourceUsage"]["sharedLeasePeakBytes"], 0);
+        assert_eq!(report["resourceUsage"]["ocr"]["recognizedRegions"], 0);
+        assert_eq!(report["resourceUsage"]["ocr"]["recognizedChars"], 0);
+    }
+}

--- a/apps/cli/src/app/timing_tests.rs
+++ b/apps/cli/src/app/timing_tests.rs
@@ -89,6 +89,11 @@ fn failures_remain_auditable_with_elapsed_time() {
     let report: serde_json::Value =
         serde_json::from_slice(&fs::read(report_path).unwrap()).unwrap();
     assert_eq!(report["items"][0]["status"], "failed");
+    assert!(report["resourceUsage"]["sharedLeaseBudgetBytes"].as_u64().unwrap() > 0);
+    assert!(
+        report["resourceUsage"]["sharedLeasePeakBytes"].as_u64().unwrap()
+            <= report["resourceUsage"]["sharedLeaseBudgetBytes"].as_u64().unwrap()
+    );
     assert!(report["items"][0]["durationMs"].as_f64().is_some_and(|value| value >= 0.0));
     assert!(report["items"][0].get("processingDurationMs").is_none());
     assert!(

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -846,6 +846,8 @@ async fn enrich(
         resource("max_memory_bytes", format!("allocate OCR contribution cache: {error}"))
     })?;
     cache.resize_with(grouping.groups.len(), || None);
+    let mut recognized_regions = 0_u64;
+    let mut recognized_chars = 0_u64;
     for (ordinal, group_index) in grouping.digest_order.iter().copied().enumerate() {
         context.checkpoint()?;
         let candidate = &candidates[grouping.groups[group_index].representative];
@@ -911,6 +913,12 @@ async fn enrich(
         if let Some(memory) = contribution.memory.take() {
             output.attach_memory_reservation(context, memory)?;
         }
+        recognized_regions = recognized_regions
+            .checked_add(contribution.recognized_regions)
+            .ok_or_else(|| resource("max_archive_entries", "OCR region telemetry overflow"))?;
+        recognized_chars = recognized_chars
+            .checked_add(contribution.recognized_chars)
+            .ok_or_else(|| resource("max_field_bytes", "OCR character telemetry overflow"))?;
         cache[group_index] = Some(CachedContribution {
             nodes: contribution.nodes,
             diagnostics: contribution.diagnostics,
@@ -956,6 +964,7 @@ async fn enrich(
     if input_format == InputFormat::Pdf && !contributions_by_asset.is_empty() {
         output = crate::pdf_ocr::reconstruct_enriched_pdf(output, options, context)?;
     }
+    context.record_ocr_contribution(recognized_regions, recognized_chars)?;
     Ok(output)
 }
 
@@ -2032,6 +2041,9 @@ mod tests {
             provenance.locator.bounds,
             Some(into_markdown_core::Rect { x: 10.0, y: 20.0, width: 20.0, height: 10.0 })
         );
+        let usage = context.resource_usage();
+        assert_eq!(usage.ocr_recognized_regions, 1);
+        assert_eq!(usage.ocr_recognized_chars, 14);
     }
 
     #[test]

--- a/crates/converters/src/image_converter/mod.rs
+++ b/crates/converters/src/image_converter/mod.rs
@@ -125,6 +125,8 @@ async fn convert_image(
     let mut leases = vec![original_memory];
     let mut diagnostics = Vec::new();
     let mut document = document_metadata(format, summary, &decoded, density);
+    let mut recognized_regions = 0_u64;
+    let mut recognized_chars = 0_u64;
 
     for (index, frame) in decoded.frames.iter().enumerate() {
         context.checkpoint()?;
@@ -177,6 +179,12 @@ async fn convert_image(
         if let Some(memory) = ocr.memory.take() {
             leases.push(memory);
         }
+        recognized_regions = recognized_regions
+            .checked_add(ocr.recognized_regions)
+            .ok_or_else(|| resource("max_archive_entries", "OCR region telemetry overflow"))?;
+        recognized_chars = recognized_chars
+            .checked_add(ocr.recognized_chars)
+            .ok_or_else(|| resource("max_field_bytes", "OCR character telemetry overflow"))?;
         if options.ai.image_description == AiMode::Fallback && !ocr.accepted_text {
             let ai_image = normalized.as_ref().ok_or_else(|| ConversionError::Internal {
                 detail: "AI fallback image input was not materialized".into(),
@@ -234,7 +242,9 @@ async fn convert_image(
     })?;
     let output =
         ConverterOutput::new_with_memory_reservations(document, assets, diagnostics, leases);
-    output.account_retained(context)
+    let output = output.account_retained(context)?;
+    context.record_ocr_contribution(recognized_regions, recognized_chars)?;
+    Ok(output)
 }
 
 fn image_block(asset: AssetId, page: u32, frame: &DecodedFrame) -> BlockNode {

--- a/crates/converters/src/image_converter/ocr.rs
+++ b/crates/converters/src/image_converter/ocr.rs
@@ -17,6 +17,8 @@ pub(crate) struct OcrContribution {
     pub(crate) diagnostics: Vec<Diagnostic>,
     pub(super) accepted_text: bool,
     pub(crate) memory: Option<ResourceReservation>,
+    pub(crate) recognized_regions: u64,
+    pub(crate) recognized_chars: u64,
 }
 
 pub(super) async fn recognize(
@@ -102,7 +104,7 @@ async fn recognize_inner(
     let bound = match recognition {
         OcrRecognition::Bound(bound) => bound,
         OcrRecognition::Remote(result) => {
-            let (document, diagnostics) =
+            let (document, diagnostics, recognized_regions, recognized_chars) =
                 materialize_remote_unbound(result, page, plan, options, context)?;
             let assets = Vec::<Asset>::new();
             let retained = estimate_retained_output(&document, &assets, &diagnostics)?;
@@ -120,6 +122,8 @@ async fn recognize_inner(
                 nodes: document.blocks,
                 diagnostics,
                 memory: Some(memory),
+                recognized_regions,
+                recognized_chars,
             });
         }
         OcrRecognition::Unbound(_) => {
@@ -174,7 +178,8 @@ async fn recognize_inner(
         engine_id: engine.id(),
         execution: context,
     };
-    let (document, diagnostics) = materialize_nodes(result, detection_confidences, &materialize)?;
+    let (document, diagnostics, recognized_regions, recognized_chars) =
+        materialize_nodes(result, detection_confidences, &materialize)?;
     let assets = Vec::<Asset>::new();
     let retained = estimate_retained_output(&document, &assets, &diagnostics)?;
     if retained > plan.max_retained_bytes() {
@@ -191,6 +196,8 @@ async fn recognize_inner(
         nodes: document.blocks,
         diagnostics,
         memory: Some(memory),
+        recognized_regions,
+        recognized_chars,
     })
 }
 
@@ -210,7 +217,7 @@ fn materialize_remote_unbound(
     plan: OcrOutputPlan,
     options: &ConversionOptions,
     execution: &ExecutionContext,
-) -> Result<(Document, Vec<Diagnostic>), ConversionError> {
+) -> Result<(Document, Vec<Diagnostic>, u64, u64), ConversionError> {
     let provider = result.provider.clone();
     if provider.trim().is_empty()
         || result.regions.len() > usize::try_from(plan.max_regions()).unwrap_or(usize::MAX)
@@ -221,6 +228,8 @@ fn materialize_remote_unbound(
         });
     }
     let mut total_text = 0_u64;
+    let mut recognized_regions = 0_u64;
+    let mut recognized_chars = 0_u64;
     let mut nodes = Vec::new();
     for (index, region) in result.regions.into_iter().enumerate() {
         if index % 64 == 0 {
@@ -245,6 +254,10 @@ fn materialize_remote_unbound(
                 detail: "remote OCR text exceeds the configured output bound".into(),
             });
         }
+        recognized_regions = recognized_regions.checked_add(1).ok_or_else(payload_limit)?;
+        recognized_chars = recognized_chars
+            .checked_add(u64::try_from(text.chars().count()).map_err(|_| payload_limit())?)
+            .ok_or_else(payload_limit)?;
         nodes.push(BlockNode {
             id: NodeId(format!("remote-ocr-page-{page}-{index}")),
             block: Block::Paragraph(vec![Inline::Text { value: text.into(), marks: Vec::new() }]),
@@ -267,7 +280,7 @@ fn materialize_remote_unbound(
         provider,
         detail: format!("remote OCR returned invalid IR at {}: {}", error.path, error.detail),
     })?;
-    Ok((document, Vec::new()))
+    Ok((document, Vec::new(), recognized_regions, recognized_chars))
 }
 
 struct MaterializeContext<'a> {
@@ -284,9 +297,11 @@ fn materialize_nodes(
     result: OcrResult,
     detection_confidences: Vec<f32>,
     materialize: &MaterializeContext<'_>,
-) -> Result<(Document, Vec<Diagnostic>), ConversionError> {
+) -> Result<(Document, Vec<Diagnostic>, u64, u64), ConversionError> {
     let mut nodes = Vec::new();
     let mut diagnostics = Vec::new();
+    let mut recognized_regions = 0_u64;
+    let mut recognized_chars = 0_u64;
     for (index, (region, detection_confidence)) in
         result.regions.into_iter().zip(detection_confidences).enumerate()
     {
@@ -344,6 +359,10 @@ fn materialize_nodes(
             locator,
             confidence: Some(confidence),
         };
+        recognized_regions = recognized_regions.checked_add(1).ok_or_else(payload_limit)?;
+        recognized_chars = recognized_chars
+            .checked_add(u64::try_from(region.text.chars().count()).map_err(|_| payload_limit())?)
+            .ok_or_else(payload_limit)?;
         nodes.push(BlockNode {
             id: NodeId(format!("image-page-{}-ocr-{}", materialize.page, index + 1)),
             block: Block::Paragraph(vec![Inline::OcrText {
@@ -356,7 +375,7 @@ fn materialize_nodes(
         });
     }
     let document = Document { blocks: nodes, ..Document::default() };
-    Ok((document, diagnostics))
+    Ok((document, diagnostics, recognized_regions, recognized_chars))
 }
 
 fn validate_plan(
@@ -586,6 +605,8 @@ fn degraded(page: u32, message: String) -> OcrContribution {
             locator: Some(SourceLocator { page: Some(page), ..SourceLocator::default() }),
         }],
         memory: None,
+        recognized_regions: 0,
+        recognized_chars: 0,
     }
 }
 
@@ -602,5 +623,12 @@ fn map_unavailable(provider: &str, error: ConversionError) -> ConversionError {
 }
 
 fn empty() -> OcrContribution {
-    OcrContribution { nodes: vec![], diagnostics: vec![], accepted_text: false, memory: None }
+    OcrContribution {
+        nodes: vec![],
+        diagnostics: vec![],
+        accepted_text: false,
+        memory: None,
+        recognized_regions: 0,
+        recognized_chars: 0,
+    }
 }

--- a/crates/converters/src/image_converter/tests.rs
+++ b/crates/converters/src/image_converter/tests.rs
@@ -602,11 +602,12 @@ fn remote_vision_ocr_runs_when_local_ocr_is_off_without_fabricating_local_eviden
     let mut options = options();
     options.ai.vision_ocr = AiMode::Only;
     let services = Services { ocr: Some(Arc::new(RemoteOcr)), ..Services::default() };
+    let context = context(&options);
     let output = block_on(convert_image(
         &input(encoded(ImageFormat::Png), "remote.png"),
         &options,
         &services,
-        &context(&options),
+        &context,
     ))
     .unwrap();
     let Block::Page { blocks, .. } = &output.document.blocks[0].block else {
@@ -619,6 +620,8 @@ fn remote_vision_ocr_runs_when_local_ocr_is_off_without_fabricating_local_eviden
     assert_eq!(remote.provenance.kind, ProvenanceKind::AiProvider);
     let Block::Paragraph(inlines) = &remote.block else { panic!("remote paragraph expected") };
     assert!(matches!(inlines.as_slice(), [Inline::Text { value, .. }] if value == "remote text"));
+    assert_eq!(context.resource_usage().ocr_recognized_regions, 1);
+    assert_eq!(context.resource_usage().ocr_recognized_chars, 11);
 }
 
 impl OcrEngine for WorkingSetOcr {
@@ -752,11 +755,12 @@ fn bound_ocr_emits_exact_geometry_confidence_and_chain() {
     let mut options = options();
     options.ocr.policy = OcrPolicy::Always;
     let services = Services { ocr: Some(Arc::new(BoundOcr)), ..Services::default() };
+    let context = context(&options);
     let output = block_on(convert_image(
         &input(encoded(ImageFormat::Png), "bound.png"),
         &options,
         &services,
-        &context(&options),
+        &context,
     ))
     .unwrap();
     let Block::Page { blocks, .. } = &output.document.blocks[0].block else {
@@ -770,6 +774,8 @@ fn bound_ocr_emits_exact_geometry_confidence_and_chain() {
     assert!((evidence.regions[0].detection_confidence - 0.98).abs() < f32::EPSILON);
     assert_eq!(evidence.chain.len(), 3);
     assert_eq!(evidence.chain[2].stage, OcrEvidenceStage::Merge);
+    assert_eq!(context.resource_usage().ocr_recognized_regions, 1);
+    assert_eq!(context.resource_usage().ocr_recognized_chars, 22);
 }
 
 #[test]
@@ -778,11 +784,12 @@ fn low_confidence_ocr_omission_is_degraded() {
     options.ocr.policy = OcrPolicy::Always;
     options.ocr.minimum_confidence = 0.99;
     let services = Services { ocr: Some(Arc::new(BoundOcr)), ..Services::default() };
+    let context = context(&options);
     let output = block_on(convert_image(
         &input(encoded(ImageFormat::Png), "low-confidence.png"),
         &options,
         &services,
-        &context(&options),
+        &context,
     ))
     .unwrap();
     let diagnostic = output
@@ -792,6 +799,8 @@ fn low_confidence_ocr_omission_is_degraded() {
         .unwrap();
     assert_eq!(diagnostic.severity, DiagnosticSeverity::Warning);
     assert_eq!(conversion_outcome(&output.diagnostics), ConversionOutcome::Degraded);
+    assert_eq!(context.resource_usage().ocr_recognized_regions, 0);
+    assert_eq!(context.resource_usage().ocr_recognized_chars, 0);
 }
 
 struct LegacyOcr;

--- a/crates/core/src/dto.rs
+++ b/crates/core/src/dto.rs
@@ -324,6 +324,26 @@ pub struct BatchLimitDto {
     pub detail: Option<String>,
 }
 
+/// Auditable OCR text that survived component filtering, deduplication, and merge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BatchOcrUsageDto {
+    /// Accepted and merged OCR source regions.
+    pub recognized_regions: u64,
+    /// Unicode scalar values contributed by those regions.
+    pub recognized_chars: u64,
+}
+
+/// Invocation-wide resource usage for a CLI batch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BatchResourceUsageDto {
+    /// Actual batch-wide shared memory lease budget.
+    pub shared_lease_budget_bytes: u64,
+    /// Historical shared memory lease high-water mark.
+    pub shared_lease_peak_bytes: u64,
+    /// OCR contribution evidence when OCR was enabled for the invocation.
+    pub ocr: Option<BatchOcrUsageDto>,
+}
+
 /// One item in a machine-readable batch report.
 #[derive(Debug, Clone, PartialEq)]
 pub struct BatchItemDto {
@@ -372,6 +392,8 @@ pub struct BatchReportDto {
     pub items: Vec<BatchItemDto>,
     /// Independent batch wall-clock time; this is never derived by summing item durations.
     pub wall_duration_ms: Option<f64>,
+    /// Invocation-wide resource accounting. Older schema-one reports may omit this field.
+    pub resource_usage: Option<BatchResourceUsageDto>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -526,6 +548,22 @@ struct RawBatchItemDto {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct RawBatchOcrUsageDto {
+    recognized_regions: u64,
+    recognized_chars: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RawBatchResourceUsageDto {
+    shared_lease_budget_bytes: u64,
+    shared_lease_peak_bytes: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ocr: Option<RawBatchOcrUsageDto>,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct RawBatchReportDto {
     schema_version: u32,
     succeeded: u64,
@@ -533,6 +571,8 @@ struct RawBatchReportDto {
     items: Vec<RawBatchItemDto>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     wall_duration_ms: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    resource_usage: Option<RawBatchResourceUsageDto>,
 }
 
 #[derive(Serialize)]
@@ -822,6 +862,14 @@ fn encode_batch_report(value: &BatchReportDto) -> RawBatchReportDto {
         succeeded: value.succeeded,
         failed: value.failed,
         wall_duration_ms: value.wall_duration_ms,
+        resource_usage: value.resource_usage.as_ref().map(|usage| RawBatchResourceUsageDto {
+            shared_lease_budget_bytes: usage.shared_lease_budget_bytes,
+            shared_lease_peak_bytes: usage.shared_lease_peak_bytes,
+            ocr: usage.ocr.map(|ocr| RawBatchOcrUsageDto {
+                recognized_regions: ocr.recognized_regions,
+                recognized_chars: ocr.recognized_chars,
+            }),
+        }),
         items: value
             .items
             .iter()
@@ -876,6 +924,20 @@ impl BatchReportDto {
         items: Vec<BatchItemDto>,
         wall_duration_ms: Option<f64>,
     ) -> Result<Self, DtoError> {
+        Self::try_new_with_resource_usage(items, wall_duration_ms, None)
+    }
+
+    /// Build a report with measured batch duration and invocation resource accounting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DtoErrorCode::ResourceLimit`] if counts cannot be represented, or
+    /// [`DtoErrorCode::InvalidField`] for invalid timing or resource telemetry.
+    pub fn try_new_with_resource_usage(
+        items: Vec<BatchItemDto>,
+        wall_duration_ms: Option<f64>,
+        resource_usage: Option<BatchResourceUsageDto>,
+    ) -> Result<Self, DtoError> {
         let succeeded = items.iter().filter(|item| item.status == BatchItemStatus::Success).count();
         let failed = items.len().saturating_sub(succeeded);
         let report = Self {
@@ -896,6 +958,7 @@ impl BatchReportDto {
             })?,
             items,
             wall_duration_ms,
+            resource_usage,
         };
         report.validate(&DtoLimits::default())?;
         Ok(report)
@@ -1492,6 +1555,32 @@ impl BatchReportDto {
     fn validate(&self, limits: &DtoLimits) -> Result<(), DtoError> {
         validate_version(self.schema_version)?;
         validate_duration(self.wall_duration_ms, "$.wallDurationMs")?;
+        if let Some(usage) = &self.resource_usage {
+            if usage.shared_lease_budget_bytes == 0 {
+                return Err(DtoError::new(
+                    DtoErrorCode::InvalidField,
+                    "$.resourceUsage.sharedLeaseBudgetBytes",
+                    "shared lease budget must be greater than zero",
+                ));
+            }
+            if usage.shared_lease_peak_bytes > usage.shared_lease_budget_bytes {
+                return Err(DtoError::new(
+                    DtoErrorCode::InvalidField,
+                    "$.resourceUsage.sharedLeasePeakBytes",
+                    "shared lease peak cannot exceed its budget",
+                ));
+            }
+            if usage
+                .ocr
+                .is_some_and(|ocr| (ocr.recognized_regions == 0) != (ocr.recognized_chars == 0))
+            {
+                return Err(DtoError::new(
+                    DtoErrorCode::InvalidField,
+                    "$.resourceUsage.ocr",
+                    "OCR regions and characters must both be zero or both be positive",
+                ));
+            }
+        }
         if self.items.len() > limits.max_batch_items {
             return limit("$.items", "batchItems", limits.max_batch_items);
         }
@@ -1882,6 +1971,14 @@ fn decode_batch_report(value: serde_json::Value) -> Result<BatchReportDto, DtoEr
         succeeded: raw.succeeded,
         failed: raw.failed,
         wall_duration_ms: raw.wall_duration_ms,
+        resource_usage: raw.resource_usage.map(|usage| BatchResourceUsageDto {
+            shared_lease_budget_bytes: usage.shared_lease_budget_bytes,
+            shared_lease_peak_bytes: usage.shared_lease_peak_bytes,
+            ocr: usage.ocr.map(|ocr| BatchOcrUsageDto {
+                recognized_regions: ocr.recognized_regions,
+                recognized_chars: ocr.recognized_chars,
+            }),
+        }),
         items: raw
             .items
             .into_iter()
@@ -3156,18 +3253,68 @@ mod tests {
             duration_ms: Some(12.34),
             processing_duration_ms: Some(9.81),
         };
-        let report = BatchReportDto::try_new_with_wall_duration(vec![item], Some(15.72)).unwrap();
+        let report = BatchReportDto::try_new_with_resource_usage(
+            vec![item],
+            Some(15.72),
+            Some(BatchResourceUsageDto {
+                shared_lease_budget_bytes: 2_147_483_648,
+                shared_lease_peak_bytes: 123_456_789,
+                ocr: Some(BatchOcrUsageDto { recognized_regions: 2, recognized_chars: 7 }),
+            }),
+        )
+        .unwrap();
         let json = report.to_json().unwrap();
         assert!(json.contains(r#""durationMs":12.34"#));
         assert!(json.contains(r#""processingDurationMs":9.81"#));
         assert!(json.contains(r#""wallDurationMs":15.72"#));
+        assert!(json.contains(r#""sharedLeaseBudgetBytes":2147483648"#));
+        assert!(json.contains(r#""sharedLeasePeakBytes":123456789"#));
+        assert!(json.contains(r#""recognizedRegions":2"#));
+        assert!(json.contains(r#""recognizedChars":7"#));
         assert_eq!(BatchReportDto::from_json(&json).unwrap(), report);
 
         let legacy = r#"{"schemaVersion":1,"succeeded":1,"failed":0,"items":[{"input":"old.txt","output":"old.md","format":"text","status":"success","diagnostics":[],"errorCode":null,"message":null,"warnings":[]}]}"#;
         let decoded = BatchReportDto::from_json(legacy).unwrap();
         assert_eq!(decoded.wall_duration_ms, None);
+        assert_eq!(decoded.resource_usage, None);
         assert_eq!(decoded.items[0].duration_ms, None);
         assert_eq!(decoded.items[0].processing_duration_ms, None);
+    }
+
+    #[test]
+    fn batch_resource_usage_rejects_zero_budget_impossible_peak_and_fake_ocr_hits() {
+        let valid = BatchResourceUsageDto {
+            shared_lease_budget_bytes: 10,
+            shared_lease_peak_bytes: 5,
+            ocr: Some(BatchOcrUsageDto { recognized_regions: 0, recognized_chars: 0 }),
+        };
+        assert!(
+            BatchReportDto::try_new_with_resource_usage(Vec::new(), Some(0.0), Some(valid.clone()))
+                .is_ok()
+        );
+
+        for (usage, path) in [
+            (
+                BatchResourceUsageDto { shared_lease_budget_bytes: 0, ..valid.clone() },
+                "$.resourceUsage.sharedLeaseBudgetBytes",
+            ),
+            (
+                BatchResourceUsageDto { shared_lease_peak_bytes: 11, ..valid.clone() },
+                "$.resourceUsage.sharedLeasePeakBytes",
+            ),
+            (
+                BatchResourceUsageDto {
+                    ocr: Some(BatchOcrUsageDto { recognized_regions: 1, recognized_chars: 0 }),
+                    ..valid
+                },
+                "$.resourceUsage.ocr",
+            ),
+        ] {
+            let error = BatchReportDto::try_new_with_resource_usage(Vec::new(), None, Some(usage))
+                .unwrap_err();
+            assert_eq!(error.code, DtoErrorCode::InvalidField);
+            assert_eq!(error.path, path);
+        }
     }
 
     #[test]

--- a/crates/core/src/execution.rs
+++ b/crates/core/src/execution.rs
@@ -173,6 +173,24 @@ pub struct ExecutionContext {
     memory_credit: Option<Arc<MemoryCredit>>,
 }
 
+/// Invocation-wide resource accounting shared by a root context and every fork.
+#[doc(hidden)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecutionResourceUsage {
+    /// Configured shared memory lease budget.
+    pub shared_lease_budget_bytes: u64,
+    /// Historical shared memory lease high-water mark.
+    pub shared_lease_peak_bytes: u64,
+    /// Configured shared temporary-storage lease budget.
+    pub temporary_lease_budget_bytes: u64,
+    /// Historical shared temporary-storage lease high-water mark.
+    pub temporary_lease_peak_bytes: u64,
+    /// OCR regions that survived component filtering and merge.
+    pub ocr_recognized_regions: u64,
+    /// Unicode scalar values contributed by those OCR regions.
+    pub ocr_recognized_chars: u64,
+}
+
 impl Clone for ExecutionContext {
     fn clone(&self) -> Self {
         // A preflight credit is a scoped capability borrowed from one mutable
@@ -197,8 +215,26 @@ struct MemoryBacking {
 
 impl Drop for MemoryBacking {
     fn drop(&mut self) {
-        self.shared.memory_bytes.fetch_sub(self.bytes.load(Ordering::Acquire), Ordering::AcqRel);
+        self.shared
+            .resources
+            .memory_bytes
+            .fetch_sub(self.bytes.load(Ordering::Acquire), Ordering::AcqRel);
     }
+}
+
+#[derive(Clone, Default)]
+struct SharedResourceAccounting {
+    memory_bytes: Arc<AtomicU64>,
+    memory_peak_bytes: Arc<AtomicU64>,
+    temporary_bytes: Arc<AtomicU64>,
+    temporary_peak_bytes: Arc<AtomicU64>,
+    ocr: Arc<Mutex<OcrAccounting>>,
+}
+
+#[derive(Default)]
+struct OcrAccounting {
+    recognized_regions: u64,
+    recognized_chars: u64,
 }
 
 struct ExecutionShared {
@@ -211,8 +247,7 @@ struct ExecutionShared {
     detected_format: Mutex<Option<InputFormat>>,
     dispatcher: Option<ProgressDispatcher>,
     limits: ResourceLimits,
-    memory_bytes: Arc<AtomicU64>,
-    temporary_bytes: Arc<AtomicU64>,
+    resources: SharedResourceAccounting,
     temporary_directory: PathBuf,
     media_checkpoint: Mutex<Option<crate::media_checkpoint::SharedMediaCheckpointBackend>>,
 }
@@ -295,8 +330,7 @@ impl ExecutionContext {
             options,
             limits,
             temporary_directory,
-            Arc::new(AtomicU64::new(0)),
-            Arc::new(AtomicU64::new(0)),
+            SharedResourceAccounting::default(),
             spawn,
         )
     }
@@ -305,8 +339,7 @@ impl ExecutionContext {
         options: ExecutionOptions,
         limits: ResourceLimits,
         temporary_directory: PathBuf,
-        memory_bytes: Arc<AtomicU64>,
-        temporary_bytes: Arc<AtomicU64>,
+        resources: SharedResourceAccounting,
         spawn: F,
     ) -> Self
     where
@@ -330,8 +363,7 @@ impl ExecutionContext {
             detected_format: Mutex::new(None),
             dispatcher,
             limits,
-            memory_bytes,
-            temporary_bytes,
+            resources,
             temporary_directory,
             media_checkpoint: Mutex::new(None),
         });
@@ -378,8 +410,7 @@ impl ExecutionContext {
             options,
             self.shared.limits.clone(),
             self.shared.temporary_directory.clone(),
-            Arc::clone(&self.shared.memory_bytes),
-            Arc::clone(&self.shared.temporary_bytes),
+            self.shared.resources.clone(),
             std::thread::Builder::spawn,
         )
     }
@@ -565,7 +596,7 @@ impl ExecutionContext {
         if let Some(credit) = &self.memory_credit {
             credit.bytes.load(Ordering::Acquire)
         } else {
-            self.shared.memory_bytes.load(Ordering::Acquire)
+            self.shared.resources.memory_bytes.load(Ordering::Acquire)
         }
     }
 
@@ -583,8 +614,64 @@ impl ExecutionContext {
             self.shared
                 .limits
                 .max_memory_bytes
-                .saturating_sub(self.shared.memory_bytes.load(Ordering::Acquire))
+                .saturating_sub(self.shared.resources.memory_bytes.load(Ordering::Acquire))
         }
+    }
+
+    /// Return the invocation-wide historical resource accounting shared with every fork.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn resource_usage(&self) -> ExecutionResourceUsage {
+        let ocr = lock_unpoisoned(&self.shared.resources.ocr);
+        ExecutionResourceUsage {
+            shared_lease_budget_bytes: self.shared.limits.max_memory_bytes,
+            shared_lease_peak_bytes: self
+                .shared
+                .resources
+                .memory_peak_bytes
+                .load(Ordering::Acquire),
+            temporary_lease_budget_bytes: self.shared.limits.max_temporary_bytes,
+            temporary_lease_peak_bytes: self
+                .shared
+                .resources
+                .temporary_peak_bytes
+                .load(Ordering::Acquire),
+            ocr_recognized_regions: ocr.recognized_regions,
+            ocr_recognized_chars: ocr.recognized_chars,
+        }
+    }
+
+    /// Record OCR text only after recognized regions survive filtering, deduplication, and merge.
+    #[doc(hidden)]
+    pub fn record_ocr_contribution(
+        &self,
+        regions: u64,
+        characters: u64,
+    ) -> Result<(), ConversionError> {
+        if regions == 0 && characters == 0 {
+            return Ok(());
+        }
+        if regions == 0 || characters == 0 {
+            return Err(ConversionError::Internal {
+                detail: "OCR contribution regions and characters must both be positive".into(),
+            });
+        }
+        let mut ocr = lock_unpoisoned(&self.shared.resources.ocr);
+        let recognized_regions = ocr.recognized_regions.checked_add(regions).ok_or_else(|| {
+            ConversionError::ResourceLimit {
+                limit: "max_archive_entries",
+                detail: "OCR region telemetry overflow".into(),
+            }
+        })?;
+        let recognized_chars = ocr.recognized_chars.checked_add(characters).ok_or_else(|| {
+            ConversionError::ResourceLimit {
+                limit: "max_field_bytes",
+                detail: "OCR character telemetry overflow".into(),
+            }
+        })?;
+        ocr.recognized_regions = recognized_regions;
+        ocr.recognized_chars = recognized_chars;
+        Ok(())
     }
 
     /// Return the immutable request resource envelope carried by this context.
@@ -684,7 +771,7 @@ impl ExecutionContext {
     #[doc(hidden)]
     #[must_use]
     pub fn reserved_temporary_bytes(&self) -> u64 {
-        self.shared.temporary_bytes.load(Ordering::Acquire)
+        self.shared.resources.temporary_bytes.load(Ordering::Acquire)
     }
 
     /// Remaining request temporary storage available to a bounded streaming
@@ -695,7 +782,7 @@ impl ExecutionContext {
         self.shared
             .limits
             .max_temporary_bytes
-            .saturating_sub(self.shared.temporary_bytes.load(Ordering::Acquire))
+            .saturating_sub(self.shared.resources.temporary_bytes.load(Ordering::Acquire))
     }
 
     /// Create an automatically cleaned temporary file charged as bytes are written.
@@ -781,15 +868,16 @@ impl ExecutionContext {
         bytes: u64,
     ) -> Result<ResourceReservation, ConversionError> {
         self.checkpoint()?;
-        let (counter, limit, name) = match kind {
+        let (counter, peak, limit, name) = match kind {
             ResourceKind::Memory => self.memory_account(),
             ResourceKind::Temporary => (
-                self.shared.temporary_bytes.as_ref(),
+                self.shared.resources.temporary_bytes.as_ref(),
+                Some(self.shared.resources.temporary_peak_bytes.as_ref()),
                 self.shared.limits.max_temporary_bytes,
                 "max_temporary_bytes",
             ),
         };
-        checked_charge(counter, bytes, limit, name)?;
+        checked_charge(counter, peak, bytes, limit, name)?;
         let global_memory_backing =
             if matches!(kind, ResourceKind::Memory) && self.memory_credit.is_none() {
                 Some(Arc::new(MemoryBacking {
@@ -815,11 +903,16 @@ impl ExecutionContext {
         }
     }
 
-    fn memory_account(&self) -> (&AtomicU64, u64, &'static str) {
+    fn memory_account(&self) -> (&AtomicU64, Option<&AtomicU64>, u64, &'static str) {
         if let Some(credit) = &self.memory_credit {
-            (&credit.bytes, credit.backing.bytes.load(Ordering::Acquire), "max_memory_bytes")
+            (&credit.bytes, None, credit.backing.bytes.load(Ordering::Acquire), "max_memory_bytes")
         } else {
-            (&self.shared.memory_bytes, self.shared.limits.max_memory_bytes, "max_memory_bytes")
+            (
+                &self.shared.resources.memory_bytes,
+                Some(&self.shared.resources.memory_peak_bytes),
+                self.shared.limits.max_memory_bytes,
+                "max_memory_bytes",
+            )
         }
     }
 }
@@ -929,15 +1022,16 @@ impl ResourceReservation {
             },
             detail: "resource reservation overflowed".into(),
         })?;
-        let (counter, limit, name) = match self.kind {
+        let (counter, peak, limit, name) = match self.kind {
             ResourceKind::Memory => self.context.memory_account(),
             ResourceKind::Temporary => (
-                self.context.shared.temporary_bytes.as_ref(),
+                self.context.shared.resources.temporary_bytes.as_ref(),
+                Some(self.context.shared.resources.temporary_peak_bytes.as_ref()),
                 self.context.shared.limits.max_temporary_bytes,
                 "max_temporary_bytes",
             ),
         };
-        checked_charge(counter, bytes, limit, name)?;
+        checked_charge(counter, peak, bytes, limit, name)?;
         self.bytes = next;
         if let Some(backing) = &self.global_memory_backing {
             backing.bytes.fetch_add(bytes, Ordering::AcqRel);
@@ -965,7 +1059,7 @@ impl ResourceReservation {
         }
         let counter = match self.kind {
             ResourceKind::Memory => self.context.memory_account().0,
-            ResourceKind::Temporary => &self.context.shared.temporary_bytes,
+            ResourceKind::Temporary => &self.context.shared.resources.temporary_bytes,
         };
         counter.fetch_sub(bytes, Ordering::AcqRel);
         Ok(())
@@ -1010,7 +1104,7 @@ impl Drop for ResourceReservation {
         }
         let counter = match self.kind {
             ResourceKind::Memory => self.context.memory_account().0,
-            ResourceKind::Temporary => &self.context.shared.temporary_bytes,
+            ResourceKind::Temporary => &self.context.shared.resources.temporary_bytes,
         };
         counter.fetch_sub(self.bytes, Ordering::AcqRel);
     }
@@ -1071,7 +1165,7 @@ impl TemporaryFile {
     #[must_use]
     pub fn persist(mut self) -> PathBuf {
         self.file.take();
-        self.context.shared.temporary_bytes.fetch_sub(self.charged, Ordering::AcqRel);
+        self.context.shared.resources.temporary_bytes.fetch_sub(self.charged, Ordering::AcqRel);
         self.charged = 0;
         std::mem::take(&mut self.path)
     }
@@ -1109,13 +1203,14 @@ impl TemporaryFile {
                 detail: "temporary byte accounting overflowed".into(),
             })?;
         checked_charge(
-            &self.context.shared.temporary_bytes,
+            &self.context.shared.resources.temporary_bytes,
+            Some(&self.context.shared.resources.temporary_peak_bytes),
             amount,
             self.context.shared.limits.max_temporary_bytes,
             "max_temporary_bytes",
         )?;
         let Some(file) = self.file.as_mut() else {
-            self.context.shared.temporary_bytes.fetch_sub(amount, Ordering::AcqRel);
+            self.context.shared.resources.temporary_bytes.fetch_sub(amount, Ordering::AcqRel);
             return Err(ConversionError::Internal { detail: "temporary file is closed".into() });
         };
         match file.write(bytes) {
@@ -1128,13 +1223,14 @@ impl TemporaryFile {
                 if written_u64 < amount {
                     self.context
                         .shared
+                        .resources
                         .temporary_bytes
                         .fetch_sub(amount - written_u64, Ordering::AcqRel);
                 }
                 Ok(written)
             }
             Err(error) => {
-                self.context.shared.temporary_bytes.fetch_sub(amount, Ordering::AcqRel);
+                self.context.shared.resources.temporary_bytes.fetch_sub(amount, Ordering::AcqRel);
                 Err(error.into())
             }
         }
@@ -1168,7 +1264,7 @@ impl Drop for TemporaryFile {
         if !self.path.as_os_str().is_empty() {
             let _ = std::fs::remove_file(&self.path);
         }
-        self.context.shared.temporary_bytes.fetch_sub(self.charged, Ordering::AcqRel);
+        self.context.shared.resources.temporary_bytes.fetch_sub(self.charged, Ordering::AcqRel);
     }
 }
 
@@ -1376,6 +1472,7 @@ where
 
 fn checked_charge(
     counter: &AtomicU64,
+    peak: Option<&AtomicU64>,
     amount: u64,
     limit: u64,
     name: &'static str,
@@ -1383,10 +1480,19 @@ fn checked_charge(
     let result = counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
         current.checked_add(amount).filter(|next| *next <= limit)
     });
-    result.map(|_| ()).map_err(|current| ConversionError::ResourceLimit {
-        limit: name,
-        detail: format!("{current} + {amount} exceeds {limit}"),
-    })
+    result
+        .map(|previous| {
+            if let Some(peak) = peak {
+                let current = previous
+                    .checked_add(amount)
+                    .expect("a successful checked charge cannot overflow");
+                peak.fetch_max(current, Ordering::AcqRel);
+            }
+        })
+        .map_err(|current| ConversionError::ResourceLimit {
+            limit: name,
+            detail: format!("{current} + {amount} exceeds {limit}"),
+        })
 }
 
 fn lock_unpoisoned<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
@@ -2209,5 +2315,121 @@ mod tests {
         drop(temporary);
         assert!(second.reserve_memory(10).is_ok());
         assert!(first.reserve_temporary(10).is_ok());
+    }
+
+    #[test]
+    fn concurrent_forks_publish_one_stable_historical_peak() {
+        let pool = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: 10, ..ResourceLimits::default() },
+        );
+        let barrier = Arc::new(std::sync::Barrier::new(3));
+        let (ready, observed) = std::sync::mpsc::channel();
+        let mut workers = Vec::new();
+        for amount in [4, 6] {
+            let context = pool.fork_with_shared_resources(ExecutionOptions::default());
+            let barrier = Arc::clone(&barrier);
+            let ready = ready.clone();
+            workers.push(std::thread::spawn(move || {
+                let reservation = context.reserve_memory(amount).unwrap();
+                ready.send(()).unwrap();
+                barrier.wait();
+                drop(reservation);
+            }));
+        }
+        observed.recv().unwrap();
+        observed.recv().unwrap();
+
+        assert_eq!(pool.reserved_memory_bytes(), 10);
+        assert_eq!(pool.resource_usage().shared_lease_peak_bytes, 10);
+        assert!(pool.reserve_memory(1).is_err());
+        assert_eq!(pool.resource_usage().shared_lease_peak_bytes, 10);
+        barrier.wait();
+        for worker in workers {
+            worker.join().unwrap();
+        }
+        assert_eq!(pool.reserved_memory_bytes(), 0);
+        assert_eq!(pool.resource_usage().shared_lease_peak_bytes, 10);
+    }
+
+    #[test]
+    fn grow_shrink_drop_temporary_and_preflight_credit_preserve_true_peaks() {
+        let context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits {
+                max_memory_bytes: 12,
+                max_temporary_bytes: 12,
+                ..ResourceLimits::default()
+            },
+        );
+        let mut memory = context.reserve_memory(3).unwrap();
+        memory.grow(4).unwrap();
+        memory.shrink(5).unwrap();
+        assert_eq!(context.resource_usage().shared_lease_peak_bytes, 7);
+        drop(memory);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let mut parent = context.reserve_memory(10).unwrap();
+        {
+            let credit = context.with_memory_credit(&mut parent).unwrap();
+            let mut child = credit.reserve_memory(4).unwrap();
+            child.grow(6).unwrap();
+            assert_eq!(credit.reserved_memory_bytes(), 10);
+            assert_eq!(context.resource_usage().shared_lease_peak_bytes, 10);
+        }
+        drop(parent);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let mut temporary = context.reserve_temporary(3).unwrap();
+        temporary.grow(2).unwrap();
+        temporary.shrink(4).unwrap();
+        drop(temporary);
+        let mut file = context.temporary_file("usage-peak").unwrap();
+        file.write_all_checked(b"1234567").unwrap();
+        drop(file);
+        let usage = context.resource_usage();
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+        assert_eq!(usage.temporary_lease_peak_bytes, 7);
+        assert_eq!(usage.temporary_lease_budget_bytes, 12);
+    }
+
+    #[test]
+    fn rejected_cancelled_and_timed_out_reserves_do_not_raise_peak() {
+        let limits = ResourceLimits { max_memory_bytes: 5, ..ResourceLimits::default() };
+        let ordinary = ExecutionContext::new(ExecutionOptions::default(), limits.clone());
+        assert!(ordinary.reserve_memory(6).is_err());
+        assert_eq!(ordinary.resource_usage().shared_lease_peak_bytes, 0);
+
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        let cancelled = ExecutionContext::new(
+            ExecutionOptions { cancellation, ..ExecutionOptions::default() },
+            limits.clone(),
+        );
+        assert!(matches!(cancelled.reserve_memory(1), Err(ConversionError::Cancelled)));
+        assert_eq!(cancelled.resource_usage().shared_lease_peak_bytes, 0);
+
+        let timed_out = ExecutionContext::new(
+            ExecutionOptions { timeout: Some(Duration::ZERO), ..ExecutionOptions::default() },
+            limits,
+        );
+        assert!(matches!(timed_out.reserve_memory(1), Err(ConversionError::Timeout)));
+        assert_eq!(timed_out.resource_usage().shared_lease_peak_bytes, 0);
+    }
+
+    #[test]
+    fn ocr_contributions_aggregate_across_forks_and_zeroes_are_not_hits() {
+        let pool = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+        let fork = pool.fork_with_shared_resources(ExecutionOptions::default());
+        pool.record_ocr_contribution(0, 0).unwrap();
+        assert!(matches!(
+            pool.record_ocr_contribution(1, 0),
+            Err(ConversionError::Internal { .. })
+        ));
+        pool.record_ocr_contribution(1, 2).unwrap();
+        fork.record_ocr_contribution(2, 5).unwrap();
+        let usage = pool.resource_usage();
+        assert_eq!(usage.ocr_recognized_regions, 3);
+        assert_eq!(usage.ocr_recognized_chars, 7);
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -24,17 +24,18 @@ mod summary;
 pub use artifact::{ArtifactSinkCapabilities, DocumentStreamEvent};
 pub use dto::{
     AssetDto, BUNDLE_SCHEMA_VERSION, BatchItemDto, BatchItemOutcome, BatchItemStatus,
-    BatchLimitDto, BatchReportDto, BundleAssetDto, BundleManifestDto, DTO_SCHEMA_VERSION,
-    DiagnosticDto, DiagnosticSeverityDto, DiagnosticsDto, DtoError, DtoErrorCode, DtoJsonStyle,
-    DtoLimits, MAX_DTO_ASSETS, MAX_DTO_BASE64_BYTES, MAX_DTO_BATCH_ITEMS, MAX_DTO_DEPTH,
-    MAX_DTO_DIAGNOSTICS, MAX_DTO_JSON_BYTES, MAX_DTO_PROVENANCE, MAX_DTO_STRING_BYTES,
-    MAX_DTO_TOTAL_STRING_BYTES, MAX_DTO_VALUES, ProvenanceDto, ProvenanceKindDto,
-    ProvenanceListDto, ResultDto, canonical_external_asset_uri,
+    BatchLimitDto, BatchOcrUsageDto, BatchReportDto, BatchResourceUsageDto, BundleAssetDto,
+    BundleManifestDto, DTO_SCHEMA_VERSION, DiagnosticDto, DiagnosticSeverityDto, DiagnosticsDto,
+    DtoError, DtoErrorCode, DtoJsonStyle, DtoLimits, MAX_DTO_ASSETS, MAX_DTO_BASE64_BYTES,
+    MAX_DTO_BATCH_ITEMS, MAX_DTO_DEPTH, MAX_DTO_DIAGNOSTICS, MAX_DTO_JSON_BYTES,
+    MAX_DTO_PROVENANCE, MAX_DTO_STRING_BYTES, MAX_DTO_TOTAL_STRING_BYTES, MAX_DTO_VALUES,
+    ProvenanceDto, ProvenanceKindDto, ProvenanceListDto, ResultDto, canonical_external_asset_uri,
 };
 pub use error::{ConversionError, ErrorCode};
 pub use execution::{
-    CancellationToken, CheckedFuture, ExecutionContext, ExecutionOptions, ExecutionStage,
-    PreflightMemoryCredit, ProgressEvent, ProgressListener, ResourceReservation, TemporaryFile,
+    CancellationToken, CheckedFuture, ExecutionContext, ExecutionOptions, ExecutionResourceUsage,
+    ExecutionStage, PreflightMemoryCredit, ProgressEvent, ProgressListener, ResourceReservation,
+    TemporaryFile,
 };
 pub use format::{FormatCandidate, InputFormat};
 pub use input::{

--- a/crates/ocr/src/merge/mod.rs
+++ b/crates/ocr/src/merge/mod.rs
@@ -141,6 +141,26 @@ pub(crate) struct Candidate {
     geometry: RegionGeometry,
 }
 
+#[derive(Default)]
+struct OcrContributionUsage {
+    regions: u64,
+    characters: u64,
+}
+
+impl OcrContributionUsage {
+    fn add(&mut self, regions: u64, characters: u64) -> Result<(), ConversionError> {
+        self.regions = self
+            .regions
+            .checked_add(regions)
+            .ok_or_else(|| ocr("recognizedRegionTelemetryOverflow"))?;
+        self.characters = self
+            .characters
+            .checked_add(characters)
+            .ok_or_else(|| ocr("recognizedCharacterTelemetryOverflow"))?;
+        Ok(())
+    }
+}
+
 #[derive(Clone, Copy)]
 pub(crate) struct PageBlocks<'a> {
     pub(crate) blocks: &'a [BlockNode],
@@ -183,6 +203,7 @@ pub fn merge_document(
     let mut diagnostics = Vec::new();
     diagnostics.try_reserve_exact(budget.planned_diagnostics()).map_err(|_| memory())?;
     let mut identifiers = BTreeSet::new();
+    let mut usage = OcrContributionUsage::default();
     collect_node_ids(&document.blocks, &mut identifiers, &budget)?;
     if config.policy != OcrPolicy::Off {
         let mut ordered = Vec::<&OcrPageInput>::new();
@@ -204,6 +225,7 @@ pub fn merge_document(
                 &mut identifiers,
                 &mut diagnostics,
                 &mut budget,
+                &mut usage,
             )?;
         }
         if sort_flat_document {
@@ -215,13 +237,15 @@ pub fn merge_document(
         ocr(format!("invalidMergedDocument:{}:{}", error.code.as_str(), error.path))
     })?;
     let reservation = budget.finish()?;
-    ConverterOutput::new_with_memory_reservation(
+    let output = ConverterOutput::new_with_memory_reservation(
         document,
         Vec::new(),
         diagnostics,
         context,
         reservation,
-    )
+    )?;
+    context.record_ocr_contribution(usage.regions, usage.characters)?;
+    Ok(output)
 }
 
 fn merge_page(
@@ -231,6 +255,7 @@ fn merge_page(
     identifiers: &mut BTreeSet<String>,
     diagnostics: &mut Vec<Diagnostic>,
     budget: &mut MergeBudget<'_>,
+    usage: &mut OcrContributionUsage,
 ) -> Result<bool, ConversionError> {
     let page_blocks = existing_page_blocks(document, page.page())?;
     if config.policy == OcrPolicy::Auto
@@ -271,6 +296,13 @@ fn merge_page(
     if candidates.is_empty() {
         return Ok(false);
     }
+    let recognized_regions =
+        u64::try_from(candidates.len()).map_err(|_| ocr("recognizedRegionTelemetryOverflow"))?;
+    let recognized_chars = candidates.iter().try_fold(0_u64, |total, candidate| {
+        let characters = u64::try_from(candidate.text.chars().count())
+            .map_err(|_| ocr("recognizedCharacterTelemetryOverflow"))?;
+        total.checked_add(characters).ok_or_else(|| ocr("recognizedCharacterTelemetryOverflow"))
+    })?;
     let lines = lines::merge_lines(
         candidates,
         page.recognition.result().language_hint.as_deref(),
@@ -279,7 +311,9 @@ fn merge_page(
     )?;
     let paragraphs = paragraphs::merge_paragraphs(lines)?;
     let nodes = provenance::materialize_paragraphs(paragraphs, page, identifiers)?;
-    insert_page_nodes(document, page, nodes, identifiers, budget)
+    let sorted_flat_document = insert_page_nodes(document, page, nodes, identifiers, budget)?;
+    usage.add(recognized_regions, recognized_chars)?;
+    Ok(sorted_flat_document)
 }
 
 fn validate_page(page: &OcrPageInput, context: &ExecutionContext) -> Result<(), ConversionError> {

--- a/crates/ocr/src/merge/tests/contracts.rs
+++ b/crates/ocr/src/merge/tests/contracts.rs
@@ -38,6 +38,9 @@ fn stable_source_indexes_form_structured_page_ir_and_chain() {
     assert_eq!(provenance.locator.page, Some(1));
     assert!(provenance.locator.bounds.is_some());
     output.document.validate().unwrap();
+    let usage = auto_context.resource_usage();
+    assert_eq!(usage.ocr_recognized_regions, 3);
+    assert_eq!(usage.ocr_recognized_chars, 21);
 }
 
 #[test]
@@ -64,6 +67,8 @@ fn policy_off_is_a_true_no_op_and_auto_respects_native_text() {
     )
     .unwrap();
     assert_eq!(auto.document, document);
+    assert_eq!(auto_context.resource_usage().ocr_recognized_regions, 0);
+    assert_eq!(auto_context.resource_usage().ocr_recognized_chars, 0);
 
     let oversized_detection = detection(&[
         (polygon(20.0, 20.0, 80.0, 16.0), 0.99),

--- a/crates/ocr/src/merge/tests/dedup.rs
+++ b/crates/ocr/src/merge/tests/dedup.rs
@@ -14,15 +14,18 @@ fn nfc_and_whitespace_equivalent_native_text_is_not_duplicated() {
         .collect();
     let detection = detection(&[(polygon(20.0, 20.0, 100.0, 16.0), 0.99)]);
     let recognition = recognition(&[(0, "Ca fé", 0.98)]);
+    let context = context();
     let output = merge_document(
         page_document(native),
         &[input(&detection, &recognition)],
         &MergeConfig { policy: OcrPolicy::Always, ..MergeConfig::default() },
-        &context(),
+        &context,
     )
     .unwrap();
     assert!(merged_text(&output.document).is_empty());
     assert_eq!(output.diagnostics[0].code, "ocr.nativeDuplicateSuppressed");
+    assert_eq!(context.resource_usage().ocr_recognized_regions, 0);
+    assert_eq!(context.resource_usage().ocr_recognized_chars, 0);
 }
 
 #[test]
@@ -32,11 +35,12 @@ fn overlapping_and_crossing_equivalent_boxes_keep_only_best_confidence() {
         ([(18.0, 22.0), (118.0, 18.0), (120.0, 36.0), (20.0, 40.0)], 0.98),
     ]);
     let recognition = recognition(&[(0, "duplicate", 0.97), (1, "duplicate", 0.98)]);
+    let context = context();
     let output = merge_document(
         page_document(Vec::new()),
         &[input(&detection, &recognition)],
         &MergeConfig { policy: OcrPolicy::Always, ..MergeConfig::default() },
-        &context(),
+        &context,
     )
     .unwrap();
     assert_eq!(merged_text(&output.document), "duplicate");
@@ -48,6 +52,8 @@ fn overlapping_and_crossing_equivalent_boxes_keep_only_best_confidence() {
             .count(),
         1
     );
+    assert_eq!(context.resource_usage().ocr_recognized_regions, 1);
+    assert_eq!(context.resource_usage().ocr_recognized_chars, 9);
 }
 
 #[test]

--- a/crates/ocr/src/merge/tests/resources.rs
+++ b/crates/ocr/src/merge/tests/resources.rs
@@ -79,6 +79,8 @@ fn cancellation_is_observed_before_merge_work_or_output() {
         merge_document(Document::default(), &[], &MergeConfig::default(), &context).unwrap_err();
     assert_eq!(error.code(), ErrorCode::Cancelled);
     assert_eq!(context.reserved_memory_bytes(), 0);
+    assert_eq!(context.resource_usage().ocr_recognized_regions, 0);
+    assert_eq!(context.resource_usage().ocr_recognized_chars, 0);
 }
 
 #[test]
@@ -235,6 +237,8 @@ fn large_text_checkpoint_observes_timeout_after_work_begins() {
     assert!(reached.load(Ordering::SeqCst) >= 4 * 1024);
     assert_eq!(error.code(), ErrorCode::Timeout);
     assert_eq!(context.reserved_memory_bytes(), 0);
+    assert_eq!(context.resource_usage().ocr_recognized_regions, 0);
+    assert_eq!(context.resource_usage().ocr_recognized_chars, 0);
 }
 
 fn subthreshold_recognition_regions() -> (DetectionResult, RecognitionResult) {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -150,7 +150,10 @@ into-md <INPUT...>
   `degraded`，失败为 `failed`；真正空源使用 `complete` / `emptySource`，未证明可用的
   空产物使用 `malformed` / `emptyContent`。报告还包含逐项 `durationMs`、成功项的
   `processingDurationMs` 和独立计量的整批 `wallDurationMs`；逐项耗时排除队列与批量
-  内存准入等待，整批墙钟时间不得由并发项耗时求和。
+  内存准入等待，整批墙钟时间不得由并发项耗时求和。顶层 `resourceUsage` 报告整个
+  invocation 的共享 lease budget 与历史 peak；budget 不随 `--jobs` 倍增。OCR auto/always
+  还报告过滤、去重并合并后的 `recognizedRegions` / `recognizedChars`，未命中或组件不可用
+  为明确的零值，不能用候选图片或最终 Markdown 反推。
 - Engine 的空结果判定发生在 stdout 编码及文件事务 stage/commit 之前。除明确
   `emptySource` 外，成功或 degraded 的 Markdown 目标必须存在且非空；`emptyContent`
   不创建目标，并使批处理失败计数和退出码与报告一致。asset-only 结果只有在所选

--- a/docs/dto.md
+++ b/docs/dto.md
@@ -92,6 +92,14 @@ DTO 解码错误为 `invalidField`、`invalidBase64`、`duplicateId` 和 `resour
   "succeeded": 1,
   "failed": 0,
   "wallDurationMs": 15.72,
+  "resourceUsage": {
+    "sharedLeaseBudgetBytes": 2147483648,
+    "sharedLeasePeakBytes": 123456789,
+    "ocr": {
+      "recognizedRegions": 2,
+      "recognizedChars": 21
+    }
+  },
   "items": [
     {
       "input": "report.pdf",
@@ -109,6 +117,13 @@ DTO 解码错误为 `invalidField`、`invalidBase64`、`duplicateId` 和 `resour
   ]
 }
 ```
+
+`resourceUsage` 是一次 CLI invocation 的共享资源快照，不按并发 `jobs` 倍增。
+`sharedLeasePeakBytes` 是根 `ExecutionContext` 与全部 fork 的真实历史高水位，拒绝的
+reserve 不抬高它，且任务释放 lease 后仍保留。OCR 计数只累计经过非空/置信度过滤、
+原生文本去重并完成结构化合并的 region 与 Unicode scalar；OCR 已启用但无命中时两个
+字段都为 `0`，关闭时省略 `ocr`。旧 schema 1 报告可缺少 `resourceUsage`；新生产者
+必须提供大于零的 budget，并保证 `0 <= peak <= budget`。
 
 ## 不可信输入边界
 


### PR DESCRIPTION
## Summary

- publish invocation-wide `resourceUsage.sharedLeaseBudgetBytes` and the true historical `sharedLeasePeakBytes` from the root/fork shared lease account
- publish OCR `recognizedRegions` / `recognizedChars` only for text that survives filtering, deduplication, and merge; omit OCR when disabled and publish explicit zeroes for enabled misses
- preserve schema version 1 compatibility and the existing per-item / batch timing semantics, including legacy reports that omit the additive resource object
- cover success, failure, cancellation, timeout, concurrent forks, reserve/grow/shrink/drop, preflight credit, rejected reservations, and OCR hit/miss paths

Example additive report field:

```json
{
  "resourceUsage": {
    "sharedLeaseBudgetBytes": 67108864,
    "sharedLeasePeakBytes": 67108864,
    "ocr": {
      "recognizedRegions": 3,
      "recognizedChars": 21
    }
  }
}
```

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p into-markdown-core -p into-markdown-ocr --all-targets --no-deps -- -D warnings`
- `cargo clippy --locked -p into-markdown-converters --all-targets --no-deps -- -D warnings`
- core: 111 passed
- OCR: 133 passed, 1 explicit acquisition audit ignored
- converters: 505 passed, 1 PDFium runtime test ignored
- CLI binary: all 6 resource/timing tests passed; full run reached 241 passed with one unrelated latest-main failure described below
- CLI empty-result / exit integration contracts: 21 passed
- documentation contract passed
- native Windows PR fast-gate contract passed

The full CLI run's `web_tasks::tests::empty_result_tests::empty_source_and_empty_content_share_the_web_terminal_contract` assertion also fails unchanged on the exact latest-main baseline `a243eba`; it is an existing altChunk fixture expectation drift and is outside this PR.

## Common-success performance A/B

Windows release builds from exact latest main `a243eba` and this branch; 12 ordinary 574-byte TXT files, 4 jobs, 64 MiB shared lease, OCR off, 2 warmups and 12 alternating samples per binary:

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Mean item duration | 81.854 ms | 54.945 ms | -32.87% |
| Batch wall duration | 982.887 ms | 660.037 ms | -32.85% |
| Mean peak RSS | 13.70 MiB | 13.85 MiB | +1.06% |
| Max temp residue | 0 B | 0 B | equal |

The baseline's absent `resourceUsage` was recorded as unavailable. Every candidate sample was fail-closed validated for presence, a 64 MiB budget, a nonzero peak within that budget, no jobs multiplication, and OCR omission while off. All observed candidate shared-lease peaks were 64 MiB.

Fixes #288