### PR TITLE
fix(rtf): support standard charsets and defer unused font decoding

### DIFF
--- a/crates/converters/src/msg/tests.rs
+++ b/crates/converters/src/msg/tests.rs
@@ -219,6 +219,20 @@ fn builtin_rtf_bodies_reuse_context_without_forging_decoded_byte_offsets() {
 }
 
 #[test]
+fn builtin_rtf_body_preserves_european_font_encodings() {
+    let raw = b"{\\rtf1\\ansi{\\fonttbl{\\f0\\fcharset238 CE;}{\\f1\\fcharset204 Cyrillic;}{\\f2\\fcharset999 Unused;}}\\f0 \\'bf\\f1 \\'d3\\uc1\\u1078?}";
+    for envelope in [lzfu_compressed_literals(raw), lzfu_uncompressed(raw)] {
+        let bytes = message(vec![], vec![], None, None, Some(&envelope));
+        let options = ConversionOptions::default();
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let output = convert_msg(&bytes, &options, &context, &BuiltinBodyAdapter).unwrap();
+        assert_eq!(output.document.metadata.properties["msg.body_kind"], "rtf");
+        assert!(paragraph_text(&output).contains("żУж"));
+        assert!(!paragraph_text(&output).contains('\u{fffd}'));
+    }
+}
+
+#[test]
 fn corrupt_and_adversarial_cfb_fail_closed_without_panics() {
     let valid = message(vec![], vec![], Some("body"), None, None);
     let mut cases = vec![valid[..valid.len() - 17].to_vec()];

--- a/crates/converters/src/rtf/control.rs
+++ b/crates/converters/src/rtf/control.rs
@@ -6,7 +6,7 @@ use super::parser::{
     CellMerge, Destination, FontCharset, MAX_CONTROL_WORD_LEN, MAX_CONTROLS, MAX_NUMERIC_DIGITS,
     MAX_RTF_FONTS, Parser,
 };
-use super::text::{encoding_for_codepage, font_charset_codepage};
+use super::text::encoding_for_codepage;
 use into_markdown_core::{ConversionError, DiagnosticSeverity, Inline};
 
 impl Parser<'_> {
@@ -130,9 +130,6 @@ impl Parser<'_> {
                 "fcharset" => {
                     let charset = parameter_u16(parameter, "font charset")?;
                     if let Some(font) = self.font_table_font {
-                        let codepage = font_charset_codepage(charset).ok_or_else(|| {
-                            malformed(format!("unsupported RTF font charset {charset}"))
-                        })?;
                         if self.font_charsets.len() >= MAX_RTF_FONTS {
                             return Err(limit("rtf_font_count", format!(">= {MAX_RTF_FONTS}")));
                         }
@@ -140,7 +137,7 @@ impl Parser<'_> {
                             limit("rtf_font_count", "font definition order overflow")
                         })?;
                         reserve_vec(&mut self.font_charsets, 1, &mut self.memory)?;
-                        self.font_charsets.push(FontCharset { font, codepage, order });
+                        self.font_charsets.push(FontCharset { font, charset, order });
                     }
                 }
                 _ => {}

--- a/crates/converters/src/rtf/parser.rs
+++ b/crates/converters/src/rtf/parser.rs
@@ -140,7 +140,7 @@ pub(super) struct Field {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct FontCharset {
     pub(super) font: i32,
-    pub(super) codepage: u16,
+    pub(super) charset: u16,
     pub(super) order: u32,
 }
 

--- a/crates/converters/src/rtf/tests.rs
+++ b/crates/converters/src/rtf/tests.rs
@@ -61,6 +61,66 @@ fn codepages_font_charset_surrogates_and_unicode_fallback_are_deterministic() {
 }
 
 #[test]
+fn standard_european_and_utf8_codepages_preserve_raw_and_hex_text() {
+    for (codepage, encoding, expected) in [
+        (1250, encoding_rs::WINDOWS_1250, "zażółć gęślą jaźń"),
+        (1251, encoding_rs::WINDOWS_1251, "Уважаемый клиент!"),
+        (65001, encoding_rs::UTF_8, "Zażółć — Привет 中文"),
+    ] {
+        let (encoded, _, errors) = encoding.encode(expected);
+        assert!(!errors);
+        let prefix = format!("{{\\rtf1\\ansi\\ansicpg{codepage} ");
+        let mut raw = prefix.as_bytes().to_vec();
+        raw.extend_from_slice(&encoded);
+        raw.push(b'}');
+        let mut escaped = prefix;
+        for byte in encoded.iter() {
+            write!(&mut escaped, "\\'{byte:02x}").unwrap();
+        }
+        escaped.push('}');
+        for source in [raw.as_slice(), escaped.as_bytes()] {
+            let output = convert(source).unwrap();
+            assert_eq!(paragraph_text(&output), expected);
+            assert!(
+                !output
+                    .diagnostics
+                    .iter()
+                    .any(|item| { item.code == "rtf.invalidByteSequenceReplaced" })
+            );
+        }
+    }
+}
+
+#[test]
+fn european_font_switches_restore_encoding_and_skip_unicode_fallback() {
+    let output = convert(
+        b"{\\rtf1\\ansi{\\fonttbl{\\f0\\fcharset0 Arial;}{\\f1\\fcharset238 Arial CE;}{\\f2\\fcharset204 Arial Cyr;}}\\f1 \\'bf{\\f2 \\'d3\\uc1\\u1078?}\\'f3{\\f0 \\'e9}\\'b3}",
+    )
+    .unwrap();
+    assert_eq!(paragraph_text(&output), "żУжóéł");
+}
+
+#[test]
+fn unused_font_charsets_do_not_require_a_decoder() {
+    let output = convert(
+        b"{\\rtf1\\ansi{\\fonttbl{\\f0\\fcharset0 Arial;}{\\f1\\fcharset161 Greek;}{\\f2\\fcharset999 Unknown;}}\\f0 \\'e9{\\f2\\uc1\\u20013?} text}",
+    )
+    .unwrap();
+    assert_eq!(paragraph_text(&output), "é中 text");
+    assert!(
+        !output.diagnostics.iter().any(|item| { item.code == "rtf.invalidByteSequenceReplaced" })
+    );
+
+    for source in [
+        b"{\\rtf1\\ansi{\\fonttbl{\\f2\\fcharset999 Unknown;}}\\f2 \\'e9}".as_slice(),
+        b"{\\rtf1\\ansi{\\fonttbl{\\f2\\fcharset999 Unknown;}}\\f2 text}".as_slice(),
+        b"{\\rtf1\\ansi\\ansicpg999 text}".as_slice(),
+    ] {
+        assert_eq!(convert(source).unwrap_err().code(), ErrorCode::Malformed);
+    }
+}
+
+#[test]
 fn active_destinations_are_skipped() {
     let output =
         convert(b"{\\rtf1\\ansi before{\\object{\\*\\objdata 0102}{\\result BAD}}after\\par}")

--- a/crates/converters/src/rtf/text.rs
+++ b/crates/converters/src/rtf/text.rs
@@ -2,7 +2,9 @@
 
 use super::budget::{hex, limit, locator, malformed, reserve_string, reserve_vec};
 use super::parser::{CHECKPOINT_INTERVAL, Destination, MAX_METADATA_BYTES, Parser};
-use encoding_rs::{BIG5, Encoding, GBK, SHIFT_JIS, WINDOWS_1252};
+use encoding_rs::{
+    BIG5, Encoding, GBK, SHIFT_JIS, UTF_8, WINDOWS_1250, WINDOWS_1251, WINDOWS_1252,
+};
 use into_markdown_core::{
     ConversionError, DiagnosticSeverity, Inline, InlineMark, MAX_DOCUMENT_INLINES,
 };
@@ -10,7 +12,9 @@ use into_markdown_core::{
 impl Parser<'_> {
     pub(super) fn plain_text(&mut self) -> Result<(), ConversionError> {
         let start = self.offset;
-        let codepage = self.current_codepage();
+        // Unknown font declarations are harmless until text uses their encoding.
+        // Zero only disables DBCS token scanning; emit_ansi still rejects decoding.
+        let codepage = self.current_codepage().unwrap_or(0);
         while self.offset < self.bytes.len() {
             let byte = self.bytes[self.offset];
             if self.state().destination != Destination::Pict
@@ -95,8 +99,11 @@ impl Parser<'_> {
             return Ok(());
         }
         let codepage = self.current_codepage();
-        let (skip, skipped_units) =
-            skip_ansi_units(bytes, codepage, self.state().fallback_remaining);
+        let (skip, skipped_units) = skip_ansi_units(
+            bytes,
+            codepage.as_ref().copied().unwrap_or(0),
+            self.state().fallback_remaining,
+        );
         self.state_mut().fallback_remaining =
             self.state().fallback_remaining.saturating_sub(skipped_units);
         let bytes = &bytes[skip..];
@@ -104,7 +111,7 @@ impl Parser<'_> {
             return Ok(());
         }
         self.flush_pending_surrogate()?;
-        let encoding = encoding_for_codepage(codepage)?;
+        let encoding = encoding_for_codepage(codepage?)?;
         if !bytes.is_ascii() {
             let decode_bound = u64::try_from(bytes.len())
                 .unwrap_or(u64::MAX)
@@ -273,12 +280,16 @@ impl Parser<'_> {
         Ok(marks)
     }
 
-    pub(super) fn current_codepage(&self) -> u16 {
-        self.font_charsets
+    pub(super) fn current_codepage(&self) -> Result<u16, ConversionError> {
+        let selected = self
+            .font_charsets
             .binary_search_by_key(&self.state().font, |entry| entry.font)
             .ok()
-            .and_then(|index| self.font_charsets.get(index))
-            .map_or(self.state().ansi_codepage, |entry| entry.codepage)
+            .and_then(|index| self.font_charsets.get(index));
+        selected.map_or(Ok(self.state().ansi_codepage), |entry| {
+            font_charset_codepage(entry.charset)
+                .ok_or_else(|| malformed(format!("unsupported RTF font charset {}", entry.charset)))
+        })
     }
 }
 
@@ -323,7 +334,10 @@ fn skip_ansi_units(bytes: &[u8], codepage: u16, maximum: u8) -> (usize, u8) {
 
 pub(super) fn encoding_for_codepage(codepage: u16) -> Result<&'static Encoding, ConversionError> {
     match codepage {
+        1250 => Ok(WINDOWS_1250),
+        1251 => Ok(WINDOWS_1251),
         1252 => Ok(WINDOWS_1252),
+        65001 => Ok(UTF_8),
         936 => Ok(GBK),
         950 => Ok(BIG5),
         932 => Ok(SHIFT_JIS),
@@ -337,6 +351,8 @@ pub(super) fn font_charset_codepage(charset: u16) -> Option<u16> {
         128 => Some(932),
         134 => Some(936),
         136 => Some(950),
+        204 => Some(1251),
+        238 => Some(1250),
         _ => None,
     }
 }


### PR DESCRIPTION
Closes #308. #309 is intentionally not implemented here; MSG's shared RTF-body path is covered, while CFB compatibility waits for this PR's independent review and merge.

## Narrow change

- Add codepages 1250 (Windows Central European), 1251 (Windows Cyrillic), and 65001 (UTF-8) using existing `encoding_rs`; map font charsets 238 -> 1250 and 204 -> 1251.
- Retain bounded font declarations as raw charset metadata and resolve the selected charset only when emitted ANSI text actually needs decoding. Unused declarations and Unicode-only runs with skipped fallback need no decoder. An unsupported selected charset still fails with a malformed error; it is never guessed as 1252.
- Cover raw/hex text, scoped font switching, Unicode fallback, unused/selected unknown fonts, and both compressed/uncompressed MSG RTF bodies through the existing shared parser.
- Five converter files only, +102/-15. No dependencies, Cargo/Bazel lock changes, workflow changes, filename special cases, parser copies, or general recovery framework.

## Exact revision and local checks

Head: `7e058fc21dea3bc9592a93bc3781f2063d038a6a`

Base: `a6cb5e227de78b51fe6dc5dc5a680dba90f78c51` (main at worktree creation). Worktree is clean after the commit. No self-review approval is asserted; parent agent owns independent review. Do not merge as part of this task.

Passed on this exact head:

```text
cargo fmt --all --check
cargo clippy --locked -j 2 -p into-markdown-converters --all-targets -- -D warnings
cargo test --locked -j 2 -p into-markdown-converters --lib --quiet
cargo test --locked -j 2 -p into-markdown-converters --all-targets --quiet
cargo build --locked -j 2 -p into-markdown-cli --bin into-md
git diff --check
```

Library: 542 passed, 0 failed, 1 existing PDFium-dependent test ignored. All-targets also includes the existing explicitly ignored pinned-PDFium layout integration target (0 failures). The library includes 33 RTF tests and the compressed/uncompressed MSG-body regression, plus legacy DOC/PPT/XLS/shared OLE coverage. No other package build/test was requested beyond necessary dependency compilation. Build concurrency was `-j 2`; real conversions used `--jobs 1`. `[skip ci]` keeps this local-only verification round from starting the PR Actions workflow; no manual Actions dispatch was made.

## Read-only real-corpus regression

44 RTF files rerun using the original quality profile: `--no-config --ocr off --asset-mode omit --error-policy best-effort --jobs 1 --max-temporary-size 4294967296 --log-format json`.

This is a debug coverage/quality run, **not final performance timing**. The debug CLI built again at the committed head has the exact same SHA-256 as the regression binary: `dd669cc6d8446f0a09e051eaf253015eec827f45c554c0f022973f8855f9315a`.

- Successful nonempty output: **11/44 -> 25/44** (+14); 19 remain rejected.
- All 11 previous successful Markdown outputs are byte-identical. All 14 newly successful outputs contain no U+FFFD. The pre-existing `testRTFInvalidUnicode.rtf` unpaired-surrogate replacements are unchanged; no claim is made that this previously accepted fixture is lossless.
- Representative newly recovered text includes `Уважаемый клиент!`, `zażółć gęślą jaźń` / its uppercase form, and the identical Czech paragraphs from Word and WordPad sources.
- All 23 initial charset/codepage-whitelist errors are gone. Fourteen succeed and nine now reach existing structural/content rejection. Both real `ansicpg65001` samples still fail for non-whitespace data after the root group; valid UTF-8 raw/hex fixtures pass. No tail-data relaxation was added.
- The remaining 19 failures are: root trailing data 5, table cell outside row 3, no usable content 3, list identity without marker 2, nested field 1, paragraph interrupting field 1, unknown list marker 1, forbidden control scalar 1, unterminated group 1, signed-16-bit Unicode resource limit 1. These are observed rejection reasons, not a blanket assertion that every source is invalid.
- SHA-256 checks before/after authenticated 138 paths: the 44 original inputs, 44 staged inputs, 44 actual cohort inputs, manifest, both current raw JSONLs, both state files, and the old RTF native report. All unchanged. Existing benchmark outputs were only read for hash comparisons. No original dataset was modified.

Independent evidence directory: `C:\im-bench-004\issue308-rtf-20260831\validated` (native report, per-file comparisons, full matrix, before/after hashes, fmt/clippy/test/build logs). Reproduction script: `C:\im-bench-004\issue308-rtf-20260831\run-regression.ps1`. The script refuses report overwrites; its first exploratory attempt is kept separately and is not the authoritative report.

Manifest SHA-256: `7f82792dca7d1011d8a1bbcdfe7de5b4f0c463515be347405d0c88a6b866cacc`

Baseline current fingerprint: `f7f3521c0fe9992ae2ec76fd7e6a402b2b3fc72480c379e91badb35e30555c4d`

Candidate current fingerprint: `75af809153636b33888f281ca408765982d6b3c39a0a41945d9502f40034fbac`

## Full-format matrix (2289 manifest entries)

Each historical column is filtered to its state file's current fingerprint and authenticated as exactly 2289 unique terminal IDs. **Only RTF was rerun on this patch.** All other patch-overlay values are carried forward from the candidate evidence, not newly executed coverage or a claim about unrelated main fixes. MSG remains 0/55 in that historical evidence; #309 is separate. Counts below are successes; failures are total minus successes.

| Extension | Total | Baseline | Candidate | Patch overlay |
|---|---:|---:|---:|---:|
| atom | 2 | 2 | 2 | 2 |
| bmp | 1 | 1 | 1 | 1 |
| csv | 13 | 11 | 11 | 11 |
| doc | 221 | 107 | 106 | 106 |
| docm | 5 | 5 | 5 | 5 |
| docx | 250 | 200 | 207 | 207 |
| epub | 7 | 0 | 4 | 4 |
| flac | 3 | 0 | 0 | 0 |
| html | 35 | 20 | 20 | 20 |
| ipynb | 5 | 5 | 5 | 5 |
| jpg | 14 | 13 | 13 | 13 |
| json | 96 | 94 | 94 | 94 |
| m4a | 8 | 0 | 0 | 0 |
| md | 3 | 3 | 3 | 3 |
| mkv | 1 | 0 | 0 | 0 |
| mov | 2 | 0 | 0 | 0 |
| mp3 | 27 | 0 | 0 | 0 |
| mp4 | 9 | 0 | 0 | 0 |
| msg | 55 | 0 | 0 | 0 |
| odp | 9 | 0 | 0 | 0 |
| ods | 7 | 0 | 0 | 0 |
| odt | 20 | 3 | 0 | 0 |
| ogg | 4 | 0 | 0 | 0 |
| pdf | 108 | 93 | 93 | 93 |
| png | 6 | 6 | 6 | 6 |
| pot | 1 | 1 | 1 | 1 |
| potx | 1 | 1 | 1 | 1 |
| pps | 1 | 1 | 1 | 1 |
| ppsm | 2 | 2 | 2 | 2 |
| ppsx | 2 | 2 | 2 | 2 |
| ppt | 200 | 124 | 124 | 124 |
| pptm | 5 | 5 | 5 | 5 |
| pptx | 159 | 143 | 143 | 143 |
| rss | 3 | 1 | 1 | 1 |
| **rtf (rerun)** | **44** | **11** | **11** | **25** |
| tif | 3 | 2 | 2 | 2 |
| tsv | 1 | 1 | 1 | 1 |
| txt | 16 | 14 | 14 | 14 |
| wav | 1 | 0 | 0 | 0 |
| webm | 1 | 0 | 0 | 0 |
| webp | 3 | 3 | 3 | 3 |
| xls | 452 | 264 | 395 | 395 |
| xlsb | 16 | 0 | 0 | 0 |
| xlsm | 15 | 7 | 13 | 13 |
| xlsx | 406 | 233 | 367 | 367 |
| xml | 29 | 27 | 27 | 27 |
| zip | 17 | 6 | 7 | 7 |
