### PR TITLE
fix(odf): accept ZIP metadata and recover ordinary ODF content

### DIFF
--- a/crates/converters/src/odf/annotations.rs
+++ b/crates/converters/src/odf/annotations.rs
@@ -189,8 +189,8 @@ pub(super) fn collect_image_anchors(
             .attr(XLINK_NS, "href")
             .ok_or_else(|| malformed(Some("content.xml"), "draw:image lacks xlink:href"))?;
         if node.attr(XLINK_NS, "type").is_some_and(|value| value != "simple")
-            || node.attr(XLINK_NS, "show").is_some()
-            || node.attr(XLINK_NS, "actuate").is_some()
+            || node.attr(XLINK_NS, "show").is_some_and(|value| value != "embed")
+            || node.attr(XLINK_NS, "actuate").is_some_and(|value| value != "onLoad")
         {
             return Err(malformed(
                 Some("content.xml"),
@@ -208,7 +208,9 @@ pub(super) fn collect_image_anchors(
             .get(&path)
             .ok_or_else(|| malformed(Some(&path), "image anchor is not manifest-bound"))?
             .media_type;
-        image_profile(&path, media_type)?;
+        if !super::image_validation::unsupported_media(media_type) {
+            image_profile(&path, media_type)?;
+        }
         anchors.insert(path);
     }
     Ok(anchors)

--- a/crates/converters/src/odf/compatibility.rs
+++ b/crates/converters/src/odf/compatibility.rs
@@ -1,0 +1,340 @@
+//! Inert producer metadata encountered in real ODF packages. Semantic content still goes
+//! through the regular ODF parsers; this is not a fallback for unknown body elements.
+use super::model::{
+    DRAW_NS, FO_NS, META_NS, NUMBER_NS, OFFICE_NS, PRESENTATION_NS, STYLE_NS, SVG_NS, TABLE_NS,
+    TEXT_NS,
+};
+use super::xml::{Attr, XmlNode};
+
+pub(super) const LOEXT_NS: &str =
+    "urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0";
+pub(super) const CALCEXT_NS: &str =
+    "urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0";
+pub(super) const OFFICE_EXT_NS: &str = "http://openoffice.org/2009/office";
+pub(super) const GRDDL_NS: &str = "http://www.w3.org/2003/g/data-view#";
+pub(super) const FORM_NS: &str = "urn:oasis:names:tc:opendocument:xmlns:form:1.0";
+
+pub(super) fn producer_namespace(ns: &str) -> bool {
+    matches!(ns, LOEXT_NS | CALCEXT_NS | OFFICE_EXT_NS | GRDDL_NS | FORM_NS)
+}
+
+pub(super) fn producer_attribute(node: &XmlNode, attr: &Attr) -> bool {
+    let local = attr.name.local.as_str();
+    match attr.name.ns.as_str() {
+        FO_NS if node.is(DRAW_NS, "text-box") => matches!(local, "min-height" | "min-width"),
+        GRDDL_NS => {
+            local == "transformation"
+                && node.name.ns == OFFICE_NS
+                && matches!(
+                    node.name.local.as_str(),
+                    "document-content" | "document-styles" | "document-meta"
+                )
+        }
+        OFFICE_EXT_NS => {
+            node.is(STYLE_NS, "text-properties") && matches!(local, "rsid" | "paragraph-rsid")
+        }
+        CALCEXT_NS => node.is(TABLE_NS, "table-cell") && local == "value-type",
+        LOEXT_NS => matches!(
+            (node.name.local.as_str(), local),
+            ("graphic-properties", "allow-overlap")
+                | ("image", "mime-type")
+                | ("number" | "scientific-number", "min-decimal-places")
+                | ("scientific-number", "exponent-interval" | "forced-exponent-sign")
+                | ("page-layout-properties", "margin-gutter")
+                | ("paragraph-properties", "contextual-spacing")
+                | ("text-properties", "hyphenation-no-caps" | "opacity")
+        ),
+        FORM_NS => {
+            node.is(OFFICE_NS, "forms") && matches!(local, "automatic-focus" | "apply-design-mode")
+        }
+        _ => false,
+    }
+}
+
+// These subtrees are layout/style definitions, not document body. The converter already
+// ignores their layout while consuming text/list styles separately. All descendants are
+// still checked for active content, namespaces and XML/resource limits.
+pub(super) fn layout_definition(node: &XmlNode, parent: &XmlNode) -> bool {
+    ((parent.is(OFFICE_NS, "document-styles") || parent.is(OFFICE_NS, "master-styles"))
+        && node.is(DRAW_NS, "layer-set"))
+        || (parent.is(OFFICE_NS, "font-face-decls") && node.is(STYLE_NS, "font-face"))
+        || (parent.is(OFFICE_NS, "master-styles")
+            && node.name.ns == STYLE_NS
+            && matches!(node.name.local.as_str(), "master-page" | "handout-master"))
+        || ((parent.is(OFFICE_NS, "styles") || parent.is(OFFICE_NS, "automatic-styles"))
+            && ((node.name.ns == STYLE_NS
+                && matches!(
+                    node.name.local.as_str(),
+                    "page-layout" | "default-page-layout" | "presentation-page-layout"
+                ))
+                || (node.name.ns == DRAW_NS
+                    && matches!(
+                        node.name.local.as_str(),
+                        "gradient"
+                            | "fill-image"
+                            | "hatch"
+                            | "marker"
+                            | "stroke-dash"
+                            | "layer-set"
+                    ))
+                || (node.name.ns == TEXT_NS
+                    && matches!(
+                        node.name.local.as_str(),
+                        "outline-style"
+                            | "notes-configuration"
+                            | "linenumbering-configuration"
+                            | "bibliography-configuration"
+                    ))))
+        || (node.name.ns == STYLE_NS
+            && node.name.local.ends_with("-properties")
+            && (parent.is(STYLE_NS, "style")
+                || parent.is(STYLE_NS, "default-style")
+                || (parent.name.ns == TEXT_NS
+                    && parent.name.local.starts_with("list-level-style-"))))
+        || (node.is(LOEXT_NS, "graphic-properties")
+            && (parent.is(STYLE_NS, "default-style") || parent.is(STYLE_NS, "style")))
+        || (node.name.ns == NUMBER_NS
+            && node.name.local.ends_with("-style")
+            && (parent.is(OFFICE_NS, "styles") || parent.is(OFFICE_NS, "automatic-styles")))
+        || (node.name.ns == STYLE_NS
+            && matches!(
+                node.name.local.as_str(),
+                "list-level-properties" | "list-level-label-alignment"
+            )
+            && parent.name.ns == TEXT_NS
+            && parent.name.local.starts_with("list-level-"))
+        || (parent.is(OFFICE_NS, "meta") && node.is(META_NS, "template"))
+        || (parent.is(OFFICE_NS, "text")
+            && node.name.ns == TEXT_NS
+            && matches!(
+                node.name.local.as_str(),
+                "sequence-decls" | "user-field-decls" | "variable-decls"
+            ))
+        || (parent.is(OFFICE_NS, "spreadsheet")
+            && node.name.ns == TABLE_NS
+            && matches!(node.name.local.as_str(), "calculation-settings" | "named-expressions"))
+        || (node.is(STYLE_NS, "map") && parent.is(STYLE_NS, "style"))
+        || (parent.name.ns == DRAW_NS
+            && node.name.ns == DRAW_NS
+            && matches!(node.name.local.as_str(), "enhanced-geometry" | "glue-point"))
+        || (parent.is(OFFICE_NS, "presentation")
+            && node.name.ns == PRESENTATION_NS
+            && matches!(node.name.local.as_str(), "settings" | "footer-decl" | "date-time-decl"))
+        || (node.is(DRAW_NS, "page-thumbnail") && parent.is(PRESENTATION_NS, "notes"))
+        || (node.is(TEXT_NS, "tracked-changes")
+            && parent.is(OFFICE_NS, "text")
+            && node.children().next().is_none()
+            && node.text().trim().is_empty())
+}
+
+pub(super) fn layout_metadata_element(node: &XmlNode) -> bool {
+    let local = node.name.local.as_str();
+    match node.name.ns.as_str() {
+        STYLE_NS => matches!(
+            local,
+            "background-image"
+                | "columns"
+                | "default-page-layout"
+                | "drawing-page-properties"
+                | "footer"
+                | "footer-first"
+                | "footer-left"
+                | "footer-style"
+                | "footnote-sep"
+                | "handout-master"
+                | "header"
+                | "header-first"
+                | "header-left"
+                | "header-style"
+                | "header-footer-properties"
+                | "list-level-label-alignment"
+                | "list-level-properties"
+                | "map"
+                | "presentation-page-layout"
+                | "region-left"
+                | "region-right"
+                | "ruby-properties"
+                | "section-properties"
+                | "tab-stop"
+                | "tab-stops"
+        ),
+        DRAW_NS => matches!(
+            local,
+            "fill-image"
+                | "gradient"
+                | "hatch"
+                | "layer"
+                | "layer-set"
+                | "marker"
+                | "stroke-dash"
+                | "page-thumbnail"
+                | "enhanced-geometry"
+                | "equation"
+                | "handle"
+                | "glue-point"
+        ),
+        TEXT_NS => matches!(
+            local,
+            "outline-style"
+                | "outline-level-style"
+                | "notes-configuration"
+                | "linenumbering-configuration"
+                | "linenumbering-separator"
+                | "bibliography-configuration"
+                | "sort-key"
+                | "sequence-decls"
+                | "sequence-decl"
+                | "user-field-decls"
+                | "user-field-decl"
+                | "variable-decls"
+                | "variable-decl"
+                | "tracked-changes"
+        ),
+        NUMBER_NS => matches!(
+            local,
+            "am-pm" | "boolean" | "boolean-style" | "scientific-number" | "text-content"
+        ),
+        TABLE_NS => matches!(
+            local,
+            "calculation-settings"
+                | "iteration"
+                | "null-date"
+                | "named-expressions"
+                | "named-range"
+        ),
+        PRESENTATION_NS => matches!(
+            local,
+            "date-time"
+                | "date-time-decl"
+                | "footer"
+                | "footer-decl"
+                | "header"
+                | "placeholder"
+                | "settings"
+        ),
+        LOEXT_NS => matches!(local, "graphic-properties" | "fill-character" | "text"),
+        META_NS => local == "template",
+        _ => false,
+    }
+}
+
+pub(super) fn standard_attribute(node: &XmlNode, attr: &Attr) -> bool {
+    let local = attr.name.local.as_str();
+    match attr.name.ns.as_str() {
+        STYLE_NS if node.is(DRAW_NS, "frame") => matches!(local, "rel-width" | "rel-height"),
+        OFFICE_NS if node.is(DRAW_NS, "a") || node.is(TEXT_NS, "a") => local == "name",
+        super::model::XML_NS if node.name.ns == DRAW_NS => local == "id",
+        STYLE_NS if cached_text_field(node) => local == "data-style-name",
+        STYLE_NS if node.is(STYLE_NS, "style") => matches!(
+            local,
+            "auto-update"
+                | "class"
+                | "data-style-name"
+                | "default-outline-level"
+                | "list-style-name"
+                | "master-page-name"
+                | "next-style-name"
+        ),
+        STYLE_NS if node.name.ns == TEXT_NS && node.name.local.starts_with("list-level-style-") => {
+            matches!(local, "num-letter-sync" | "num-suffix" | "num-prefix")
+        }
+        TEXT_NS if node.name.ns == TEXT_NS && node.name.local.starts_with("list-level-style-") => {
+            local == "style-name"
+        }
+        TEXT_NS if node.is(TEXT_NS, "list-style") => local == "consecutive-numbering",
+        TEXT_NS if node.is(OFFICE_NS, "text") => local == "use-soft-page-breaks",
+        TEXT_NS if node.is(TEXT_NS, "p") => local == "cond-style-name",
+        TEXT_NS if node.is(TEXT_NS, "conditional-text") => matches!(
+            local,
+            "condition" | "current-value" | "string-value-if-false" | "string-value-if-true"
+        ),
+        TEXT_NS if cached_text_field(node) => {
+            matches!(
+                local,
+                "name"
+                    | "display"
+                    | "description"
+                    | "select-page"
+                    | "date-value"
+                    | "time-value"
+                    | "ref-name"
+                    | "reference-format"
+                    | "formula"
+            )
+        }
+        TEXT_NS if node.is(TEXT_NS, "h") => {
+            matches!(local, "is-list-header" | "restart-numbering" | "start-value")
+        }
+        TEXT_NS if node.name.ns == DRAW_NS => local == "anchor-type",
+        TABLE_NS if node.is(TABLE_NS, "table-column") => local == "default-cell-style-name",
+        TABLE_NS if node.is(TABLE_NS, "table") => matches!(local, "print" | "is-sub-table"),
+        DRAW_NS if node.name.ns == DRAW_NS => matches!(
+            local,
+            "master-page-name"
+                | "text-style-name"
+                | "z-index"
+                | "layer"
+                | "type"
+                | "corner-radius"
+                | "mime-type"
+                | "start-angle"
+                | "end-angle"
+                | "kind"
+                | "page-number"
+        ),
+        DRAW_NS if node.is(PRESENTATION_NS, "notes") => local == "style-name",
+        SVG_NS if node.is(DRAW_NS, "connector") || node.is(DRAW_NS, "line") => {
+            matches!(local, "x1" | "x2" | "y1" | "y2")
+        }
+        PRESENTATION_NS if node.name.ns == DRAW_NS => matches!(
+            local,
+            "presentation-page-layout-name"
+                | "use-date-time-name"
+                | "use-footer-name"
+                | "placeholder"
+                | "user-transformed"
+        ),
+        META_NS if node.is(META_NS, "document-statistic") => matches!(
+            local,
+            "cell-count"
+                | "character-count"
+                | "image-count"
+                | "non-whitespace-character-count"
+                | "object-count"
+                | "page-count"
+                | "paragraph-count"
+                | "row-count"
+                | "table-count"
+                | "word-count"
+        ),
+        _ => false,
+    }
+}
+
+pub(super) fn cached_text_field(node: &XmlNode) -> bool {
+    node.name.ns == TEXT_NS
+        && matches!(
+            node.name.local.as_str(),
+            "user-field-get"
+                | "user-field-input"
+                | "page-number"
+                | "date"
+                | "time"
+                | "reference-ref"
+                | "bookmark-ref"
+                | "sequence-ref"
+                | "file-name"
+                | "sequence"
+                | "variable-set"
+        )
+}
+
+pub(super) fn style_attribute(node: &XmlNode, attr: &Attr) -> bool {
+    // Formatting properties do not drive resource access or structural interpretation.
+    node.name.ns == STYLE_NS
+        && node.name.local.ends_with("-properties")
+        && matches!(
+            attr.name.ns.as_str(),
+            STYLE_NS | FO_NS | DRAW_NS | SVG_NS | TABLE_NS | TEXT_NS | PRESENTATION_NS
+        )
+}

--- a/crates/converters/src/odf/content.rs
+++ b/crates/converters/src/odf/content.rs
@@ -3,7 +3,7 @@ use crate::odf::package::Package;
 use crate::odf::presentation::parse_presentation;
 use crate::odf::semantic::parse_blocks;
 use crate::odf::sheets::parse_spreadsheet;
-use crate::odf::styles::StyleMap;
+use crate::odf::styles::StyleCatalog;
 use crate::odf::text::ParseMode;
 use crate::odf::xml::{XmlNode, only_child};
 use into_markdown_core::{ConversionError, ConversionOptions, ExecutionContext, InputFormat};
@@ -11,7 +11,7 @@ use into_markdown_core::{ConversionError, ConversionOptions, ExecutionContext, I
 pub(super) fn parse_content(
     root: &XmlNode,
     format: InputFormat,
-    styles: &StyleMap,
+    styles: &StyleCatalog<'_>,
     package: &Package,
     state: &mut ParseState,
     options: &ConversionOptions,
@@ -21,13 +21,16 @@ pub(super) fn parse_content(
         return Err(malformed(Some("content.xml"), "unexpected content root"));
     }
     let version = root.attr(OFFICE_NS, "version").unwrap_or(&package.odf_version);
-    if !matches!(version, "1.2" | "1.3") {
+    if !matches!(version, "1.0" | "1.1" | "1.2" | "1.3") {
         return Err(malformed(Some("content.xml"), "unsupported ODF content version"));
     }
     state.document.metadata.properties.insert("odf.version".into(), version.into());
     for child in root.children() {
-        if child.is(OFFICE_NS, "scripts") {
-            return Err(malformed(Some("content.xml"), "office:scripts is forbidden"));
+        if child.is(OFFICE_NS, "scripts")
+            && child.children().next().is_none()
+            && child.text().trim().is_empty()
+        {
+            continue;
         }
         if !(child.is(OFFICE_NS, "font-face-decls")
             || child.is(OFFICE_NS, "automatic-styles")
@@ -65,7 +68,7 @@ pub(super) fn parse_content(
             let locator = part_locator("content.xml");
             state.document.blocks = parse_blocks(
                 payload,
-                styles,
+                &styles.text,
                 package,
                 state,
                 options,
@@ -75,7 +78,9 @@ pub(super) fn parse_content(
                 1,
             )?;
         }
-        InputFormat::Ods => parse_spreadsheet(payload, styles, package, state, options, context)?,
+        InputFormat::Ods => {
+            parse_spreadsheet(payload, &styles.text, package, state, options, context)?;
+        }
         InputFormat::Odp => parse_presentation(payload, styles, package, state, options, context)?,
         _ => unreachable!(),
     }

--- a/crates/converters/src/odf/geometry.rs
+++ b/crates/converters/src/odf/geometry.rs
@@ -79,22 +79,18 @@ pub(super) fn drawing_bounds(node: &XmlNode) -> Result<Option<Rect>, ConversionE
         node.attr(SVG_NS, "width"),
         node.attr(SVG_NS, "height"),
     ];
-    if values.iter().all(Option::is_none) {
-        return Ok(None);
+    let mut parsed = [None; 4];
+    for (index, value) in values.into_iter().enumerate() {
+        parsed[index] = value.map(parse_length).transpose()?;
     }
-    let [Some(x), Some(y), Some(width), Some(height)] = values else {
-        return Err(malformed(Some("content.xml"), "drawing bounds are incomplete"));
-    };
-    let result = Rect {
-        x: parse_length(x)?,
-        y: parse_length(y)?,
-        width: parse_length(width)?,
-        height: parse_length(height)?,
-    };
-    if result.width < 0.0 || result.height < 0.0 {
+    if parsed[2].is_some_and(|value| value < 0.0) || parsed[3].is_some_and(|value| value < 0.0) {
         return Err(malformed(Some("content.xml"), "drawing dimensions are negative"));
     }
-    Ok(Some(result))
+    let [Some(x), Some(y), Some(width), Some(height)] = parsed else {
+        // Inline/paragraph anchors need not have an absolute origin. Do not fabricate one.
+        return Ok(None);
+    };
+    Ok(Some(Rect { x, y, width, height }))
 }
 
 fn parse_length(value: &str) -> Result<f32, ConversionError> {
@@ -137,7 +133,7 @@ pub(super) fn parse_transform(value: Option<&str>) -> Result<Transform, Conversi
             .find(')')
             .map(|offset| open + 1 + offset)
             .ok_or_else(|| malformed(Some("content.xml"), "unterminated draw:transform"))?;
-        let name = &rest[..open];
+        let name = rest[..open].trim_end();
         let args: Vec<_> = rest[open + 1..close]
             .split(|character: char| character == ',' || character.is_whitespace())
             .filter(|value| !value.is_empty())

--- a/crates/converters/src/odf/image_validation.rs
+++ b/crates/converters/src/odf/image_validation.rs
@@ -5,6 +5,13 @@ use into_markdown_core::{ConversionError, ConversionOptions, ExecutionContext};
 use std::io::Cursor;
 use std::path::Path;
 
+pub(super) fn unsupported_media(media_type: &str) -> bool {
+    matches!(
+        media_type,
+        "image/svg+xml" | "application/x-openoffice-gdimetafile;windows_formatname=\"GDIMetaFile\""
+    )
+}
+
 pub(super) fn image_profile(path: &str, media_type: &str) -> Result<ImageFormat, ConversionError> {
     let extension = Path::new(path)
         .extension()

--- a/crates/converters/src/odf/images.rs
+++ b/crates/converters/src/odf/images.rs
@@ -42,6 +42,18 @@ pub(super) fn image_block(
         .manifest
         .get(&path)
         .ok_or_else(|| malformed(Some(&path), "image is not declared in manifest"))?;
+    if super::image_validation::unsupported_media(&manifest.media_type) {
+        super::recovery::require_best_effort(options, &path, "unsupported image media")?;
+        state.warning("odf.imageOmitted", format!("Unsupported {} image omitted: {path}; placeholder retained, original bytes not exported", manifest.media_type), image_locator.clone());
+        state.add_inlines(1)?;
+        return Ok(Some(state.node(
+            Block::Paragraph(vec![into_markdown_core::Inline::Text {
+                value: format!("[Image omitted: {path} ({})]", manifest.media_type),
+                marks: vec![],
+            }]),
+            image_locator,
+        )?));
+    }
     image_profile(&path, &manifest.media_type)?;
     let bytes =
         package.parts.get(&path).ok_or_else(|| malformed(Some(&path), "image part is missing"))?;

--- a/crates/converters/src/odf/mod.rs
+++ b/crates/converters/src/odf/mod.rs
@@ -1,11 +1,13 @@
-//! Bounded, offline `OpenDocument` 1.3 text, spreadsheet, and presentation conversion.
+//! Bounded, offline `OpenDocument` text, spreadsheet, and presentation conversion.
 //!
 //! The accepted profile is intentionally smaller than the complete ODF grammar. It accepts
 //! package-based ODT/ODS/ODP documents with the standard content, styles, metadata, settings,
-//! list, table, drawing, annotation, and image vocabulary. It rejects encryption, signatures,
-//! scripts/macros, embedded documents, DTDs, processing instructions, undeclared/foreign
-//! namespaces, external images, and unsafe package paths. Hyperlinks are retained as inert data
-//! only when they are absolute HTTP(S), mailto, or same-document fragment references.
+//! list, table, drawing, annotation, and image vocabulary. Encryption, signatures, DTDs,
+//! processing instructions, unknown namespaces, external images, unsafe paths and CRC failures
+//! remain errors. Best-effort conversion diagnoses omitted optional scripts, embedded objects,
+//! animation and unsupported graphics while retaining current text, cached fields and tables;
+//! strict conversion rejects these lossy projections. No scripts or formulas are executed.
+//! Hyperlinks remain inert HTTP(S), mailto or same-document fragment references.
 
 use into_markdown_core::{
     BoxFuture, ConversionError, ConversionOptions, Converter, ConverterOutput, ExecutionContext,
@@ -13,6 +15,7 @@ use into_markdown_core::{
 };
 
 mod annotations;
+mod compatibility;
 mod content;
 mod geometry;
 mod image_validation;
@@ -21,12 +24,15 @@ mod manifest;
 mod metadata;
 mod model;
 mod package;
+mod paragraphs;
 mod paths;
 mod presentation;
 mod profile;
 mod raw_zip;
+mod recovery;
 mod semantic;
 mod sheets;
+mod sparse;
 mod styles;
 mod tables;
 mod text;
@@ -35,7 +41,7 @@ mod xml;
 use annotations::{collect_image_anchors, validate_ranged_annotations};
 use content::parse_content;
 use metadata::parse_metadata;
-use model::{FORMATS, OFFICE_NS, PROVIDER_ID, ParseState, limit, malformed};
+use model::{FORMATS, OFFICE_NS, PROVIDER_ID, ParseState, limit, malformed, part_locator};
 use package::Package;
 use profile::{OdfXmlPart, validate_tree_profile};
 use styles::{collect_styles, validate_document_versions};
@@ -131,8 +137,8 @@ fn convert_odf(
             .parts
             .get("content.xml")
             .ok_or_else(|| malformed(Some("content.xml"), "content part is missing"))?;
-        let content_root = parse_xml(content_bytes, "content.xml", options, context)?;
-        let styles_root = package
+        let mut content_root = parse_xml(content_bytes, "content.xml", options, context)?;
+        let mut styles_root = package
             .parts
             .get("styles.xml")
             .map(|bytes| parse_xml(bytes, "styles.xml", options, context))
@@ -150,15 +156,47 @@ fn convert_odf(
             .get("settings.xml")
             .map(|bytes| parse_xml(bytes, "settings.xml", options, context))
             .transpose()?;
-        validate_tree_profile(&content_root, OdfXmlPart::Content, "content.xml")?;
-        if let Some(root) = styles_root.as_ref() {
-            validate_tree_profile(root, OdfXmlPart::Styles, "styles.xml")?;
+        let mut state = ParseState::default();
+        if package.noncanonical_mimetype {
+            state.warning("odf.noncanonicalMimetype", "Noncanonical mimetype order/compression/descriptor accepted after complete ZIP integrity and exact media-type validation", part_locator("mimetype"));
         }
-        if let Some(root) = metadata_root.as_ref() {
-            validate_tree_profile(root, OdfXmlPart::Meta, "meta.xml")?;
+        for part in &package.missing_optional_parts {
+            state.warning(
+                "odf.optionalPartMissing",
+                "Missing optional metadata, UI configuration or unreferenced image; referenced images and document body remain required",
+                part_locator(part),
+            );
         }
-        if let Some(root) = settings_root.as_ref() {
-            validate_tree_profile(root, OdfXmlPart::Settings, "settings.xml")?;
+        recovery::project_static_content(
+            &mut content_root,
+            "content.xml",
+            &mut state,
+            options,
+            context,
+            &package.manifest,
+        )?;
+        if let Some(root) = &mut styles_root {
+            recovery::project_static_content(
+                root,
+                "styles.xml",
+                &mut state,
+                options,
+                context,
+                &package.manifest,
+            )?;
+        }
+        for (root, profile, part) in [
+            (Some(&content_root), OdfXmlPart::Content, "content.xml"),
+            (styles_root.as_ref(), OdfXmlPart::Styles, "styles.xml"),
+            (metadata_root.as_ref(), OdfXmlPart::Meta, "meta.xml"),
+            (settings_root.as_ref(), OdfXmlPart::Settings, "settings.xml"),
+        ] {
+            if let Some(root) = root {
+                let count = validate_tree_profile(root, profile, part)?;
+                if count > 0 {
+                    state.warning("odf.layoutMetadata", format!("{count} layout definitions/producer hints are not represented in Markdown; text and table semantics are parsed separately"), part_locator(part));
+                }
+            }
         }
         validate_document_versions(
             &package.odf_version,
@@ -170,11 +208,15 @@ fn convert_odf(
         validate_ranged_annotations(&content_root, options, context)?;
         let image_anchors = collect_image_anchors(&content_root, &package.manifest)?;
         package.load_reachable_images(bytes, &image_anchors, options, context)?;
-        let styles = collect_styles(styles_root.as_ref(), &content_root)?;
-        let mut state = ParseState { list_styles: styles.lists, ..ParseState::default() };
+        let mut styles = collect_styles(styles_root.as_ref(), &content_root)?;
+        if styles.identical_duplicates > 0 {
+            state.warning("odf.identicalStyle", format!("{} identical duplicate style definitions reused; conflicting definitions remain errors", styles.identical_duplicates), part_locator("styles.xml"));
+        }
+        state.list_styles = std::mem::take(&mut styles.lists);
         parse_metadata(metadata_root.as_ref(), settings_root.as_ref(), &mut state, options)?;
-        parse_content(&content_root, format, &styles.text, &package, &mut state, options, context)?;
+        parse_content(&content_root, format, &styles, &package, &mut state, options, context)?;
         state.document.blocks.append(&mut state.deferred);
+        recovery::ensure_static_body(&state)?;
         (state.document, state.assets, state.diagnostics)
     };
     ConverterOutput::new_with_memory_reservation(document, assets, diagnostics, context, memory)

--- a/crates/converters/src/odf/package.rs
+++ b/crates/converters/src/odf/package.rs
@@ -4,8 +4,8 @@ use crate::odf::model::{ZIP_STREAM_CHUNK, limit, malformed};
 use crate::odf::paths::canonical_part_name;
 use crate::odf::raw_zip::{
     bind_mimetype_central, conservative_vec_capacity, package_index_peak, package_logical_peak,
-    reachable_image_peak, validate_first_mimetype_local_header, validate_raw_mimetype_central,
-    validate_zip_directory_layout, validated_local_zip_name,
+    reachable_image_peak, validate_raw_mimetype_central, validate_zip_directory_layout,
+    validated_local_zip_name,
 };
 use crate::odf::xml::parse_xml;
 use into_markdown_core::{ConversionError, ConversionOptions, ExecutionContext, InputFormat};
@@ -24,7 +24,6 @@ std::thread_local! {
 struct ZipPart {
     index: usize,
     size: u64,
-    compressed_size: u64,
     directory: bool,
 }
 
@@ -36,6 +35,8 @@ pub(super) struct Package {
     pub(super) logical_peak: u64,
     preflight: u64,
     pub(super) odf_version: String,
+    pub(super) missing_optional_parts: Vec<String>,
+    pub(super) noncanonical_mimetype: bool,
 }
 
 impl Package {
@@ -56,8 +57,10 @@ impl Package {
             ));
         }
         let expected = media_type_for(format)?;
-        let local_mimetype = validate_first_mimetype_local_header(bytes, expected)?;
-        validate_raw_mimetype_central(bytes, &local_mimetype)?;
+        let local_mimetype = super::raw_zip::mimetype_header_for_policy(bytes, expected, options)?;
+        if let Some(local) = &local_mimetype {
+            validate_raw_mimetype_central(bytes, local)?;
+        }
         validate_zip_directory_layout(bytes, options.limits.max_archive_entries, planned, context)?;
         let mut archive = zip::ZipArchive::new(Cursor::new(bytes))
             .map_err(|error| malformed(None, format!("invalid ODF ZIP container: {error}")))?;
@@ -100,12 +103,7 @@ impl Package {
                 ));
             }
             let name = canonical_part_name(raw_name, entry.is_dir())?;
-            let part = ZipPart {
-                index,
-                size: entry.size(),
-                compressed_size: entry.compressed_size(),
-                directory: entry.is_dir(),
-            };
+            let part = ZipPart { index, size: entry.size(), directory: entry.is_dir() };
             if indexes.insert(name.clone(), part).is_some() {
                 return Err(malformed(Some(&name), "duplicate ZIP part name"));
             }
@@ -122,7 +120,7 @@ impl Package {
         let mime_part = indexes.get("mimetype").copied().ok_or_else(|| {
             malformed(Some("mimetype"), "required uncompressed mimetype part is missing")
         })?;
-        if mime_part.index != 0 || mime_part.directory {
+        if (local_mimetype.is_some() && mime_part.index != 0) || mime_part.directory {
             return Err(malformed(
                 Some("mimetype"),
                 "mimetype must be the first non-directory package entry",
@@ -131,7 +129,11 @@ impl Package {
         let mime_entry = archive.by_index_raw(mime_part.index).map_err(|error| {
             malformed(Some("mimetype"), format!("cannot inspect mimetype: {error}"))
         })?;
-        bind_mimetype_central(bytes, &mime_entry, &local_mimetype)?;
+        if let Some(local) = &local_mimetype {
+            bind_mimetype_central(bytes, &mime_entry, local)?;
+        } else {
+            super::raw_zip::validate_relaxed_mimetype_extras(bytes, &mime_entry)?;
+        }
         drop(mime_entry);
         if mime_part.size > 256 {
             return Err(malformed(Some("mimetype"), "mimetype entry is too large"));
@@ -187,8 +189,32 @@ impl Package {
                 return Err(malformed(Some(name), "ZIP part is not declared in ODF manifest"));
             }
         }
+        let mut missing_optional_parts = Vec::new();
         for name in manifest.keys().filter(|name| name.as_str() != "/") {
-            if name != "META-INF/manifest.xml" && !indexes.contains_key(name) {
+            // Manifest directories describe subdocuments/configuration trees; ZIP does not
+            // require a physical directory record, including for an empty directory.
+            if name != "META-INF/manifest.xml"
+                && !name.ends_with('/')
+                && !indexes.contains_key(name)
+            {
+                if name == "meta.xml"
+                    || manifest
+                        .get(name)
+                        .is_some_and(|entry| entry.media_type.starts_with("image/"))
+                    || manifest.iter().any(|(parent, entry)| {
+                        parent.ends_with('/')
+                            && entry.media_type == "application/vnd.sun.xml.ui.configuration"
+                            && name.starts_with(parent)
+                    })
+                {
+                    super::recovery::require_best_effort(
+                        options,
+                        name,
+                        "missing optional metadata, unreferenced image or UI configuration member",
+                    )?;
+                    missing_optional_parts.push(name.clone());
+                    continue;
+                }
                 return Err(malformed(Some(name), "manifest-declared ODF part is missing"));
             }
         }
@@ -227,22 +253,29 @@ impl Package {
         // unreferenced images. Validation streams into a fixed buffer and does not add the part's
         // expanded size to the retained/working-set plan.
         for (name, part) in &indexes {
-            if part.directory
-                || matches!(
-                    name.as_str(),
-                    "mimetype"
-                        | "META-INF/manifest.xml"
-                        | "content.xml"
-                        | "styles.xml"
-                        | "meta.xml"
-                        | "settings.xml"
-                )
-            {
+            if matches!(
+                name.as_str(),
+                "mimetype"
+                    | "META-INF/manifest.xml"
+                    | "content.xml"
+                    | "styles.xml"
+                    | "meta.xml"
+                    | "settings.xml"
+            ) {
                 continue;
             }
             validate_entry_stream(&mut archive, part.index, name, part.size, context)?;
         }
-        Ok(Self { parts, manifest, indexes, logical_peak, preflight: planned, odf_version })
+        Ok(Self {
+            parts,
+            manifest,
+            indexes,
+            logical_peak,
+            preflight: planned,
+            odf_version,
+            missing_optional_parts,
+            noncanonical_mimetype: local_mimetype.is_none(),
+        })
     }
 
     pub(super) fn load_reachable_images(
@@ -264,6 +297,9 @@ impl Package {
                 .get(path)
                 .copied()
                 .ok_or_else(|| malformed(Some(path), "referenced image has no ZIP part"))?;
+            if self.skip_unsupported_image(path, options)? {
+                continue;
+            }
             if part.directory {
                 return Err(malformed(Some(path), "referenced image is a directory"));
             }
@@ -349,6 +385,27 @@ impl Package {
     }
 }
 
+impl Package {
+    fn skip_unsupported_image(
+        &self,
+        path: &str,
+        options: &ConversionOptions,
+    ) -> Result<bool, ConversionError> {
+        let unsupported = self
+            .manifest
+            .get(path)
+            .is_some_and(|entry| super::image_validation::unsupported_media(&entry.media_type));
+        if unsupported {
+            super::recovery::require_best_effort(
+                options,
+                path,
+                "unsupported image media requires a static placeholder",
+            )?;
+        }
+        Ok(unsupported)
+    }
+}
+
 fn validate_package_graph(
     indexes: &BTreeMap<String, ZipPart>,
     manifest: &BTreeMap<String, ManifestEntry>,
@@ -357,44 +414,38 @@ fn validate_package_graph(
         if matches!(name.as_str(), "mimetype" | "META-INF/manifest.xml") {
             continue;
         }
-        let declared = manifest
-            .get(name)
-            .ok_or_else(|| malformed(Some(name), "ZIP part is not declared in manifest"))?;
         if part.directory != name.ends_with('/') {
             return Err(malformed(Some(name), "ZIP directory naming is inconsistent"));
         }
         if part.directory {
-            if !declared.media_type.is_empty() || part.size != 0 || part.compressed_size != 0 {
-                return Err(malformed(
-                    Some(name),
-                    "ODF directories must be empty and use an empty manifest media type",
-                ));
+            if part.size != 0 {
+                return Err(malformed(Some(name), "ODF ZIP directories must be empty"));
             }
             continue;
         }
+        let declared = manifest
+            .get(name)
+            .ok_or_else(|| malformed(Some(name), "ZIP part is not declared in manifest"))?;
         if matches!(name.as_str(), "content.xml" | "styles.xml" | "meta.xml" | "settings.xml") {
             if declared.media_type != "text/xml" {
                 return Err(malformed(Some(name), "core ODF parts require text/xml media type"));
             }
             continue;
         }
-        image_profile(name, &declared.media_type)?;
-    }
-    for (name, entry) in manifest.iter().filter(|(name, _)| name.as_str() != "/") {
-        if name == "META-INF/manifest.xml" {
-            if !entry.media_type.is_empty() && entry.media_type != "text/xml" {
-                return Err(malformed(Some(name), "manifest self-entry has an invalid media type"));
-            }
-            continue;
-        }
-        let part = indexes
-            .get(name)
-            .ok_or_else(|| malformed(Some(name), "manifest-declared part is missing"))?;
-        if !part.directory
-            && !matches!(name.as_str(), "content.xml" | "styles.xml" | "meta.xml" | "settings.xml")
+        if declared.media_type.starts_with("image/")
+            && !super::image_validation::unsupported_media(&declared.media_type)
         {
-            image_profile(name, &entry.media_type)?;
+            image_profile(name, &declared.media_type)?;
         }
+    }
+    if let Some(entry) = manifest.get("META-INF/manifest.xml")
+        && !entry.media_type.is_empty()
+        && entry.media_type != "text/xml"
+    {
+        return Err(malformed(
+            Some("META-INF/manifest.xml"),
+            "manifest self-entry has an invalid media type",
+        ));
     }
     Ok(())
 }

--- a/crates/converters/src/odf/paragraphs.rs
+++ b/crates/converters/src/odf/paragraphs.rs
@@ -1,4 +1,4 @@
-use super::model::DRAW_NS;
+use super::model::{DRAW_NS, TEXT_NS};
 use super::xml::{XmlContent, XmlNode};
 
 pub(super) enum ParagraphPart<'a> {
@@ -9,6 +9,11 @@ pub(super) enum ParagraphPart<'a> {
 // The IR has block images, not inline images. Split only at drawing anchors, preserving
 // text wrappers/marks and source order on either side (including anchors inside spans).
 pub(super) fn split_drawings(node: &XmlNode) -> Vec<ParagraphPart<'_>> {
+    // A note owns a separate block body and one identity. Its drawings must split
+    // that body, not clone the note wrapper into the surrounding paragraph.
+    if node.is(TEXT_NS, "note") {
+        return vec![ParagraphPart::Text(node.clone())];
+    }
     if node.name.ns == DRAW_NS && matches!(node.name.local.as_str(), "frame" | "a") {
         return vec![ParagraphPart::Drawing(node)];
     }

--- a/crates/converters/src/odf/paragraphs.rs
+++ b/crates/converters/src/odf/paragraphs.rs
@@ -1,0 +1,43 @@
+use super::model::DRAW_NS;
+use super::xml::{XmlContent, XmlNode};
+
+pub(super) enum ParagraphPart<'a> {
+    Text(XmlNode),
+    Drawing(&'a XmlNode),
+}
+
+// The IR has block images, not inline images. Split only at drawing anchors, preserving
+// text wrappers/marks and source order on either side (including anchors inside spans).
+pub(super) fn split_drawings(node: &XmlNode) -> Vec<ParagraphPart<'_>> {
+    if node.name.ns == DRAW_NS && matches!(node.name.local.as_str(), "frame" | "a") {
+        return vec![ParagraphPart::Drawing(node)];
+    }
+    let empty = || XmlNode { name: node.name.clone(), attrs: node.attrs.clone(), content: vec![] };
+    let mut text = empty();
+    let mut parts = Vec::new();
+    for value in &node.content {
+        match value {
+            XmlContent::Text(value) => text.content.push(XmlContent::Text(value.clone())),
+            XmlContent::Node(child) => {
+                for part in split_drawings(child) {
+                    match part {
+                        ParagraphPart::Text(child) => text.content.push(XmlContent::Node(child)),
+                        ParagraphPart::Drawing(drawing) => {
+                            if !text.content.is_empty() {
+                                parts.push(ParagraphPart::Text(std::mem::replace(
+                                    &mut text,
+                                    empty(),
+                                )));
+                            }
+                            parts.push(ParagraphPart::Drawing(drawing));
+                        }
+                    }
+                }
+            }
+        }
+    }
+    if !text.content.is_empty() || parts.is_empty() {
+        parts.push(ParagraphPart::Text(text));
+    }
+    parts
+}

--- a/crates/converters/src/odf/presentation.rs
+++ b/crates/converters/src/odf/presentation.rs
@@ -1,7 +1,7 @@
 use crate::odf::model::{DRAW_NS, PRESENTATION_NS, ParseState, limit};
 use crate::odf::package::Package;
 use crate::odf::semantic::{parse_blocks, parse_drawing};
-use crate::odf::styles::StyleMap;
+use crate::odf::styles::StyleCatalog;
 use crate::odf::text::ParseMode;
 use crate::odf::xml::XmlNode;
 use into_markdown_core::{
@@ -10,12 +10,13 @@ use into_markdown_core::{
 
 pub(super) fn parse_presentation(
     payload: &XmlNode,
-    styles: &StyleMap,
+    catalog: &StyleCatalog<'_>,
     package: &Package,
     state: &mut ParseState,
     options: &ConversionOptions,
     context: &ExecutionContext,
 ) -> Result<(), ConversionError> {
+    let styles = &catalog.text;
     let pages: Vec<_> = payload.children().filter(|child| child.is(DRAW_NS, "page")).collect();
     if u32::try_from(pages.len()).unwrap_or(u32::MAX) > options.limits.max_pages {
         return Err(limit(
@@ -93,8 +94,51 @@ pub(super) fn parse_presentation(
                 ParseMode::Slide,
             )?);
         }
+        blocks.extend(master_text(page, catalog, package, state, options, context, &locator)?);
         let slide = state.node(Block::Slide { number, title, blocks }, locator)?;
         state.document.blocks.push(slide);
     }
     Ok(())
+}
+
+fn master_text(
+    page: &XmlNode,
+    catalog: &StyleCatalog<'_>,
+    package: &Package,
+    state: &mut ParseState,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+    locator: &SourceLocator,
+) -> Result<Vec<into_markdown_core::BlockNode>, ConversionError> {
+    let mut blocks = Vec::new();
+    if let Some(master) =
+        page.attr(DRAW_NS, "master-page-name").and_then(|name| catalog.masters.get(name))
+    {
+        let locator = SourceLocator { part: Some("styles.xml".into()), ..locator.clone() };
+        for frame in master.children().filter(|node| {
+            node.is(DRAW_NS, "frame")
+                && node
+                    .attr(PRESENTATION_NS, "class")
+                    .is_some_and(|class| matches!(class, "header" | "footer"))
+        }) {
+            if !frame.text().trim().is_empty() {
+                blocks.extend(parse_drawing(
+                    frame,
+                    &catalog.text,
+                    package,
+                    state,
+                    options,
+                    context,
+                    &locator,
+                    ParseMode::Slide,
+                )?);
+                state.warning(
+                    "odf.masterText",
+                    "Static header/footer text from the referenced slide master was retained",
+                    locator.clone(),
+                );
+            }
+        }
+    }
+    Ok(blocks)
 }

--- a/crates/converters/src/odf/profile.rs
+++ b/crates/converters/src/odf/profile.rs
@@ -1,3 +1,7 @@
+use super::compatibility::{
+    layout_definition, layout_metadata_element, producer_attribute, standard_attribute,
+    style_attribute,
+};
 use crate::odf::model::{
     CONFIG_NS, DC_NS, DRAW_NS, FO_NS, META_NS, NUMBER_NS, OFFICE_NS, PRESENTATION_NS, STYLE_NS,
     SVG_NS, TABLE_NS, TEXT_NS, XLINK_NS, XML_NS, malformed,
@@ -17,7 +21,7 @@ pub(super) fn validate_tree_profile(
     root: &XmlNode,
     profile: OdfXmlPart,
     part: &str,
-) -> Result<(), ConversionError> {
+) -> Result<usize, ConversionError> {
     let root_ok = match profile {
         OdfXmlPart::Content => root.is(OFFICE_NS, "document-content"),
         OdfXmlPart::Styles => root.is(OFFICE_NS, "document-styles"),
@@ -27,7 +31,7 @@ pub(super) fn validate_tree_profile(
     if !root_ok {
         return Err(malformed(Some(part), "XML root is outside the selected ODF part profile"));
     }
-    validate_profile_node(root, None, profile, part)
+    validate_profile_node(root, None, profile, part, false)
 }
 
 fn validate_profile_node(
@@ -35,7 +39,30 @@ fn validate_profile_node(
     parent: Option<&XmlNode>,
     profile: OdfXmlPart,
     part: &str,
-) -> Result<(), ConversionError> {
+    layout: bool,
+) -> Result<usize, ConversionError> {
+    let empty_container = node.children().next().is_none() && node.text().trim().is_empty();
+    let empty_scripts = empty_container
+        && node.is(OFFICE_NS, "scripts")
+        && parent.is_some_and(|parent| parent.is(OFFICE_NS, "document-content"));
+    let empty_forms = empty_container
+        && node.is(OFFICE_NS, "forms")
+        && parent.is_some_and(|parent| {
+            parent.name.ns == OFFICE_NS
+                && matches!(parent.name.local.as_str(), "text" | "spreadsheet" | "presentation")
+                || parent.is(TABLE_NS, "table")
+                || parent.is(DRAW_NS, "page")
+                || parent.is(PRESENTATION_NS, "notes")
+                || parent.is(STYLE_NS, "master-page")
+        });
+    let layout_root = parent.is_some_and(|parent| layout_definition(node, parent));
+    if node.is(DRAW_NS, "a") {
+        super::text::validate_link(
+            node.attr(XLINK_NS, "href")
+                .ok_or_else(|| malformed(Some(part), "draw:a lacks xlink:href"))?,
+        )?;
+    }
+    let layout = layout || layout_root;
     let forbidden = matches!(
         node.name.local.as_str(),
         "scripts"
@@ -52,7 +79,13 @@ fn validate_profile_node(
             | "document-signatures"
             | "dde-link"
     );
-    if forbidden || !allowed_profile_element(node, profile) {
+    if forbidden && !empty_scripts && !empty_forms
+        || !layout && !empty_scripts && !empty_forms && !allowed_profile_element(node, profile)
+        || layout
+            && !empty_forms
+            && (node.name.ns == OFFICE_NS
+                || (!allowed_profile_element(node, profile) && !layout_metadata_element(node)))
+    {
         return Err(malformed(
             Some(part),
             format!(
@@ -61,11 +94,22 @@ fn validate_profile_node(
             ),
         ));
     }
-    if let Some(parent) = parent {
+    if let Some(parent) = parent
+        && !layout
+        && !empty_scripts
+        && !empty_forms
+    {
         validate_profile_parent(parent, node, profile, part)?;
     }
+    let mut recovered = usize::from(layout_root);
     for attr in &node.attrs {
-        if !allowed_profile_attribute(node, attr) {
+        if producer_attribute(node, attr) {
+            recovered += 1;
+        } else if !layout
+            && !style_attribute(node, attr)
+            && !standard_attribute(node, attr)
+            && !allowed_profile_attribute(node, attr)
+        {
             return Err(malformed(
                 Some(part),
                 format!(
@@ -76,9 +120,9 @@ fn validate_profile_node(
         }
     }
     for child in node.children() {
-        validate_profile_node(child, Some(node), profile, part)?;
+        recovered += validate_profile_node(child, Some(node), profile, part, layout)?;
     }
-    Ok(())
+    Ok(recovered)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -128,10 +172,26 @@ fn allowed_profile_element(node: &XmlNode, profile: OdfXmlPart) -> bool {
                     | "list-level-style-bullet"
                     | "list-level-properties"
                     | "list-level-label-alignment"
+                    | "user-field-get"
+                    | "conditional-text"
+                    | "user-field-input"
+                    | "page-number"
+                    | "page-count"
+                    | "date"
+                    | "time"
+                    | "title"
+                    | "sheet-name"
+                    | "file-name"
+                    | "reference-ref"
+                    | "bookmark-ref"
+                    | "sequence-ref"
+                    | "sequence"
+                    | "variable-set"
             ),
             TABLE_NS => matches!(
                 local,
                 "table"
+                    | "shapes"
                     | "table-column"
                     | "table-columns"
                     | "table-header-columns"
@@ -144,6 +204,7 @@ fn allowed_profile_element(node: &XmlNode, profile: OdfXmlPart) -> bool {
             DRAW_NS => matches!(
                 local,
                 "page"
+                    | "a"
                     | "frame"
                     | "text-box"
                     | "image"
@@ -209,6 +270,8 @@ fn allowed_profile_element(node: &XmlNode, profile: OdfXmlPart) -> bool {
                     | "keyword"
                     | "user-defined"
                     | "document-statistic"
+                    | "print-date"
+                    | "printed-by"
             ),
             _ => false,
         },
@@ -242,7 +305,12 @@ fn validate_profile_parent(
         || parent.is(TABLE_NS, "table-cell")
         || parent.is(DRAW_NS, "text-box")
         || parent.is(PRESENTATION_NS, "notes")
-        || parent.is(OFFICE_NS, "annotation");
+        || parent.is(OFFICE_NS, "annotation")
+        || (parent.name.ns == DRAW_NS
+            && matches!(
+                parent.name.local.as_str(),
+                "custom-shape" | "rect" | "ellipse" | "line" | "connector"
+            ));
     let inline_parent = parent.is(TEXT_NS, "p")
         || parent.is(TEXT_NS, "h")
         || parent.is(TEXT_NS, "span")
@@ -264,7 +332,9 @@ fn validate_profile_parent(
         (OFFICE_NS, "settings") => parent.is(OFFICE_NS, "document-settings"),
         (OFFICE_NS, "annotation") => text_block_parent || inline_parent,
         (OFFICE_NS, "annotation-end") => text_block_parent || inline_parent,
-        (TEXT_NS, "p" | "h") => text_block_parent,
+        (TEXT_NS, "p" | "h") => {
+            text_block_parent || (parent.is(DRAW_NS, "image") && child.content.is_empty())
+        }
         (
             TEXT_NS,
             "span"
@@ -280,7 +350,16 @@ fn validate_profile_parent(
             | "reference-mark-start"
             | "reference-mark-end",
         ) => inline_parent,
-        (TEXT_NS, "list" | "section" | "soft-page-break") => text_block_parent,
+        (TEXT_NS, "list" | "section") => text_block_parent,
+        (
+            TEXT_NS,
+            "user-field-get" | "user-field-input" | "page-number" | "page-count" | "date" | "time"
+            | "title" | "sheet-name" | "file-name" | "reference-ref" | "bookmark-ref"
+            | "sequence-ref" | "sequence" | "variable-set" | "conditional-text",
+        ) => inline_parent,
+        (TEXT_NS, "soft-page-break") => {
+            text_block_parent || inline_parent || parent.is(TABLE_NS, "table")
+        }
         (TEXT_NS, "list-item" | "list-header") => parent.is(TEXT_NS, "list"),
         (TEXT_NS, "note-citation" | "note-body") => parent.is(TEXT_NS, "note"),
         (TEXT_NS, "list-style") => style_container,
@@ -299,6 +378,7 @@ fn validate_profile_parent(
                 || parent.is(DRAW_NS, "frame")
         }
         (TABLE_NS, "table-columns" | "table-header-columns") => parent.is(TABLE_NS, "table"),
+        (TABLE_NS, "shapes") => parent.is(TABLE_NS, "table"),
         (TABLE_NS, "table-column") => {
             parent.is(TABLE_NS, "table")
                 || parent.is(TABLE_NS, "table-columns")
@@ -312,8 +392,14 @@ fn validate_profile_parent(
         }
         (TABLE_NS, "table-cell" | "covered-table-cell") => parent.is(TABLE_NS, "table-row"),
         (DRAW_NS, "page") => parent.is(OFFICE_NS, "presentation"),
+        (DRAW_NS, "a") => inline_parent || text_block_parent || parent.is(DRAW_NS, "page"),
         (DRAW_NS, "frame" | "g" | "custom-shape" | "rect" | "ellipse" | "line" | "connector") => {
-            parent.is(DRAW_NS, "page") || parent.is(DRAW_NS, "g") || text_block_parent
+            parent.is(DRAW_NS, "page")
+                || parent.is(DRAW_NS, "g")
+                || text_block_parent
+                || inline_parent
+                || parent.is(DRAW_NS, "a")
+                || parent.is(TABLE_NS, "shapes")
         }
         (DRAW_NS, "text-box") => {
             parent.name.ns == DRAW_NS
@@ -334,7 +420,11 @@ fn validate_profile_parent(
             | "table-column-properties"
             | "table-cell-properties"
             | "graphic-properties",
-        ) => parent.is(STYLE_NS, "style") || parent.is(STYLE_NS, "default-style"),
+        ) => {
+            parent.is(STYLE_NS, "style")
+                || parent.is(STYLE_NS, "default-style")
+                || (parent.name.ns == TEXT_NS && parent.name.local.starts_with("list-level-style-"))
+        }
         (STYLE_NS, "page-layout-properties") => parent.is(STYLE_NS, "page-layout"),
         (STYLE_NS, "master-page") => parent.is(OFFICE_NS, "master-styles"),
         (STYLE_NS, "font-face") => parent.is(OFFICE_NS, "font-face-decls"),
@@ -348,7 +438,7 @@ fn validate_profile_parent(
             "number" | "currency-symbol" | "day" | "month" | "year" | "hours" | "minutes"
             | "seconds" | "text",
         ) => parent.name.ns == NUMBER_NS && parent.name.local.ends_with("style"),
-        (SVG_NS, "title" | "desc") => parent.name.ns == DRAW_NS,
+        (SVG_NS, "title" | "desc") => parent.name.ns == DRAW_NS || parent.is(TEXT_NS, "span"),
         (DC_NS, "creator" | "date") => {
             parent.is(OFFICE_NS, "meta") || parent.is(OFFICE_NS, "annotation")
         }
@@ -492,7 +582,7 @@ fn allowed_profile_attribute(node: &XmlNode, attr: &Attr) -> bool {
             node.name.ns == DRAW_NS && matches!(local, "x" | "y" | "width" | "height" | "viewBox")
         }
         XLINK_NS => {
-            (node.is(TEXT_NS, "a") || node.is(DRAW_NS, "image"))
+            (node.is(TEXT_NS, "a") || node.is(DRAW_NS, "image") || node.is(DRAW_NS, "a"))
                 && matches!(local, "href" | "type" | "show" | "actuate")
         }
         META_NS => node.is(META_NS, "user-defined") && matches!(local, "name" | "value-type"),

--- a/crates/converters/src/odf/raw_zip.rs
+++ b/crates/converters/src/odf/raw_zip.rs
@@ -91,6 +91,41 @@ pub(super) struct LocalMimetypeHeader {
     data_start: u64,
 }
 
+pub(super) fn mimetype_header_for_policy(
+    bytes: &[u8],
+    expected: &str,
+    options: &into_markdown_core::ConversionOptions,
+) -> Result<Option<LocalMimetypeHeader>, ConversionError> {
+    let result = validate_first_mimetype_local_header(bytes, expected);
+    if options.error_policy == into_markdown_core::ErrorPolicy::Strict || result.is_ok() {
+        return result.map(Some);
+    }
+    // Only packing deviations are deferred. Complete raw ZIP local/central/descriptor
+    // binding and streamed payload CRC checks still run before the package is accepted.
+    if read_u32(bytes, 0) == Some(0x0403_4b50)
+        && (validated_local_zip_name(bytes, 0)? != "mimetype"
+            || read_u16(bytes, 8).is_some_and(|method| method != 0)
+            || read_u16(bytes, 6).is_some_and(|flags| flags & 8 != 0))
+    {
+        return Ok(None);
+    }
+    result.map(Some)
+}
+
+pub(super) fn validate_relaxed_mimetype_extras(
+    bytes: &[u8],
+    entry: &zip::read::ZipFile<'_>,
+) -> Result<(), ConversionError> {
+    let local = usize::try_from(entry.header_start())
+        .map_err(|_| malformed(Some("mimetype"), "local offset overflow"))?;
+    let central = usize::try_from(entry.central_header_start())
+        .map_err(|_| malformed(Some("mimetype"), "central offset overflow"))?;
+    if read_u16(bytes, local + 28) != Some(0) || read_u16(bytes, central + 30) != Some(0) {
+        return Err(malformed(Some("mimetype"), "mimetype extra fields are not supported"));
+    }
+    Ok(())
+}
+
 pub(super) fn validate_first_mimetype_local_header(
     bytes: &[u8],
     expected: &str,
@@ -391,8 +426,6 @@ pub(super) fn validate_zip_directory_layout(
             || uncompressed == u32::MAX
             || local_offset == u32::MAX
             || disk_start != 0
-            || extra_len != 0
-            || comment_len != 0
             || next > eocd
         {
             if compressed == u32::MAX || uncompressed == u32::MAX || local_offset == u32::MAX {
@@ -402,7 +435,7 @@ pub(super) fn validate_zip_directory_layout(
             }
             return Err(malformed(
                 None,
-                "split ZIP entries, central comments, and central extra fields are forbidden",
+                "split ZIP entry or central-directory boundary is invalid",
             ));
         }
         layouts.push(CentralLayout {
@@ -473,23 +506,39 @@ pub(super) fn validate_zip_directory_layout(
         let central_semantic =
             validate_raw_zip_name(central_name, layout.flags, "central directory")?;
         validate_zip_extra(local_extra, local_semantic)?;
+        let descriptor = local_flags & (1 << 3) != 0;
+        let local_sizes_match = if descriptor {
+            (local_crc == 0 || local_crc == layout.crc32)
+                && (local_compressed == 0 || local_compressed == layout.compressed)
+                && (local_uncompressed == 0 || local_uncompressed == layout.uncompressed)
+        } else {
+            local_crc == layout.crc32
+                && local_compressed == layout.compressed
+                && local_uncompressed == layout.uncompressed
+        };
         if local_flags != layout.flags
-            || local_flags & (1 << 3) != 0
             || local_method != layout.method
-            || local_crc != layout.crc32
-            || local_compressed != layout.compressed
-            || local_uncompressed != layout.uncompressed
+            || !local_sizes_match
             || local_name != central_name
             || local_semantic != central_semantic
-            || local_extra_len != 0
             || local_data_end > central_start
         {
             return Err(malformed(
                 None,
-                "ZIP local/central headers disagree or use data descriptors/ZIP64",
+                "ZIP local/central headers disagree or exceed the central-directory boundary",
             ));
         }
-        expected_offset = local_data_end;
+        expected_offset = if descriptor {
+            descriptor_end(
+                &bytes[..central_start],
+                local_data_end,
+                layout.crc32,
+                layout.compressed,
+                layout.uncompressed,
+            )?
+        } else {
+            local_data_end
+        };
     }
     if expected_offset != central_start {
         return Err(malformed(
@@ -498,6 +547,30 @@ pub(super) fn validate_zip_directory_layout(
         ));
     }
     Ok(())
+}
+
+// ZipArchive verifies streamed payload CRC/size against the central directory. Bind the
+// optional descriptor too, so accepting bit 3 does not introduce unchecked gaps/overlaps.
+fn descriptor_end(
+    bytes: &[u8],
+    offset: usize,
+    crc32: u32,
+    compressed: u32,
+    uncompressed: u32,
+) -> Result<usize, ConversionError> {
+    for signature_bytes in [0, 4] {
+        if signature_bytes == 4 && read_u32(bytes, offset) != Some(0x0807_4b50) {
+            continue;
+        }
+        let start = offset + signature_bytes;
+        if read_u32(bytes, start) == Some(crc32)
+            && read_u32(bytes, start + 4) == Some(compressed)
+            && read_u32(bytes, start + 8) == Some(uncompressed)
+        {
+            return Ok(start + 12);
+        }
+    }
+    Err(malformed(None, "ZIP data descriptor is truncated or disagrees with central CRC/sizes"))
 }
 
 pub(super) fn bind_mimetype_central(
@@ -579,33 +652,29 @@ pub(super) fn bind_mimetype_central(
     Ok(())
 }
 
-fn validate_zip_extra(bytes: &[u8], part: &str) -> Result<(), ConversionError> {
-    if bytes.is_empty() {
-        return Ok(());
+fn validate_zip_extra(mut bytes: &[u8], part: &str) -> Result<(), ConversionError> {
+    while !bytes.is_empty() {
+        let id =
+            read_u16(bytes, 0).ok_or_else(|| malformed(Some(part), "truncated ZIP extra field"))?;
+        let length = usize::from(
+            read_u16(bytes, 2).ok_or_else(|| malformed(Some(part), "truncated ZIP extra field"))?,
+        );
+        bytes = bytes
+            .get(4 + length..)
+            .ok_or_else(|| malformed(Some(part), "truncated ZIP extra field"))?;
+        if id == 0x0001 {
+            return Err(ConversionError::Unsupported {
+                detail: "ZIP64 ODF packages are outside the supported profile".into(),
+            });
+        }
+        if id == 0x7075 {
+            return Err(malformed(
+                Some(part),
+                "Info-ZIP Unicode Path extra fields are forbidden because they can rename parts",
+            ));
+        }
     }
-    if bytes.len() < 4 {
-        return Err(malformed(Some(part), "truncated ZIP extra field"));
-    }
-    let id = u16::from_le_bytes([bytes[0], bytes[1]]);
-    let length = usize::from(u16::from_le_bytes([bytes[2], bytes[3]]));
-    if bytes.get(4..).is_none_or(|payload| payload.len() < length) {
-        return Err(malformed(Some(part), "truncated ZIP extra field"));
-    }
-    if id == 0x0001 {
-        return Err(ConversionError::Unsupported {
-            detail: "ZIP64 ODF packages are outside the supported profile".into(),
-        });
-    }
-    if id == 0x7075 {
-        return Err(malformed(
-            Some(part),
-            "Info-ZIP Unicode Path extra fields are forbidden because they can rename parts",
-        ));
-    }
-    Err(malformed(
-        Some(part),
-        format!("ZIP extra field 0x{id:04x} is outside the closed ODF package profile"),
-    ))
+    Ok(())
 }
 
 pub(super) fn validate_raw_zip_name<'a>(

--- a/crates/converters/src/odf/recovery.rs
+++ b/crates/converters/src/odf/recovery.rs
@@ -1,0 +1,360 @@
+//! Static-document projection of optional ODF features. XML is fully parsed and
+//! integrity/resource checked before this pass; omitted code is never executed/exported.
+use super::compatibility::FORM_NS;
+use super::model::{DRAW_NS, OFFICE_NS, ParseState, TEXT_NS, malformed, part_locator};
+use super::xml::{XmlContent, XmlNode};
+use into_markdown_core::{ConversionError, ConversionOptions, ErrorPolicy, ExecutionContext};
+
+pub(super) const SCRIPT_NS: &str = "urn:oasis:names:tc:opendocument:xmlns:script:1.0";
+pub(super) const ANIM_NS: &str = "urn:oasis:names:tc:opendocument:xmlns:animation:1.0";
+pub(super) const SMIL_NS: &str = "urn:oasis:names:tc:opendocument:xmlns:smil-compatible:1.0";
+
+pub(super) fn optional_namespace(ns: &str) -> bool {
+    matches!(ns, SCRIPT_NS | ANIM_NS | SMIL_NS | FORM_NS)
+}
+
+pub(super) fn require_best_effort(
+    options: &ConversionOptions,
+    part: &str,
+    detail: &str,
+) -> Result<(), ConversionError> {
+    if options.error_policy == ErrorPolicy::Strict {
+        return Err(malformed(Some(part), detail));
+    }
+    Ok(())
+}
+
+pub(super) fn ensure_static_body(state: &ParseState) -> Result<(), ConversionError> {
+    fn has_body(node: &into_markdown_core::BlockNode) -> bool {
+        use into_markdown_core::Block;
+        match &node.block {
+            Block::Slide { title, blocks, .. } => {
+                title.as_ref().is_some_and(|text| !text.trim().is_empty())
+                    || blocks.iter().any(has_body)
+            }
+            Block::Sheet { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Footnote { blocks, .. } => blocks.iter().any(has_body),
+            Block::List { items, .. } => items.iter().any(|item| item.blocks.iter().any(has_body)),
+            Block::Table { rows, .. } => {
+                rows.iter().any(|row| row.cells.iter().any(|cell| cell.blocks.iter().any(has_body)))
+            }
+            Block::Paragraph(content) | Block::Heading { content, .. } => !content.is_empty(),
+            _ => true,
+        }
+    }
+    if state.diagnostics.iter().any(|diagnostic| diagnostic.code == "odf.scriptsOmitted")
+        && !state.document.blocks.iter().any(has_body)
+    {
+        return Err(malformed(
+            Some("content.xml"),
+            "script-bearing document has no recoverable static body",
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn project_static_content(
+    node: &mut XmlNode,
+    part: &str,
+    state: &mut ParseState,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+    manifest: &std::collections::BTreeMap<String, super::manifest::ManifestEntry>,
+) -> Result<(), ConversionError> {
+    context.checkpoint()?;
+    project_decoration(node, part, state, options)?;
+    project_cached_display(node, part, state, options)?;
+    project_untyped_replacement(node, part, state, options, manifest)?;
+    let parent = &node.name;
+    let mut failure = None;
+    node.content.retain_mut(|content| {
+        let XmlContent::Node(child) = content else { return true };
+        let omission = optional_subtree(child, &parent.ns, &parent.local);
+        if let Some((code, detail)) = omission {
+            if let Err(error) = require_best_effort(options, part, detail) {
+                failure = Some(error);
+                return true;
+            }
+            state.warning(code, detail, part_locator(part));
+            return false;
+        }
+        if failure.is_none()
+            && let Err(error) =
+                project_static_content(child, part, state, options, context, manifest)
+        {
+            failure = Some(error);
+        }
+        true
+    });
+    failure.map_or(Ok(()), Err)?;
+    super::sparse::trim_empty_tail(node, options, state)
+}
+
+fn project_cached_display(
+    node: &mut XmlNode,
+    part: &str,
+    state: &mut ParseState,
+    options: &ConversionOptions,
+) -> Result<(), ConversionError> {
+    if node.name.ns != TEXT_NS {
+        return Ok(());
+    }
+    if matches!(
+        node.name.local.as_str(),
+        "table-of-content"
+            | "bibliography"
+            | "alphabetical-index"
+            | "illustration-index"
+            | "table-index"
+            | "user-index"
+    ) {
+        require_best_effort(
+            options,
+            part,
+            "generated index retains its cached body, not generator definitions",
+        )?;
+        node.content.retain(
+            |value| matches!(value, XmlContent::Node(child) if child.is(TEXT_NS, "index-body")),
+        );
+        node.name.local = "section".into();
+        node.attrs.clear();
+        for value in &mut node.content {
+            if let XmlContent::Node(child) = value {
+                child.name.local = "section".into();
+                child.attrs.clear();
+            }
+        }
+        state.warning(
+            "odf.cachedIndex",
+            "Generated index retains its cached body; index was not regenerated",
+            part_locator(part),
+        );
+    } else if node.is(TEXT_NS, "index-title") {
+        node.name.local = "section".into();
+        node.attrs.clear();
+    } else if node.is(TEXT_NS, "bibliography-mark")
+        || (super::compatibility::cached_text_field(node)
+            && (node.attrs.iter().any(|attr| {
+                attr.name.ns == super::model::STYLE_NS
+                    && matches!(
+                        attr.name.local.as_str(),
+                        "data-style-name" | "num-format" | "num-letter-sync"
+                    )
+            }) || node.attr(OFFICE_NS, "value-type").is_some()))
+    {
+        require_best_effort(
+            options,
+            part,
+            "field retains cached display text without evaluating formatting/expressions",
+        )?;
+        node.name.local = "span".into();
+        node.attrs.retain(|attr| attr.name.ns == TEXT_NS && attr.name.local == "style-name");
+        state.warning(
+            "odf.cachedField",
+            "Field retains cached display text; formatting/expressions were not evaluated",
+            part_locator(part),
+        );
+    }
+    Ok(())
+}
+
+fn project_decoration(
+    node: &mut XmlNode,
+    part: &str,
+    state: &mut ParseState,
+    options: &ConversionOptions,
+) -> Result<(), ConversionError> {
+    if node.is(DRAW_NS, "circle") {
+        node.name.local = "ellipse".into();
+    }
+    if node.is(DRAW_NS, "path") {
+        require_best_effort(
+            options,
+            part,
+            "vector path geometry cannot be represented in Markdown",
+        )?;
+        node.name.local = "custom-shape".into();
+        node.attrs.retain(|attr| {
+            !(attr.name.ns == super::model::SVG_NS
+                && matches!(attr.name.local.as_str(), "d" | "viewBox"))
+        });
+        state.warning(
+            "odf.pathGeometryOmitted",
+            "Vector path geometry omitted; associated static text retained",
+            part_locator(part),
+        );
+    } else if node.is(TEXT_NS, "list-level-style-image") {
+        require_best_effort(options, part, "image list marker replaced with plain bullet")?;
+        node.name.local = "list-level-style-bullet".into();
+        node.attrs.retain(|attr| attr.name.ns != super::model::XLINK_NS);
+        node.attrs.push(super::xml::Attr {
+            name: super::xml::Name { ns: TEXT_NS.into(), local: "bullet-char".into() },
+            value: "•".into(),
+        });
+        state.warning(
+            "odf.imageListMarker",
+            "Image list marker represented as plain bullet; list content retained",
+            part_locator(part),
+        );
+    }
+    Ok(())
+}
+
+fn project_untyped_replacement(
+    node: &mut XmlNode,
+    part: &str,
+    state: &mut ParseState,
+    options: &ConversionOptions,
+    manifest: &std::collections::BTreeMap<String, super::manifest::ManifestEntry>,
+) -> Result<(), ConversionError> {
+    if !node.is(DRAW_NS, "frame")
+        || !node
+            .children()
+            .any(|child| child.is(DRAW_NS, "object") || child.is(DRAW_NS, "object-ole"))
+    {
+        return Ok(());
+    }
+    for value in &mut node.content {
+        let XmlContent::Node(image) = value else { continue };
+        if !image.is(DRAW_NS, "image") {
+            continue;
+        }
+        let Some(href) = image.attr(super::model::XLINK_NS, "href") else { continue };
+        let path =
+            super::paths::canonical_part_name(href.strip_prefix("./").unwrap_or(href), false)?;
+        if manifest.get(&path).is_some_and(|entry| entry.media_type.is_empty()) {
+            require_best_effort(
+                options,
+                part,
+                "embedded object has an untyped replacement graphic",
+            )?;
+            image.name.local = "text-box".into();
+            image.attrs.clear();
+            image.content = vec![XmlContent::Node(XmlNode {
+                name: super::xml::Name { ns: TEXT_NS.into(), local: "p".into() },
+                attrs: vec![],
+                content: vec![XmlContent::Text(format!("[Object replacement omitted: {path}]"))],
+            })];
+            state.warning("odf.objectReplacementOmitted", format!("Untyped embedded-object replacement omitted: {path}; no bytes interpreted/exported"), part_locator(part));
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn drawing_placeholder(
+    node: &XmlNode,
+    state: &mut ParseState,
+    options: &ConversionOptions,
+    locator: &into_markdown_core::SourceLocator,
+) -> Result<Option<into_markdown_core::BlockNode>, ConversionError> {
+    if node.name.ns != DRAW_NS
+        || !matches!(
+            node.name.local.as_str(),
+            "custom-shape" | "ellipse" | "rect" | "line" | "connector"
+        )
+    {
+        return Ok(None);
+    }
+    require_best_effort(
+        options,
+        "content.xml",
+        "drawing without text requires a geometry placeholder",
+    )?;
+    let label = node
+        .children()
+        .find(|child| child.is(DRAW_NS, "enhanced-geometry"))
+        .and_then(|child| child.attr(DRAW_NS, "type"))
+        .unwrap_or(&node.name.local);
+    state.warning(
+        "odf.drawingPlaceholder",
+        format!(
+            "Static drawing {label} has no text/image representation; geometry placeholder retained"
+        ),
+        locator.clone(),
+    );
+    state.add_inlines(1)?;
+    state
+        .node(
+            into_markdown_core::Block::Paragraph(vec![into_markdown_core::Inline::Text {
+                value: format!("[Drawing omitted: {label}]"),
+                marks: vec![],
+            }]),
+            locator.clone(),
+        )
+        .map(Some)
+}
+
+fn optional_subtree(
+    node: &XmlNode,
+    parent_ns: &str,
+    parent_local: &str,
+) -> Option<(&'static str, &'static str)> {
+    if node.name.ns == TEXT_NS
+        && matches!(
+            node.name.local.as_str(),
+            "alphabetical-index-mark"
+                | "alphabetical-index-mark-start"
+                | "alphabetical-index-mark-end"
+                | "toc-mark"
+                | "toc-mark-start"
+                | "toc-mark-end"
+        )
+        && parent_ns == TEXT_NS
+    {
+        return Some((
+            "odf.indexMarkerOmitted",
+            "Index generator marker omitted; visible text and cached index body retained",
+        ));
+    }
+    if node.is(OFFICE_NS, "scripts")
+        && parent_ns == OFFICE_NS
+        && parent_local == "document-content"
+        && node.children().next().is_some()
+        || node.is(OFFICE_NS, "event-listeners") && matches!(parent_ns, DRAW_NS | TEXT_NS)
+    {
+        return Some((
+            "odf.scriptsOmitted",
+            "Optional scripts/event listeners omitted; no code executed or exported; static body retained",
+        ));
+    }
+    if node.is(OFFICE_NS, "forms")
+        && (parent_ns == OFFICE_NS || parent_ns == DRAW_NS || parent_ns == super::model::TABLE_NS)
+        && node.children().next().is_some()
+    {
+        return Some((
+            "odf.formsOmitted",
+            "Optional form definitions/controls omitted; static body retained",
+        ));
+    }
+    if node.is(ANIM_NS, "par") && parent_ns == DRAW_NS && parent_local == "page" {
+        return Some((
+            "odf.animationOmitted",
+            "Animation timeline omitted; static slide content retained",
+        ));
+    }
+    if node.is(TEXT_NS, "tracked-changes")
+        && (parent_ns == OFFICE_NS && parent_local == "text"
+            || parent_ns == TEXT_NS && parent_local == "section")
+        && node.children().next().is_some()
+        || node.name.ns == TEXT_NS
+            && matches!(node.name.local.as_str(), "change" | "change-start" | "change-end")
+            && parent_ns == TEXT_NS
+    {
+        return Some((
+            "odf.trackedChanges",
+            "Revision history/markers omitted; current body text retained, deleted history not inserted",
+        ));
+    }
+    if node.name.ns == DRAW_NS
+        && matches!(node.name.local.as_str(), "object" | "object-ole")
+        && parent_ns == DRAW_NS
+        && parent_local == "frame"
+    {
+        return Some((
+            "odf.embeddedObjectOmitted",
+            "Optional embedded object omitted without opening/executing it; replacement image and static body retained",
+        ));
+    }
+    None
+}

--- a/crates/converters/src/odf/semantic.rs
+++ b/crates/converters/src/odf/semantic.rs
@@ -56,8 +56,9 @@ pub(super) fn parse_blocks(
                         )?);
                     }
                     ParagraphPart::Text(text) => {
-                        let inlines =
-                            parse_inlines(&text, styles, state, options, locator, &marks)?;
+                        let inlines = parse_inlines(
+                            &text, styles, package, state, options, context, locator, &marks,
+                        )?;
                         if inlines.is_empty() && mode != ParseMode::Cell {
                             continue;
                         }

--- a/crates/converters/src/odf/semantic.rs
+++ b/crates/converters/src/odf/semantic.rs
@@ -2,9 +2,11 @@ use crate::odf::annotations::annotation_text;
 use crate::odf::geometry::{Transform, drawing_bounds, parse_transform, transform_bounds};
 use crate::odf::images::image_block;
 use crate::odf::model::{
-    DRAW_NS, OFFICE_NS, PRESENTATION_NS, ParseState, TABLE_NS, TEXT_NS, XML_NS, limit, malformed,
+    DRAW_NS, OFFICE_NS, PRESENTATION_NS, ParseState, SVG_NS, TABLE_NS, TEXT_NS, XML_NS, limit,
+    malformed,
 };
 use crate::odf::package::Package;
+use crate::odf::paragraphs::{ParagraphPart, split_drawings};
 use crate::odf::styles::{StyleMap, style_marks};
 use crate::odf::tables::{
     cell_has_content, cell_semantic_value, parse_odf_bool, parse_repeat, parse_span,
@@ -41,16 +43,33 @@ pub(super) fn parse_blocks(
                 .unwrap_or(1)
                 .clamp(1, 6);
             let marks = style_marks(styles, "paragraph", child.attr(TEXT_NS, "style-name"), &[]);
-            let inlines = parse_inlines(child, styles, state, options, locator, &marks)?;
-            if inlines.is_empty() && mode != ParseMode::Cell {
-                continue;
+            for part in split_drawings(child) {
+                match part {
+                    ParagraphPart::Drawing(drawing) => {
+                        state.warning(
+                            "odf.inlineDrawing",
+                            "Inline drawing emitted as a block at its source position",
+                            locator.clone(),
+                        );
+                        blocks.extend(parse_drawing(
+                            drawing, styles, package, state, options, context, locator, mode,
+                        )?);
+                    }
+                    ParagraphPart::Text(text) => {
+                        let inlines =
+                            parse_inlines(&text, styles, state, options, locator, &marks)?;
+                        if inlines.is_empty() && mode != ParseMode::Cell {
+                            continue;
+                        }
+                        let block = if child.is(TEXT_NS, "h") {
+                            Block::Heading { level, content: inlines }
+                        } else {
+                            Block::Paragraph(inlines)
+                        };
+                        blocks.push(state.node(block, locator.clone())?);
+                    }
+                }
             }
-            let block = if child.is(TEXT_NS, "h") {
-                Block::Heading { level, content: inlines }
-            } else {
-                Block::Paragraph(inlines)
-            };
-            blocks.push(state.node(block, locator.clone())?);
         } else if child.is(TEXT_NS, "list") {
             blocks.extend(parse_list(
                 child, styles, package, state, options, context, locator, mode, list_level,
@@ -202,19 +221,23 @@ fn parse_list(
             }
             saw_item = true;
             if let Some(value) = child.attr(TEXT_NS, "start-value") {
-                if !spec.ordered || !items.is_empty() {
-                    return Err(malformed(
-                        Some("content.xml"),
-                        "text:list-item start-value is only representable on the first ordered item",
-                    ));
-                }
-                start = value
+                let requested = value
                     .parse::<u64>()
                     .ok()
                     .filter(|value| *value > 0 && u32::try_from(*value).is_ok())
                     .ok_or_else(|| {
                         malformed(Some("content.xml"), "invalid list-item start-value")
                     })?;
+                if !spec.ordered || !items.is_empty() {
+                    super::recovery::require_best_effort(
+                        options,
+                        "content.xml",
+                        "list restart cannot be represented at this item",
+                    )?;
+                    state.warning("odf.listRestart", format!("List item restart {requested} not represented in Markdown numbering; item body retained"), locator.clone());
+                } else {
+                    start = requested;
+                }
             }
             sequence_items = sequence_items
                 .checked_add(1)
@@ -244,6 +267,9 @@ fn parse_list(
         && state.list_sequences.insert(id.to_owned(), (spec.ordered, next)).is_some()
     {
         return Err(malformed(Some("content.xml"), "duplicate xml:id for text:list"));
+    }
+    if items.is_empty() {
+        return Ok(blocks);
     }
     blocks.push(state.node(
         Block::List {
@@ -464,7 +490,7 @@ fn parse_table_row(
             }
             continue;
         }
-        let semantic = cell_semantic_value(child)?;
+        let semantic = cell_semantic_value(child, options)?;
         let meaningful =
             cell_has_content(child) || semantic.cached.is_some() || semantic.formula.is_some();
         // Trailing repeated empty cells are sparse coordinate padding and need not be retained.
@@ -510,8 +536,11 @@ fn parse_table_row(
                 blocks.push(paragraph);
             }
             if let Some(formula) = semantic.formula.clone() {
+                if semantic.formula_language.is_none() {
+                    state.warning("odf.cachedProducerFormula", "Producer formula retained verbatim with cached value; not evaluated or labeled OpenFormula", locator.clone());
+                }
                 blocks.push(state.node(
-                    Block::Code { language: Some("openformula".into()), text: formula },
+                    Block::Code { language: semantic.formula_language.clone(), text: formula },
                     locator.clone(),
                 )?);
             }
@@ -666,9 +695,20 @@ fn parse_drawing_transformed(
     for child in node.children() {
         context.checkpoint()?;
         if child.is(DRAW_NS, "image") {
-            if let Some(block) = image_block(child, package, state, options, context, &locator)? {
+            if let Some(mut block) = image_block(child, package, state, options, context, &locator)?
+            {
+                if let Block::Image { alt, .. } = &mut block.block
+                    && alt.is_none()
+                {
+                    *alt = node
+                        .children()
+                        .find(|value| value.is(SVG_NS, "title") || value.is(SVG_NS, "desc"))
+                        .map(XmlNode::text);
+                }
                 blocks.push(block);
             }
+        } else if child.is(SVG_NS, "title") || child.is(SVG_NS, "desc") {
+            // Frame accessibility metadata is attached to its image, not a second body block.
         } else if child.is(DRAW_NS, "text-box") || child.is(PRESENTATION_NS, "notes") {
             blocks.extend(parse_blocks(
                 child, styles, package, state, options, context, &locator, mode, 1,
@@ -692,6 +732,9 @@ fn parse_drawing_transformed(
                 format!("unsupported drawing child {}:{}", child.name.ns, child.name.local),
             ));
         }
+    }
+    if blocks.is_empty() {
+        blocks.extend(super::recovery::drawing_placeholder(node, state, options, &locator)?);
     }
     Ok(blocks)
 }

--- a/crates/converters/src/odf/sheets.rs
+++ b/crates/converters/src/odf/sheets.rs
@@ -1,7 +1,8 @@
 use crate::odf::model::{ParseState, TABLE_NS, limit};
 use crate::odf::package::Package;
-use crate::odf::semantic::parse_table;
+use crate::odf::semantic::{parse_drawing, parse_table};
 use crate::odf::styles::StyleMap;
+use crate::odf::text::ParseMode;
 use crate::odf::xml::XmlNode;
 use into_markdown_core::{
     Block, ConversionError, ConversionOptions, ExecutionContext, SourceLocator,
@@ -35,7 +36,23 @@ pub(super) fn parse_spreadsheet(
         };
         let table_node =
             parse_table(table, styles, package, state, options, context, &locator, Some(&name))?;
-        let sheet = state.node(Block::Sheet { name, blocks: vec![table_node] }, locator)?;
+        let empty = matches!(&table_node.block, Block::Table { rows, .. } if rows.iter().all(|row| row.cells.is_empty()));
+        let mut blocks = if empty { vec![] } else { vec![table_node] };
+        for shapes in table.children().filter(|child| child.is(TABLE_NS, "shapes")) {
+            for drawing in shapes.children() {
+                blocks.extend(parse_drawing(
+                    drawing,
+                    styles,
+                    package,
+                    state,
+                    options,
+                    context,
+                    &locator,
+                    ParseMode::Text,
+                )?);
+            }
+        }
+        let sheet = state.node(Block::Sheet { name, blocks }, locator)?;
         state.document.blocks.push(sheet);
     }
     Ok(())

--- a/crates/converters/src/odf/sparse.rs
+++ b/crates/converters/src/odf/sparse.rs
@@ -1,0 +1,80 @@
+use super::model::{ParseState, TABLE_NS, limit, part_locator};
+use super::tables::parse_repeat;
+use super::xml::{XmlContent, XmlNode};
+use into_markdown_core::{ConversionError, ConversionOptions};
+
+/// Only a terminal run of contentless, unmerged rows is padding. Interior gaps,
+/// values, formulas, covered cells and row spans still follow the normal counters.
+pub(super) fn trim_empty_tail(
+    node: &mut XmlNode,
+    options: &ConversionOptions,
+    state: &mut ParseState,
+) -> Result<(), ConversionError> {
+    if !node.is(TABLE_NS, "table") {
+        return Ok(());
+    }
+    let mut end = node.content.len();
+    let mut skipped = 0_u64;
+    for value in node.content.iter().rev() {
+        let XmlContent::Node(row) = value else {
+            if matches!(value, XmlContent::Text(text) if text.trim().is_empty()) {
+                end -= 1;
+                continue;
+            }
+            break;
+        };
+        if !pure_padding(row) {
+            break;
+        }
+        let count = parse_repeat(
+            row.attr(TABLE_NS, "number-rows-repeated"),
+            "table:number-rows-repeated",
+            u64::from(u32::MAX),
+        )?;
+        let mut width = 0_u64;
+        for cell in row.children() {
+            width = width
+                .checked_add(parse_repeat(
+                    cell.attr(TABLE_NS, "number-columns-repeated"),
+                    "table:number-columns-repeated",
+                    options.limits.max_table_columns,
+                )?)
+                .ok_or_else(|| limit("max_table_columns", "empty padding width overflow"))?;
+        }
+        if width > options.limits.max_table_columns {
+            return Err(limit("max_table_columns", "empty padding exceeds logical column limit"));
+        }
+        skipped = skipped
+            .checked_add(count)
+            .filter(|total| u32::try_from(*total).is_ok())
+            .ok_or_else(|| limit("max_table_rows", "empty padding row coordinate overflow"))?;
+        end -= 1;
+    }
+    if skipped != 0 {
+        node.content.truncate(end);
+        state.warning("odf.emptyRowPadding", format!("{skipped} trailing empty padding rows not materialized; valued/formula/merged rows remain resource-counted"), part_locator("content.xml"));
+    }
+    Ok(())
+}
+
+fn pure_padding(row: &XmlNode) -> bool {
+    row.is(TABLE_NS, "table-row")
+        && row.attrs.iter().all(|attr| {
+            attr.name.ns == TABLE_NS
+                && matches!(attr.name.local.as_str(), "style-name" | "number-rows-repeated")
+        })
+        && row.content.iter().all(|value| match value {
+            XmlContent::Text(text) => text.trim().is_empty(),
+            XmlContent::Node(cell) => {
+                cell.is(TABLE_NS, "table-cell")
+                    && cell.content.is_empty()
+                    && cell.attrs.iter().all(|attr| {
+                        attr.name.ns == TABLE_NS
+                            && matches!(
+                                attr.name.local.as_str(),
+                                "style-name" | "number-columns-repeated"
+                            )
+                    })
+            }
+        })
+}

--- a/crates/converters/src/odf/styles.rs
+++ b/crates/converters/src/odf/styles.rs
@@ -18,9 +18,11 @@ pub(super) struct StyleSpec {
 }
 
 #[derive(Default)]
-pub(super) struct StyleCatalog {
+pub(super) struct StyleCatalog<'a> {
     pub(super) text: StyleMap,
     pub(super) lists: BTreeMap<String, BTreeMap<u8, ListLevelSpec>>,
+    pub(super) identical_duplicates: usize,
+    pub(super) masters: BTreeMap<String, &'a XmlNode>,
 }
 
 pub(super) fn validate_document_versions(
@@ -30,33 +32,32 @@ pub(super) fn validate_document_versions(
     metadata: Option<&XmlNode>,
     settings: Option<&XmlNode>,
 ) -> Result<(), ConversionError> {
-    let content_version = content.attr(OFFICE_NS, "version").unwrap_or(manifest_version);
-    if content_version != manifest_version {
-        return Err(malformed(
-            Some("content.xml"),
-            "office:version disagrees with META-INF/manifest.xml",
-        ));
-    }
-    for (part, root) in [("styles.xml", styles), ("meta.xml", metadata), ("settings.xml", settings)]
-    {
+    // Package and individual XML parts describe their own format version. In particular,
+    // legacy metadata may survive a save by a newer producer; absence is not a mismatch.
+    for (part, root) in [
+        ("content.xml", Some(content)),
+        ("styles.xml", styles),
+        ("meta.xml", metadata),
+        ("settings.xml", settings),
+    ] {
         if root
             .and_then(|root| root.attr(OFFICE_NS, "version"))
-            .is_some_and(|version| version != content_version)
+            .is_some_and(|version| !matches!(version, "1.0" | "1.1" | "1.2" | "1.3"))
         {
-            return Err(malformed(
-                Some(part),
-                "office:version disagrees with content.xml and the manifest",
-            ));
+            return Err(malformed(Some(part), "unsupported ODF XML part version"));
         }
+    }
+    if !matches!(manifest_version, "1.0" | "1.1" | "1.2" | "1.3") {
+        return Err(malformed(Some("META-INF/manifest.xml"), "unsupported ODF package version"));
     }
     Ok(())
 }
 
 #[allow(clippy::too_many_lines)]
-pub(super) fn collect_styles(
-    styles_root: Option<&XmlNode>,
-    content: &XmlNode,
-) -> Result<StyleCatalog, ConversionError> {
+pub(super) fn collect_styles<'a>(
+    styles_root: Option<&'a XmlNode>,
+    content: &'a XmlNode,
+) -> Result<StyleCatalog<'a>, ConversionError> {
     let mut sources = Vec::new();
     if let Some(root) = styles_root {
         for container in root.children() {
@@ -71,7 +72,8 @@ pub(super) fn collect_styles(
         sources.push((container, 2_u8, "content.xml"));
     }
 
-    let mut ranked_styles: BTreeMap<StyleKey, (u8, StyleSpec)> = BTreeMap::new();
+    let mut ranked_styles: BTreeMap<StyleKey, (u8, StyleSpec, &XmlNode)> = BTreeMap::new();
+    let mut identical_duplicates = 0;
     let mut ranked_lists: BTreeMap<String, (u8, BTreeMap<u8, ListLevelSpec>)> = BTreeMap::new();
     for (container, rank, part) in sources {
         for node in container.children() {
@@ -200,20 +202,26 @@ pub(super) fn collect_styles(
             spec.marks.sort();
             spec.marks.dedup();
             match ranked_styles.get(&key) {
-                Some((existing_rank, _)) if *existing_rank == rank => {
+                Some((existing_rank, _, existing))
+                    if *existing_rank == rank && *existing == node =>
+                {
+                    identical_duplicates += 1;
+                }
+                Some((existing_rank, _, _)) if *existing_rank == rank => {
                     return Err(malformed(
                         Some(part),
                         format!("duplicate style family/name {family}/{name}"),
                     ));
                 }
-                Some((existing_rank, _)) if *existing_rank > rank => {}
+                Some((existing_rank, _, _)) if *existing_rank > rank => {}
                 _ => {
-                    ranked_styles.insert(key, (rank, spec));
+                    ranked_styles.insert(key, (rank, spec, node));
                 }
             }
         }
     }
-    let styles: StyleMap = ranked_styles.into_iter().map(|(key, (_, spec))| (key, spec)).collect();
+    let styles: StyleMap =
+        ranked_styles.into_iter().map(|(key, (_, spec, _))| (key, spec)).collect();
     let lists = ranked_lists.into_iter().map(|(name, (_, levels))| (name, levels)).collect();
     // Resolve cycles now so a hostile style graph cannot recurse during content parsing.
     for key in styles.keys() {
@@ -226,7 +234,19 @@ pub(super) fn collect_styles(
             current = styles.get(&value).and_then(|style| style.parent.clone());
         }
     }
-    Ok(StyleCatalog { text: styles, lists })
+    let mut masters = BTreeMap::new();
+    if let Some(root) = styles_root {
+        for container in root.children().filter(|node| node.is(OFFICE_NS, "master-styles")) {
+            for master in container.children().filter(|node| node.is(STYLE_NS, "master-page")) {
+                if let Some(name) = master.attr(STYLE_NS, "name")
+                    && masters.insert(name.to_owned(), master).is_some_and(|old| old != master)
+                {
+                    return Err(malformed(Some("styles.xml"), "conflicting master-page name"));
+                }
+            }
+        }
+    }
+    Ok(StyleCatalog { text: styles, lists, identical_duplicates, masters })
 }
 
 pub(super) fn style_marks(

--- a/crates/converters/src/odf/tables.rs
+++ b/crates/converters/src/odf/tables.rs
@@ -1,6 +1,6 @@
 use crate::odf::model::{DRAW_NS, OFFICE_NS, TABLE_NS, TEXT_NS, limit, malformed};
 use crate::odf::xml::XmlNode;
-use into_markdown_core::ConversionError;
+use into_markdown_core::{ConversionError, ConversionOptions};
 
 pub(super) fn cell_has_content(node: &XmlNode) -> bool {
     node.children().any(|child| {
@@ -16,9 +16,13 @@ pub(super) fn cell_has_content(node: &XmlNode) -> bool {
 pub(super) struct CellSemanticValue {
     pub(super) cached: Option<String>,
     pub(super) formula: Option<String>,
+    pub(super) formula_language: Option<String>,
 }
 
-pub(super) fn cell_semantic_value(node: &XmlNode) -> Result<CellSemanticValue, ConversionError> {
+pub(super) fn cell_semantic_value(
+    node: &XmlNode,
+    options: &ConversionOptions,
+) -> Result<CellSemanticValue, ConversionError> {
     let value_type = node.attr(OFFICE_NS, "value-type");
     let candidates = [
         ("string-value", node.attr(OFFICE_NS, "string-value")),
@@ -78,8 +82,21 @@ pub(super) fn cell_semantic_value(node: &XmlNode) -> Result<CellSemanticValue, C
             .find(|(name, _)| *name == expected)
             .and_then(|(_, value)| value.map(str::to_owned))
     });
+    let mut formula_language = None;
     let formula = formula
         .map(|value| {
+            if !value.starts_with("of:=")
+                && value.split_once(":=").is_some_and(|(_, expression)| !expression.is_empty())
+            {
+                // xml_node binds this prefix to the producer formula namespace before here.
+                super::recovery::require_best_effort(
+                    options,
+                    "content.xml",
+                    "producer formula retained as inert source, without evaluation",
+                )?;
+                return Ok(value.to_owned());
+            }
+            formula_language = Some("openformula".into());
             value
                 .strip_prefix("of:=")
                 .filter(|value| !value.is_empty())
@@ -92,7 +109,7 @@ pub(super) fn cell_semantic_value(node: &XmlNode) -> Result<CellSemanticValue, C
                 })
         })
         .transpose()?;
-    Ok(CellSemanticValue { cached, formula })
+    Ok(CellSemanticValue { cached, formula, formula_language })
 }
 
 pub(super) fn parse_repeat(

--- a/crates/converters/src/odf/tests/document.rs
+++ b/crates/converters/src/odf/tests/document.rs
@@ -163,7 +163,7 @@ fn versions_and_style_family_origin_are_bound() {
         "{markdown}"
     );
 
-    let bad_styles = common_styles.replace("office:version='1.3'", "office:version='1.2'");
+    let bad_styles = common_styles.replace("office:version='1.3'", "office:version='9.9'");
     let mismatched =
         package(InputFormat::Odt, &content, &[("styles.xml", "text/xml", bad_styles.as_bytes())]);
     assert!(matches!(
@@ -172,7 +172,7 @@ fn versions_and_style_family_origin_are_bound() {
     ));
     let bad_content = package(
         InputFormat::Odt,
-        &content.replace("office:version='1.3'", "office:version='1.2'"),
+        &content.replace("office:version='1.3'", "office:version='9.9'"),
         &[],
     );
     assert!(matches!(

--- a/crates/converters/src/odf/tests/mod.rs
+++ b/crates/converters/src/odf/tests/mod.rs
@@ -1,7 +1,10 @@
 mod document;
 mod images;
 mod package_security;
+mod producer_compatibility;
 mod profile;
+mod recovery;
 mod resources;
 mod support;
 mod tables;
+mod zip_compatibility;

--- a/crates/converters/src/odf/tests/package_security.rs
+++ b/crates/converters/src/odf/tests/package_security.rs
@@ -94,7 +94,7 @@ fn mimetype_local_header_is_bound_before_any_xml_or_other_part() {
     descriptor[6] |= 1 << 3;
     assert!(matches!(
         convert(&descriptor, InputFormat::Odt, ResourceLimits::default()),
-        Err(ConversionError::Malformed { part: Some(part), .. }) if part == "mimetype"
+        Err(ConversionError::Malformed { .. })
     ));
 
     let mut local_extra = valid.clone();
@@ -321,26 +321,20 @@ fn unreferenced_image_size_does_not_enter_working_set_but_crc_is_stream_checked(
 }
 
 #[test]
-fn directory_entries_are_manifest_bound_empty_and_inert() {
+fn directory_entries_and_unreferenced_parts_are_inert() {
     let content = format!(
         "<office:document-content {NS}><office:body><office:text><text:p>x</text:p></office:text></office:body></office:document-content>"
     );
     let valid = package_with_directory(&content, "");
     assert!(convert(&valid, InputFormat::Odt, ResourceLimits::default()).is_ok());
     let typed = package_with_directory(&content, "image/png");
-    assert!(matches!(
-        convert(&typed, InputFormat::Odt, ResourceLimits::default()),
-        Err(ConversionError::Malformed { part: Some(part), .. }) if part == "Pictures/"
-    ));
+    assert!(convert(&typed, InputFormat::Odt, ResourceLimits::default()).is_ok());
     for media_type in ["", "application/xml", "application/vnd.sun.star.oleobject"] {
         let object = package(
             InputFormat::Odt,
             &content,
             &[("Object 1/content.xml", media_type, b"<object/>")],
         );
-        assert!(matches!(
-            convert(&object, InputFormat::Odt, ResourceLimits::default()),
-            Err(ConversionError::Malformed { .. })
-        ));
+        assert!(convert(&object, InputFormat::Odt, ResourceLimits::default()).is_ok());
     }
 }

--- a/crates/converters/src/odf/tests/producer_compatibility.rs
+++ b/crates/converters/src/odf/tests/producer_compatibility.rs
@@ -105,6 +105,47 @@ fn inline_image_anchor_preserves_bytes_marks_and_text_image_text_order() {
 }
 
 #[test]
+fn note_body_drawing_stays_inside_one_footnote_with_source_order() {
+    let mut png = Cursor::new(Vec::new());
+    image::DynamicImage::new_rgba8(2, 2).write_to(&mut png, image::ImageFormat::Png).unwrap();
+    for class in ["footnote", "endnote"] {
+        let content = format!(
+            "<office:document-content {NS}><office:body><office:text><text:p>body-before<text:span><text:note text:id='n1' text:note-class='{class}'><text:note-citation>1</text:note-citation><text:note-body><text:p>note-before<text:span><draw:frame><draw:image xlink:href='Pictures/a.png'/></draw:frame></text:span>note-after</text:p></text:note-body></text:note></text:span>body-after</text:p></office:text></office:body></office:document-content>"
+        );
+        let bytes =
+            package(InputFormat::Odt, &content, &[("Pictures/a.png", "image/png", png.get_ref())]);
+        let output = convert(&bytes, InputFormat::Odt, ResourceLimits::default()).unwrap();
+        output.document.validate().unwrap();
+        assert_eq!(output.document.blocks.len(), 2);
+        let Block::Paragraph(body) = &output.document.blocks[0].block else { panic!() };
+        assert_eq!(body.iter().filter(|inline| matches!(inline, into_markdown_core::Inline::FootnoteReference(id) if id == "n1")).count(), 1);
+        let Block::Footnote { label, blocks } = &output.document.blocks[1].block else { panic!() };
+        assert_eq!(label, "n1");
+        assert_eq!(blocks.len(), 3);
+        assert!(
+            matches!(&blocks[0].block, Block::Paragraph(inlines) if matches!(inlines.as_slice(), [into_markdown_core::Inline::Text { value, .. }] if value == "note-before"))
+        );
+        assert!(
+            matches!(&blocks[1].block, Block::Image { asset, .. } if *asset == output.assets[0].id)
+        );
+        assert!(
+            matches!(&blocks[2].block, Block::Paragraph(inlines) if matches!(inlines.as_slice(), [into_markdown_core::Inline::Text { value, .. }] if value == "note-after"))
+        );
+        assert_eq!(output.assets.len(), 1);
+        assert_eq!(output.assets[0].bytes, *png.get_ref());
+        let markdown =
+            render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+        assert_eq!(markdown.matches("[^fn-6e31]:").count(), 1);
+        assert_eq!(markdown.matches("[^fn-6e31]").count(), 2);
+        let plain = markdown.replace("\\-", "-");
+        let before = plain.find("note-before").unwrap();
+        let image = plain.find("![").unwrap();
+        let after = plain.find("note-after").unwrap();
+        assert!(before < image && image < after, "{markdown}");
+    }
+}
+
+#[test]
 fn empty_sheet_does_not_emit_invalid_zero_column_table() {
     let content = format!(
         "<office:document-content {NS}><office:body><office:spreadsheet><table:table table:name='Data'><table:table-row><table:table-cell><text:p>value</text:p></table:table-cell></table:table-row></table:table><table:table table:name='Empty'><table:table-row><table:table-cell/></table:table-row></table:table></office:spreadsheet></office:body></office:document-content>"

--- a/crates/converters/src/odf/tests/producer_compatibility.rs
+++ b/crates/converters/src/odf/tests/producer_compatibility.rs
@@ -1,0 +1,139 @@
+use super::support::{NS, convert, package};
+use crate::odf::compatibility::{GRDDL_NS, LOEXT_NS};
+use into_markdown_core::{Block, ConversionError, ConversionOptions, InputFormat, ResourceLimits};
+use into_markdown_render_markdown::render;
+use std::io::Cursor;
+
+#[test]
+fn producer_hints_fonts_and_empty_scripts_preserve_body_and_marks() {
+    let content = format!(
+        "<office:document-content {NS} xmlns:g='{GRDDL_NS}' xmlns:lo='{LOEXT_NS}' g:transformation='https://example.invalid/never-fetch' office:version='1.0'><office:scripts/><office:font-face-decls><style:font-face style:name='A' svg:font-family='Arial'/></office:font-face-decls><office:automatic-styles><style:style style:name='P' style:family='paragraph' style:master-page-name='Standard'><style:text-properties fo:font-weight='bold' lo:opacity='100%'/></style:style></office:automatic-styles><office:body><office:text><text:p text:style-name='P'>before<text:soft-page-break/>after</text:p></office:text></office:body></office:document-content>"
+    );
+    let meta = format!(
+        "<office:document-meta {NS} office:version='1.1'><office:meta><dc:title>Title</dc:title><meta:document-statistic xmlns:meta='urn:oasis:names:tc:opendocument:xmlns:meta:1.0' meta:word-count='2'/></office:meta></office:document-meta>"
+    );
+    let bytes = package(InputFormat::Odt, &content, &[("meta.xml", "text/xml", meta.as_bytes())]);
+    let output = convert(&bytes, InputFormat::Odt, ResourceLimits::default()).unwrap();
+    output.document.validate().unwrap();
+    let markdown = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+    assert!(
+        markdown.contains("before") && markdown.contains("after") && markdown.contains("<strong>")
+    );
+    assert!(output.diagnostics.iter().any(|d| d.code == "odf.layoutMetadata"));
+}
+
+#[test]
+fn compatibility_does_not_hide_active_or_unknown_content_in_layout_definitions() {
+    for layout in [
+        "<office:automatic-styles><style:style style:name='s' style:family='text'><style:text-properties><office:body/></style:text-properties></style:style></office:automatic-styles>",
+        "<office:automatic-styles><style:style style:name='s' style:family='text'><style:text-properties><office:event-listeners/></style:text-properties></style:style></office:automatic-styles>",
+    ] {
+        let content = format!(
+            "<office:document-content {NS}>{layout}<office:body><office:text><text:p>body</text:p></office:text></office:body></office:document-content>"
+        );
+        assert!(matches!(
+            convert(
+                &package(InputFormat::Odt, &content, &[]),
+                InputFormat::Odt,
+                ResourceLimits::default()
+            ),
+            Err(ConversionError::Malformed { .. })
+        ));
+    }
+    let content = format!(
+        "<office:document-content {NS} xmlns:lo='{LOEXT_NS}'><office:body><office:text><text:p lo:unknown='x'>body</text:p></office:text></office:body></office:document-content>"
+    );
+    assert!(
+        convert(
+            &package(InputFormat::Odt, &content, &[]),
+            InputFormat::Odt,
+            ResourceLimits::default()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn duplicate_styles_must_be_identical_not_merely_have_equal_text_marks() {
+    let style = "<style:style style:name='same' style:family='graphic'><style:graphic-properties draw:fill='none'/></style:style>";
+    for identical in [true, false] {
+        let other = if identical { style.to_owned() } else { style.replace("'none'", "'solid'") };
+        let content = format!(
+            "<office:document-content {NS}><office:automatic-styles>{style}{other}</office:automatic-styles><office:body><office:text><text:p>body</text:p></office:text></office:body></office:document-content>"
+        );
+        let result = convert(
+            &package(InputFormat::Odt, &content, &[]),
+            InputFormat::Odt,
+            ResourceLimits::default(),
+        );
+        if identical {
+            assert!(result.unwrap().diagnostics.iter().any(|d| d.code == "odf.identicalStyle"));
+        } else {
+            assert!(matches!(result, Err(ConversionError::Malformed { .. })));
+        }
+    }
+}
+
+#[test]
+fn inline_image_anchor_preserves_bytes_marks_and_text_image_text_order() {
+    let mut png = Cursor::new(Vec::new());
+    image::DynamicImage::new_rgba8(2, 2).write_to(&mut png, image::ImageFormat::Png).unwrap();
+    let content = format!(
+        "<office:document-content {NS}><office:body><office:text><text:p>before<text:span><draw:frame svg:width='0.2in' svg:height='0.2in'><svg:title>caption</svg:title><draw:image xlink:href='Pictures/a.png' xlink:type='simple' xlink:show='embed' xlink:actuate='onLoad'/></draw:frame></text:span>after</text:p></office:text></office:body></office:document-content>"
+    );
+    let bytes =
+        package(InputFormat::Odt, &content, &[("Pictures/a.png", "image/png", png.get_ref())]);
+    let output = convert(&bytes, InputFormat::Odt, ResourceLimits::default()).unwrap();
+    output.document.validate().unwrap();
+    assert_eq!(output.assets.len(), 1);
+    assert_eq!(output.assets[0].bytes, *png.get_ref());
+    assert_eq!(output.document.blocks.len(), 3);
+    assert!(matches!(&output.document.blocks[0].block, Block::Paragraph(_)));
+    assert!(
+        matches!(&output.document.blocks[1].block, Block::Image { alt: Some(alt), .. } if alt == "caption")
+    );
+    assert!(output.document.blocks[1].provenance.locator.bounds.is_none());
+    assert!(matches!(&output.document.blocks[2].block, Block::Paragraph(_)));
+    for bad in [
+        content.replace("0.2in", "-1in"),
+        content.replace("Pictures/a.png", "https://example.invalid/a.png"),
+    ] {
+        let bytes =
+            package(InputFormat::Odt, &bad, &[("Pictures/a.png", "image/png", png.get_ref())]);
+        assert!(convert(&bytes, InputFormat::Odt, ResourceLimits::default()).is_err());
+    }
+}
+
+#[test]
+fn empty_sheet_does_not_emit_invalid_zero_column_table() {
+    let content = format!(
+        "<office:document-content {NS}><office:body><office:spreadsheet><table:table table:name='Data'><table:table-row><table:table-cell><text:p>value</text:p></table:table-cell></table:table-row></table:table><table:table table:name='Empty'><table:table-row><table:table-cell/></table:table-row></table:table></office:spreadsheet></office:body></office:document-content>"
+    );
+    let output = convert(
+        &package(InputFormat::Ods, &content, &[]),
+        InputFormat::Ods,
+        ResourceLimits::default(),
+    )
+    .unwrap();
+    output.document.validate().unwrap();
+    assert!(
+        matches!(&output.document.blocks[1].block, Block::Sheet { blocks, .. } if blocks.is_empty())
+    );
+}
+
+#[test]
+fn referenced_master_footer_supplies_real_text_not_an_empty_slide_shell() {
+    let content = format!(
+        "<office:document-content {NS}><office:body><office:presentation><draw:page draw:master-page-name='Default'/></office:presentation></office:body></office:document-content>"
+    );
+    let styles = format!(
+        "<office:document-styles {NS}><office:master-styles><style:master-page style:name='Default'><draw:frame presentation:class='footer'><draw:text-box><text:p>Actual master footer</text:p></draw:text-box></draw:frame></style:master-page></office:master-styles></office:document-styles>"
+    );
+    let bytes =
+        package(InputFormat::Odp, &content, &[("styles.xml", "text/xml", styles.as_bytes())]);
+    let output = convert(&bytes, InputFormat::Odp, ResourceLimits::default()).unwrap();
+    let markdown = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+    assert!(markdown.contains("Actual master footer"));
+    let Block::Slide { blocks, .. } = &output.document.blocks[0].block else { panic!() };
+    assert_eq!(blocks[0].provenance.locator.part.as_deref(), Some("styles.xml"));
+}

--- a/crates/converters/src/odf/tests/recovery.rs
+++ b/crates/converters/src/odf/tests/recovery.rs
@@ -1,0 +1,443 @@
+use super::support::{NS, context_with, package};
+use crate::odf::convert_odf;
+use into_markdown_core::{
+    ConversionError, ConversionOptions, ErrorPolicy, InputFormat, ResourceLimits,
+};
+use into_markdown_render_markdown::render;
+
+fn convert_policy(
+    bytes: &[u8],
+    format: InputFormat,
+    policy: ErrorPolicy,
+    limits: ResourceLimits,
+) -> Result<into_markdown_core::ConverterOutput, ConversionError> {
+    convert_odf(
+        bytes,
+        format,
+        &ConversionOptions {
+            error_policy: policy,
+            limits: limits.clone(),
+            ..ConversionOptions::default()
+        },
+        &context_with(limits),
+    )
+}
+
+#[test]
+fn optional_scripts_and_revision_history_do_not_replace_static_body() {
+    let content = format!(
+        "<office:document-content {NS} xmlns:s='urn:oasis:names:tc:opendocument:xmlns:script:1.0'><office:scripts><office:script s:language='Basic'>DO_NOT_EXPORT</office:script></office:scripts><office:body><office:text><text:tracked-changes><text:changed-region><text:deletion><text:p>deleted history</text:p></text:deletion></text:changed-region></text:tracked-changes><text:p>before<text:change-start text:change-id='x'/>inserted<text:change-end text:change-id='x'/>after</text:p><draw:frame><office:event-listeners><s:event-listener s:language='Basic' xlink:href='vnd.sun.star.script:DO_NOT_EXPORT'/></office:event-listeners><draw:text-box><text:p>Static shape</text:p></draw:text-box></draw:frame></office:text></office:body></office:document-content>"
+    );
+    let bytes = package(InputFormat::Odt, &content, &[]);
+    let output = convert_policy(
+        &bytes,
+        InputFormat::Odt,
+        ErrorPolicy::BestEffort,
+        ResourceLimits::default(),
+    )
+    .unwrap();
+    let md = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+    assert!(md.contains("beforeinsertedafter") && md.contains("Static shape"));
+    assert!(!md.contains("DO_NOT_EXPORT") && !md.contains("deleted history"));
+    assert!(output.assets.is_empty());
+    for code in ["odf.scriptsOmitted", "odf.trackedChanges"] {
+        assert!(output.diagnostics.iter().any(|d| d.code == code));
+    }
+    assert!(
+        convert_policy(&bytes, InputFormat::Odt, ErrorPolicy::Strict, ResourceLimits::default())
+            .is_err()
+    );
+    let dtd = content
+        .replace("DO_NOT_EXPORT</office:script>", "<!DOCTYPE bad>DO_NOT_EXPORT</office:script>");
+    assert!(
+        convert_policy(
+            &package(InputFormat::Odt, &dtd, &[]),
+            InputFormat::Odt,
+            ErrorPolicy::BestEffort,
+            ResourceLimits::default()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn forms_animation_and_svg_keep_static_slide_with_auditable_omissions() {
+    let content = format!(
+        "<office:document-content {NS} xmlns:form='urn:oasis:names:tc:opendocument:xmlns:form:1.0' xmlns:anim='urn:oasis:names:tc:opendocument:xmlns:animation:1.0'><office:body><office:presentation><draw:page><office:forms><form:form form:name='search'/></office:forms><draw:frame><draw:text-box><text:p>Static slide</text:p></draw:text-box></draw:frame><draw:frame><draw:image xlink:href='Pictures/vector.svg'/></draw:frame><anim:par><anim:seq/></anim:par></draw:page></office:presentation></office:body></office:document-content>"
+    );
+    let bytes =
+        package(InputFormat::Odp, &content, &[("Pictures/vector.svg", "image/svg+xml", b"<svg/>")]);
+    let output = convert_policy(
+        &bytes,
+        InputFormat::Odp,
+        ErrorPolicy::BestEffort,
+        ResourceLimits::default(),
+    )
+    .unwrap();
+    let md = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+    assert!(md.contains("Static slide") && md.contains("Image omitted:"));
+    assert!(output.assets.is_empty());
+    for code in ["odf.formsOmitted", "odf.animationOmitted", "odf.imageOmitted"] {
+        assert!(output.diagnostics.iter().any(|d| d.code == code));
+    }
+    assert!(
+        convert_policy(&bytes, InputFormat::Odp, ErrorPolicy::Strict, ResourceLimits::default())
+            .is_err()
+    );
+}
+
+#[test]
+fn million_empty_tail_rows_are_sparse_but_real_repeats_remain_limited() {
+    let make = |tail: &str| {
+        format!(
+            "<office:document-content {NS}><office:body><office:spreadsheet><table:table table:name='S'><table:table-row><table:table-cell><text:p>actual value</text:p></table:table-cell></table:table-row><table:table-row table:number-rows-repeated='1048575'>{tail}</table:table-row></table:table></office:spreadsheet></office:body></office:document-content>"
+        )
+    };
+    let limits = ResourceLimits { max_table_rows: 1, ..ResourceLimits::default() };
+    let bytes = package(
+        InputFormat::Ods,
+        &make("<table:table-cell table:number-columns-repeated='16384'/>"),
+        &[],
+    );
+    for policy in [ErrorPolicy::BestEffort, ErrorPolicy::Strict] {
+        let output = convert_policy(&bytes, InputFormat::Ods, policy, limits.clone()).unwrap();
+        output.document.validate().unwrap();
+        let md = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+        assert!(md.contains("actual value") && md.len() < 100);
+        assert!(output.diagnostics.iter().any(|d| d.code == "odf.emptyRowPadding"));
+    }
+    for cell in [
+        "<table:table-cell office:value-type='float' office:value='1'/>",
+        "<table:table-cell table:formula='of:=1' office:value-type='float' office:value='1'/>",
+        "<table:table-cell table:number-rows-spanned='2'/>",
+        "<table:covered-table-cell/>",
+    ] {
+        assert!(matches!(
+            convert_policy(
+                &package(InputFormat::Ods, &make(cell), &[]),
+                InputFormat::Ods,
+                ErrorPolicy::BestEffort,
+                limits.clone()
+            ),
+            Err(ConversionError::ResourceLimit { limit: "max_table_rows", .. })
+        ));
+    }
+    let interior = make("<table:table-cell/>").replace("</table:table>", "<table:table-row><table:table-cell><text:p>later</text:p></table:table-cell></table:table-row></table:table>");
+    assert!(matches!(
+        convert_policy(
+            &package(InputFormat::Ods, &interior, &[]),
+            InputFormat::Ods,
+            ErrorPolicy::BestEffort,
+            limits
+        ),
+        Err(ConversionError::ResourceLimit { limit: "max_table_rows", .. })
+    ));
+}
+
+#[test]
+fn producer_formula_is_namespace_bound_inert_and_retains_cached_value() {
+    let content = format!(
+        "<office:document-content {NS} xmlns:old='http://schemas.microsoft.com/office/excel/formula'><office:body><office:spreadsheet><table:table><table:table-row><table:table-cell office:value-type='float' office:value='190.944' table:formula='old:=C5*95.472'/></table:table-row></table:table></office:spreadsheet></office:body></office:document-content>"
+    );
+    let bytes = package(InputFormat::Ods, &content, &[]);
+    let output = convert_policy(
+        &bytes,
+        InputFormat::Ods,
+        ErrorPolicy::BestEffort,
+        ResourceLimits::default(),
+    )
+    .unwrap();
+    let md = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+    assert!(md.contains(r"190\.944") && !md.contains("openformula"), "{md}");
+    let into_markdown_core::Block::Sheet { blocks, .. } = &output.document.blocks[0].block else {
+        panic!()
+    };
+    let into_markdown_core::Block::Table { rows, .. } = &blocks[0].block else { panic!() };
+    assert!(rows[0].cells[0].blocks.iter().any(|block| matches!(&block.block, into_markdown_core::Block::Code { language: None, text } if text == "old:=C5*95.472")));
+    assert!(output.diagnostics.iter().any(|d| d.code == "odf.cachedProducerFormula"));
+    assert!(
+        convert_policy(&bytes, InputFormat::Ods, ErrorPolicy::Strict, ResourceLimits::default())
+            .is_err()
+    );
+    let wrong =
+        content.replace("http://schemas.microsoft.com/office/excel/formula", "urn:untrusted");
+    assert!(
+        convert_policy(
+            &package(InputFormat::Ods, &wrong, &[]),
+            InputFormat::Ods,
+            ErrorPolicy::BestEffort,
+            ResourceLimits::default()
+        )
+        .is_err()
+    );
+}
+
+fn rewrite_archive(bytes: &[u8], omit: &[&str], compressed_mimetype: bool) -> Vec<u8> {
+    use std::io::{Cursor, Read, Write};
+    let mut archive = zip::ZipArchive::new(Cursor::new(bytes)).unwrap();
+    let mut writer = zip::ZipWriter::new(Cursor::new(Vec::new()));
+    let mut names: Vec<_> = archive.file_names().map(str::to_owned).collect();
+    if compressed_mimetype {
+        names.sort();
+    }
+    for name in names {
+        if omit.contains(&name.as_str()) {
+            continue;
+        }
+        let mut value = Vec::new();
+        archive.by_name(&name).unwrap().read_to_end(&mut value).unwrap();
+        let options = if name == "mimetype" && !compressed_mimetype {
+            zip::write::SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Stored)
+        } else {
+            zip::write::SimpleFileOptions::default()
+        };
+        writer.start_file(name, options).unwrap();
+        writer.write_all(&value).unwrap();
+    }
+    writer.finish().unwrap().into_inner()
+}
+
+#[test]
+fn optional_part_roles_do_not_relax_consumed_part_requirements() {
+    let content = format!(
+        "<office:document-content {NS}><office:body><office:text><text:p>actual body</text:p></office:text></office:body></office:document-content>"
+    );
+    let original = package(
+        InputFormat::Odt,
+        &content,
+        &[
+            ("CustomUI/", "application/vnd.sun.xml.ui.configuration", b""),
+            ("CustomUI/keys.xml", "", b""),
+            ("preview.png", "image/png", b""),
+            ("meta.xml", "text/xml", b""),
+        ],
+    );
+    let bytes =
+        rewrite_archive(&original, &["CustomUI/keys.xml", "preview.png", "meta.xml"], false);
+    let output = convert_policy(
+        &bytes,
+        InputFormat::Odt,
+        ErrorPolicy::BestEffort,
+        ResourceLimits::default(),
+    )
+    .unwrap();
+    assert_eq!(
+        output.diagnostics.iter().filter(|d| d.code == "odf.optionalPartMissing").count(),
+        3
+    );
+    assert!(
+        convert_policy(&bytes, InputFormat::Odt, ErrorPolicy::Strict, ResourceLimits::default())
+            .is_err()
+    );
+    let missing_body = rewrite_archive(&bytes, &["content.xml"], false);
+    assert!(
+        convert_policy(
+            &missing_body,
+            InputFormat::Odt,
+            ErrorPolicy::BestEffort,
+            ResourceLimits::default()
+        )
+        .is_err()
+    );
+    let with_reference = content.replace(
+        "</office:text>",
+        "<draw:frame><draw:image xlink:href='preview.png'/></draw:frame></office:text>",
+    );
+    let missing_image = rewrite_archive(
+        &package(InputFormat::Odt, &with_reference, &[("preview.png", "image/png", b"")]),
+        &["preview.png"],
+        false,
+    );
+    assert!(
+        convert_policy(
+            &missing_image,
+            InputFormat::Odt,
+            ErrorPolicy::BestEffort,
+            ResourceLimits::default()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn noncanonical_mimetype_packing_is_diagnosed_but_integrity_is_mandatory() {
+    let content = format!(
+        "<office:document-content {NS}><office:body><office:text><text:p>real body</text:p></office:text></office:body></office:document-content>"
+    );
+    let original = package(InputFormat::Odt, &content, &[]);
+    for reordered in [false, true] {
+        let base = if reordered { rewrite_archive(&original, &[], true) } else { original.clone() };
+        for signed in [false, true] {
+            let (bytes, descriptor) =
+                super::zip_compatibility::named_descriptor(base.clone(), signed, "mimetype");
+            let output = convert_policy(
+                &bytes,
+                InputFormat::Odt,
+                ErrorPolicy::BestEffort,
+                ResourceLimits::default(),
+            )
+            .unwrap();
+            assert!(output.diagnostics.iter().any(|d| d.code == "odf.noncanonicalMimetype"));
+            assert!(
+                convert_policy(
+                    &bytes,
+                    InputFormat::Odt,
+                    ErrorPolicy::Strict,
+                    ResourceLimits::default()
+                )
+                .is_err()
+            );
+            for field in [0, 4, 8] {
+                let mut corrupt = bytes.clone();
+                corrupt[descriptor + usize::from(signed) * 4 + field] ^= 1;
+                assert!(
+                    convert_policy(
+                        &corrupt,
+                        InputFormat::Odt,
+                        ErrorPolicy::BestEffort,
+                        ResourceLimits::default()
+                    )
+                    .is_err()
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn cached_index_fields_and_image_bullets_retain_body_under_best_effort() {
+    let content = format!(
+        "<office:document-content {NS}><office:automatic-styles><text:list-style style:name='L'><text:list-level-style-image text:level='1' xlink:href='ignored.png'/></text:list-style></office:automatic-styles><office:body><office:text><text:table-of-content><text:table-of-content-source/><text:index-body><text:index-title><text:p>Contents</text:p></text:index-title><text:p>Entry one</text:p></text:index-body></text:table-of-content><text:p><text:user-field-get text:name='f' style:data-style-name='n'>cached value</text:user-field-get><text:bibliography-mark text:identifier='r'>[reference]</text:bibliography-mark></text:p><text:list text:style-name='L'><text:list-item><text:p>Bullet body</text:p></text:list-item></text:list></office:text></office:body></office:document-content>"
+    );
+    let bytes = package(InputFormat::Odt, &content, &[]);
+    let output = convert_policy(
+        &bytes,
+        InputFormat::Odt,
+        ErrorPolicy::BestEffort,
+        ResourceLimits::default(),
+    )
+    .unwrap();
+    let md = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+    for expected in ["Contents", "Entry one", "cached value", "reference", "Bullet body"] {
+        assert!(md.contains(expected), "{md}");
+    }
+    for code in ["odf.cachedIndex", "odf.cachedField", "odf.imageListMarker"] {
+        assert!(output.diagnostics.iter().any(|d| d.code == code));
+    }
+    assert!(
+        convert_policy(&bytes, InputFormat::Odt, ErrorPolicy::Strict, ResourceLimits::default())
+            .is_err()
+    );
+}
+
+#[test]
+fn vector_paths_keep_text_and_whitespace_separated_transforms_are_parsed() {
+    let content = format!(
+        "<office:document-content {NS}><office:body><office:presentation><draw:page><draw:path svg:x='1cm' svg:y='2cm' svg:width='3cm' svg:height='4cm' svg:d='M0 0' svg:viewBox='0 0 10 10' draw:transform='rotate (0) translate (1cm 2cm)'><text:p>Path caption</text:p></draw:path></draw:page></office:presentation></office:body></office:document-content>"
+    );
+    let bytes = package(InputFormat::Odp, &content, &[]);
+    let output = convert_policy(
+        &bytes,
+        InputFormat::Odp,
+        ErrorPolicy::BestEffort,
+        ResourceLimits::default(),
+    )
+    .unwrap();
+    let md = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+    assert!(md.contains("Path caption"));
+    let into_markdown_core::Block::Slide { blocks, .. } = &output.document.blocks[0].block else {
+        panic!()
+    };
+    let bounds = blocks[0].provenance.locator.bounds.unwrap();
+    assert!((bounds.x - 2.0 * 72.0 / 2.54).abs() < 0.01);
+    assert!((bounds.y - 4.0 * 72.0 / 2.54).abs() < 0.01);
+    assert!(
+        convert_policy(&bytes, InputFormat::Odp, ErrorPolicy::Strict, ResourceLimits::default())
+            .is_err()
+    );
+    let bad = content.replace("rotate (0)", "rotate (NaN)");
+    assert!(
+        convert_policy(
+            &package(InputFormat::Odp, &bad, &[]),
+            InputFormat::Odp,
+            ErrorPolicy::BestEffort,
+            ResourceLimits::default()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn unsupported_images_still_require_present_crc_valid_members() {
+    let content = format!(
+        "<office:document-content {NS}><office:body><office:text><text:p>body</text:p><draw:frame><draw:image xlink:href='a.svg'/></draw:frame></office:text></office:body></office:document-content>"
+    );
+    let bytes = package(InputFormat::Odt, &content, &[("a.svg", "image/svg+xml", b"<svg/>")]);
+    let missing = rewrite_archive(&bytes, &["a.svg"], false);
+    assert!(
+        convert_policy(
+            &missing,
+            InputFormat::Odt,
+            ErrorPolicy::BestEffort,
+            ResourceLimits::default()
+        )
+        .is_err()
+    );
+    let mut archive = zip::ZipArchive::new(std::io::Cursor::new(&bytes)).unwrap();
+    let offset = usize::try_from(archive.by_name("a.svg").unwrap().data_start()).unwrap();
+    drop(archive);
+    let mut corrupt = bytes;
+    corrupt[offset] ^= 0x80;
+    assert!(
+        convert_policy(
+            &corrupt,
+            InputFormat::Odt,
+            ErrorPolicy::BestEffort,
+            ResourceLimits::default()
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn drawing_only_macro_has_source_shape_placeholder_not_heading_only_output() {
+    let content = format!(
+        "<office:document-content {NS} xmlns:s='urn:oasis:names:tc:opendocument:xmlns:script:1.0'><office:body><office:presentation><draw:page><draw:custom-shape><office:event-listeners><s:event-listener s:language='Basic'/></office:event-listeners><text:p/><draw:enhanced-geometry draw:type='smiley'/></draw:custom-shape></draw:page></office:presentation></office:body></office:document-content>"
+    );
+    let bytes = package(InputFormat::Odp, &content, &[]);
+    let output = convert_policy(
+        &bytes,
+        InputFormat::Odp,
+        ErrorPolicy::BestEffort,
+        ResourceLimits::default(),
+    )
+    .unwrap();
+    let md = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+    assert!(md.contains("Drawing omitted: smiley"));
+    assert!(output.diagnostics.iter().any(|d| d.code == "odf.scriptsOmitted"));
+    assert!(output.diagnostics.iter().any(|d| d.code == "odf.drawingPlaceholder"));
+    assert!(output.assets.is_empty());
+}
+
+#[test]
+fn unsupported_list_restart_keeps_items_and_diagnoses_numbering() {
+    let content = format!(
+        "<office:document-content {NS}><office:automatic-styles><text:list-style style:name='L'><text:list-level-style-number text:level='1' style:num-format='1'/></text:list-style></office:automatic-styles><office:body><office:text><text:list text:style-name='L'><text:list-item><text:p>first</text:p></text:list-item><text:list-item text:start-value='9'><text:p>second</text:p></text:list-item></text:list></office:text></office:body></office:document-content>"
+    );
+    let bytes = package(InputFormat::Odt, &content, &[]);
+    let output = convert_policy(
+        &bytes,
+        InputFormat::Odt,
+        ErrorPolicy::BestEffort,
+        ResourceLimits::default(),
+    )
+    .unwrap();
+    let md = render(&output.document, &output.assets, &ConversionOptions::default()).unwrap();
+    assert!(md.contains("first") && md.contains("second"));
+    assert!(output.diagnostics.iter().any(|d| d.code == "odf.listRestart"));
+    assert!(
+        convert_policy(&bytes, InputFormat::Odt, ErrorPolicy::Strict, ResourceLimits::default())
+            .is_err()
+    );
+}

--- a/crates/converters/src/odf/tests/support.rs
+++ b/crates/converters/src/odf/tests/support.rs
@@ -127,6 +127,14 @@ pub(super) fn make_raw_name_invalid(bytes: &mut [u8], target: &[u8]) {
 }
 
 pub(super) fn package_with_directory(content: &str, media_type: &str) -> Vec<u8> {
+    package_with_optional_directory(content, media_type, true)
+}
+
+pub(super) fn package_with_optional_directory(
+    content: &str,
+    media_type: &str,
+    physical: bool,
+) -> Vec<u8> {
     let mimetype = media_type_for(InputFormat::Odt).unwrap();
     let declaration = format!(
         "<manifest:file-entry manifest:full-path='Pictures/' manifest:media-type='{media_type}'/>"
@@ -145,7 +153,9 @@ pub(super) fn package_with_directory(content: &str, media_type: &str) -> Vec<u8>
         writer.write_all(content.as_bytes()).unwrap();
         writer.start_file("META-INF/manifest.xml", SimpleFileOptions::default()).unwrap();
         writer.write_all(manifest(mimetype, &declaration).as_bytes()).unwrap();
-        writer.add_directory("Pictures/", SimpleFileOptions::default()).unwrap();
+        if physical {
+            writer.add_directory("Pictures/", SimpleFileOptions::default()).unwrap();
+        }
         writer.finish().unwrap();
     }
     cursor.into_inner()
@@ -180,6 +190,7 @@ pub(super) fn package_with_central_extra(
             writer.start_file("content.xml", SimpleFileOptions::default()).unwrap();
         } else {
             let mut options = FileOptions::<ExtendedFileOptions>::default();
+            options.add_extra_data(0x5455, Box::from([1_u8, 0, 0, 0, 0]), false).unwrap();
             options.add_extra_data(header_id, payload.take().unwrap(), true).unwrap();
             writer.start_file("content.xml", options).unwrap();
         }

--- a/crates/converters/src/odf/tests/zip_compatibility.rs
+++ b/crates/converters/src/odf/tests/zip_compatibility.rs
@@ -1,0 +1,138 @@
+use super::support::{
+    NS, convert, package, package_with_central_extra, package_with_optional_directory,
+};
+use crate::odf::raw_zip::{read_u16, read_u32};
+use into_markdown_core::{ConversionError, InputFormat, ResourceLimits};
+use std::io::Cursor;
+
+fn document() -> String {
+    format!(
+        "<office:document-content {NS}><office:body><office:text><text:p>kept text</text:p></office:text></office:body></office:document-content>"
+    )
+}
+
+// Make a seek-written fixture equivalent to a streaming producer. The ZIP crate still
+// supplies the payload, CRC and central directory; only the descriptor is inserted here.
+fn with_descriptor(bytes: Vec<u8>, signed: bool) -> (Vec<u8>, usize) {
+    named_descriptor(bytes, signed, "content.xml")
+}
+
+pub(super) fn named_descriptor(mut bytes: Vec<u8>, signed: bool, name: &str) -> (Vec<u8>, usize) {
+    let mut zip = zip::ZipArchive::new(Cursor::new(bytes.as_slice())).unwrap();
+    let entry = zip.by_name(name).unwrap();
+    let local = usize::try_from(entry.header_start()).unwrap();
+    let central = usize::try_from(entry.central_header_start()).unwrap();
+    let end = usize::try_from(entry.data_start() + entry.compressed_size()).unwrap();
+    let mut descriptor = Vec::new();
+    if signed {
+        descriptor.extend_from_slice(&0x0807_4b50_u32.to_le_bytes());
+    }
+    descriptor.extend_from_slice(&entry.crc32().to_le_bytes());
+    descriptor.extend_from_slice(&u32::try_from(entry.compressed_size()).unwrap().to_le_bytes());
+    descriptor.extend_from_slice(&u32::try_from(entry.size()).unwrap().to_le_bytes());
+    drop(entry);
+    drop(zip);
+    let flags = read_u16(&bytes, local + 6).unwrap() | 8;
+    bytes[local + 6..local + 8].copy_from_slice(&flags.to_le_bytes());
+    bytes[local + 14..local + 26].fill(0);
+    bytes[central + 8..central + 10].copy_from_slice(&flags.to_le_bytes());
+    let delta = u32::try_from(descriptor.len()).unwrap();
+    bytes.splice(end..end, descriptor);
+    let eocd = bytes.len() - 22;
+    let start = read_u32(&bytes, eocd + 16).unwrap() + delta;
+    bytes[eocd + 16..eocd + 20].copy_from_slice(&start.to_le_bytes());
+    let mut central = usize::try_from(start).unwrap();
+    while central < eocd {
+        let offset = read_u32(&bytes, central + 42).unwrap();
+        if usize::try_from(offset).unwrap() >= end {
+            bytes[central + 42..central + 46].copy_from_slice(&(offset + delta).to_le_bytes());
+        }
+        central += 46
+            + usize::from(read_u16(&bytes, central + 28).unwrap())
+            + usize::from(read_u16(&bytes, central + 30).unwrap())
+            + usize::from(read_u16(&bytes, central + 32).unwrap());
+    }
+    (bytes, end)
+}
+
+#[test]
+fn ordinary_members_accept_both_descriptor_encodings_and_keep_crc_binding() {
+    for signed in [false, true] {
+        let (bytes, descriptor) =
+            with_descriptor(package(InputFormat::Odt, &document(), &[]), signed);
+        assert!(convert(&bytes, InputFormat::Odt, ResourceLimits::default()).is_ok());
+        for field in [0, 4, 8] {
+            let mut corrupt = bytes.clone();
+            corrupt[descriptor + usize::from(signed) * 4 + field] ^= 1;
+            assert!(matches!(
+                convert(&corrupt, InputFormat::Odt, ResourceLimits::default()),
+                Err(ConversionError::Malformed { .. })
+            ));
+        }
+        let mut corrupt = bytes;
+        // Changing the actual payload is still caught by the ZIP reader's CRC/decompressor.
+        let mut zip = zip::ZipArchive::new(Cursor::new(corrupt.as_slice())).unwrap();
+        let offset = usize::try_from(zip.by_name("content.xml").unwrap().data_start()).unwrap();
+        drop(zip);
+        corrupt[offset] ^= 0xff;
+        assert!(matches!(
+            convert(&corrupt, InputFormat::Odt, ResourceLimits::default()),
+            Err(ConversionError::Malformed { .. })
+        ));
+    }
+}
+
+#[test]
+fn ordinary_members_accept_ntfs_and_unknown_metadata_extras() {
+    let mut ntfs = vec![0; 4];
+    ntfs.extend_from_slice(&1_u16.to_le_bytes());
+    ntfs.extend_from_slice(&24_u16.to_le_bytes());
+    ntfs.extend_from_slice(&[0; 24]);
+    for (id, payload) in [(0x000a, ntfs), (0xcafe, vec![1, 2, 3])] {
+        // The writer reserves NTFS for a feature we do not enable. Write an inert same-size
+        // field, then set its wire ID; no dependency/features are needed for this read test.
+        let mut bytes =
+            package_with_central_extra(&document(), false, 0xcafe, payload.into_boxed_slice());
+        let mut zip = zip::ZipArchive::new(Cursor::new(bytes.as_slice())).unwrap();
+        let central =
+            usize::try_from(zip.by_name("content.xml").unwrap().central_header_start()).unwrap();
+        drop(zip);
+        let mut extra = central + 46 + usize::from(read_u16(&bytes, central + 28).unwrap());
+        while read_u16(&bytes, extra).unwrap() != 0xcafe {
+            extra += 4 + usize::from(read_u16(&bytes, extra + 2).unwrap());
+        }
+        bytes[extra..extra + 2].copy_from_slice(&u16::to_le_bytes(id));
+        let (bytes, _) = with_descriptor(bytes, true);
+        assert!(convert(&bytes, InputFormat::Odt, ResourceLimits::default()).is_ok());
+    }
+}
+
+#[test]
+fn metadata_parts_are_not_images_but_image_references_still_require_image_media() {
+    let extra = [
+        ("manifest.rdf", "application/rdf+xml", b"<rdf/>".as_slice()),
+        ("layout-cache", "application/binary", b"cache".as_slice()),
+    ];
+    let bytes = package(InputFormat::Odt, &document(), &extra);
+    assert!(convert(&bytes, InputFormat::Odt, ResourceLimits::default()).is_ok());
+    let content = format!(
+        "<office:document-content {NS}><office:body><office:text><draw:frame><draw:image xlink:type='simple' xlink:href='layout-cache'/></draw:frame></office:text></office:body></office:document-content>"
+    );
+    let bytes = package(InputFormat::Odt, &content, &extra);
+    assert!(matches!(
+        convert(&bytes, InputFormat::Odt, ResourceLimits::default()),
+        Err(ConversionError::Malformed { .. })
+    ));
+}
+
+#[test]
+fn manifest_directories_do_not_require_physical_zip_records() {
+    for physical in [false, true] {
+        let bytes = package_with_optional_directory(
+            &document(),
+            "application/vnd.sun.xml.ui.configuration",
+            physical,
+        );
+        assert!(convert(&bytes, InputFormat::Odt, ResourceLimits::default()).is_ok());
+    }
+}

--- a/crates/converters/src/odf/text.rs
+++ b/crates/converters/src/odf/text.rs
@@ -1,5 +1,7 @@
 use crate::odf::annotations::annotation_text;
-use crate::odf::model::{DRAW_NS, OFFICE_NS, ParseState, TEXT_NS, XLINK_NS, limit, malformed};
+use crate::odf::model::{
+    DRAW_NS, OFFICE_NS, ParseState, SVG_NS, TEXT_NS, XLINK_NS, limit, malformed,
+};
 use crate::odf::styles::{StyleMap, style_marks};
 use crate::odf::tables::parse_repeat;
 use crate::odf::xml::{XmlContent, XmlNode, bounded_text};
@@ -28,7 +30,11 @@ pub(super) fn parse_inlines(
     for value in &node.content {
         match value {
             XmlContent::Text(text) => push_text(&mut output, text, marks, state, options)?,
-            XmlContent::Node(child) if child.is(TEXT_NS, "span") => {
+            XmlContent::Node(child)
+                if child.is(TEXT_NS, "span")
+                    || child.is(SVG_NS, "title")
+                    || child.is(SVG_NS, "desc") =>
+            {
                 let marks = style_marks(styles, "text", child.attr(TEXT_NS, "style-name"), marks);
                 output.extend(parse_inlines(child, styles, state, options, locator, &marks)?);
             }
@@ -95,6 +101,9 @@ pub(super) fn parse_inlines(
                     || child.is(TEXT_NS, "reference-mark-start")
                     || child.is(TEXT_NS, "reference-mark-end") => {}
             XmlContent::Node(child) if child.name.ns == TEXT_NS || child.name.ns == OFFICE_NS => {
+                if child.is(TEXT_NS, "conditional-text") {
+                    state.warning("odf.cachedField", "Conditional field retains its stored display text; expression was not evaluated", locator.clone());
+                }
                 output.extend(parse_inlines(child, styles, state, options, locator, marks)?);
             }
             XmlContent::Node(child) if child.name.ns == DRAW_NS => {
@@ -134,7 +143,7 @@ fn push_text(
     Ok(())
 }
 
-fn validate_link(value: &str) -> Result<(), ConversionError> {
+pub(super) fn validate_link(value: &str) -> Result<(), ConversionError> {
     if value.starts_with('#') && value.len() > 1 {
         return Ok(());
     }

--- a/crates/converters/src/odf/text.rs
+++ b/crates/converters/src/odf/text.rs
@@ -2,11 +2,13 @@ use crate::odf::annotations::annotation_text;
 use crate::odf::model::{
     DRAW_NS, OFFICE_NS, ParseState, SVG_NS, TEXT_NS, XLINK_NS, limit, malformed,
 };
+use crate::odf::package::Package;
+use crate::odf::semantic::parse_blocks;
 use crate::odf::styles::{StyleMap, style_marks};
 use crate::odf::tables::parse_repeat;
-use crate::odf::xml::{XmlContent, XmlNode, bounded_text};
+use crate::odf::xml::{XmlContent, XmlNode};
 use into_markdown_core::{
-    Block, ConversionError, ConversionOptions, Inline, InlineMark, SourceLocator,
+    Block, ConversionError, ConversionOptions, ExecutionContext, Inline, InlineMark, SourceLocator,
 };
 
 #[derive(Clone, Copy, Eq, PartialEq)]
@@ -21,8 +23,10 @@ pub(super) enum ParseMode {
 pub(super) fn parse_inlines(
     node: &XmlNode,
     styles: &StyleMap,
+    package: &Package,
     state: &mut ParseState,
     options: &ConversionOptions,
+    context: &ExecutionContext,
     locator: &SourceLocator,
     marks: &[InlineMark],
 ) -> Result<Vec<Inline>, ConversionError> {
@@ -36,16 +40,19 @@ pub(super) fn parse_inlines(
                     || child.is(SVG_NS, "desc") =>
             {
                 let marks = style_marks(styles, "text", child.attr(TEXT_NS, "style-name"), marks);
-                output.extend(parse_inlines(child, styles, state, options, locator, &marks)?);
+                output.extend(parse_inlines(
+                    child, styles, package, state, options, context, locator, &marks,
+                )?);
             }
             XmlContent::Node(child) if child.is(TEXT_NS, "a") => {
                 let href = child
                     .attr(XLINK_NS, "href")
                     .ok_or_else(|| malformed(Some("content.xml"), "text:a lacks xlink:href"))?;
                 validate_link(href)?;
-                let content = parse_inlines(child, styles, state, options, locator, marks)?;
+                let inlines =
+                    parse_inlines(child, styles, package, state, options, context, locator, marks)?;
                 state.add_inlines(1)?;
-                output.push(Inline::Link { target: href.to_owned(), content });
+                output.push(Inline::Link { target: href.to_owned(), content: inlines });
             }
             XmlContent::Node(child) if child.is(TEXT_NS, "s") => {
                 let repeat = parse_repeat(
@@ -65,23 +72,7 @@ pub(super) fn parse_inlines(
                 output.push(Inline::LineBreak);
             }
             XmlContent::Node(child) if child.is(TEXT_NS, "note") => {
-                let id = child.attr(TEXT_NS, "id").unwrap_or("note");
-                let body = child
-                    .children()
-                    .find(|value| value.is(TEXT_NS, "note-body"))
-                    .ok_or_else(|| malformed(Some("content.xml"), "text:note lacks note-body"))?;
-                let note_text = bounded_text(body, options, "content.xml")?;
-                state.add_inlines(1)?;
-                let paragraph = state.node(
-                    Block::Paragraph(vec![Inline::Text { value: note_text, marks: vec![] }]),
-                    locator.clone(),
-                )?;
-                let blocks = vec![paragraph];
-                let deferred = state
-                    .node(Block::Footnote { label: id.to_owned(), blocks }, locator.clone())?;
-                state.deferred.push(deferred);
-                state.add_inlines(1)?;
-                output.push(Inline::FootnoteReference(id.to_owned()));
+                output.push(parse_note(child, styles, package, state, options, context, locator)?);
             }
             XmlContent::Node(child) if child.is(OFFICE_NS, "annotation") => {
                 let text = annotation_text(child, options)?;
@@ -104,7 +95,9 @@ pub(super) fn parse_inlines(
                 if child.is(TEXT_NS, "conditional-text") {
                     state.warning("odf.cachedField", "Conditional field retains its stored display text; expression was not evaluated", locator.clone());
                 }
-                output.extend(parse_inlines(child, styles, state, options, locator, marks)?);
+                output.extend(parse_inlines(
+                    child, styles, package, state, options, context, locator, marks,
+                )?);
             }
             XmlContent::Node(child) if child.name.ns == DRAW_NS => {
                 // Block images are handled by parse_drawing. Inline frames have no exact IR shape;
@@ -123,6 +116,28 @@ pub(super) fn parse_inlines(
         }
     }
     Ok(output)
+}
+
+fn parse_note(
+    node: &XmlNode,
+    styles: &StyleMap,
+    package: &Package,
+    state: &mut ParseState,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+    locator: &SourceLocator,
+) -> Result<Inline, ConversionError> {
+    let id = node.attr(TEXT_NS, "id").unwrap_or("note");
+    let body = node
+        .children()
+        .find(|value| value.is(TEXT_NS, "note-body"))
+        .ok_or_else(|| malformed(Some("content.xml"), "text:note lacks note-body"))?;
+    let blocks =
+        parse_blocks(body, styles, package, state, options, context, locator, ParseMode::Text, 1)?;
+    let deferred = state.node(Block::Footnote { label: id.to_owned(), blocks }, locator.clone())?;
+    state.deferred.push(deferred);
+    state.add_inlines(1)?;
+    Ok(Inline::FootnoteReference(id.to_owned()))
 }
 
 fn push_text(

--- a/crates/converters/src/odf/xml.rs
+++ b/crates/converters/src/odf/xml.rs
@@ -15,19 +15,19 @@ pub(super) struct Name {
     pub(super) local: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) struct Attr {
     pub(super) name: Name,
     pub(super) value: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) enum XmlContent {
     Text(String),
     Node(XmlNode),
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub(super) struct XmlNode {
     pub(super) name: Name,
     pub(super) attrs: Vec<Attr>,
@@ -281,6 +281,21 @@ fn xml_node(
             })?
             .into_owned();
         validate_xml_chars(&value, part)?;
+        if name.ns == TABLE_NS && name.local == "formula" && !value.starts_with("of:=") {
+            let (prefix, expression) = value
+                .split_once(":=")
+                .filter(|(_, expression)| !expression.is_empty())
+                .ok_or_else(|| {
+                    malformed(Some(part), "formula must have a namespace-prefixed expression")
+                })?;
+            let qname = format!("{prefix}:formula");
+            let resolved = resolved_name(reader, quick_xml::name::QName(qname.as_bytes()), part)?;
+            if resolved.ns != "http://schemas.microsoft.com/office/excel/formula"
+                || expression.is_empty()
+            {
+                return Err(malformed(Some(part), "unsupported producer formula namespace"));
+            }
+        }
         attrs.push(Attr { name, value });
     }
     Ok(XmlNode { name, attrs, content: Vec::new() })
@@ -330,6 +345,8 @@ fn validate_known_namespace(name: &Name, part: &str) -> Result<(), ConversionErr
         NUMBER_NS,
     ]
     .contains(&name.ns.as_str())
+        || super::compatibility::producer_namespace(&name.ns)
+        || super::recovery::optional_namespace(&name.ns)
     {
         Ok(())
     } else {
@@ -360,6 +377,8 @@ fn validate_known_attribute_namespace(name: &Name, part: &str) -> Result<(), Con
             NUMBER_NS,
         ]
         .contains(&name.ns.as_str())
+        || super::compatibility::producer_namespace(&name.ns)
+        || super::recovery::optional_namespace(&name.ns)
     {
         Ok(())
     } else {

--- a/docs/evidence/issue-307-odf.md
+++ b/docs/evidence/issue-307-odf.md
@@ -1,0 +1,188 @@
+# Issue 307: real ODF compatibility evidence
+
+The frozen current report failed all 36 ODF inputs. This patch converts **33/36**
+under BestEffort: **ODT 17/20, ODS 7/7, ODP 9/9**. The three remaining rejections
+have independent source evidence: a manifest DOCTYPE, encrypted content, and a
+plain-text file masquerading as ODT. They are not generic unsupported-profile errors.
+No new Action, dependency, lint exemption, renderer, detector fallback, or resource
+limit increase is introduced. The existing PR fast gate remains enabled; independent
+review belongs to the parent task, not this implementation task.
+
+## Reproduction and isolation
+
+- Starting main: `a6cb5e227de78b51fe6dc5dc5a680dba90f78c51`.
+- Branch: `codex/issue-307-odf-compat`, separate `307-odf` worktree.
+- Read-only manifest: `C:/im-bench-004/formal-schema3/manifest.json`.
+- Manifest SHA-256: `7f82792dca7d1011d8a1bbcdfe7de5b4f0c463515be347405d0c88a6b866cacc`.
+- Frozen current fingerprint: `75af809153636b33888f281ca408765982d6b3c39a0a41945d9502f40034fbac`.
+- Frozen baseline fingerprint: `f7f3521c0fe9992ae2ec76fd7e6a402b2b3fc72480c379e91badb35e30555c4d`.
+- Isolated evidence root: `C:/im-bench-004/issue307-odf-20260831/`.
+- Authoritative BestEffort run: **`final4/`**, including `report.json`, `matrix.json`,
+  `matrix.csv`, `run.json`, `content-evidence.json`, logs, and 11 `samples/` result JSONs.
+- Full Strict run: **`strict1/`**, **18 success / 18 rejection**. Recovery-specific
+  unit tests also assert Strict rejection for the same constructed source.
+- Candidate debug executable SHA-256:
+  `399d8741f77d5a576b03f2c13a53ce413f2415a9d8ced0ea9020a29efb17afe3`.
+- `inspect_corpus.py`, `classify_xml.py`, `run_corpus.py`, and `verify_outputs.py`
+  retain exact reproduction logic in the evidence root. Originals, formal JSONL
+  reports and benchmark state are never changed. Input SHA-256 values are checked
+  against the frozen manifest before/after conversion.
+
+Each batch has a dry-run followed by conversion of all 36 original source paths:
+
+```text
+--no-config --ocr off --asset-mode omit --error-policy best-effort --jobs 1
+--max-temporary-size 4294967296 --conflict error --log-format json
+--output-dir <isolated run>/outputs --report <isolated run>/report.json
+```
+
+`strict1` changes only error policy and output paths. Samples use `--emit result-json
+--asset-mode embed`, also jobs=1/conflict=error. These are coverage/content checks,
+**not timing benchmarks**; no performance conclusion is drawn from debug runs.
+
+## Implemented boundaries
+
+- Ordinary ZIP extras and signed/unsigned descriptors are accepted with exact
+  local/central CRC, size, offset, and descriptor binding. ZIP decoding still checks
+  actual payload CRC/expanded size for every real member, including ignored parts.
+  Encryption, aliases, traversal, overlapping records, malformed extras and ZIP64
+  retain their existing rejection paths.
+- Only image media enters the image profile. Missing UI members are optional by
+  their manifest ancestor's `application/vnd.sun.xml.ui.configuration` role, not
+  sample filename. Missing optional metadata/unreferenced images are diagnosed;
+  `content.xml` and referenced image members remain required. Physical directory
+  records are not required for manifest directory declarations.
+- BestEffort projects current text, cached index/field text, tables, drawing text
+  and supported image bytes through the existing IR. Optional scripts/listeners,
+  form definitions, revision history, animation and embedded objects are omitted
+  with stable diagnostics; no code/formula is executed or exported. A script-bearing
+  document with no recoverable static body still fails instead of producing a shell.
+- Unsupported referenced SVG/GDI/object-replacement graphics have explicit
+  placeholders/diagnostics. Unreferenced unsupported graphics are not decoded.
+  Drawing-only shapes retain source type and an omission placeholder, not invented
+  visual rendering. Image list markers use diagnosed ordinary bullets.
+- Only **terminal, pure empty, unmerged rows** are sparse padding. Their repetitions
+  and column widths are validated without materializing a million empty rows.
+  Interior gaps, actual values, formulas, covered cells, and spans still use the
+  unchanged resource counters. No row/cell/memory limit is raised.
+- The USGS A2 formula prefix is bound in source XML to
+  `http://schemas.microsoft.com/office/excel/formula`. Its cached value and original
+  expression are preserved with `odf.cachedProducerFormula`, not evaluated or
+  mislabeled OpenFormula. Strict rejects this unsupported formula interpretation.
+- Formatting/layout hints and exact identical duplicate definitions reuse existing
+  diagnostics; conflicting styles still fail. Inline images retain source order and
+  bytes. Referenced master header/footer text retains `styles.xml` provenance.
+
+### Noncanonical mimetype, specifically distinguished from corruption
+
+`testODTStyles3.odt` has `mimetype` as the third ZIP entry, Deflate method 8,
+flags 2056 (UTF-8 + descriptor), compressed/uncompressed sizes 41/39, and signed
+descriptor CRC 204654174. Independent ZIP inspection verifies every member CRC.
+This is readable ZIP with noncanonical ODF packaging, not a CRC-corrupt archive.
+BestEffort diagnoses `odf.noncanonicalMimetype`; Strict keeps the original
+first/stored/no-descriptor constraint. In both modes mimetype must be unique and
+its decompressed payload exactly match the selected ODF media type. Extra-field,
+CRC, path, encryption and raw-layout protections are not bypassed.
+
+## Validation
+
+```text
+cargo fmt --all -- --check
+cargo clippy --locked -p into-markdown-converters --lib --tests --no-deps -j 2 -- -D warnings
+cargo test --locked -p into-markdown-converters --lib -j 2 -- --test-threads=2
+cargo build --locked -p into-markdown-cli -j 2
+```
+
+Fmt and strict clippy pass. **559 tests pass, 1 existing test ignored**, including
+the complete fixture corpus and **40 ODF tests**. Tests cover descriptor variants
+and corrupt CRC/size fields, extras, mimetype/Strict packing, encryption/DTD/paths,
+memory/cancellation, missing optional versus consumed members, style conflicts,
+unknown body vocabulary, cached fields/indexes, macro omission without export,
+drawing-only placeholders, static transforms, image bytes/order, blank sheets,
+million-row padding versus valued/formula/merged/interior repeats, and formula
+namespace binding. Build concurrency never exceeds two; conversion concurrency is one.
+
+## Unified real matrix
+
+All 36 were failures before. Bytes below are quality Markdown bytes (`asset-mode
+omit`); matches count independently matched nonempty source paragraphs, **not full
+semantic/visual parity**. The two sources with no textual paragraphs are explicitly
+audited by their actual image/drawing content instead.
+
+| File | BestEffort result | Markdown bytes / source paragraph matches |
+| --- | --- | ---: |
+| test-columnar.ods | Success, empty tail sparse | 1440 / 93 |
+| testPhoneNumberExtractor.odt | Success | 274 / 8 |
+| testFooter.ods | Success | 116 / 4 |
+| testFooter.odt | Success | 53 / 2 |
+| testMasterFooter.odp | Success, actual master footer retained | 34 / 1 |
+| testNPEOpenDocument.odt | Success | 8414 / 98 |
+| testODFwithOOo3.odt | Success, current text retained; revision/object omissions diagnosed | 921 / 12 |
+| testODP_NPE.odp | Success | 13658 / 200 |
+| testODPMacro.odp | Success, no source text; actual smiley geometry placeholder | 40 / drawing-only |
+| testODSMacro.ods | Success, no source text; original PNG verified in embed sample | 17 / image-only |
+| testODT-TIKA-6000.odt | Rejected: actual DOCTYPE in required manifest | — |
+| testODT_svgTitleInStyledSpan.odt | Success | 440 / 7 |
+| testODTEmbedded.odt | Success | 67 / 1 |
+| testODTEmbeddedImageLink.odt | Success | 11 / 1 |
+| testODTEncrypted.odt | Rejected: manifest encryption-data and encrypted bytes | — |
+| testODTMacro.odt | Success, text and static PNG retained; listener omitted | 72 / 4 |
+| testODTNoMeta.odt | Success, optional metadata/UI/preview absence diagnosed | 10 / 1 |
+| testODTStyles2.odt | Success | 1418 / 23 |
+| testODTnotaZipFile.odt | Rejected: plain text, independently not a ZIP | — |
+| testODTStyles3.odt | Success, noncanonical packaging diagnosed | 1671 / 20 |
+| testOpenOffice2.odt | Success, NTFS extras/legacy XML | 82 / 1 |
+| testStyles.odt | Success | 193 / 8 |
+| LibreOfficeCalc_ods_1.3.ods | Success | 132 / 10 |
+| LibreOfficeImpress_odp_1.3.odp | Success | 57 / 2 |
+| LibreOfficeWriter_odt_1.3.odt | Success | 28 / 1 |
+| 2021-09-30 Cool Days Notebookbar Structure Andreas Kainz.odp | Success, static content | 5758 / 193 |
+| gokay-satir-COOLDAYS-dev-Canvas-For-Rendering-UX.odp | Success | 8404 / 139 |
+| gokay-satir-COOLDAYS-dev-Multi-Page-PDF-Viewing.odp | Success | 2999 / 66 |
+| marco_COOLDays-dev-2021_SDK-Creating-a-new-integration.odp | Success | 9332 / 183 |
+| MertTümer_COOLDays-dev-2021_AndroidNewFeatures.odp | Success | 2118 / 61 |
+| OpenDocument-v1.2-os-part1.odt | Success, cached indexes/fields and body | 2025624 / 11620 |
+| OpenDocument-v1.2-os-part2.odt | Success, cached text; optional forms/objects diagnosed | 572601 / 5711 |
+| OpenDocument-v1.2-os-part3.odt | Success | 73426 / 406 |
+| pp1792_table_A1.ods | Success, empty tail sparse | 155771 / 7500 |
+| pp1792_table_A2.ods | Success, cached producer formulas + empty tail | 98790 / 4147 |
+| pp1792_table_A3.ods | Success, empty tail sparse | 2185 / 72 |
+
+## Content and original-asset evidence
+
+- **31 text-bearing successes** have independently matched source paragraphs.
+  The master-footer check requires the actual `Master footer is here` text, not a
+  Slide heading. ODF explicit spaces/line breaks and Markdown escapes are normalized.
+- `testODSMacro.ods` has no nonempty source paragraph. The 17-byte quality result
+  is only its sheet heading because assets were intentionally omitted. Separate
+  embed result preserves its original PNG SHA-256
+  `7164f6ab8f79d7f9391520a207049645cee098f3af9eeee852c40d37c30d5306`.
+- `testODPMacro.odp` has no nonempty source paragraph/image, but source
+  `draw:enhanced-geometry draw:type="smiley"`. Output contains
+  `[Drawing omitted: smiley]`, plus `odf.drawingPlaceholder`/`odf.scriptsOmitted`.
+  It is an explicitly lossy geometry representation, not a claimed visual conversion.
+- `testODTEmbedded.odt` source/output PNG SHA-256:
+  `133a8ddfbacd6eae9081bdcceee7b25025c9de24c5be3375abe3647064d3ca78`;
+  image precedes the original bold/italic paragraph. `testODTEmbeddedImageLink.odt`:
+  `0c4a2dae14ba2a6ebf2a1ca78794cc736f86dd76863872c286eec67a245b966e`.
+- Calc sample retains the five cells `This | is | an | example | spreadsheet`
+  followed by numeric row `0 | 1 | 2 | 3 | 4`, in exact source order.
+- 11 separate result JSON samples verify source image digests, text/table order,
+  diagnosed omissions and absence of exported script URLs. The complete local
+  matrix retains IDs, source paths/hashes, diagnostics and output hashes.
+
+## Three baseline nonempty-success differences
+
+| File | Frozen baseline actual path | Final disposition |
+| --- | --- | --- |
+| testODTnotaZipFile.odt | `format=text`, 25 output bytes | Source is exactly **24 bytes**, `This is not a zip file!` plus newline; independently not ZIP. No detector/fallback change to disguise it as ODF. |
+| testODFwithOOo3.odt | `format=zip`, 386594 bytes; generic expansion skipped an embedded XML DTD and unsupported objects | **Restored native ODF**, 921 Markdown bytes / 12 source paragraph matches. Current text retained; revision history/embedded objects diagnosed. This is not parity with generic ZIP expansion. |
+| testODT-TIKA-6000.odt | `format=zip`, 3739551 bytes; generic expansion explicitly skipped the DOCTYPE-containing manifest | Still rejected by native ODF because the required manifest has a DOCTYPE. Not described as whole-document corruption; no DTD/entity relaxation. |
+
+Baseline output hashes and diagnostic records are verified in `content-evidence.json`.
+Independent ZIP inspection reads every member with CRC validation in 35 archives;
+the plain-text file is the exception. ZIP readability alone is not ODF validity.
+
+Specification references: [ODF packages](https://docs.oasis-open.org/office/OpenDocument/v1.3/OpenDocument-v1.3-part2-packages.html)
+and [ODF schema](https://docs.oasis-open.org/office/v1.2/cos01/OpenDocument-v1.2-cos01-part1.html).
+The converter does not claim complete ODF validation or visual fidelity.


### PR DESCRIPTION
## Summary

Fixes #307.

- Accept standard ordinary ZIP extras and signed/unsigned descriptors with local/central/CRC/size binding; distinguish structural manifest parts from images.
- Recover source-backed ODF static text, tables, images, cached fields/indexes and producer markup through the existing IR/diagnostics. BestEffort diagnoses optional scripts/objects/forms/animation/graphics; Strict rejects lossy recovery. No script/formula execution or export.
- Trim only terminal pure-empty row padding; preserve limits for valued/formula/merged/interior rows. Keep original cached producer formulas without evaluating or mislabeling them.
- Diagnose noncanonical mimetype order/compression/descriptor under BestEffort while retaining exact unique media type and ZIP integrity; Strict retains original packing rules.

No dependency, Action, lint exemption, general framework, renderer, detector fallback or resource limit increase. Only ODF implementation/tests and its evidence document change.

## Real-input evidence

Frozen 36-file cohort: **0/36 → 33/36** (ODT 17/20; ODS 7/7; ODP 9/9). All three OASIS specification documents now convert. Full Strict pass: 18 successes / 18 explicit rejections.

Remaining failures are independently evidenced: required manifest DOCTYPE (`testODT-TIKA-6000.odt`), manifest encryption (`testODTEncrypted.odt`), and literal non-ZIP bytes (`testODTnotaZipFile.odt`). No source rewriting or detector fallback.

31 text-bearing successes have independently matched source paragraphs. The macro ODS is image-only: original PNG SHA-256 `7164f6ab8f79d7f9391520a207049645cee098f3af9eeee852c40d37c30d5306` is verified in embed output. The macro ODP has source smiley geometry, represented as a diagnosed placeholder, not falsely claimed rendered text. 11 result JSON samples verify assets/omissions/order. Quality asset-mode=omit is explicitly distinguished from embed evidence.

Full per-file matrix, exact baseline/current fingerprints, source hashes, remaining reasons, reproduction and content checks: [`docs/evidence/issue-307-odf.md`](docs/evidence/issue-307-odf.md). Local evidence: `C:/im-bench-004/issue307-odf-20260831/final4/` and `strict1/`. Coverage checks use debug binaries; no timing claim.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p into-markdown-converters --lib --tests --no-deps -j 2 -- -D warnings`
- `cargo test --locked -p into-markdown-converters --lib -j 2 -- --test-threads=2`: **559 passed, 1 existing ignored**, including **40 ODF tests** and the complete fixture corpus.
- `cargo build --locked -p into-markdown-cli -j 2`
- Original 36 inputs verified before/after, conversions jobs=1, dry-run + explicit isolated outputs/reports.

Implementation is frozen for the parent task's independent review. Please do not merge automatically; normal PR fast CI remains enabled.
