### PR TITLE
fix(cli): create missing output root before staging

### DIFF
--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -7060,6 +7060,111 @@ mod tests {
     }
 
     #[test]
+    fn single_file_creates_missing_output_root_and_report() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().canonicalize().unwrap();
+        let input = root.join("document.txt");
+        let output = root.join("missing-output");
+        let report = root.join("report.json");
+        fs::write(&input, b"transactional output\n").unwrap();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let result = run(
+            vec![
+                OsString::from("--no-config"),
+                input.into_os_string(),
+                OsString::from("--output-dir"),
+                output.clone().into_os_string(),
+                OsString::from("--conflict"),
+                OsString::from("error"),
+                OsString::from("--report"),
+                report.clone().into_os_string(),
+                OsString::from("--ocr"),
+                OsString::from("off"),
+                OsString::from("--asset-mode"),
+                OsString::from("omit"),
+                OsString::from("--progress"),
+                OsString::from("never"),
+            ],
+            RunContext {
+                user_data_anchor: Some(root.join("user-data")),
+                stdout: &mut stdout,
+                stderr: &mut stderr,
+                stdin_is_terminal: true,
+                cwd: root.clone(),
+            },
+        );
+
+        assert!(
+            result.is_ok(),
+            "conversion failed: {result:?}; stdout={}; stderr={}",
+            String::from_utf8_lossy(&stdout),
+            String::from_utf8_lossy(&stderr)
+        );
+        assert_eq!(
+            fs::read_to_string(output.join("document.md")).unwrap(),
+            "transactional output\n"
+        );
+        let report: serde_json::Value = serde_json::from_slice(&fs::read(report).unwrap()).unwrap();
+        assert_eq!(report["succeeded"], 1);
+        assert_eq!(report["failed"], 0);
+    }
+
+    #[test]
+    fn recursive_batch_creates_missing_output_tree_and_report() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().canonicalize().unwrap();
+        let input = root.join("input");
+        let output = root.join("missing-output");
+        let report = root.join("reports/batch.json");
+        fs::create_dir_all(input.join("nested")).unwrap();
+        fs::write(input.join("first.txt"), b"first\n").unwrap();
+        fs::write(input.join("nested/second.txt"), b"second\n").unwrap();
+        let mut stdout = Vec::new();
+        let mut stderr = Vec::new();
+
+        let result = run(
+            vec![
+                OsString::from("--no-config"),
+                input.into_os_string(),
+                OsString::from("--recursive"),
+                OsString::from("--output-dir"),
+                output.clone().into_os_string(),
+                OsString::from("--jobs"),
+                OsString::from("4"),
+                OsString::from("--report"),
+                report.clone().into_os_string(),
+                OsString::from("--ocr"),
+                OsString::from("off"),
+                OsString::from("--asset-mode"),
+                OsString::from("omit"),
+                OsString::from("--progress"),
+                OsString::from("never"),
+            ],
+            RunContext {
+                user_data_anchor: Some(root.join("user-data")),
+                stdout: &mut stdout,
+                stderr: &mut stderr,
+                stdin_is_terminal: true,
+                cwd: root.clone(),
+            },
+        );
+
+        assert!(
+            result.is_ok(),
+            "batch failed: {result:?}; stdout={}; stderr={}",
+            String::from_utf8_lossy(&stdout),
+            String::from_utf8_lossy(&stderr)
+        );
+        assert_eq!(fs::read_to_string(output.join("first.md")).unwrap(), "first\n");
+        assert_eq!(fs::read_to_string(output.join("nested/second.md")).unwrap(), "second\n");
+        let report: serde_json::Value = serde_json::from_slice(&fs::read(report).unwrap()).unwrap();
+        assert_eq!(report["succeeded"], 2);
+        assert_eq!(report["failed"], 0);
+    }
+
+    #[test]
     fn parallel_batch_serializes_atomic_output_leases() {
         let temporary = tempfile::tempdir().unwrap();
         let root = temporary.path().canonicalize().unwrap();

--- a/apps/cli/src/transaction/stage/prepare.rs
+++ b/apps/cli/src/transaction/stage/prepare.rs
@@ -118,8 +118,14 @@ pub fn prepare_file_and_bytes(
     unreachable!("bounded recovery loop always returns")
 }
 
-/// Recover any interrupted transaction owning one of these physical parent
-/// directories before higher-level conflict planning observes the filesystem.
+/// Create and authenticate target parents, then recover any interrupted
+/// transaction owning one of those physical directories before higher-level
+/// conflict planning observes the filesystem.
+///
+/// Output encoders call this preflight before allocating their same-filesystem
+/// temporary file. Creating the parent here restores that directory contract
+/// without bypassing the transaction manager's no-follow path checks or
+/// allocating a transaction registry before staging begins.
 pub fn recover_for_paths(paths: &[PathBuf], context: &ExecutionContext) -> Result<(), CliError> {
     ensure_transaction_platform()?;
     let paths = paths.iter().map(|path| absolute_lexical(path)).collect::<Result<Vec<_>, _>>()?;
@@ -130,6 +136,10 @@ pub fn recover_for_paths(paths: &[PathBuf], context: &ExecutionContext) -> Resul
     let _preparing_root = PreparingTransactionRoot::enter(&root)?;
     for recovered in 0..=MAX_RECOVERY_RETRIES {
         context.checkpoint().map_err(CliError::from)?;
+        for path in &paths {
+            let parent = path.parent().ok_or_else(|| recovery_error("target has no parent"))?;
+            SafeDir::open_or_create_absolute(parent)?;
+        }
         match recover_root_transactions(&root, context)
             .and_then(|()| recover_existing_target_parents(&paths, context))
         {

--- a/apps/cli/src/transaction/tests/basics.rs
+++ b/apps/cli/src/transaction/tests/basics.rs
@@ -45,6 +45,32 @@ fn concurrent_parent_creation_authenticates_the_winning_directory() {
     assert!(identities.windows(2).all(|pair| pair[0] == pair[1]));
 }
 
+#[test]
+fn concurrent_preflights_create_one_missing_output_root_without_transaction_residue() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = temporary.path().canonicalize().unwrap();
+    let output = root.join("missing-output");
+    let barrier = Arc::new(Barrier::new(16));
+    std::thread::scope(|scope| {
+        let handles = (0..16)
+            .map(|index| {
+                let barrier = Arc::clone(&barrier);
+                let target = output.join(format!("item-{index}.md"));
+                scope.spawn(move || {
+                    barrier.wait();
+                    recover_for_paths(&[target], &context()).unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+    });
+
+    assert!(output.is_dir());
+    assert!(manager_artifacts(&root).is_empty());
+}
+
 #[cfg(unix)]
 #[test]
 fn output_transaction_resolves_an_existing_symlinked_parent_once() {


### PR DESCRIPTION
## Summary

- securely create and authenticate missing output parents during output preflight, before same-filesystem encoding and transaction staging
- preserve dry-run as write-free while retaining conflict, no-follow path safety, atomic publication, rollback, and recovery behavior
- add single-file, recursive batch/report, and concurrent first-creation regressions

## Validation

- cargo fmt --all -- --check
- cargo test -p into-markdown-cli missing_output -- --nocapture (3 passed)
- cargo test -p into-markdown-cli transaction::tests -- --nocapture (48 passed, including cancellation, timeout, disk-full, concurrency, rollback, and recovery)
- real regression: specified candidate 6ad203bd dry-run exit 0 with no directory; actual exit 10 / io with no directory or Markdown; frozen 9e797178 and this branch both exit 0 with directory, Markdown, and report
- paired debug A/B, 20 measured runs each after warm-up: 9e797178 = 119.05 ms, 20.76 MiB observed peak RSS, 3.18 KiB sampled temporary peak; this branch = 150.44 ms, 21.99 MiB, 3.51 KiB (+26.4%, +5.9%, +10.4%); transaction residue 0 for both

Strict workspace and CLI Clippy runs with -D warnings were executed. They are currently blocked by pre-existing diagnostics outside this patch, beginning with third_party/whisper-rs-0.16.0/sys/build.rs:135 and existing CLI pedantic warnings; no diagnostic points to a changed line.

Fixes #298