### PR TITLE
fix(xls): preserve root authority and legal BIFF sheet/cache records

### DIFF
--- a/crates/converters/src/legacy_office/xls.rs
+++ b/crates/converters/src/legacy_office/xls.rs
@@ -12,6 +12,7 @@ mod binary;
 mod inventory;
 mod objects;
 mod preflight;
+mod reader_view;
 mod wrapper;
 
 use binary::{read_u16, read_u32};
@@ -34,6 +35,8 @@ const FORMULA: u16 = 0x0006;
 const STRING: u16 = 0x0207;
 const CONTINUE: u16 = 0x003c;
 const SHARED_FORMULA: u16 = 0x04bc;
+const ARRAY: u16 = 0x0221;
+const TABLE: u16 = 0x0236;
 const DIMENSIONS: u16 = 0x0200;
 const BOUND_SHEET: u16 = 0x0085;
 const SUP_BOOK: u16 = 0x01ae;
@@ -146,38 +149,22 @@ pub(super) fn convert(
         context,
         options.error_policy,
     )?;
-    let wrapper_layout = (container_view_required
-        || preflight.has(PreflightFlag::DimensionMetadata)
-        || preflight.has(PreflightFlag::FormulaCacheMetadata)
-        || preflight.logical_end != workbook.len())
-    .then(|| cfb_wrapper_layout(workbook_view.len()))
-    .transpose()?;
-    let wrapper_memory = wrapper_layout
-        .as_ref()
-        .map(|layout| {
-            context.reserve_memory(
-                u64::try_from(layout.output_bytes.saturating_add(layout.total_sectors * 4))
-                    .unwrap_or(u64::MAX),
-            )
-        })
-        .transpose()?;
-    let wrapper = wrapper_layout
-        .as_ref()
-        .map(|layout| {
-            build_cfb_wrapper(
-                workbook_view,
-                preflight.has(PreflightFlag::DimensionMetadata),
-                preflight.has(PreflightFlag::FormulaCacheMetadata),
-                preflight.biff_version,
-                *layout,
-            )
-        })
-        .transpose()?;
-    let conversion_bytes = wrapper.as_deref().unwrap_or(bytes);
+    let format_remap = if preflight.biff_version == BIFF8 {
+        reader_view::format_id_remap(workbook_view, &preflight.hints, options.error_policy)?
+    } else {
+        std::collections::BTreeMap::new()
+    };
+    let wrapper = reader_view::prepare_wrapper(
+        workbook,
+        &preflight,
+        container_view_required,
+        &format_remap,
+        context,
+    )?;
+    let conversion_bytes = wrapper.as_ref().map_or(bytes, |(view, _memory)| view.as_slice());
     let mut output =
         crate::workbook::convert_legacy_xls(conversion_bytes, &preflight.hints, options, context)?;
     drop(wrapper);
-    drop(wrapper_memory);
     normalize_xls_output(&mut output);
     output.document.metadata.properties.insert(
         "legacyOffice.xls.biff".into(),
@@ -191,6 +178,14 @@ pub(super) fn convert(
 
     append_preflight_diagnostics(&mut output, &preflight, part);
     append_inventory_diagnostics(&mut output, &preflight.hints, part);
+    if !format_remap.is_empty() {
+        output.diagnostics.push(Diagnostic {
+            code: "legacyOffice.xls.formatIndexRecovered".into(),
+            severity: DiagnosticSeverity::Info,
+            message: "non-canonical Format identifiers and XF references were remapped to unused custom slots without changing their format strings".into(),
+            locator: Some(locator(part)),
+        });
+    }
     if !preflight.has(PreflightFlag::EmbeddedObjects)
         && (root.storage("ObjectPool").is_some() || root.storage("ActiveX").is_some())
     {

--- a/crates/converters/src/legacy_office/xls/inventory.rs
+++ b/crates/converters/src/legacy_office/xls/inventory.rs
@@ -1,5 +1,6 @@
 use super::preflight::{
-    biff_record, decode_continued_formula_string, has_noncanonical_formula_string_cache,
+    biff_record, bound_sheet_name_length, bound_sheet_substream, decode_continued_formula_string,
+    has_noncanonical_formula_string_cache,
 };
 use super::{
     BIFF4, BIFF5, BOF, BOF4, EOF, ErrorPolicy, FORMULA, LegacyBudget, malformed, read_u16, read_u32,
@@ -21,6 +22,7 @@ const XF: u16 = 0x00e0;
 #[derive(Debug)]
 struct BoundSheet {
     offset: usize,
+    substream: u16,
     name: String,
 }
 
@@ -60,7 +62,7 @@ pub(super) fn scan_workbook_inventory(
     let memory = context.reserve_memory(inventory_memory_plan(bytes.len())?)?;
     let mut global = collect_globals(bytes, biff_version, part, budget, error_policy)?;
     if global.sheets.is_empty() {
-        global.sheets.push(BoundSheet { offset: 0, name: "Sheet 1".into() });
+        global.sheets.push(BoundSheet { offset: 0, substream: 0x0010, name: "Sheet 1".into() });
     }
     let offsets = authenticate_sheets(&global.sheets, bytes.len(), part)?;
     let inventory = collect_sheet_inventory(bytes, biff_version, part, budget, &global, &offsets)?;
@@ -71,11 +73,13 @@ fn authenticate_sheets(
     sheets: &[BoundSheet],
     workbook_bytes: usize,
     part: &str,
-) -> Result<BTreeMap<usize, usize>, ConversionError> {
+) -> Result<BTreeMap<usize, (usize, u16)>, ConversionError> {
     let mut offsets = BTreeMap::new();
     let mut names = BTreeSet::new();
     for (index, sheet) in sheets.iter().enumerate() {
-        if sheet.offset >= workbook_bytes || offsets.insert(sheet.offset, index).is_some() {
+        if sheet.offset >= workbook_bytes
+            || offsets.insert(sheet.offset, (index, sheet.substream)).is_some()
+        {
             return Err(malformed(part, "duplicate or out-of-range BoundSheet offset"));
         }
         if !names.insert(sheet.name.to_lowercase()) {
@@ -105,7 +109,7 @@ impl InventorySubstreams {
         &mut self,
         body: &[u8],
         record_start: usize,
-        offsets: &BTreeMap<usize, usize>,
+        offsets: &BTreeMap<usize, (usize, u16)>,
         completed: &[bool],
         part: &str,
     ) -> Result<(), ConversionError> {
@@ -118,13 +122,13 @@ impl InventorySubstreams {
         }
         self.stack[self.depth] = substream;
         self.depth += 1;
-        if substream == 0x0010 {
-            if self.current_sheet.is_some() || self.depth != 1 {
-                return Err(malformed(part, "nested BIFF worksheet substream"));
-            }
-            let index = offsets.get(&record_start).copied().ok_or_else(|| {
+        if self.depth == 1 && matches!(substream, 0x0010 | 0x0020 | 0x0040) {
+            let (index, expected) = offsets.get(&record_start).copied().ok_or_else(|| {
                 malformed(part, "worksheet BOF is not authenticated by BoundSheet")
             })?;
+            if substream != expected {
+                return Err(malformed(part, "BoundSheet type disagrees with sheet BOF"));
+            }
             if completed[index] {
                 return Err(malformed(part, "duplicate worksheet substream"));
             }
@@ -138,7 +142,7 @@ impl InventorySubstreams {
             return Err(malformed(part, "BIFF inventory EOF has no BOF"));
         }
         self.depth -= 1;
-        if self.stack[self.depth] == 0x0010 {
+        if self.depth == 0 && matches!(self.stack[0], 0x0010 | 0x0020 | 0x0040) {
             let index = self
                 .current_sheet
                 .take()
@@ -149,7 +153,7 @@ impl InventorySubstreams {
     }
 
     fn in_worksheet(&self) -> bool {
-        self.current_sheet.is_some() && self.depth == 1
+        self.current_sheet.is_some() && self.depth == 1 && self.stack[0] == 0x0010
     }
 }
 
@@ -159,7 +163,7 @@ fn collect_sheet_inventory(
     part: &str,
     budget: &mut LegacyBudget<'_>,
     global: &GlobalInventory,
-    offsets: &BTreeMap<usize, usize>,
+    offsets: &BTreeMap<usize, (usize, u16)>,
 ) -> Result<SheetInventory, ConversionError> {
     let mut output = SheetInventory {
         bounds: (0..global.sheets.len()).map(|_| SheetBounds::default()).collect(),
@@ -242,7 +246,7 @@ fn collect_sheet_inventory(
         || substreams.current_sheet.is_some()
         || output.completed.iter().any(|value| !value)
     {
-        return Err(malformed(part, "BoundSheet inventory is not closed by worksheet EOF records"));
+        return Err(malformed(part, "BoundSheet inventory is not closed by sheet EOF records"));
     }
     Ok(output)
 }
@@ -405,7 +409,9 @@ fn collect_globals(
         budget.work(1, part)?;
         let (kind, body, end) = biff_record(bytes, cursor, part)?;
         match kind {
-            BOUND_SHEET => output.sheets.push(parse_bound_sheet(body, biff_version, part)?),
+            BOUND_SHEET => {
+                output.sheets.push(parse_bound_sheet(body, biff_version, part, error_policy)?);
+            }
             FORMAT => {
                 let index = if biff_version == BIFF4 {
                     let index = legacy_format_index;
@@ -581,15 +587,11 @@ fn parse_bound_sheet(
     body: &[u8],
     biff_version: u16,
     part: &str,
+    error_policy: ErrorPolicy,
 ) -> Result<BoundSheet, ConversionError> {
     let offset = usize::try_from(read_u32(body, 0, part)?)
         .map_err(|_| malformed(part, "BoundSheet offset is not representable"))?;
-    let characters = usize::from(
-        *body.get(6).ok_or_else(|| malformed(part, "truncated BoundSheet name length"))?,
-    );
-    if characters == 0 || characters > 31 {
-        return Err(malformed(part, "invalid BoundSheet name length"));
-    }
+    let characters = bound_sheet_name_length(body, part, error_policy)?;
     let (name, consumed) = if matches!(biff_version, BIFF4 | BIFF5) {
         let bytes = body
             .get(7..7 + characters)
@@ -622,7 +624,7 @@ fn parse_bound_sheet(
     if consumed != body.len() || name.contains(['/', '\\', '\0']) {
         return Err(malformed(part, "BoundSheet name contains trailing or unsafe data"));
     }
-    Ok(BoundSheet { offset, name })
+    Ok(BoundSheet { offset, substream: bound_sheet_substream(body, part)?, name })
 }
 
 fn is_single_cell_record(kind: u16, biff_version: u16) -> bool {

--- a/crates/converters/src/legacy_office/xls/preflight.rs
+++ b/crates/converters/src/legacy_office/xls/preflight.rs
@@ -1,11 +1,11 @@
 use super::{
-    BIFF4, BIFF5, BIFF8, BOF, BOF4, BOUND_SHEET, Block, BlockNode, CONTINUE, ConversionError,
-    ConverterOutput, DIMENSIONS, Diagnostic, DiagnosticSeverity, EOF, EXTERN_SHEET, ErrorPolicy,
-    FILE_PASS, FORMULA, LegacyBudget, MSO_DRAWING, MSO_DRAWING_GROUP, OBJ, PANE, SCL, SELECTION,
-    SHARED_FORMULA, STRING, SUP_BOOK, WINDOW1, WINDOW2, limit, locator, malformed, read_u16,
-    read_u32,
+    ARRAY, BIFF4, BIFF5, BIFF8, BOF, BOF4, BOUND_SHEET, Block, BlockNode, CONTINUE,
+    ConversionError, ConverterOutput, DIMENSIONS, Diagnostic, DiagnosticSeverity, EOF,
+    EXTERN_SHEET, ErrorPolicy, FILE_PASS, FORMULA, LegacyBudget, MSO_DRAWING, MSO_DRAWING_GROUP,
+    OBJ, PANE, SCL, SELECTION, SHARED_FORMULA, STRING, SUP_BOOK, TABLE, WINDOW1, WINDOW2, limit,
+    locator, malformed, read_u16, read_u32,
 };
-use std::collections::BTreeSet;
+use std::collections::BTreeMap;
 
 pub(super) fn append_preflight_diagnostics(
     output: &mut ConverterOutput,
@@ -76,6 +76,24 @@ pub(super) fn append_preflight_diagnostics(
             locator: Some(locator(part)),
         });
     }
+    if preflight.has(PreflightFlag::SheetNameMetadata) {
+        output.diagnostics.push(Diagnostic {
+            code: "legacyOffice.xls.longSheetNameRecovered".into(),
+            severity: DiagnosticSeverity::Info,
+            message: "a complete, bounded sheet name exceeding the canonical 31-character limit was retained"
+                .into(),
+            locator: Some(locator(part)),
+        });
+    }
+    if preflight.has(PreflightFlag::NestedCharts) {
+        output.diagnostics.push(Diagnostic {
+            code: "legacyOffice.xls.chartCachesSkipped".into(),
+            severity: DiagnosticSeverity::Warning,
+            message: "nested chart caches were excluded from worksheet cells and were not rendered"
+                .into(),
+            locator: Some(locator(part)),
+        });
+    }
 }
 
 pub(super) fn biff_record<'a>(
@@ -106,7 +124,8 @@ pub(super) fn decode_continued_formula_string(
     max_field_bytes: u64,
 ) -> Result<Option<String>, ConversionError> {
     let (mut kind, mut body, mut next) = biff_record(workbook, cursor, part)?;
-    if kind == SHARED_FORMULA {
+    if matches!(kind, SHARED_FORMULA | ARRAY | TABLE) {
+        validate_formula_attachment(kind, body, part)?;
         (kind, body, next) = biff_record(workbook, next, part)?;
     }
     if kind != STRING {
@@ -195,6 +214,53 @@ pub(super) fn decode_continued_formula_string(
         ));
     }
     Ok(Some(output))
+}
+
+fn validate_formula_attachment(kind: u16, body: &[u8], part: &str) -> Result<(), ConversionError> {
+    let minimum = match kind {
+        SHARED_FORMULA => 10,
+        ARRAY => 14, // Range, flags, calculation chain, token count.
+        TABLE => 16, // Range, flags, and two input-cell addresses.
+        _ => unreachable!(),
+    };
+    if body.len() < minimum {
+        return Err(malformed(part, "truncated Formula attachment"));
+    }
+    if kind == TABLE && body.len() != minimum {
+        return Err(malformed(part, "invalid Table attachment length"));
+    }
+    if kind != TABLE {
+        let token_bytes = usize::from(read_u16(body, minimum - 2, part)?);
+        if token_bytes > body.len() - minimum {
+            return Err(malformed(part, "truncated Formula attachment tokens"));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn bound_sheet_substream(body: &[u8], part: &str) -> Result<u16, ConversionError> {
+    match body.get(5).ok_or_else(|| malformed(part, "truncated BoundSheet type"))? {
+        0 => Ok(0x0010),
+        1 => Ok(0x0040),
+        2 => Ok(0x0020),
+        kind => Err(ConversionError::Unsupported {
+            detail: format!("unsupported BoundSheet type 0x{kind:02x}"),
+        }),
+    }
+}
+
+pub(super) fn bound_sheet_name_length(
+    body: &[u8],
+    part: &str,
+    error_policy: ErrorPolicy,
+) -> Result<usize, ConversionError> {
+    let characters = usize::from(
+        *body.get(6).ok_or_else(|| malformed(part, "truncated BoundSheet name length"))?,
+    );
+    if characters == 0 || (characters > 31 && error_policy == ErrorPolicy::Strict) {
+        return Err(malformed(part, "invalid BoundSheet name length"));
+    }
+    Ok(characters)
 }
 
 pub(super) fn append_utf16_string_units(
@@ -289,6 +355,8 @@ pub(super) enum PreflightFlag {
     OptionalTailRecord,
     DimensionMetadata,
     FormulaCacheMetadata,
+    SheetNameMetadata,
+    NestedCharts,
 }
 
 #[derive(Default)]
@@ -323,8 +391,8 @@ struct PreflightState {
     biff_version: Option<u16>,
     at_substream_boundary: bool,
     zero_padding_start: Option<usize>,
-    bound_sheet_offsets: BTreeSet<u32>,
-    completed_sheet_offsets: BTreeSet<u32>,
+    bound_sheet_offsets: BTreeMap<u32, u16>,
+    completed_sheet_offsets: BTreeMap<u32, u16>,
     open_sheet_offset: Option<u32>,
     substreams: [u16; 16],
     substream_depth: usize,
@@ -361,7 +429,11 @@ impl PreflightState {
             EOF => self.close_biff_substream(part)?,
             BOUND_SHEET => {
                 let offset = read_u32(body, 0, part)?;
-                if !self.bound_sheet_offsets.insert(offset) {
+                let substream = bound_sheet_substream(body, part)?;
+                if bound_sheet_name_length(body, part, error_policy)? > 31 {
+                    self.result.flags.insert(PreflightFlag::SheetNameMetadata);
+                }
+                if self.bound_sheet_offsets.insert(offset, substream).is_some() {
                     return Err(malformed(part, "duplicate BoundSheet offset"));
                 }
             }
@@ -416,17 +488,20 @@ impl PreflightState {
             if parent != 0x0010 || substream != 0x0020 {
                 return Err(malformed(part, "unsupported nested BIFF substream"));
             }
+            self.result.flags.insert(PreflightFlag::NestedCharts);
         }
         self.substreams[self.substream_depth] = substream;
         self.substream_depth += 1;
-        if substream == 0x0010 {
-            if self.substream_depth != 1 {
-                return Err(malformed(part, "nested BIFF worksheet substream"));
-            }
+        if self.substream_depth == 1 && matches!(substream, 0x0010 | 0x0020 | 0x0040) {
             let offset = u32::try_from(cursor)
                 .map_err(|_| malformed(part, "worksheet BOF offset overflowed"))?;
-            if !self.bound_sheet_offsets.is_empty() && !self.bound_sheet_offsets.contains(&offset) {
-                return Err(malformed(part, "worksheet BOF is not authenticated by BoundSheet"));
+            if (!self.bound_sheet_offsets.is_empty() || substream != 0x0010)
+                && self.bound_sheet_offsets.get(&offset) != Some(&substream)
+            {
+                return Err(malformed(
+                    part,
+                    "sheet BOF offset/type is not authenticated by BoundSheet",
+                ));
             }
             self.open_sheet_offset = Some(offset);
         }
@@ -439,21 +514,20 @@ impl PreflightState {
         }
         self.substream_depth -= 1;
         let substream = self.substreams[self.substream_depth];
-        if substream == 0x0010 {
-            if self.substream_depth != 0 {
-                return Err(malformed(part, "worksheet substream closes inside another substream"));
-            }
+        if self.substream_depth == 0 && matches!(substream, 0x0010 | 0x0020 | 0x0040) {
             let offset = self
                 .open_sheet_offset
                 .take()
                 .ok_or_else(|| malformed(part, "worksheet EOF has no BOF offset"))?;
-            if !self.completed_sheet_offsets.insert(offset) {
+            if self.completed_sheet_offsets.insert(offset, substream).is_some() {
                 return Err(malformed(part, "duplicate worksheet substream"));
             }
-            self.completed_worksheets = self
-                .completed_worksheets
-                .checked_add(1)
-                .ok_or_else(|| malformed(part, "worksheet count overflowed"))?;
+            if substream == 0x0010 {
+                self.completed_worksheets = self
+                    .completed_worksheets
+                    .checked_add(1)
+                    .ok_or_else(|| malformed(part, "worksheet count overflowed"))?;
+            }
         } else if substream == 0x0005 {
             if self.substream_depth != 0 {
                 return Err(malformed(part, "workbook globals close inside another substream"));
@@ -550,8 +624,8 @@ pub(super) fn preflight(
 }
 
 fn final_substream_proven(
-    bound_sheet_offsets: &BTreeSet<u32>,
-    completed_sheet_offsets: &BTreeSet<u32>,
+    bound_sheet_offsets: &BTreeMap<u32, u16>,
+    completed_sheet_offsets: &BTreeMap<u32, u16>,
     open_substream: Option<u16>,
     completed_globals: usize,
     completed_worksheets: usize,

--- a/crates/converters/src/legacy_office/xls/reader_view.rs
+++ b/crates/converters/src/legacy_office/xls/reader_view.rs
@@ -1,0 +1,128 @@
+//! Offset-preserving reader adjustments after BIFF structure authentication.
+
+use super::preflight::{Preflight, PreflightFlag, biff_record};
+use super::{BOF, BOF4, ConversionError, EOF, ErrorPolicy, WORKBOOK, malformed, read_u16};
+use crate::workbook::LegacyXlsHints;
+use into_markdown_core::{ExecutionContext, ResourceReservation};
+use std::collections::{BTreeMap, BTreeSet};
+
+const FORMAT: u16 = 0x041e;
+const XF: u16 = 0x00e0;
+
+pub(super) fn prepare_wrapper(
+    workbook: &[u8],
+    preflight: &Preflight,
+    container_required: bool,
+    remap: &BTreeMap<u16, u16>,
+    context: &ExecutionContext,
+) -> Result<Option<(Vec<u8>, ResourceReservation)>, ConversionError> {
+    let required = container_required
+        || preflight.has(PreflightFlag::DimensionMetadata)
+        || preflight.has(PreflightFlag::FormulaCacheMetadata)
+        || preflight.has(PreflightFlag::NestedCharts)
+        || !remap.is_empty()
+        || preflight.logical_end != workbook.len();
+    if !required {
+        return Ok(None);
+    }
+    let workbook = &workbook[..preflight.logical_end];
+    let layout = super::cfb_wrapper_layout(workbook.len())?;
+    let memory = context.reserve_memory(
+        u64::try_from(layout.output_bytes.saturating_add(layout.total_sectors * 4))
+            .unwrap_or(u64::MAX),
+    )?;
+    let mut wrapper = super::build_cfb_wrapper(
+        workbook,
+        preflight.has(PreflightFlag::DimensionMetadata),
+        preflight.has(PreflightFlag::FormulaCacheMetadata),
+        preflight.biff_version,
+        layout,
+    )?;
+    if preflight.has(PreflightFlag::NestedCharts) || !remap.is_empty() {
+        patch_reader_view(
+            &mut wrapper[super::CFB_SECTOR_BYTES..super::CFB_SECTOR_BYTES + workbook.len()],
+            workbook,
+            remap,
+        )?;
+    }
+    Ok(Some((wrapper, memory)))
+}
+
+pub(super) fn format_id_remap(
+    workbook: &[u8],
+    hints: &LegacyXlsHints,
+    error_policy: ErrorPolicy,
+) -> Result<BTreeMap<u16, u16>, ConversionError> {
+    // Calamine's BIFF8 FORMAT reader accepts the MS-XLS custom-format ranges only.
+    let unsupported = hints
+        .format_codes
+        .keys()
+        .copied()
+        .filter(|index| !matches!(index, 5..=8 | 23..=26 | 41..=44 | 63..=66 | 164..=382));
+    let mut remap = unsupported.take(220).map(|index| (index, 0)).collect::<BTreeMap<_, _>>();
+    if remap.len() > 219 {
+        return Err(ConversionError::Unsupported {
+            detail: "too many non-canonical Format identifiers for available custom slots".into(),
+        });
+    }
+    if remap.is_empty() {
+        return Ok(remap);
+    }
+    if error_policy == ErrorPolicy::Strict {
+        return Err(malformed(WORKBOOK, "non-canonical BIFF Format index"));
+    }
+    let mut used = hints.format_codes.keys().copied().collect::<BTreeSet<_>>();
+    let mut cursor = 0;
+    while cursor < workbook.len() {
+        let (kind, body, end) = biff_record(workbook, cursor, WORKBOOK)?;
+        if kind == EOF {
+            break;
+        }
+        if kind == XF {
+            used.insert(read_u16(body, 2, WORKBOOK)?);
+        }
+        cursor = end;
+    }
+    let mut available = (164..=382).filter(|index| !used.contains(index));
+    for replacement in remap.values_mut() {
+        *replacement = available.next().ok_or_else(|| ConversionError::Unsupported {
+            detail: "no unused BIFF custom-format index is available for compatibility".into(),
+        })?;
+    }
+    Ok(remap)
+}
+
+pub(super) fn patch_reader_view(
+    output: &mut [u8],
+    workbook: &[u8],
+    remap: &BTreeMap<u16, u16>,
+) -> Result<(), ConversionError> {
+    let mut cursor = 0;
+    let mut depth = 0_usize;
+    while cursor < workbook.len() {
+        let (kind, body, end) = biff_record(workbook, cursor, WORKBOOK)?;
+        if matches!(kind, BOF | BOF4) {
+            depth = depth
+                .checked_add(1)
+                .ok_or_else(|| malformed(WORKBOOK, "reader-view substream depth overflowed"))?;
+        }
+        if depth > 1 {
+            // Nested chart caches are not worksheet cells. Hide even the chart BOF/EOF,
+            // retaining framing so the reader reaches the enclosing worksheet's EOF.
+            super::wrapper::put_u16(output, cursor, 0xffff)?;
+        } else if matches!(kind, FORMAT | XF) && !remap.is_empty() {
+            let field = if kind == FORMAT { 0 } else { 2 };
+            let index = read_u16(body, field, WORKBOOK)?;
+            if let Some(replacement) = remap.get(&index) {
+                super::wrapper::put_u16(output, cursor + 4 + field, *replacement)?;
+            }
+        }
+        if kind == EOF {
+            depth = depth
+                .checked_sub(1)
+                .ok_or_else(|| malformed(WORKBOOK, "reader-view EOF has no substream"))?;
+        }
+        cursor = end;
+    }
+    Ok(())
+}

--- a/crates/converters/src/legacy_office/xls/tests.rs
+++ b/crates/converters/src/legacy_office/xls/tests.rs
@@ -5,6 +5,8 @@ use super::*;
 use crate::msg::ole::CompoundFile;
 use into_markdown_core::{Cell, ExecutionOptions, Inline, ResourceLimits};
 
+mod records;
+
 fn budget<'a>(options: &'a ConversionOptions, context: &'a ExecutionContext) -> LegacyBudget<'a> {
     LegacyBudget::new(64, options, context).unwrap()
 }

--- a/crates/converters/src/legacy_office/xls/tests/records.rs
+++ b/crates/converters/src/legacy_office/xls/tests/records.rs
@@ -1,0 +1,280 @@
+use super::*;
+
+mod reader;
+
+fn sheet(kind: u16, text: &[u8]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    let mut bof = BIFF8.to_le_bytes().to_vec();
+    bof.extend_from_slice(&kind.to_le_bytes());
+    push_biff_record(&mut bytes, BOF, &bof).unwrap();
+    if !text.is_empty() {
+        let mut label = vec![0; 6];
+        label.extend_from_slice(&u16::try_from(text.len()).unwrap().to_le_bytes());
+        label.push(0);
+        label.extend_from_slice(text);
+        push_biff_record(&mut bytes, 0x0204, &label).unwrap();
+    }
+    push_biff_record(&mut bytes, EOF, &[]).unwrap();
+    bytes
+}
+
+fn workbook(sheets: &[(u8, &[u8])]) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    push_biff_record(&mut bytes, BOF, &[0, 6, 5, 0]).unwrap();
+    push_biff_record(&mut bytes, 0x0042, &1200_u16.to_le_bytes()).unwrap();
+    push_biff_record(&mut bytes, 0x00e0, &[0; 20]).unwrap();
+    let mut pointers = Vec::new();
+    for (index, (kind, _)) in sheets.iter().enumerate() {
+        pointers.push(bytes.len() + 4);
+        let name = b'A' + u8::try_from(index).unwrap();
+        push_biff_record(&mut bytes, BOUND_SHEET, &[0, 0, 0, 0, 0, *kind, 1, 0, name]).unwrap();
+    }
+    push_biff_record(&mut bytes, EOF, &[]).unwrap();
+    for ((_, data), pointer) in sheets.iter().zip(pointers) {
+        let offset = u32::try_from(bytes.len()).unwrap();
+        bytes[pointer..pointer + 4].copy_from_slice(&offset.to_le_bytes());
+        bytes.extend_from_slice(data);
+    }
+    bytes
+}
+
+fn converted(bytes: &[u8]) -> ConverterOutput {
+    let layout = cfb_wrapper_layout(bytes.len()).unwrap();
+    convert_fixture(&build_cfb_wrapper(bytes, false, false, BIFF8, layout).unwrap())
+}
+
+#[test]
+fn chart_and_macro_sheets_preserve_worksheet_content_order_and_diagnostics() {
+    for kind in [1, 2] {
+        let before = sheet(0x0010, b"first");
+        let optional = sheet(if kind == 1 { 0x0040 } else { 0x0020 }, b"inert");
+        let after = sheet(0x0010, b"last");
+        let bytes = workbook(&[(0, &before), (kind, &optional), (0, &after)]);
+        let options = ConversionOptions::default();
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        for policy in [ErrorPolicy::Strict, ErrorPolicy::BestEffort] {
+            preflight(&bytes, WORKBOOK, &mut budget(&options, &context), policy).unwrap();
+        }
+        let output = converted(&bytes);
+        assert_eq!(output.document.blocks.len(), 2);
+        for (block, (expected_name, expected_value)) in
+            output.document.blocks.iter().zip([("A", "first"), ("C", "last")])
+        {
+            let Block::Sheet { name, blocks } = &block.block else { panic!("not a sheet") };
+            let Block::Table { rows, .. } = &blocks[0].block else { panic!("not a table") };
+            assert_eq!(name, expected_name);
+            assert_eq!(cell_text(&rows[0].cells[0]), expected_value);
+        }
+        let diagnostic = output
+            .diagnostics
+            .iter()
+            .find(|item| item.code == "legacyOffice.xls.nonWorksheetSkipped")
+            .unwrap();
+        assert_eq!(diagnostic.locator.as_ref().unwrap().sheet.as_deref(), Some("B"));
+        assert_eq!(output.document, converted(&bytes).document);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+}
+
+#[test]
+fn optional_sheet_types_do_not_mask_mismatches_or_incomplete_substreams() {
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    let ordinary = sheet(0x0010, b"keep");
+    let chart = sheet(0x0020, b"");
+    let mut truncated = chart.clone();
+    truncated.truncate(truncated.len() - 4);
+    let cases = [
+        workbook(&[(0, &ordinary), (1, &chart)]),
+        workbook(&[(0, &ordinary), (2, &truncated)]),
+        workbook(&[(0, &ordinary), (2, &[])]),
+    ];
+    for bytes in cases {
+        for policy in [ErrorPolicy::Strict, ErrorPolicy::BestEffort] {
+            assert!(matches!(
+                preflight(&bytes, WORKBOOK, &mut budget(&options, &context), policy),
+                Err(ConversionError::Malformed { .. })
+            ));
+        }
+    }
+    let unknown = workbook(&[(0, &ordinary), (9, &chart)]);
+    assert!(matches!(
+        preflight(&unknown, WORKBOOK, &mut budget(&options, &context), ErrorPolicy::BestEffort),
+        Err(ConversionError::Unsupported { .. })
+    ));
+}
+
+fn attachment(kind: u16) -> Vec<u8> {
+    let size = match kind {
+        SHARED_FORMULA => 10,
+        0x0221 => 14,
+        0x0236 => 16,
+        _ => panic!(),
+    };
+    let mut body = vec![0; size];
+    if kind != 0x0236 {
+        body[size - 2] = 3;
+        body.extend_from_slice(&[0x1e, 1, 0]);
+    }
+    body
+}
+
+#[test]
+fn formula_attachments_preserve_continued_cached_strings() {
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    for kind in [SHARED_FORMULA, 0x0221, 0x0236] {
+        let mut bytes = Vec::new();
+        push_biff_record(&mut bytes, kind, &attachment(kind)).unwrap();
+        push_biff_record(&mut bytes, STRING, &[5, 0, 0, b'c', b'a']).unwrap();
+        push_biff_record(&mut bytes, CONTINUE, &[0, b'c', b'h', b'e']).unwrap();
+        assert_eq!(
+            decode_continued_formula_string(
+                &bytes,
+                0,
+                WORKBOOK,
+                &mut budget(&options, &context),
+                100
+            )
+            .unwrap()
+            .as_deref(),
+            Some("cache")
+        );
+        let mut formula_sheet = sheet(0x0010, b"");
+        formula_sheet.truncate(formula_sheet.len() - 4);
+        let mut formula = vec![0; 22];
+        formula[7] = 1; // Noncanonical reserved cache bytes require compatibility decoding.
+        formula[12..14].fill(0xff);
+        formula[20] = 3;
+        formula.extend_from_slice(&[0x1e, 1, 0]);
+        push_biff_record(&mut formula_sheet, FORMULA, &formula).unwrap();
+        formula_sheet.extend_from_slice(&bytes);
+        push_biff_record(&mut formula_sheet, EOF, &[]).unwrap();
+        let output = converted(&workbook(&[(0, &formula_sheet)]));
+        let (_, rows) = table(&output);
+        assert!(cell_text(&rows[0].cells[0]).ends_with("[cached: cache]"));
+    }
+}
+
+#[test]
+fn formula_attachments_do_not_hide_truncation_or_arbitrary_records() {
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    for kind in [SHARED_FORMULA, 0x0221, 0x0236, 0x1234] {
+        let mut bytes = Vec::new();
+        push_biff_record(&mut bytes, kind, &[0; 9]).unwrap();
+        push_biff_record(&mut bytes, STRING, &[1, 0, 0, b'x']).unwrap();
+        assert!(
+            decode_continued_formula_string(
+                &bytes,
+                0,
+                WORKBOOK,
+                &mut budget(&options, &context),
+                100
+            )
+            .is_err()
+        );
+    }
+    for kind in [SHARED_FORMULA, 0x0221] {
+        let mut body = attachment(kind);
+        body.pop();
+        let mut bytes = Vec::new();
+        push_biff_record(&mut bytes, kind, &body).unwrap();
+        push_biff_record(&mut bytes, STRING, &[1, 0, 0, b'x']).unwrap();
+        assert!(
+            decode_continued_formula_string(
+                &bytes,
+                0,
+                WORKBOOK,
+                &mut budget(&options, &context),
+                100
+            )
+            .is_err()
+        );
+    }
+}
+
+fn named_workbook(name: &[u8]) -> Vec<u8> {
+    let ordinary = sheet(0x0010, b"retained");
+    let mut bytes = workbook(&[(0, &ordinary)]);
+    let mut cursor = 0;
+    loop {
+        let (kind, _, end) = biff_record(&bytes, cursor, WORKBOOK).unwrap();
+        if kind == BOUND_SHEET {
+            let mut record = vec![0; 6];
+            record.push(u8::try_from(name.len()).unwrap());
+            record.push(0);
+            record.extend_from_slice(name);
+            // The single sheet immediately follows this record and the globals EOF.
+            let offset = u32::try_from(cursor + 4 + record.len() + 4).unwrap();
+            record[..4].copy_from_slice(&offset.to_le_bytes());
+            let mut replacement = Vec::new();
+            push_biff_record(&mut replacement, BOUND_SHEET, &record).unwrap();
+            bytes.splice(cursor..end, replacement);
+            return bytes;
+        }
+        cursor = end;
+    }
+}
+
+#[test]
+fn long_sheet_names_are_complete_safe_and_best_effort_only() {
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    for length in [32, 55, 255] {
+        let name = vec![b'N'; length];
+        let bytes = named_workbook(&name);
+        assert!(
+            preflight(&bytes, WORKBOOK, &mut budget(&options, &context), ErrorPolicy::Strict)
+                .is_err()
+        );
+        let output = converted(&bytes);
+        let (actual_name, rows) = table(&output);
+        assert_eq!(actual_name.as_bytes(), name);
+        assert_eq!(cell_text(&rows[0].cells[0]), "retained");
+        assert!(
+            output
+                .diagnostics
+                .iter()
+                .any(|item| item.code == "legacyOffice.xls.longSheetNameRecovered")
+        );
+    }
+    for suffix in [b"/../x".as_slice(), b"\\x", b"\0x"] {
+        let mut name = vec![b'N'; 32];
+        name.extend_from_slice(suffix);
+        let bytes = named_workbook(&name);
+        assert!(
+            scan_workbook_inventory(
+                &bytes,
+                BIFF8,
+                WORKBOOK,
+                &mut budget(&options, &context),
+                &context,
+                ErrorPolicy::BestEffort
+            )
+            .is_err()
+        );
+    }
+    let mut truncated = named_workbook(&[b'N'; 32]);
+    // Increase the declared count without adding name payload or moving the sheet.
+    let mut cursor = 0;
+    loop {
+        let (kind, _, end) = biff_record(&truncated, cursor, WORKBOOK).unwrap();
+        if kind == BOUND_SHEET {
+            truncated[cursor + 10] = 33;
+            break;
+        }
+        cursor = end;
+    }
+    assert!(
+        scan_workbook_inventory(
+            &truncated,
+            BIFF8,
+            WORKBOOK,
+            &mut budget(&options, &context),
+            &context,
+            ErrorPolicy::BestEffort
+        )
+        .is_err()
+    );
+}

--- a/crates/converters/src/legacy_office/xls/tests/records/reader.rs
+++ b/crates/converters/src/legacy_office/xls/tests/records/reader.rs
@@ -1,0 +1,135 @@
+use super::*;
+use crate::legacy_office::xls::reader_view::{format_id_remap, patch_reader_view};
+
+#[test]
+fn nested_chart_cannot_replace_cells_or_terminate_the_worksheet() {
+    let mut ordinary = sheet(0x0010, b"source");
+    ordinary.truncate(ordinary.len() - 4);
+    ordinary.extend_from_slice(&sheet(0x0020, b"wrong"));
+    let mut tail = sheet(0x0010, b"after");
+    tail[12..14].copy_from_slice(&1_u16.to_le_bytes());
+    ordinary.extend_from_slice(&tail[8..]);
+    let bytes = workbook(&[(0, &ordinary)]);
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    for policy in [ErrorPolicy::Strict, ErrorPolicy::BestEffort] {
+        let result = preflight(&bytes, WORKBOOK, &mut budget(&options, &context), policy).unwrap();
+        assert!(result.has(PreflightFlag::NestedCharts));
+    }
+    let mut view = bytes.clone();
+    patch_reader_view(&mut view, &bytes, &std::collections::BTreeMap::new()).unwrap();
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        let (kind, body, end) = biff_record(&bytes, cursor, WORKBOOK).unwrap();
+        let (patched_kind, patched_body, patched_end) =
+            biff_record(&view, cursor, WORKBOOK).unwrap();
+        assert_eq!(end, patched_end);
+        assert_eq!(body, patched_body);
+        if matches!(kind, BOUND_SHEET) {
+            assert_eq!(kind, patched_kind);
+        }
+        cursor = end;
+    }
+    let output = converted(&bytes);
+    let (_, rows) = table(&output);
+    assert_eq!(rows.len(), 2);
+    assert_eq!(cell_text(&rows[0].cells[0]), "source");
+    assert_eq!(cell_text(&rows[1].cells[0]), "after");
+    assert!(
+        output.diagnostics.iter().any(|item| item.code == "legacyOffice.xls.chartCachesSkipped")
+    );
+    assert_eq!(output.document, converted(&bytes).document);
+}
+
+fn formatted_workbook(epoch: u16) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    push_biff_record(&mut bytes, BOF, &[0, 6, 5, 0]).unwrap();
+    push_biff_record(&mut bytes, 0x0042, &1200_u16.to_le_bytes()).unwrap();
+    push_biff_record(&mut bytes, 0x0022, &epoch.to_le_bytes()).unwrap();
+    for (index, code) in [(50_u16, "dd\"-\"mmm\"-\"yyyy"), (51, "hh\":\"mm AM/PM"), (164, "0.00%")]
+    {
+        let mut format = index.to_le_bytes().to_vec();
+        format.extend_from_slice(&u16::try_from(code.len()).unwrap().to_le_bytes());
+        format.push(0);
+        format.extend_from_slice(code.as_bytes());
+        push_biff_record(&mut bytes, 0x041e, &format).unwrap();
+        let mut xf = vec![0; 20];
+        xf[2..4].copy_from_slice(&index.to_le_bytes());
+        push_biff_record(&mut bytes, 0x00e0, &xf).unwrap();
+    }
+    let pointer = bytes.len() + 4;
+    push_biff_record(&mut bytes, BOUND_SHEET, &[0, 0, 0, 0, 0, 0, 1, 0, b'A']).unwrap();
+    push_biff_record(&mut bytes, EOF, &[]).unwrap();
+    let offset = u32::try_from(bytes.len()).unwrap();
+    bytes[pointer..pointer + 4].copy_from_slice(&offset.to_le_bytes());
+    push_biff_record(&mut bytes, BOF, &[0, 6, 0x10, 0]).unwrap();
+    for (column, value) in [(0_u16, 1_f64), (1, 0.5), (2, 0.25)] {
+        let mut number = vec![0; 2];
+        number.extend_from_slice(&column.to_le_bytes());
+        number.extend_from_slice(&column.to_le_bytes()); // XF index.
+        number.extend_from_slice(&value.to_le_bytes());
+        push_biff_record(&mut bytes, 0x0203, &number).unwrap();
+    }
+    let mut formula = vec![0; 22];
+    formula[0] = 1;
+    formula[6..14].copy_from_slice(&1_f64.to_le_bytes());
+    formula[20] = 3;
+    formula.extend_from_slice(&[0x1e, 1, 0]);
+    push_biff_record(&mut bytes, FORMULA, &formula).unwrap();
+    push_biff_record(&mut bytes, EOF, &[]).unwrap();
+    bytes
+}
+
+#[test]
+fn format_identifier_recovery_preserves_dates_epoch_and_formula_caches() {
+    let options = ConversionOptions::default();
+    let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    for (epoch, date, time) in [
+        (0, "1900-01-01 00:00:00", "1899-12-31 12:00:00"),
+        (1, "1904-01-02 00:00:00", "1904-01-01 12:00:00"),
+    ] {
+        let bytes = formatted_workbook(epoch);
+        let hints = scan_workbook_inventory(
+            &bytes,
+            BIFF8,
+            WORKBOOK,
+            &mut budget(&options, &context),
+            &context,
+            ErrorPolicy::BestEffort,
+        )
+        .unwrap();
+        assert!(format_id_remap(&bytes, &hints, ErrorPolicy::Strict).is_err());
+        let remap = format_id_remap(&bytes, &hints, ErrorPolicy::BestEffort).unwrap();
+        assert_eq!(remap.get(&50), Some(&165)); // Existing 164 must not be overwritten.
+        assert_eq!(remap.get(&51), Some(&166));
+        let output = converted(&bytes);
+        let (_, rows) = table(&output);
+        assert_eq!(cell_text(&rows[0].cells[0]), date);
+        assert_eq!(cell_text(&rows[0].cells[1]), time);
+        assert_eq!(cell_text(&rows[0].cells[2]), "25.00%");
+        assert!(cell_text(&rows[1].cells[0]).ends_with(&format!("[cached: {date}]")));
+        assert!(
+            output
+                .diagnostics
+                .iter()
+                .any(|item| item.code == "legacyOffice.xls.formatIndexRecovered")
+        );
+    }
+}
+
+#[test]
+fn format_remapping_never_reuses_referenced_slots_or_exhausted_space() {
+    let mut hints = crate::workbook::LegacyXlsHints::default();
+    hints.format_codes.insert(50, "yyyy".into());
+    let mut bytes = Vec::new();
+    for index in 164_u16..=382 {
+        let mut xf = vec![0; 4];
+        xf[2..4].copy_from_slice(&index.to_le_bytes());
+        push_biff_record(&mut bytes, 0x00e0, &xf).unwrap();
+    }
+    push_biff_record(&mut bytes, EOF, &[]).unwrap();
+    assert!(matches!(
+        format_id_remap(&bytes, &hints, ErrorPolicy::BestEffort),
+        Err(ConversionError::Unsupported { .. })
+    ));
+}

--- a/crates/converters/src/lib.rs
+++ b/crates/converters/src/lib.rs
@@ -2850,34 +2850,60 @@ fn cfb_directory_stream_names(bytes: &[u8]) -> Result<Vec<String>, String> {
     let first_directory_sector = read_u32(bytes, 48)?;
     let mut directory_sector = first_directory_sector;
     let mut seen_directory = std::collections::BTreeSet::new();
-    let mut names = Vec::new();
+    let mut entries = Vec::new();
     while directory_sector != CFB_END_OF_CHAIN {
         if !seen_directory.insert(directory_sector) || seen_directory.len() > sector_count {
             return Err("CFB directory chain is cyclic or exceeds the inspection limit".into());
         }
         let sector = cfb_sector(bytes, directory_sector, sector_size, inspected_len)?;
-        for entry in sector.chunks_exact(128) {
-            if entry[66] != 2 {
-                continue;
-            }
-            let name_bytes = usize::from(u16::from_le_bytes([entry[64], entry[65]]));
-            if !(2..=64).contains(&name_bytes) || name_bytes % 2 != 0 {
-                return Err("CFB directory stream contains an invalid stream name".into());
-            }
-            let name = entry[..name_bytes - 2]
-                .chunks_exact(2)
-                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]));
-            let name = char::decode_utf16(name)
-                .collect::<Result<String, _>>()
-                .map_err(|_| "CFB directory stream contains invalid UTF-16")?;
-            names.push(name);
-        }
+        entries.extend(sector.chunks_exact(128));
         directory_sector = *fat
             .get(
                 usize::try_from(directory_sector)
                     .map_err(|_| "CFB directory sector is too large")?,
             )
             .ok_or("CFB directory sector has no FAT entry")?;
+    }
+    cfb_root_stream_names(&entries)
+}
+
+fn cfb_root_stream_names(entries: &[&[u8]]) -> Result<Vec<String>, String> {
+    let root = entries.first().ok_or("CFB directory has no root storage")?;
+    if root[66] != 5 {
+        return Err("CFB directory does not begin with root storage".into());
+    }
+    let mut pending = vec![read_u32(root, 76)?];
+    let mut visited = std::collections::BTreeSet::new();
+    let mut names = Vec::new();
+    while let Some(index) = pending.pop() {
+        if index == CFB_FREE_SECTOR {
+            continue;
+        }
+        if !visited.insert(index) {
+            return Err("CFB root directory tree is cyclic or aliased".into());
+        }
+        let entry = entries.get(index as usize).ok_or("CFB root child is out of range")?;
+        if !matches!(entry[66], 1 | 2) {
+            return Err("CFB root child has an invalid entry type".into());
+        }
+        pending.push(read_u32(entry, 68)?);
+        pending.push(read_u32(entry, 72)?);
+        // Follow siblings, never a storage's child tree: embedded streams cannot
+        // supply the enclosing document's format authority.
+        if entry[66] == 2 {
+            let name_bytes = usize::from(read_u16(entry, 64)?);
+            if !(2..=64).contains(&name_bytes) || name_bytes % 2 != 0 {
+                return Err("CFB directory stream contains an invalid stream name".into());
+            }
+            let name = entry[..name_bytes - 2]
+                .chunks_exact(2)
+                .map(|pair| u16::from_le_bytes([pair[0], pair[1]]));
+            names.push(
+                char::decode_utf16(name)
+                    .collect::<Result<String, _>>()
+                    .map_err(|_| "CFB directory stream contains invalid UTF-16")?,
+            );
+        }
     }
     Ok(names)
 }
@@ -3420,9 +3446,12 @@ mod tests {
         bytes[516..520].copy_from_slice(&CFB_END_OF_CHAIN.to_le_bytes());
         let encoded =
             format!("{name}\0").encode_utf16().flat_map(u16::to_le_bytes).collect::<Vec<_>>();
-        bytes[1024..1024 + encoded.len()].copy_from_slice(&encoded);
-        bytes[1088..1090].copy_from_slice(&u16::try_from(encoded.len()).unwrap().to_le_bytes());
-        bytes[1090] = 2;
+        bytes[1090] = 5;
+        bytes[1100..1104].copy_from_slice(&1_u32.to_le_bytes());
+        bytes[1152..1152 + encoded.len()].copy_from_slice(&encoded);
+        bytes[1216..1218].copy_from_slice(&u16::try_from(encoded.len()).unwrap().to_le_bytes());
+        bytes[1218] = 2;
+        bytes[1220..1232].fill(0xff);
         bytes
     }
 
@@ -3948,6 +3977,41 @@ mod tests {
         .unwrap();
         assert_eq!(candidates[0].format, InputFormat::Ppt);
         assert!((candidates[0].confidence - 0.98).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn embedded_ole_streams_do_not_supply_root_format_authority() {
+        let mut bytes = cfb_with_stream("Workbook");
+        bytes[1224..1228].copy_from_slice(&2_u32.to_le_bytes());
+        bytes[1346] = 1; // Root sibling storage, with its own child tree.
+        bytes[1348..1356].fill(0xff);
+        bytes[1356..1360].copy_from_slice(&3_u32.to_le_bytes());
+        let encoded =
+            "WordDocument\0".encode_utf16().flat_map(u16::to_le_bytes).collect::<Vec<_>>();
+        bytes[1408..1408 + encoded.len()].copy_from_slice(&encoded);
+        bytes[1472..1474].copy_from_slice(&u16::try_from(encoded.len()).unwrap().to_le_bytes());
+        bytes[1474] = 2;
+        bytes[1476..1488].fill(0xff);
+        let candidates = detect_ole(&bytes);
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].format, InputFormat::Xls);
+
+        // Moving the same stream into the root sibling tree restores real ambiguity.
+        bytes[1352..1356].copy_from_slice(&3_u32.to_le_bytes());
+        let candidates = detect_ole(&bytes);
+        assert_eq!(candidates.len(), 2);
+        assert!(candidates.iter().any(|candidate| candidate.format == InputFormat::Doc));
+        assert!(candidates.iter().any(|candidate| candidate.format == InputFormat::Xls));
+    }
+
+    #[test]
+    fn root_directory_cycles_and_bad_indices_never_supply_authority() {
+        for invalid in [0, 1, 4, u32::MAX - 1] {
+            let mut bytes = cfb_with_stream("Workbook");
+            bytes[1224..1228].copy_from_slice(&invalid.to_le_bytes());
+            let candidates = detect_ole(&bytes);
+            assert!(candidates.iter().all(|candidate| candidate.confidence < 0.5));
+        }
     }
 
     #[test]

--- a/crates/converters/src/workbook/calamine_adapter.rs
+++ b/crates/converters/src/workbook/calamine_adapter.rs
@@ -198,6 +198,23 @@ where
             );
         }
         if sheet.typ != SheetType::WorkSheet {
+            if legacy_hints.is_some()
+                && matches!(sheet.typ, SheetType::ChartSheet | SheetType::MacroSheet)
+            {
+                diagnostics.push(Diagnostic {
+                    code: "legacyOffice.xls.nonWorksheetSkipped".into(),
+                    severity: DiagnosticSeverity::Warning,
+                    message: format!(
+                        "{:?} {} was authenticated but its contents were not rendered or executed",
+                        sheet.typ, sheet.name
+                    ),
+                    locator: Some(SourceLocator {
+                        sheet: Some(sheet.name.clone()),
+                        ..SourceLocator::default()
+                    }),
+                });
+                continue;
+            }
             return Err(ConversionError::Unsupported {
                 detail: format!(
                     "Calamine reported non-worksheet sheet type {:?} for {}",


### PR DESCRIPTION
Closes #310.

## Scope

- OLE detection follows the root storage's direct sibling tree; embedded documents cannot supply the outer document's format authority. Genuine root-level ambiguity still fails closed.
- Authenticate BoundSheet offsets **and types**, including chart and macro sheets. Non-worksheet content is explicitly diagnosed, never executed.
- Keep nested chart caches out of worksheet cells by changing record IDs only in the authenticated reader view. Record lengths, BoundSheet offsets, and the outer worksheet EOF are preserved.
- Accept bounded Formula → Array/Table/SharedFormula → String sequences while retaining attachment/token/continuation truncation checks.
- Retain complete noncanonical long sheet names in BestEffort only. Remap authenticated noncanonical BIFF8 FORMAT IDs and corresponding XF references into unused custom slots; keep format strings and the existing date/epoch implementation unchanged. Strict rejects these recoveries.

No MSG/RTF module, dependency, workflow, lint exemption, filename/corpus rule, or formula decompiler change. Independent worktree from `a6cb5e227de78b51fe6dc5dc5a680dba90f78c51`. No merge requested.

## Verification

- `cargo fmt --all --check`
- `cargo clippy -p into-markdown-converters --all-targets -j 2 -- -D warnings`
- `cargo test -p into-markdown-converters -p into-markdown-engine -p into-markdown-render-markdown -j 2`: **624 passed**, two existing PDFium-dependent ignored tests.
- Ten added regression tests: embedded/root authority and hostile links, sheet type/offset/EOF authentication, chart-cell contamination and post-chart body cells, formula attachments/continuations/truncation, complete long names, FORMAT slot collision/exhaustion, numeric/formula cache display, both Excel date epochs, and stable output.

## Frozen real corpus

Final head `9b2cf5b0dbcef5f48c7709f2597e975a8c54842b`, release binary SHA256 `dd4e7da3735be7165887bd9adecdd075657b6f9b8c7648c5e47b1c64e0c2736a`, all 452 XLS inputs, jobs=1:

| Frozen cohort | Baseline successful | Candidate successful |
| --- | ---: | ---: |
| Raw, 452 files | 395 (87.39%) | **412 (91.15%)** |
| Independently valid, 425 files | 392 (92.24%) | **409 (96.24%)** |
| Safe-recoverable, 2 files | 2 | 2 |
| Invalid, 24 files | 1 | 1 |
| Unclassified, 1 file | 0 | 0 |

**395/395 existing successes retained**. Of those, 383 Markdown SHA256s are unchanged; 11 change because nested chart caches no longer overwrite/truncate worksheet cells or merges, and one gains the authenticated date display. Twenty-five common successes gain recovery/skip diagnostics; no old diagnostics are removed. `all-4.json` and `evidence-4.json` record each source and drift.

The debug-only empty-Dimensions overflow on `LIBRE_OFFICE-94379-0.zip-57.xls` also reproduces with the pre-#310 debug binary. Its canonical empty bounds are `(16,16,4,4)` at BIFF offset `0xea8`. The final release conversion succeeds and matches the frozen baseline SHA; no workaround or unrelated parser change was added.

The original 16 confirmed failures plus the independently confirmed long-name regression are recovered. Independent xlrd 2.0.2 verifies all **8,339/8,339** required cells across these 17 files: cached/display values, original formula-token SHA, sheet/grid shape, sheet/cell/provenance order, merged ranges, and no missing/extra/duplicate coordinates. The same checks caught and drove the nested-chart and date-format corrections; this is not a non-empty-output check.

Two independent release reads of the 18-case target/policy cohort have identical statuses, Markdown hashes, and document-IR hashes (`confirmed-4.json` / `confirmed-5.json`).

Full formula-body agreement is reported separately, **12/17**, not relabeled as passing. The unchanged decompiler still disagrees with xlrd on **343 formula expressions in five files**, including operators/references; cached values and original token fingerprints match. These expressions are not claimed semantically equivalent, and this PR does not expand into formula decompilation.

The frozen validity labels and source hashes are unchanged. The six dual Book/Workbook cases remain policy rejections, not newly classified corrupt files. `43251.xls`, for example, has separate root Book (BIFF5, 83,415 bytes) and Workbook (BIFF8, 71,676 bytes) streams. The two genuine resource-limit cases and eight other unresolved legacy BIFF/CFB failures remain out of scope. One frozen-invalid source (`57456.xls`) was already accepted by the baseline and retains identical output; there is no new invalid acceptance.

## Evidence and execution boundary

Local reproducible evidence: `C:/im-bench-004/issue310-xls-20260831/` (`matrix.py`, `verify.py`, `summarize.py`, source oracles/IR, native reports, full comparison JSON, and test log). Frozen inputs: `C:/im-bench-004/formal-schema3/`, manifest SHA256 `7f82792dca7d1011d8a1bbcdfe7de5b4f0c463515be347405d0c88a6b866cacc`. Inputs and classifications were read-only; builds use at most two jobs and conversions one job.

Formal cross-PR performance/RSS/lease/temp/re-read comparison is reserved for the parent task's serialized harness; these correctness runs do not claim that performance gate. Existing resource and lease tests passed. No new Action or `[skip ci]`; the existing PR fast gate should run normally.

Protocol references: [BoundSheet8](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-xls/b9ec509a-235d-424e-871d-f8e721106501), [Array](https://learn.microsoft.com/en-us/openspecs/office_file_formats/ms-xls/c6ee7512-d6ec-4d81-8dfb-a01a744a1f39), [Table](https://learn.microsoft.com/en-us/openspecs/office_file_formats/MS-XLS/2e33c7ad-8a8a-4abc-b36f-01c682ad2eb9).
