### PR TITLE
fix(cli): verify embedded OCR as Core capability

### DIFF
--- a/apps/cli/src/app.rs
+++ b/apps/cli/src/app.rs
@@ -826,6 +826,23 @@ fn run_capability_verify(
     loaded: &LoadedConfig,
     context: &mut RunContext<'_>,
 ) -> Result<(), CliError> {
+    if uses_embedded_ocr_verification(id, crate::embedded_runtime::enabled()) {
+        let started = std::time::Instant::now();
+        verify_capability_runtime(id, loaded, &context.cwd)?;
+        let elapsed_ms = u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX);
+        if json {
+            return write_json(context.stdout, &core_ocr_verification_json(elapsed_ms));
+        }
+        writeln!(
+            context.stdout,
+            "{}: verified {} {} in {} ms",
+            capability_name(id),
+            capability_source_name(CORE_OCR_SOURCE),
+            env!("CARGO_PKG_VERSION"),
+            elapsed_ms
+        )?;
+        return Ok(());
+    }
     let (plugin_id, shared) = capability_plugin(id)?;
     let started = std::time::Instant::now();
     let installed = verify_admin_effective_plugin_from_loaded(loaded, &context.cwd, plugin_id)?;
@@ -867,6 +884,23 @@ fn run_capability_verify(
         )?;
     }
     Ok(())
+}
+
+fn uses_embedded_ocr_verification(id: &str, embedded_ocr: bool) -> bool {
+    embedded_ocr && id == "ocr"
+}
+
+fn core_ocr_verification_json(elapsed_ms: u64) -> serde_json::Value {
+    serde_json::json!({
+        "schemaVersion": 1,
+        "capability": "ocr",
+        "source": CORE_OCR_SOURCE,
+        "sourceName": capability_source_name(CORE_OCR_SOURCE),
+        "status": "ready",
+        "version": env!("CARGO_PKG_VERSION"),
+        "elapsedMs": elapsed_ms,
+        "sharedCapabilities": ["ocr"],
+    })
 }
 
 pub(crate) fn capability_views(
@@ -7948,6 +7982,29 @@ api_key_env = "MISSING_LOCAL_ASR_TEST_KEY"
         assert!(ocr.sources.iter().all(|source| !source.starts_with("plugin:")));
         assert_eq!(ocr.version.as_deref(), Some(env!("CARGO_PKG_VERSION")));
         assert_eq!(ocr.local_version, ocr.version);
+    }
+
+    #[test]
+    fn capability_verification_targets_core_only_for_embedded_ocr() {
+        assert!(uses_embedded_ocr_verification("ocr", true));
+        assert!(!uses_embedded_ocr_verification("ocr", false));
+        assert!(!uses_embedded_ocr_verification("transcription", true));
+        assert!(!uses_embedded_ocr_verification("missing", true));
+    }
+
+    #[test]
+    fn embedded_ocr_verification_json_uses_public_core_identity_and_version() {
+        let verification = core_ocr_verification_json(17);
+        assert_eq!(verification["schemaVersion"], 1);
+        assert_eq!(verification["capability"], "ocr");
+        assert_eq!(verification["source"], CORE_OCR_SOURCE);
+        assert_eq!(verification["sourceName"], "内置 OCR");
+        assert_eq!(verification["status"], "ready");
+        assert_eq!(verification["version"], env!("CARGO_PKG_VERSION"));
+        assert_eq!(verification["elapsedMs"], 17);
+        assert_eq!(verification["sharedCapabilities"], serde_json::json!(["ocr"]));
+        assert!(verification.get("plugin").is_none());
+        assert!(verification.get("pluginName").is_none());
     }
 
     #[test]

--- a/apps/cli/tests/exit_contract.rs
+++ b/apps/cli/tests/exit_contract.rs
@@ -73,6 +73,58 @@ fn run_with_stdin(arguments: &[&str], input: &[u8]) -> std::process::Output {
     child.wait_with_output().unwrap()
 }
 
+fn run_isolated_ocr_capability_verify() -> std::process::Output {
+    let temporary = tempfile::tempdir().unwrap();
+    let project = temporary.path().join("project");
+    let user_data = temporary.path().join("user-data");
+    let home = temporary.path().join("home");
+    std::fs::create_dir(&project).unwrap();
+    std::fs::create_dir(&home).unwrap();
+    #[cfg(windows)]
+    into_markdown_process_plugin::create_windows_plugin_store_directory(&user_data).unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::DirBuilderExt as _;
+        std::fs::DirBuilder::new().mode(0o700).create(&user_data).unwrap();
+    }
+    Command::new(binary())
+        .args(["--no-config", "capabilities", "verify", "ocr", "--json"])
+        .current_dir(project)
+        .env("APPDATA", &user_data)
+        .env("LOCALAPPDATA", &user_data)
+        .env_remove("XDG_CONFIG_HOME")
+        .env("HOME", home)
+        .env("INTO_MARKDOWN_USER_DATA_HOME", user_data)
+        .output()
+        .unwrap()
+}
+
+#[cfg(not(feature = "embedded-runtime"))]
+#[test]
+fn non_embedded_ocr_verification_retains_external_plugin_semantics() {
+    let output = run_isolated_ocr_capability_verify();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("unknown plugin 'official.ocr.ppocrv6'"),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[cfg(feature = "embedded-runtime")]
+#[test]
+fn embedded_ocr_verification_reports_the_public_core_identity() {
+    let output = run_isolated_ocr_capability_verify();
+    assert!(output.status.success(), "{}", String::from_utf8_lossy(&output.stderr));
+    let verification: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(verification["schemaVersion"], 1);
+    assert_eq!(verification["capability"], "ocr");
+    assert_eq!(verification["source"], "core:ocr");
+    assert_eq!(verification["status"], "ready");
+    assert_eq!(verification["version"], env!("CARGO_PKG_VERSION"));
+    assert!(verification.get("plugin").is_none());
+}
+
 #[test]
 fn real_cli_relabels_a_meeting_ir_without_running_transcription() {
     let directory = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- route `capabilities verify ocr` directly through the embedded OCR runtime in compact Core builds, without consulting or recording an external plugin
- report the public `core:ocr` source and the Core package version in embedded verification JSON while leaving the non-embedded plugin response unchanged
- add focused unit and real-CLI regression coverage for embedded and non-embedded verification semantics

## Tests

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p into-markdown-cli capability` (8 passed)
- `cargo test -p into-markdown-cli --test exit_contract` (16 passed)
- focused embedded routing/JSON and non-embedded real-CLI tests passed individually

## Additional gate attempts

- `cargo test -p into-markdown-cli --bin into-md`: 286 passed; the unrelated `web_tasks::tests::empty_result_tests::empty_source_and_empty_content_share_the_web_terminal_contract` assertion failed and also fails when rerun alone
- Bazel CLI targets were attempted twice but did not reach tests because the local Windows linker reported LNK1181 for a missing temporary `wasmtime_internal_component_macro` object

Fixes #302