### PR TITLE
fix(ocr): restore bounded scanned-page recognition (#319)

### DIFF
--- a/crates/converters/src/image_converter/ocr.rs
+++ b/crates/converters/src/image_converter/ocr.rs
@@ -95,7 +95,7 @@ async fn recognize_inner(
     let recognition = match context.run(engine.recognize_bound(request, provider_context)).await? {
         Ok(value) => value,
         Err(error @ ConversionError::ComponentUnavailable { .. }) if policy == OcrPolicy::Auto => {
-            return Ok(degraded(page, format!("OCR was unavailable ({error}); {INSTALL_HINT}")));
+            return Ok(degraded(page, format!("OCR was unavailable ({error})")));
         }
         Err(error) if policy == OcrPolicy::Auto => return Err(error),
         Err(error) => return Err(map_unavailable(engine.id(), error)),
@@ -487,7 +487,7 @@ fn preflight_unavailable(
 ) -> Result<OcrContribution, ConversionError> {
     match error {
         error @ ConversionError::ComponentUnavailable { .. } if policy == OcrPolicy::Auto => {
-            Ok(degraded(page, format!("OCR was unavailable ({error}); {INSTALL_HINT}")))
+            Ok(degraded(page, format!("OCR was unavailable ({error})")))
         }
         error if policy == OcrPolicy::Auto => Err(error),
         ConversionError::Cancelled
@@ -614,10 +614,11 @@ fn map_unavailable(provider: &str, error: ConversionError) -> ConversionError {
     match error {
         ConversionError::Cancelled
         | ConversionError::Timeout
+        | ConversionError::Ocr { .. }
         | ConversionError::ResourceLimit { .. } => error,
         _ => ConversionError::ComponentUnavailable {
             component: provider.into(),
-            detail: format!("{error}; {INSTALL_HINT}"),
+            detail: error.to_string(),
         },
     }
 }

--- a/crates/converters/src/image_converter/tests.rs
+++ b/crates/converters/src/image_converter/tests.rs
@@ -937,11 +937,35 @@ fn auto_ocr_degrades_only_provider_component_unavailability() {
     let contribution =
         block_on(ocr::recognize(b"opaque-png", 1, 3, 2, &options, &services, &context)).unwrap();
     assert_eq!(contribution.diagnostics[0].code, "image.ocrUnavailable");
+    assert!(!contribution.diagnostics[0].message.contains("setup ocr"));
     assert_eq!(context.reserved_memory_bytes(), 0);
 }
 
 struct PreflightFailingOcr {
     unavailable: bool,
+}
+
+#[test]
+fn always_ocr_preserves_runtime_errors_without_installation_advice() {
+    let mut options = options();
+    options.ocr.policy = OcrPolicy::Always;
+    for (failure, expected) in [
+        (ProviderExecutionFailure::ResourceLimit, into_markdown_core::ErrorCode::ResourceLimit),
+        (ProviderExecutionFailure::Ocr, into_markdown_core::ErrorCode::Ocr),
+        (
+            ProviderExecutionFailure::ComponentUnavailable,
+            into_markdown_core::ErrorCode::ComponentUnavailable,
+        ),
+    ] {
+        let context = context(&options);
+        let services =
+            Services { ocr: Some(Arc::new(FailingOcr { failure })), ..Services::default() };
+        let error = block_on(ocr::recognize(b"opaque-png", 1, 3, 2, &options, &services, &context))
+            .unwrap_err();
+        assert_eq!(error.code(), expected);
+        assert!(!error.to_string().contains("setup ocr"));
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
 }
 
 impl OcrEngine for PreflightFailingOcr {

--- a/crates/ocr/src/detection.rs
+++ b/crates/ocr/src/detection.rs
@@ -208,12 +208,15 @@ impl PageDetection {
     }
 }
 
-/// Local safety bounds. Detection algorithm parameters come only from the
-/// embedded, commit-pinned authority and cannot be changed by callers.
+/// Local safety bounds. Detection algorithm parameters come from the embedded,
+/// commit-pinned authority; callers may additionally bound inference resolution.
 #[derive(Debug, Clone)]
 pub struct DetectionConfig {
     pub max_source_pixels: usize,
     pub max_model_pixels: usize,
+    /// Maximum stride-aligned inference side after the pinned resize. Detection
+    /// polygons still map to the original pixels used for recognition crops.
+    pub max_inference_side: usize,
     pub max_contour_events: usize,
     pub max_contour_points: usize,
     pub max_score_pixels: usize,
@@ -226,6 +229,7 @@ impl Default for DetectionConfig {
         Self {
             max_source_pixels: 100_000_000,
             max_model_pixels: 16_000_000,
+            max_inference_side: MAX_SIDE_LEN,
             max_contour_events: 16_000_000,
             max_contour_points: 16_000_000,
             max_score_pixels: 32_000_000,
@@ -369,6 +373,9 @@ struct Prepared {
 fn validate_config(c: &DetectionConfig) -> Result<(), ConversionError> {
     if c.max_source_pixels == 0
         || c.max_model_pixels == 0
+        || c.max_inference_side < STRIDE
+        || c.max_inference_side > MAX_SIDE_LEN
+        || !c.max_inference_side.is_multiple_of(STRIDE)
         || c.max_contour_events == 0
         || c.max_contour_points == 0
         || c.max_score_pixels == 0
@@ -442,6 +449,22 @@ fn official_resize_dimensions(
     Ok((round_stride(resized_w)?, round_stride(resized_h)?))
 }
 
+fn inference_dimensions(
+    width: usize,
+    height: usize,
+    maximum_side: usize,
+) -> Result<(usize, usize), ConversionError> {
+    let (width, height) = official_resize_dimensions(width, height)?;
+    if width.max(height) <= maximum_side {
+        return Ok((width, height));
+    }
+    let ratio = maximum_side as f64 / width.max(height) as f64;
+    Ok((
+        round_stride(((width as f64 * ratio) as usize).max(1))?,
+        round_stride(((height as f64 * ratio) as usize).max(1))?,
+    ))
+}
+
 fn preprocess(
     image: PixelView<'_>,
     c: &DetectionConfig,
@@ -456,7 +479,7 @@ fn preprocess(
     } else {
         (ow, oh)
     };
-    let (mw, mh) = official_resize_dimensions(padded_w, padded_h)?;
+    let (mw, mh) = inference_dimensions(padded_w, padded_h, c.max_inference_side)?;
     let count = mw.checked_mul(mh).ok_or_else(|| limit("modelPixels"))?;
     if count > c.max_model_pixels {
         return Err(limit("modelPixels"));
@@ -1489,6 +1512,7 @@ mod tests {
         DetectionConfig {
             max_source_pixels: 4096,
             max_model_pixels: 736 * 736,
+            max_inference_side: MAX_SIDE_LEN,
             max_contour_events: 4096,
             max_contour_points: 4096,
             max_score_pixels: 16_384,
@@ -1528,6 +1552,80 @@ mod tests {
         assert_eq!(round_stride(81).unwrap(), 96);
         assert_eq!(official_resize_dimensions(99, 32).unwrap(), (2272, 736));
         assert_eq!(official_resize_dimensions(99, 2).unwrap(), (4000, 64));
+    }
+
+    #[test]
+    fn inference_resolution_is_explicitly_bounded_without_changing_pinned_resize() {
+        assert_eq!(official_resize_dimensions(2609, 3512).unwrap(), (2624, 3520));
+        assert_eq!(inference_dimensions(2609, 3512, 1536).unwrap(), (1152, 1536));
+        assert_eq!(inference_dimensions(3512, 2609, 1536).unwrap(), (1536, 1152));
+        assert_eq!(inference_dimensions(800, 736, 1536).unwrap(), (800, 736));
+        assert_eq!(inference_dimensions(4000, 32, 32).unwrap(), (32, 32));
+        for side in [0, 31, 33, 4032] {
+            assert!(
+                validate_config(&DetectionConfig {
+                    max_inference_side: side,
+                    ..DetectionConfig::default()
+                })
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn bounded_preprocessing_keeps_original_geometry_and_releases_on_limits_and_cancel() {
+        let bytes = vec![255_u8; 99 * 67];
+        let config = DetectionConfig { max_inference_side: 64, ..DetectionConfig::default() };
+        for orientation in [
+            ImageOrientation::Normal,
+            ImageOrientation::MirrorHorizontal,
+            ImageOrientation::Rotate180,
+            ImageOrientation::MirrorVertical,
+            ImageOrientation::MirrorHorizontalRotate270,
+            ImageOrientation::Rotate90,
+            ImageOrientation::MirrorHorizontalRotate90,
+            ImageOrientation::Rotate270,
+        ] {
+            let image = PixelView { orientation, ..view(&bytes, 99, 67) };
+            let context =
+                ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+            let prepared = preprocess(image, &config, &context).unwrap();
+            let transform = prepared.transform;
+            let (width, height) = oriented_size(image);
+            assert_eq!((transform.oriented_w, transform.oriented_h), (width, height));
+            assert_eq!(transform.model_w.max(transform.model_h), 64);
+            let far = model_to_source(
+                [
+                    (width - 1) as f64 * transform.model_w as f64 / width as f64,
+                    (height - 1) as f64 * transform.model_h as f64 / height as f64,
+                ],
+                image,
+                transform,
+            );
+            let expected = source_xy(image, width - 1, height - 1);
+            assert_eq!(far, (expected.0 as f32, expected.1 as f32));
+            drop(prepared);
+            assert_eq!(context.reserved_memory_bytes(), 0);
+        }
+        let limits =
+            ResourceLimits { max_memory_bytes: 64 * 32 * 3 * 4 - 1, ..ResourceLimits::default() };
+        let context = ExecutionContext::new(ExecutionOptions::default(), limits);
+        assert!(matches!(
+            preprocess(view(&bytes, 99, 67), &config, &context),
+            Err(ConversionError::ResourceLimit { .. })
+        ));
+        assert_eq!(context.reserved_memory_bytes(), 0);
+        let cancellation = into_markdown_core::CancellationToken::new();
+        cancellation.cancel();
+        let context = ExecutionContext::new(
+            into_markdown_core::ExecutionOptions { cancellation, ..Default::default() },
+            ResourceLimits::default(),
+        );
+        assert!(matches!(
+            preprocess(view(&bytes, 99, 67), &config, &context),
+            Err(ConversionError::Cancelled)
+        ));
+        assert_eq!(context.reserved_memory_bytes(), 0);
     }
 
     #[test]
@@ -1728,6 +1826,7 @@ mod tests {
                 max_source_pixels: width * height,
                 max_model_pixels: width * height,
                 max_contour_events: 16,
+                max_inference_side: MAX_SIDE_LEN,
                 max_contour_points: width * height,
                 max_score_pixels: width * height,
                 max_score_work: width * height * SCORE_WORK_PER_PIXEL_UPPER_BOUND,
@@ -1766,6 +1865,7 @@ mod tests {
                 max_source_pixels: width * height,
                 max_model_pixels: width * height,
                 max_contour_events: 16,
+                max_inference_side: MAX_SIDE_LEN,
                 max_contour_points: width * height,
                 max_score_pixels: width * height,
                 max_score_work: width * height * SCORE_WORK_PER_PIXEL_UPPER_BOUND,
@@ -1811,6 +1911,7 @@ mod tests {
                 max_source_pixels: width * height,
                 max_model_pixels: width * height,
                 max_contour_events: discovered.len() + 1,
+                max_inference_side: MAX_SIDE_LEN,
                 max_contour_points: discovered.len() + 1,
                 max_score_pixels: width * height,
                 max_score_work: width * height * SCORE_WORK_PER_PIXEL_UPPER_BOUND,
@@ -2352,6 +2453,7 @@ mod tests {
                 max_source_pixels: width * height,
                 max_model_pixels: width * height,
                 max_contour_events: width * height,
+                max_inference_side: MAX_SIDE_LEN,
                 max_contour_points: width * height,
                 max_score_pixels: width * height,
                 max_score_work: width * height * SCORE_WORK_PER_PIXEL_UPPER_BOUND,
@@ -2465,6 +2567,7 @@ mod tests {
                 max_source_pixels: width * height,
                 max_model_pixels: width * height,
                 max_contour_events: 128,
+                max_inference_side: MAX_SIDE_LEN,
                 max_contour_points: width * height,
                 max_score_pixels: width * height,
                 max_score_work: width * height * SCORE_WORK_PER_PIXEL_UPPER_BOUND,
@@ -2492,6 +2595,7 @@ mod tests {
             max_source_pixels: width * height,
             max_model_pixels: width * height,
             max_contour_events: 1,
+            max_inference_side: MAX_SIDE_LEN,
             max_contour_points: width * height,
             max_score_pixels: width * height,
             max_score_work: width * height * SCORE_WORK_PER_PIXEL_UPPER_BOUND,

--- a/crates/ocr/src/image_engine.rs
+++ b/crates/ocr/src/image_engine.rs
@@ -22,6 +22,9 @@ const MAX_REGIONS: u32 = 3000;
 const MAX_TEXT_BYTES: u64 = 16 * 1024 * 1024;
 const OUTPUT_BYTES_PER_REGION: u64 = 2048;
 const OUTPUT_FIXED_BYTES: u64 = 16 * 1024;
+// Full scan-sized feature maps exceed the isolated detector's native envelope.
+// Only detection is resized; recognition samples the original-resolution image.
+const DETECTOR_INFERENCE_SIDE: usize = 1536;
 
 /// Installed, offline PP-OCRv6 image pipeline.
 pub struct PpOcrImageEngine {
@@ -90,6 +93,7 @@ impl PpOcrImageEngine {
             Arc::clone(&self.runtime),
             DetectionConfig {
                 max_source_pixels,
+                max_inference_side: DETECTOR_INFERENCE_SIDE,
                 max_contour_events: max_source_pixels.min(16_000_000),
                 max_contour_points: max_source_pixels.min(16_000_000),
                 max_score_pixels: max_source_pixels.min(32_000_000),

--- a/crates/ocr/src/recognition/tests.rs
+++ b/crates/ocr/src/recognition/tests.rs
@@ -381,6 +381,7 @@ fn all_exif_orientations_flow_from_detection_to_raw_source_recognition() {
             max_score_pixels: 1_500_000,
             max_score_work: 100_000_000_000,
             max_offset_points: 1_000,
+            ..DetectionConfig::default()
         },
     )
     .unwrap();

--- a/crates/onnxruntime/src/worker.rs
+++ b/crates/onnxruntime/src/worker.rs
@@ -222,7 +222,9 @@ impl WorkerClient {
                     #[cfg(not(target_os = "linux"))]
                     {
                         self.terminate();
-                        return Err(resource_error("nativeWorkerMemory"));
+                        // A disconnected pipe alone does not establish allocation
+                        // failure. Explicit native resource replies remain typed.
+                        return Err(ort_error("workerCrashed"));
                     }
                 }
                 Err(mpsc::RecvTimeoutError::Timeout) => {

--- a/crates/process-plugin/src/bin/process_plugin_fixture.rs
+++ b/crates/process-plugin/src/bin/process_plugin_fixture.rs
@@ -166,6 +166,9 @@ fn main() -> std::io::Result<()> {
                 Ok(result("ok"))
             }
             value if value.starts_with("large-ok") => Ok(result("large-ok")),
+            "resource-error" => Err(WorkerError::new("resourceLimit", "bounded inference failed")),
+            "timeout-error" => Err(WorkerError::new("timeout", "bounded inference timed out")),
+            "cancelled-error" => Err(WorkerError::new("cancelled", "bounded inference cancelled")),
             _ => Err(WorkerError::new("unknownFixture", "unknown fixture command")),
         }
     })

--- a/crates/process-plugin/src/lib.rs
+++ b/crates/process-plugin/src/lib.rs
@@ -61,7 +61,7 @@ pub enum PluginErrorCode {
     InvalidResult,
     /// The plugin returned a controlled terminal error.
     Plugin,
-    /// A host resource budget was exceeded.
+    /// A host or provider resource budget was exceeded.
     ResourceLimit,
 }
 
@@ -927,7 +927,7 @@ impl ProcessPlugin {
                         reader,
                         stderr_reader,
                         PluginError::new(
-                            PluginErrorCode::Plugin,
+                            terminal_error_code(&code),
                             format!(
                                 "plugin returned {code}: {}",
                                 message
@@ -950,6 +950,15 @@ impl ProcessPlugin {
                 }
             }
         }
+    }
+}
+
+fn terminal_error_code(code: &str) -> PluginErrorCode {
+    match code {
+        "resourceLimit" => PluginErrorCode::ResourceLimit,
+        "cancelled" => PluginErrorCode::Cancelled,
+        "timeout" => PluginErrorCode::Timeout,
+        _ => PluginErrorCode::Plugin,
     }
 }
 

--- a/crates/process-plugin/tests/runtime.rs
+++ b/crates/process-plugin/tests/runtime.rs
@@ -52,6 +52,14 @@ fn real_process_fixture_enforces_protocol_lifecycle_and_capabilities() {
     let controlled = harness.execute(b"controlled-error", ExecutionOptions::default()).unwrap_err();
     assert_eq!(controlled.code, PluginErrorCode::Plugin);
     assert_eq!(controlled.detail, "plugin returned unknownFixture: unknown fixture command");
+    for (mode, expected) in [
+        (b"resource-error".as_slice(), PluginErrorCode::ResourceLimit),
+        (b"timeout-error".as_slice(), PluginErrorCode::Timeout),
+        (b"cancelled-error".as_slice(), PluginErrorCode::Cancelled),
+    ] {
+        let error = harness.execute(mode, ExecutionOptions::default()).unwrap_err();
+        assert_eq!(error.code, expected);
+    }
 
     for (mode, expected) in [
         (b"malformed".as_slice(), PluginErrorCode::Protocol),


### PR DESCRIPTION
## Summary

Closes #319.

Bound only the product detector's inference long side to 1536 (stride 32), while keeping the original decoded pixels for recognition crops and mapping detector coordinates back to the original orientation/dimensions. The low-level pinned detector resize/default remains unchanged. No model, native worker cap, shared memory limit, dependency, workflow, or alternative OCR engine is changed.

Preserve validated resource/cancellation/timeout plugin terminal errors across the process boundary. An unexplained non-Linux disconnected worker is now a worker crash, not asserted memory exhaustion. Already-configured image OCR runtime failures no longer recommend installing an already-ready capability.

## Actual cause and real source

Temporary native-only instrumentation (removed from this diff) reproduced an explicit resource error from ONNX Runtime `Concat.0`: `bad allocation`. This is an allocation failure inside the fixed worker envelope, **not evidence of system OOM**. The original detector tensor was 2624×3520; bounded detection is 1152×1536. The Windows worker memory limit remains 807,084,032 bytes and model/DLL hashes are unchanged.

Source TIFF `47a6533826cd5b9fb97168cc` (2609×3512, SHA-256 `951a968ff7ce6fd6f9e1ff01a54bc2ff8e4076906ebe50b65b23afcd488b4e2f`) now succeeds through the real ImageConverter + bound native OCR path with default auto/minimum confidence 0.70:

- No diagnostics; 35 regions = 2 header + all 32 independently transcribed body lines + 1 footer.
- Full-body, punctuation-preserving CER 28/1671 = **1.6756%**; ordered token recall **98.5981%**, token precision **99.0610%**.
- No duplicate body regions; body coordinates increase in reading order; lowest accepted combined body confidence **0.73015**.
- Lease returns to zero. Source transcript was prepared independently before the OCR output; reviewer labels are excluded from body scoring.

## Successful-path comparison

Three serial alternating runs, same debug build/settings/model/worker, only detector resolution 4000 versus 1536. This is a focused implementation comparison, not a release-performance claim. The previously failing book page is not used as a speedup baseline.

| Successful input | Original mean | Bounded mean | Text/order |
| --- | ---: | ---: | --- |
| Existing English small-text line, 1800×80 | 11.834s | 1.597s (-86.50%) | identical, complete |
| Existing multicolumn PDF rendered at 150 DPI, 1250×1667 | 3.379s | 3.121s (-7.64%) | all five source strings, identical order |

Every comparison run had no diagnostics and zero final lease. The image path retains the existing row ordering on the multicolumn sample; this is not a claim that its PDF column-layout orchestration was changed or independently end-to-end accepted here.

## Validation

- `cargo fmt --all -- --check` and `git diff --check`.
- `cargo clippy --locked -j 2 -p into-markdown-ocr -p into-markdown-converters -p into-markdown-process-plugin -p into-markdown-onnxruntime --all-targets -- -D warnings`.
- `cargo test --locked -j 2 -p into-markdown-ocr -p into-markdown-converters -p into-markdown-process-plugin -p into-markdown-onnxruntime`: passed. Converters **566 passed / 3 ignored**, OCR **135 / 1**, ONNX Runtime **15 / 0**, process plugin **7 unit + 8 real-process integration passed**; separate default quality markers remain explicitly ignored. Coverage includes detector stride/dimension bounds, all eight EXIF coordinate mappings, exact-memory rejection, cancellation lease cleanup and real process terminal-error integration.
- Existing native PP-OCRv6 recognizer: exact frozen aggregate errors unchanged: English 1/185, mixed 1/116, simplified 0/65, traditional 6/65. Existing hash-bound degraded-scan recognizer + merge quality gate passed.
- Important test limitation: the cfg-enabled native quality suite's separate `missing_model_error_contains_only_the_safe_runfile_relative_path` assertion fails on Windows because the pre-existing test hardcodes `/` while `Path::display()` returns `\`. It is unchanged in this PR; the complete cfg-enabled suite is **not** claimed green. The actual recognizer and merge quality cases are separately rerun against the clean worker.

## Scope / risks / handoff

Nine files only: detector config/preprocessing + tests; product image-engine selection; one existing recognition test initializer; native disconnected-worker classification; process terminal-error mapping + executable fixture tests; configured image OCR error reporting + tests. Temporary diagnosis/benchmark scripts and models are outside the repository. No new lint exemptions.

Reducing detector resolution can miss unusually tiny text on very large/dense pages; original-resolution recognition does not eliminate that detection tradeoff. The source and representative checks above passed, but the root task still owns independent review and full 2,289-file / 1.78GB release-package OCR-off/OCR-auto acceptance. This PR is not merged here.

Local immutable evidence: `C:\im-bench-004\issue319-ocr-20260831` (`logs/native-baseline-diagnostic.log`, `sheep-pipeline.json`, `sheep-quality-pipeline.json`, `successful-path-comparison.json`, final test/quality logs). Clean worker SHA-256 `9dfc4f514a464888bfeb234807b8c785c461c5ec9de8d191b1a3812e0e1fa5a1`; bounded local driver SHA-256 `555b228a943ca4a730430d8e25b24b74d1d57666ff537c3f3c9a0cef3bf55dca`.
