### PR TITLE
fix(pptx): tolerate bounded ZIP tail whitespace in best-effort

### DIFF
--- a/crates/converters/src/presentation/mod.rs
+++ b/crates/converters/src/presentation/mod.rs
@@ -212,6 +212,17 @@ fn convert_presentation(
     let main_relationships = package.relationships(&main_part, options, context)?;
     let main_relationship_part = relationship_part(&main_part)?;
     let mut state = ParseState::default();
+    if package.trailing_whitespace_bytes != 0 {
+        state.diagnostics.push(Diagnostic {
+            code: "presentation.zipTrailingWhitespaceIgnored".into(),
+            severity: DiagnosticSeverity::Info,
+            message: format!(
+                "ignored {} whitespace byte(s) after ZIP end record and comment",
+                package.trailing_whitespace_bytes
+            ),
+            locator: None,
+        });
+    }
     if omitted_slide_references > 0 {
         state.diagnostics.try_reserve(1).map_err(|error| {
             limit("max_memory_bytes", format!("cannot reserve slide omission diagnostic: {error}"))

--- a/crates/converters/src/presentation/model.rs
+++ b/crates/converters/src/presentation/model.rs
@@ -90,11 +90,13 @@ pub(super) struct PackageOpenPlan {
     pub(super) entry_count: u32,
     pub(super) name_bytes: u64,
     pub(super) memory_charge: u64,
+    pub(super) archive_len: usize,
 }
 
 #[derive(Debug)]
 pub(super) struct Package<'a> {
     pub(super) source: &'a [u8],
+    pub(super) trailing_whitespace_bytes: usize,
     pub(super) entries: Vec<(String, EntryMetadata)>,
     // Lookup-only indexes are never iterated into output, so hash randomization cannot affect
     // conversion order. Fallible capacity admission precedes every new key.

--- a/crates/converters/src/presentation/opc_package.rs
+++ b/crates/converters/src/presentation/opc_package.rs
@@ -27,6 +27,8 @@ impl<'a> Package<'a> {
             return Err(ConversionError::Encrypted);
         }
         let plan = package_open_plan(bytes, options, context)?;
+        let trailing_whitespace_bytes = bytes.len() - plan.archive_len;
+        let bytes = &bytes[..plan.archive_len];
         // This reservation intentionally precedes `ZipArchive::new`: the raw, allocation-free
         // central-directory plan above bounds zip-rs's internal metadata materialization.
         let mut memory = context.reserve_memory(plan.memory_charge)?;
@@ -175,6 +177,7 @@ impl<'a> Package<'a> {
         })?;
         Ok(Self {
             source: bytes,
+            trailing_whitespace_bytes,
             entries,
             parts,
             content_types,

--- a/crates/converters/src/presentation/raw_zip.rs
+++ b/crates/converters/src/presentation/raw_zip.rs
@@ -1,20 +1,23 @@
 use super::budget::{PRESENTATION_ALLOCATION_BASE, ZIP_METADATA_BYTES_PER_ENTRY};
 use super::error::{limit, malformed};
 use super::model::PackageOpenPlan;
-use into_markdown_core::{ConversionError, ConversionOptions, ExecutionContext};
+use into_markdown_core::{ConversionError, ConversionOptions, ErrorPolicy, ExecutionContext};
 
-#[allow(clippy::too_many_lines)]
-fn zip_central_plan(
+const EOCD_BYTES: usize = 22;
+const MAX_COMMENT_BYTES: usize = 65_535;
+const MAX_TRAILING_WHITESPACE_BYTES: usize = 64;
+
+fn end_record(
     bytes: &[u8],
+    policy: ErrorPolicy,
     context: &ExecutionContext,
-) -> Result<(u32, u64, u64), ConversionError> {
-    const EOCD_BYTES: usize = 22;
-    const MAX_COMMENT_BYTES: usize = 65_535;
+) -> Result<(usize, usize), ConversionError> {
     if bytes.len() < EOCD_BYTES {
         return Err(malformed(None, "ZIP end record is missing"));
     }
-    let search_start = bytes.len().saturating_sub(EOCD_BYTES + MAX_COMMENT_BYTES);
-    let mut end_record = None;
+    let tail_limit =
+        if policy == ErrorPolicy::BestEffort { MAX_TRAILING_WHITESPACE_BYTES } else { 0 };
+    let search_start = bytes.len().saturating_sub(EOCD_BYTES + MAX_COMMENT_BYTES + tail_limit);
     for position in (search_start..=bytes.len() - EOCD_BYTES).rev() {
         if position.is_multiple_of(4096) {
             context.checkpoint()?;
@@ -23,14 +26,27 @@ fn zip_central_plan(
             continue;
         }
         let comment = usize::from(zip_u16(bytes, position + 20)?);
-        if position.checked_add(EOCD_BYTES).and_then(|end| end.checked_add(comment))
-            == Some(bytes.len())
+        let Some(end) = position.checked_add(EOCD_BYTES).and_then(|end| end.checked_add(comment))
+        else {
+            continue;
+        };
+        if let Some(tail) = bytes.get(end..)
+            && tail.len() <= tail_limit
+            && tail.iter().all(|byte| matches!(byte, b' ' | b'\t' | b'\r' | b'\n'))
         {
-            end_record = Some(position);
-            break;
+            return Ok((position, end));
         }
     }
-    let end_record = end_record.ok_or_else(|| malformed(None, "ZIP end record is invalid"))?;
+    Err(malformed(None, "ZIP end record is invalid"))
+}
+
+#[allow(clippy::too_many_lines)]
+fn zip_central_plan(
+    bytes: &[u8],
+    policy: ErrorPolicy,
+    context: &ExecutionContext,
+) -> Result<(u32, u64, u64, usize), ConversionError> {
+    let (end_record, archive_len) = end_record(bytes, policy, context)?;
     if zip_u16(bytes, end_record + 4)? != 0 || zip_u16(bytes, end_record + 6)? != 0 {
         return Err(malformed(None, "multi-disk ZIP archives are not supported"));
     }
@@ -124,7 +140,7 @@ fn zip_central_plan(
         .unwrap_or(u64::MAX)
         .checked_add(u64::from(zip_u16(bytes, end_record + 20)?))
         .ok_or_else(|| limit("max_memory_bytes", "ZIP variable metadata plan overflow"))?;
-    Ok((entry_count, name_bytes, variable_bytes))
+    Ok((entry_count, name_bytes, variable_bytes, archive_len))
 }
 
 fn zip_u16(bytes: &[u8], offset: usize) -> Result<u16, ConversionError> {
@@ -164,7 +180,8 @@ pub(super) fn package_open_plan(
             format!("{input_size} > {}", options.limits.max_input_bytes),
         ));
     }
-    let (entry_count, name_bytes, variable_bytes) = zip_central_plan(bytes, context)?;
+    let (entry_count, name_bytes, variable_bytes, archive_len) =
+        zip_central_plan(bytes, options.error_policy, context)?;
     if entry_count > options.limits.max_archive_entries {
         return Err(limit(
             "max_archive_entries",
@@ -177,5 +194,5 @@ pub(super) fn package_open_plan(
         .and_then(|value| value.checked_add(variable_bytes.checked_mul(2)?))
         .and_then(|value| value.checked_add(PRESENTATION_ALLOCATION_BASE))
         .ok_or_else(|| limit("max_memory_bytes", "ZIP metadata budget overflow"))?;
-    Ok(PackageOpenPlan { entry_count, name_bytes, memory_charge })
+    Ok(PackageOpenPlan { entry_count, name_bytes, memory_charge, archive_len })
 }

--- a/crates/converters/src/presentation/tests/mod.rs
+++ b/crates/converters/src/presentation/tests/mod.rs
@@ -5,3 +5,4 @@ mod geometry;
 mod inheritance;
 mod relationships;
 mod security;
+mod zip_tail;

--- a/crates/converters/src/presentation/tests/zip_tail.rs
+++ b/crates/converters/src/presentation/tests/zip_tail.rs
@@ -1,0 +1,85 @@
+use super::super::convert_presentation;
+use super::support::{corrupt_stored_entry, fixture};
+use into_markdown_core::{
+    ConversionError, ConversionOptions, ConverterOutput, DiagnosticSeverity, ErrorPolicy,
+    ExecutionContext, ExecutionOptions,
+};
+
+fn convert(bytes: &[u8], options: &ConversionOptions) -> Result<ConverterOutput, ConversionError> {
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    convert_presentation(bytes, options, &context)
+}
+
+fn presentation(comment: &[u8]) -> Vec<u8> {
+    let mut bytes = fixture(
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml",
+        &[],
+    );
+    let end = bytes.len();
+    bytes[end - 2..].copy_from_slice(&u16::try_from(comment.len()).unwrap().to_le_bytes());
+    bytes.extend_from_slice(comment);
+    bytes
+}
+
+#[test]
+fn trailing_lf_crlf_and_bounded_whitespace_preserve_content_and_zip_comments() {
+    let options = ConversionOptions { error_policy: ErrorPolicy::BestEffort, ..Default::default() };
+    let strict = ConversionOptions { error_policy: ErrorPolicy::Strict, ..Default::default() };
+    for comment in [Vec::new(), b"audit comment\r\n ".to_vec(), vec![b'x'; 65_535]] {
+        let original = presentation(&comment);
+        let expected = convert(&original, &options).unwrap();
+        assert!(convert(&original, &strict).is_ok());
+        for tail in [b"\n".as_slice(), b"\r\n", &[b' '; 64], b" \t\r\n"] {
+            let mut bytes = original.clone();
+            bytes.extend_from_slice(tail);
+            let mut actual = convert(&bytes, &options).unwrap();
+            assert_eq!(actual.document, expected.document);
+            assert_eq!(actual.assets, expected.assets);
+            let diagnostic = actual.diagnostics.remove(0);
+            assert_eq!(diagnostic.code, "presentation.zipTrailingWhitespaceIgnored");
+            assert_eq!(diagnostic.severity, DiagnosticSeverity::Info);
+            assert!(diagnostic.message.starts_with(&format!("ignored {} whitespace", tail.len())));
+            assert_eq!(actual.diagnostics, expected.diagnostics);
+            assert!(matches!(convert(&bytes, &strict), Err(ConversionError::Malformed { .. })));
+        }
+    }
+}
+
+#[test]
+fn non_whitespace_and_excessive_zip_tails_remain_malformed() {
+    let options = ConversionOptions { error_policy: ErrorPolicy::BestEffort, ..Default::default() };
+    for tail in [b"\0".as_slice(), b"\nX", b"\x0b", &[b'\n'; 65], b"PK\x05\x06"] {
+        let mut bytes = presentation(b"comment");
+        bytes.extend_from_slice(tail);
+        assert!(matches!(convert(&bytes, &options), Err(ConversionError::Malformed { .. })));
+    }
+}
+
+#[test]
+fn tolerated_tail_does_not_bypass_crc_central_directory_or_resource_limits() {
+    let options = ConversionOptions { error_policy: ErrorPolicy::BestEffort, ..Default::default() };
+    let original = presentation(b"");
+    let mut bad_crc = corrupt_stored_entry(original.clone(), "ppt/slides/slide1.xml");
+    bad_crc.push(b'\n');
+    assert!(matches!(convert(&bad_crc, &options), Err(ConversionError::Malformed { .. })));
+    let mut bad_central = original.clone();
+    let end = bad_central.len();
+    bad_central[end - 6..end - 2].copy_from_slice(&0_u32.to_le_bytes());
+    bad_central.push(b'\n');
+    assert!(matches!(convert(&bad_central, &options), Err(ConversionError::Malformed { .. })));
+
+    let mut bytes = original;
+    bytes.push(b'\n');
+    let mut limited = options.clone();
+    limited.limits.max_input_bytes = u64::try_from(bytes.len() - 1).unwrap();
+    assert!(matches!(
+        convert(&bytes, &limited),
+        Err(ConversionError::ResourceLimit { limit: "max_input_bytes", .. })
+    ));
+    limited = options;
+    limited.limits.max_archive_entries = 1;
+    assert!(matches!(
+        convert(&bytes, &limited),
+        Err(ConversionError::ResourceLimit { limit: "max_archive_entries", .. })
+    ));
+}


### PR DESCRIPTION
## Scope

Fixes #304.

Independent branch from main `8f98dc6c6c2fc683ab7d42641a284ce5e52b7a1e`. Only the PresentationML package opening path and its regression tests change; no dependencies, Actions, lint exemptions, or broader refactoring.

- Best-effort accepts at most 64 bytes of SP/TAB/CR/LF **after the declared EOCD and ZIP comment**. The existing bounded EOCD search grows by only that fixed allowance; no second conversion, archive copy, or reparsing is introduced.
- The validated archive slice excludes only that suffix. Emit one stable Info diagnostic, `presentation.zipTrailingWhitespaceIgnored`, including its byte count. Whitespace itself does not imply content loss; existing degradation diagnostics still determine the outcome.
- Strict remains exact-end-only. Non-whitespace, over-limit tails, central-directory validation, ZIP64 validation, CRC checks, encryption rejection, and resource limits retain their existing rejection paths. Input-size accounting includes the full original bytes.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked -p into-markdown-converters --lib presentation::tests::zip_tail -j 2` — 3 passed.
- `cargo test --locked -p into-markdown-converters --lib presentation::tests -j 2 -- --test-threads=1` — 42 passed, including existing security/encryption/CRC/resource-boundary tests.
- `cargo clippy --locked -p into-markdown-converters --lib --no-deps -j 2 -- -D warnings`
- `cargo build --locked -p into-markdown-cli --bin into-md -j 2`
- `git diff --check`

New tests cover LF, CRLF, mixed allowed whitespace, exact 64/65-byte boundary, empty/ordinary/maximum-length ZIP comments, strict rejection, non-whitespace rejection, corrupt CRC/central offset with LF, and full-input/archive-entry limits.

## Real corpus (OCR off, jobs=1)

Ran all 159 PPTX from the frozen schema-3 manifest against the baseline report supplied for #304, without modifying the source corpus or formal benchmark artifacts:

- **146 success / 13 failed**, versus baseline 143 / 16.
- All **143 prior successes** retain exact Markdown SHA-256, diagnostics, outcome, reasonCode and errorCode.
- All **13 independently invalid files** remain rejected with the same error/message/reason; no failed target exists.
- All 3 issue samples now succeed, original SHA-256 verified. Asset-extract result JSON matches a copy with only the final LF removed: exact Document (including order/geometry), Markdown, assets, and all other diagnostics. Strict still reports malformed and leaves no output.

| Original sample | Slides in order | Extracted assets | Quality outcome (asset omit) |
| --- | ---: | ---: | --- |
| `ca.ubc.cs.people_~emhill_presentations_HowWeRefactor.pptx` | 28 | 13 | complete |
| `bug62513.pptx` | 19 | 1 | degraded: existing `office.extensionOmitted` |
| `au.asn.aes.www_conferences_2011_presentations_Fri_20Room4Level4_20930_20Maloney.pptx` | 28 | 7 | degraded: existing `presentation.externalRelationshipsOmitted` |

Local reproducible evidence is in `C:\Users\19321\Documents\workspace\into-markdown-issue304-validation` (`validate.ps1`, `summary.json`, `quality-report.json`, `samples.ps1`, `samples-summary.json`, per-sample outputs). Large source fixtures/results are deliberately not committed.

## Limits / handoff

This is a debug-build correctness run, **not a timing/RSS benchmark**; formal fair performance measurement stays with the coordinating task. Compatibility is deliberately limited to 64 explicitly allowed ASCII whitespace bytes, not arbitrary ZIP suffixes. Independent review is requested before merge; this task does not merge the PR.
