### PR TITLE
fix(pdf): skip unused image pixels and recognize BOM-prefixed PDF

### DIFF
--- a/crates/converters/src/lib.rs
+++ b/crates/converters/src/lib.rs
@@ -890,7 +890,7 @@ fn detect_content(
 }
 
 fn magic_candidate(bytes: &[u8]) -> Option<FormatCandidate> {
-    let (format, confidence, evidence) = if bytes.starts_with(b"%PDF-") {
+    let (format, confidence, evidence) = if pdf::has_pdf_header(bytes) {
         (InputFormat::Pdf, 0.99, "PDF magic bytes")
     } else if rtf::strict_header(bytes).is_some() {
         (InputFormat::Rtf, 0.99, "RTF signature")

--- a/crates/converters/src/pdf/mod.rs
+++ b/crates/converters/src/pdf/mod.rs
@@ -32,10 +32,11 @@ use geometry::normalize_point;
 use ir::character_ir_allocation_bytes;
 
 use into_markdown_core::{
-    Asset, AssetId, Block, BlockNode, BoxFuture, ConversionError, ConversionOptions, Converter,
-    ConverterOutput, Diagnostic, DiagnosticSeverity, Document, ErrorPolicy, ExecutionContext,
-    FormatCandidate, Inline, InputFormat, NodeId, OcrPolicy, ProbeOutcome, Provenance,
-    ProvenanceKind, Rect, ResolvedInput, ResourceReservation, Services, SourceLocator,
+    AiMode, Asset, AssetId, AssetMode, Block, BlockNode, BoxFuture, ConversionError,
+    ConversionOptions, Converter, ConverterOutput, Diagnostic, DiagnosticSeverity, Document,
+    ErrorPolicy, ExecutionContext, FormatCandidate, Inline, InputFormat, NodeId, OcrPolicy,
+    ProbeOutcome, Provenance, ProvenanceKind, Rect, ResolvedInput, ResourceReservation, Services,
+    SourceLocator,
 };
 use into_markdown_pdfium::{
     Bitmap, Character, Error as PdfiumError, ImageBitmap, Limits, LinkTarget, PageInfo, PdfRect,
@@ -58,6 +59,29 @@ const MAX_PAGE_RENDER_DIMENSION: u32 = 4096;
 static PDF_CONVERSION_GATE: OnceLock<Mutex<()>> = OnceLock::new();
 type PdfiumRuntimeResolver = fn() -> Result<PathBuf, ConversionError>;
 static PDFIUM_RUNTIME_RESOLVER: OnceLock<PdfiumRuntimeResolver> = OnceLock::new();
+
+#[cfg(test)]
+thread_local! {
+    static IMAGE_BITMAP_MATERIALIZATIONS: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+pub(crate) fn has_pdf_header(bytes: &[u8]) -> bool {
+    bytes.strip_prefix(b"\xef\xbb\xbf").unwrap_or(bytes).starts_with(b"%PDF-")
+}
+
+fn image_pixels_required(options: &ConversionOptions) -> bool {
+    options.output.asset_mode != AssetMode::Omit
+        || options.ocr.policy != OcrPolicy::Off
+        || [
+            options.ai.vision_ocr,
+            options.ai.image_description,
+            options.ai.layout_repair,
+            options.ai.table_repair,
+            options.ai.formula_repair,
+        ]
+        .iter()
+        .any(|mode| *mode != AiMode::Off)
+}
 
 fn request_path_scan<T>(
     context: &ExecutionContext,
@@ -277,7 +301,7 @@ impl Converter for PdfConverter {
     ) -> BoxFuture<'a, Result<ProbeOutcome, ConversionError>> {
         Box::pin(async move {
             context.checkpoint()?;
-            Ok(if candidate.format == InputFormat::Pdf && input.bytes.starts_with(b"%PDF-") {
+            Ok(if candidate.format == InputFormat::Pdf && has_pdf_header(&input.bytes) {
                 ProbeOutcome::Match { confidence: 1.0 }
             } else {
                 ProbeOutcome::NotApplicable
@@ -357,6 +381,7 @@ fn convert_pdf(
     let mut total_inlines = 0_usize;
     let mut total_page_objects = 0_usize;
     let mut retained_memory = Vec::new();
+    let retain_image_pixels = image_pixels_required(options);
     let path_page_capacity =
         allocation_capacity_bound(usize::try_from(pdf.page_count()).unwrap_or(usize::MAX))?;
     let path_page_bytes = path_page_capacity
@@ -550,34 +575,43 @@ fn convert_pdf(
             context.checkpoint()?;
             let bounds = normalize_rect(image.bounds(), &info)?;
             coverage.add(bounds, &info);
-            let bitmap_plan = image.plan_bitmap().map_err(map_pdfium_error)?;
-            let bitmap_plan_bytes = bitmap_plan.allocation_bytes();
-            let (bitmap, bitmap_memory) =
-                materialize_after_reserve(context, bitmap_plan_bytes, || {
-                    bitmap_plan.materialize().map_err(map_pdfium_error)
-                })?;
-            let (encoded, encoded_memory) = image_bitmap_to_bmp(&bitmap, options, context)?;
-            drop(bitmap);
-            drop(bitmap_memory);
-            account_asset(&encoded, &mut total_asset_bytes, options)?;
-            retain_output_bytes(context, &mut retained_memory, asset_record_overhead()?)?;
-            let id = content_asset_id("pdf-image", &encoded)?;
-            asset_ids
-                .try_reserve(1)
-                .map_err(|_| resource("max_memory_bytes", "asset ID allocation failed"))?;
-            if asset_ids.insert(id.clone()) {
-                retain_existing_reservation(context, &mut retained_memory, encoded_memory)?;
-                assets.try_reserve(1).map_err(|_| {
-                    resource("max_memory_bytes", "asset inventory allocation failed")
-                })?;
-                assets.push(Asset {
-                    id: AssetId(id.clone()),
-                    filename: Some(format!("{id}.bmp")),
-                    media_type: "image/bmp".into(),
-                    bytes: encoded,
-                    external_uri: None,
-                });
-            }
+            let id = if retain_image_pixels {
+                #[cfg(test)]
+                IMAGE_BITMAP_MATERIALIZATIONS.set(IMAGE_BITMAP_MATERIALIZATIONS.get() + 1);
+                let bitmap_plan = image.plan_bitmap().map_err(map_pdfium_error)?;
+                let bitmap_plan_bytes = bitmap_plan.allocation_bytes();
+                let (bitmap, bitmap_memory) =
+                    materialize_after_reserve(context, bitmap_plan_bytes, || {
+                        bitmap_plan.materialize().map_err(map_pdfium_error)
+                    })?;
+                let (encoded, encoded_memory) = image_bitmap_to_bmp(&bitmap, options, context)?;
+                drop(bitmap);
+                drop(bitmap_memory);
+                account_asset(&encoded, &mut total_asset_bytes, options)?;
+                retain_output_bytes(context, &mut retained_memory, asset_record_overhead()?)?;
+                let id = content_asset_id("pdf-image", &encoded)?;
+                asset_ids
+                    .try_reserve(1)
+                    .map_err(|_| resource("max_memory_bytes", "asset ID allocation failed"))?;
+                if asset_ids.insert(id.clone()) {
+                    retain_existing_reservation(context, &mut retained_memory, encoded_memory)?;
+                    assets.try_reserve(1).map_err(|_| {
+                        resource("max_memory_bytes", "asset inventory allocation failed")
+                    })?;
+                    assets.push(Asset {
+                        id: AssetId(id.clone()),
+                        filename: Some(format!("{id}.bmp")),
+                        media_type: "image/bmp".into(),
+                        bytes: encoded,
+                        external_uri: None,
+                    });
+                }
+                id
+            } else {
+                // Preserve image geometry through reading-order reconstruction.
+                // This transient reference is removed before publishing the IR.
+                "pdf-omitted-image".into()
+            };
             total_nodes = checked_count(
                 total_nodes,
                 1,
@@ -707,6 +741,13 @@ fn convert_pdf(
     drop(path_evidence);
     drop(path_memory);
     document = rebuilt_document;
+    if !retain_image_pixels {
+        for page in &mut document.blocks {
+            if let Block::Page { blocks, .. } = &mut page.block {
+                blocks.retain(|node| !matches!(node.block, Block::Image { .. }));
+            }
+        }
+    }
     if let Some(reservation) = layout_reservation {
         retain_existing_reservation(context, &mut retained_memory, reservation)?;
     }

--- a/crates/converters/src/pdf/tests.rs
+++ b/crates/converters/src/pdf/tests.rs
@@ -6,6 +6,156 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 static TEMPORARY_SEQUENCE: AtomicUsize = AtomicUsize::new(1);
 
+#[test]
+fn direct_pdf_probe_accepts_only_the_header_or_one_utf8_bom() {
+    let context = ExecutionContext::new(
+        into_markdown_core::ExecutionOptions::default(),
+        into_markdown_core::ResourceLimits::default(),
+    );
+    let candidate = FormatCandidate::new(InputFormat::Pdf, 1.0, "test PDF");
+    for (bytes, accepted) in [
+        (b"%PDF-1.7\n".to_vec(), true),
+        (b"\xef\xbb\xbf%PDF-1.7\n".to_vec(), true),
+        (b"\xef\xbb\xbf\xef\xbb\xbf%PDF-1.7\n".to_vec(), false),
+        (b" %PDF-1.7\n".to_vec(), false),
+        ([vec![0; 174], b"%PDF-1.7\n".to_vec()].concat(), false),
+    ] {
+        assert_eq!(
+            crate::magic_candidate(&bytes).is_some_and(|found| found.format == InputFormat::Pdf),
+            accepted
+        );
+        let input = ResolvedInput { bytes: Arc::from(bytes), metadata: SourceMetadata::default() };
+        let outcome = futures::executor::block_on(
+            PdfConverter::default().probe(&input, &candidate, &context),
+        )
+        .unwrap();
+        assert_eq!(matches!(outcome, ProbeOutcome::Match { .. }), accepted);
+    }
+}
+
+#[test]
+fn only_omitted_images_without_pixel_consumers_skip_materialization() {
+    let mut options = ConversionOptions::default();
+    for asset_mode in [AssetMode::Omit, AssetMode::Extract, AssetMode::Embed] {
+        for policy in [OcrPolicy::Off, OcrPolicy::Auto, OcrPolicy::Always] {
+            options.output.asset_mode = asset_mode;
+            options.ocr.policy = policy;
+            assert_eq!(
+                image_pixels_required(&options),
+                asset_mode != AssetMode::Omit || policy != OcrPolicy::Off
+            );
+        }
+    }
+    options.output.asset_mode = AssetMode::Omit;
+    options.ocr.policy = OcrPolicy::Off;
+    for mode in [AiMode::Fallback, AiMode::Prefer, AiMode::Only] {
+        for field in 0..5 {
+            let mut visual = options.clone();
+            match field {
+                0 => visual.ai.vision_ocr = mode,
+                1 => visual.ai.image_description = mode,
+                2 => visual.ai.layout_repair = mode,
+                3 => visual.ai.table_repair = mode,
+                _ => visual.ai.formula_repair = mode,
+            }
+            assert!(image_pixels_required(&visual));
+        }
+    }
+}
+
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn native_omit_off_skips_bitmap_work_and_preserves_native_text_order() {
+    let path = PathBuf::from(std::env::var_os("PDFIUM_LIBRARY").expect("PDFIUM_LIBRARY"));
+    let input = ResolvedInput {
+        bytes: Arc::from(one_page_fixture(
+            b"BT /F1 8 Tf 10 160 Td (Before) Tj ET\nq 100 0 0 200 0 0 cm /Im1 Do Q\nBT /F1 8 Tf 65 145 Td (Beside) Tj ET\nBT /F1 8 Tf 10 130 Td (After) Tj ET\n",
+            true,
+        )),
+        metadata: SourceMetadata::default(),
+    };
+    let mut expected = None;
+    for asset_mode in [AssetMode::Omit, AssetMode::Extract, AssetMode::Embed] {
+        for policy in [OcrPolicy::Off, OcrPolicy::Auto, OcrPolicy::Always] {
+            let mut options = ConversionOptions::default();
+            options.output.asset_mode = asset_mode;
+            options.ocr.policy = policy;
+            let context = ExecutionContext::new(
+                into_markdown_core::ExecutionOptions::default(),
+                options.limits.clone(),
+            );
+            IMAGE_BITMAP_MATERIALIZATIONS.set(0);
+            let output = convert_pdf(&path, &input, &options, &context).unwrap();
+            let skipped = asset_mode == AssetMode::Omit && policy == OcrPolicy::Off;
+            assert_eq!(IMAGE_BITMAP_MATERIALIZATIONS.get(), usize::from(!skipped));
+            assert_eq!(output.assets.is_empty(), skipped);
+            assert_eq!(
+                output.assets.iter().any(|asset| asset.id.0.starts_with("pdf-page-render-")),
+                policy == OcrPolicy::Always
+            );
+            options.output.asset_mode = AssetMode::Omit;
+            let markdown =
+                into_markdown_render_markdown::render(&output.document, &output.assets, &options)
+                    .unwrap();
+            let before = markdown.find("Before").expect("first native body line");
+            let beside = markdown.find("Beside").expect("native body in second column");
+            let after = markdown.find("After").expect("last native body line");
+            assert!(before < beside && beside < after, "{markdown}");
+            assert!(output.document.blocks.iter().all(|page| {
+                let Block::Page { blocks, .. } = &page.block else { return false };
+                !skipped || blocks.iter().all(|node| !matches!(node.block, Block::Image { .. }))
+            }));
+            if policy != OcrPolicy::Always {
+                assert_eq!(expected.get_or_insert_with(|| markdown.clone()), &markdown);
+            }
+            drop(output);
+            assert_eq!(context.reserved_memory_bytes(), 0);
+        }
+    }
+
+    let mut options = ConversionOptions::default();
+    options.output.asset_mode = AssetMode::Omit;
+    options.ocr.policy = OcrPolicy::Off;
+    options.limits.max_asset_bytes = 1;
+    options.limits.max_total_asset_bytes = 1;
+    let context = ExecutionContext::new(
+        into_markdown_core::ExecutionOptions::default(),
+        options.limits.clone(),
+    );
+    assert!(convert_pdf(&path, &input, &options, &context).unwrap().assets.is_empty());
+    let scanned_input =
+        ResolvedInput { bytes: Arc::from(scanned_pdf()), metadata: SourceMetadata::default() };
+    let scanned = convert_pdf(&path, &scanned_input, &options, &context).unwrap();
+    assert!(scanned.assets.is_empty());
+    assert!(scanned.diagnostics.iter().any(|diagnostic| diagnostic.code == "pdf.scannedPage"));
+    drop(scanned);
+    options.output.asset_mode = AssetMode::Extract;
+    assert!(matches!(
+        convert_pdf(&path, &input, &options, &context),
+        Err(ConversionError::ResourceLimit { .. })
+    ));
+    assert_eq!(context.reserved_memory_bytes(), 0);
+}
+
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn native_bom_pdf_reaches_pdfium_without_rewriting_original_offsets() {
+    let path = PathBuf::from(std::env::var_os("PDFIUM_LIBRARY").expect("PDFIUM_LIBRARY"));
+    let original = [b"\xef\xbb\xbf".as_slice(), &text_only_pdf()].concat();
+    let input =
+        ResolvedInput { bytes: Arc::from(original.clone()), metadata: SourceMetadata::default() };
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(
+        into_markdown_core::ExecutionOptions::default(),
+        options.limits.clone(),
+    );
+    let output = convert_pdf(&path, &input, &options, &context).unwrap();
+    assert_eq!(&*input.bytes, original);
+    let markdown =
+        into_markdown_render_markdown::render(&output.document, &output.assets, &options).unwrap();
+    assert!(markdown.contains("Text only page"));
+}
+
 struct TemporaryDirectory(PathBuf);
 
 impl TemporaryDirectory {


### PR DESCRIPTION
Closes #311

## Narrow change

- Skip bitmap planning/materialization, BMP encoding, asset accounting and pixel retention only when images are omitted, OCR is off, and no visual/structural AI consumer is enabled.
- Preserve lightweight image geometry nodes through the existing reading-order reconstruction, then remove those transient nodes before publishing IR. Removing them earlier changed text partitioning in four corpus PDFs; the final implementation preserves all 93 previously successful Markdown files byte-for-byte.
- Share direct-PDF header recognition between detection and probe: offset 0, or offset 3 after exactly one UTF-8 BOM. PDFium receives the unchanged original bytes; no xref rewriting or AppleSingle unpacking.
- Only `crates/converters/src/lib.rs`, `pdf/mod.rs`, and `pdf/tests.rs` change. No dependency, resource-limit, workflow, pipeline, or unrelated integration changes. Existing PR fast gate remains enabled; no skip-CI marker.

Base: `a6cb5e227de78b51fe6dc5dc5a680dba90f78c51`, independent worktree/branch. The dirty main working directory was not modified.

## Verification

- `cargo fmt --all -- --check` and `git diff --check`: pass.
- `cargo clippy --locked -j 2 -p into-markdown-converters --all-targets -- -D warnings`: pass.
- `cargo test --locked -j 2 -p into-markdown-converters`: 540 passed, 3 native unit tests ignored; the separate pinned-runtime quality integration target is also ignored by its existing configuration.
- Both new ignored PDFium tests run explicitly against the pinned DLL: pass. The fixture covers all nine asset/OCR combinations, actual bitmap calls, native reading order, no escaped transient image references, retained leases returning to zero, preserved scan metadata, and asset-limit enforcement on the extract path. Header tests reject double BOM, whitespace, and the offset-174 wrapper. The BOM conversion test preserves original offsets/bytes.
- The reading-order fixture was verified red with early image-node removal and green with the final geometry-preserving implementation.
- The existing ignored `native_production_converter_is_serialized_and_emits_unified_ir` test fails its fixed `blocks[0]` text assertion on BOTH this branch and clean base a6cb (independently rebuilt, 538 other baseline tests filtered). It was not changed or suppressed; this is not a claim that all optional native tests pass.

## Real PDF acceptance

Inputs and formal evidence are read-only. Manifest SHA-256: `7f82792dca7d1011d8a1bbcdfe7de5b4f0c463515be347405d0c88a6b866cacc`. Each selected input SHA was checked before and after conversion. Conversion uses `--no-config --ocr off --asset-mode omit --error-policy best-effort --jobs 1`, unchanged default asset/object limits, and the formal run's 4-GiB temporary limit.

| Run | CLI success / failure | Non-heading text present | Successful but no body | Previous-success exact Markdown parity |
| --- | --- | --- | --- | --- |
| All 108 PDFs | 100 / 8 | 64 | 36 | 93 / 93, zero changes |
| Ten old asset-limit failures + BOM | 7 / 4 | 7 | 0 | Matches final matrix results |

All 100 successful files have sequential page headings and page counts matching the manifest. Non-heading text is not a claim of full-document extraction: the 679-page `adictionaryinhi00unkngoog.pdf` and 681-page `haydnsuniversal00haydgoog.pdf` have native text only on Google's first-page notice. They are not claimed as complete book-body successes. The Wizard pair has non-heading text on 244/312 pages; the Draw pair on 76/88 pages; BOM emits `Hello World` on 1/1 page. The 36 empty-body outputs are not counted as body conversions.

All ten old `max_total_asset_bytes` failures no longer hit that limit. Six convert; four now reach the existing `pdfPageObjects=100000` limit: Newton (100450), both Droz dictionary versions (100585), and Haydn `_text` (100612). No limits were raised. Other failures remain one malformed PDF, two encrypted PDFs, and the explicitly out-of-scope AppleSingle wrapper.

Evidence: `C:/im-bench-004/issue311-pdf-20260831/`, specifically `matrix-final/acceptance.json`, `focus-11-final/acceptance.json`, their raw native reports/outputs, `run-matrix.ps1`, and `logs/`. Earlier non-final matrix folders are diagnostic iterations, not final acceptance.

Diagnostic-only runs: 108 files 61.902 s / sampled process peak working set 369471488 bytes; focused 11 files 31.202 s / 367104000 bytes; both left zero temp files. These were acceptance runs on a shared machine, not a controlled speed/RSS comparison. Formal performance/memory certification remains with the root final-candidate run.

Release binary SHA-256: `18d006702f17a9ea60b91b1562d94ac14621c1857e89f970cf2a739d8612db37`. Pinned PDFium DLL SHA-256: `fb898a1f5ace57805834f390407500bdb6ef93eff326a252ad334a8aae809d8e`.

Root independent review is still required. Do not merge automatically.
