### PR TITLE
fix(ocr): preserve decodable container JPEGs during enrichment

### DIFF
--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -14,6 +14,7 @@ use std::io::Cursor;
 
 mod candidate_index;
 mod geometry;
+mod jpeg_input;
 use candidate_index::{
     CandidateBuffer, OcrCandidate, ReferenceIndex, candidate_index_plan, group_candidates,
     validate_visual_references_without_index,
@@ -651,7 +652,11 @@ fn validated_candidate_dimensions(
             detail: "embedded raster media type disagrees with its byte envelope".into(),
         });
     }
-    let summary = envelope::preflight_validate(raster, &asset.bytes, &options.limits, context)?;
+    let summary = if raster == format::RasterFormat::Jpeg {
+        jpeg_input::envelope(&asset.bytes, options, context)?.0
+    } else {
+        envelope::preflight_validate(raster, &asset.bytes, &options.limits, context)?
+    };
     if summary.frames != 1 || summary.animated {
         return Err(ConversionError::Unsupported {
             detail: "animated or multi-page embedded raster is not eligible for OCR".into(),
@@ -724,6 +729,7 @@ struct NormalizedImage {
     bytes: Vec<u8>,
     width: u32,
     height: u32,
+    trailing_bytes: usize,
     _leases: Vec<ResourceReservation>,
 }
 
@@ -876,6 +882,8 @@ async fn enrich(
             normalized.height,
             0,
         )?;
+        let mut diagnostics: Vec<_> =
+            jpeg_input::diagnostic(normalized.trailing_bytes).into_iter().collect();
         let normalized_plan = match services.ocr.as_deref() {
             Some(engine) => engine.planned_normalized_png_output(
                 normalized.width,
@@ -894,10 +902,8 @@ async fn enrich(
                 if effective_ocr_policy(options) == OcrPolicy::Auto
                     && matches!(error, ConversionError::ComponentUnavailable { .. }) =>
             {
-                cache[group_index] = Some(CachedContribution {
-                    nodes: Vec::new(),
-                    diagnostics: vec![visual_diagnostic(None, error.to_string())],
-                });
+                diagnostics.push(visual_diagnostic(None, error.to_string()));
+                cache[group_index] = Some(CachedContribution { nodes: Vec::new(), diagnostics });
                 continue;
             }
             Err(error) => return Err(error),
@@ -923,10 +929,8 @@ async fn enrich(
         recognized_chars = recognized_chars
             .checked_add(contribution.recognized_chars)
             .ok_or_else(|| resource("max_field_bytes", "OCR character telemetry overflow"))?;
-        cache[group_index] = Some(CachedContribution {
-            nodes: contribution.nodes,
-            diagnostics: contribution.diagnostics,
-        });
+        diagnostics.append(&mut contribution.diagnostics);
+        cache[group_index] = Some(CachedContribution { nodes: contribution.nodes, diagnostics });
     }
 
     let mut contributions_by_asset = BTreeMap::new();
@@ -1075,13 +1079,20 @@ fn normalize(
             detail: "embedded raster media type disagrees with its byte envelope".into(),
         });
     }
-    let summary = envelope::validate(raster, &asset.bytes, &options.limits, context)?;
+    let (summary, source) = if raster == format::RasterFormat::Jpeg {
+        jpeg_input::envelope(&asset.bytes, options, context)?
+    } else {
+        (
+            envelope::validate(raster, &asset.bytes, &options.limits, context)?,
+            asset.bytes.as_slice(),
+        )
+    };
     if summary.frames != 1 || summary.animated {
         return Err(ConversionError::Unsupported {
             detail: "animated or multi-page embedded raster is not eligible for OCR".into(),
         });
     }
-    let decoded = decode::decode(raster, &asset.bytes, summary, &options.limits, context)?;
+    let decoded = decode::decode(raster, source, summary, &options.limits, context)?;
     let frame = decoded.frames.first().ok_or_else(|| ConversionError::Malformed {
         part: asset.filename.clone(),
         detail: "embedded raster decoder returned no frame".into(),
@@ -1095,7 +1106,13 @@ fn normalize(
     let height = frame.pixels.height();
     let encoded = encode::png(&frame.pixels, true, &options.limits, context)?;
     let (bytes, memory) = encoded.into_parts();
-    Ok(NormalizedImage { bytes, width, height, _leases: vec![memory] })
+    Ok(NormalizedImage {
+        bytes,
+        width,
+        height,
+        trailing_bytes: asset.bytes.len() - source.len(),
+        _leases: vec![memory],
+    })
 }
 
 fn normalize_gif(
@@ -1163,7 +1180,13 @@ fn normalize_gif(
     }
     let encoded = encode::png(&pixels, true, &options.limits, context)?;
     let (bytes, png_memory) = encoded.into_parts();
-    Ok(NormalizedImage { bytes, width, height, _leases: vec![memory, png_memory] })
+    Ok(NormalizedImage {
+        bytes,
+        width,
+        height,
+        trailing_bytes: 0,
+        _leases: vec![memory, png_memory],
+    })
 }
 
 fn checkpointed_sha256(
@@ -1346,6 +1369,8 @@ fn resource(limit: &'static str, detail: impl Into<String>) -> ConversionError {
 
 #[cfg(test)]
 mod tests {
+    mod jpeg;
+
     use super::*;
     use image::{DynamicImage, Frame, ImageFormat, Rgba, RgbaImage, codecs::gif::GifEncoder};
     use into_markdown_core::{

--- a/crates/converters/src/embedded_visual_ocr/jpeg_input.rs
+++ b/crates/converters/src/embedded_visual_ocr/jpeg_input.rs
@@ -1,0 +1,38 @@
+//! Container JPEG adaptation before the existing bounded pixel decoder.
+
+use crate::image_converter::envelope;
+use into_markdown_core::{
+    ConversionError, ConversionOptions, Diagnostic, DiagnosticSeverity, ErrorPolicy,
+    ExecutionContext,
+};
+
+pub(super) fn envelope<'a>(
+    bytes: &'a [u8],
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+) -> Result<(envelope::Summary, &'a [u8]), ConversionError> {
+    let end = envelope::jpeg_codestream_end(bytes, &options.limits, context)?;
+    if end != bytes.len() && options.error_policy == ErrorPolicy::Strict {
+        return Err(ConversionError::Malformed {
+            part: Some("image".into()),
+            detail: "embedded JPEG has trailing bytes after EOI in strict mode".into(),
+        });
+    }
+    if options.limits.max_pages == 0 {
+        return Err(super::resource("max_pages", "1 image frame exceeds the request limit"));
+    }
+    // Borrow only the structurally delimited codestream. The caller must still
+    // decode it completely; this neither repairs pixels nor changes the asset.
+    Ok((envelope::Summary { frames: 1, animated: false }, &bytes[..end]))
+}
+
+pub(super) fn diagnostic(trailing_bytes: usize) -> Option<Diagnostic> {
+    (trailing_bytes != 0).then(|| Diagnostic {
+        code: "embeddedVisualOcr.jpegTrailingData".into(),
+        severity: DiagnosticSeverity::Warning,
+        message: format!(
+            "Ignored {trailing_bytes} trailing byte(s) after JPEG EOI for OCR after complete pixel decoding; original asset bytes are unchanged"
+        ),
+        locator: None,
+    })
+}

--- a/crates/converters/src/embedded_visual_ocr/tests/jpeg.rs
+++ b/crates/converters/src/embedded_visual_ocr/tests/jpeg.rs
@@ -1,0 +1,210 @@
+use super::*;
+use into_markdown_core::ErrorPolicy;
+
+fn asset(tail: &[u8]) -> Asset {
+    let pixels = image::RgbImage::from_fn(3, 2, |x, y| {
+        image::Rgb([u8::try_from(x * 70).unwrap(), u8::try_from(y * 110).unwrap(), 40])
+    });
+    let mut buffer = Cursor::new(Vec::new());
+    DynamicImage::ImageRgb8(pixels).write_to(&mut buffer, ImageFormat::Jpeg).unwrap();
+    let mut bytes = buffer.into_inner();
+    bytes.extend_from_slice(tail);
+    Asset {
+        id: AssetId("jpeg".into()),
+        filename: None,
+        media_type: "image/jpeg".into(),
+        bytes,
+        external_uri: None,
+    }
+}
+
+fn source(asset: &Asset) -> ConverterOutput {
+    let mut result = output();
+    for target in &mut result.assets {
+        target.bytes.clone_from(&asset.bytes);
+        target.media_type.clone_from(&asset.media_type);
+        target.filename = None;
+    }
+    result
+}
+
+fn context(options: &ConversionOptions) -> ExecutionContext {
+    ExecutionContext::new(ExecutionOptions::default(), options.limits.clone())
+}
+
+#[test]
+fn jpeg_trailing_bytes_preserve_pixels_and_assets_with_located_diagnostics() {
+    let options = ConversionOptions::default();
+    let plain = asset(&[]);
+    let expected = normalize(&plain, &options, &context(&options)).unwrap();
+    for tail in [vec![0], vec![0xa5; 17], vec![0xff; 4097], plain.bytes.clone()] {
+        let original = asset(&tail);
+        let normalized = normalize(&original, &options, &context(&options)).unwrap();
+        assert_eq!(normalized.bytes, expected.bytes);
+        assert_eq!((normalized.width, normalized.height), (3, 2));
+        assert_eq!(normalized.trailing_bytes, tail.len());
+    }
+    for policy in [OcrPolicy::Auto, OcrPolicy::Always] {
+        let original = asset(&[0xa5; 17]);
+        let before = source(&original);
+        let expected_assets = before.assets.clone();
+        let ocr = source_bound_ocr(false);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = options.clone();
+        options.ocr.policy = policy;
+        let context = context(&options);
+        assert!(matches!(
+            plan_enrichment(&before, InputFormat::Odp, &options, &services, &context).unwrap(),
+            EnrichmentPlan::Reserve(_)
+        ));
+        let after =
+            block_on(enrich(before, InputFormat::Odp, &options, &services, &context)).unwrap();
+        assert_eq!(after.assets, expected_assets);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 1);
+        let Block::Page { blocks, .. } = &after.document.blocks[0].block else {
+            panic!("expected the original page")
+        };
+        assert_eq!(blocks.len(), 4);
+        let warnings: Vec<_> = after
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "embeddedVisualOcr.jpegTrailingData")
+            .collect();
+        assert_eq!(warnings.len(), 2);
+        for warning in warnings {
+            assert!(warning.message.contains("17 trailing byte(s)"));
+            assert_eq!(warning.locator.as_ref().unwrap().page, Some(2));
+        }
+    }
+}
+
+#[test]
+fn jpeg_strict_and_standalone_keep_exact_eof_contract() {
+    let original = asset(&[0xa5; 17]);
+    let mut options = ConversionOptions::default();
+    options.ocr.policy = OcrPolicy::Auto;
+    for policy in [ErrorPolicy::BestEffort, ErrorPolicy::Strict] {
+        options.error_policy = policy;
+        assert!(matches!(
+            envelope::validate(
+                format::RasterFormat::Jpeg,
+                &original.bytes,
+                &options.limits,
+                &context(&options)
+            ),
+            Err(ConversionError::Malformed { .. })
+        ));
+    }
+    let ocr = source_bound_ocr(false);
+    let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+    assert!(matches!(
+        plan_enrichment(
+            &source(&original),
+            InputFormat::Odp,
+            &options,
+            &services,
+            &context(&options)
+        ),
+        Err(ConversionError::Malformed { .. })
+    ));
+    assert!(matches!(
+        normalize(&original, &options, &context(&options)),
+        Err(ConversionError::Malformed { .. })
+    ));
+    assert_eq!(ocr.plans.load(Ordering::SeqCst), 0);
+    assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn jpeg_marker_payload_is_not_a_terminator_and_bad_pixels_are_not_recovered() {
+    let options = ConversionOptions::default();
+    let mut original = asset(&[0xa5; 17]);
+    // APP data contains marker-like bytes; only the actual marker stream delimits JPEG.
+    original.bytes.splice(2..2, [0xff, 0xe2, 0, 6, 0xff, 0xd9, 0xff, 0xd8]);
+    assert_eq!(normalize(&original, &options, &context(&options)).unwrap().trailing_bytes, 17);
+    let mut truncated = asset(&[]);
+    truncated.bytes.truncate(truncated.bytes.len() - 2);
+    let mut bad_pixels = asset(&[0xa5; 17]);
+    let quantization = bad_pixels.bytes.windows(2).position(|pair| pair == [0xff, 0xdb]).unwrap();
+    bad_pixels.bytes[quantization + 4] = 0xf0; // Impossible quantization precision, intact envelope.
+    assert!(jpeg_input::envelope(&bad_pixels.bytes, &options, &context(&options)).is_ok());
+    let ocr = source_bound_ocr(false);
+    let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+    for original in [truncated, bad_pixels] {
+        for policy in [OcrPolicy::Auto, OcrPolicy::Always] {
+            let mut options = options.clone();
+            options.ocr.policy = policy;
+            assert!(matches!(
+                block_on(enrich(
+                    source(&original),
+                    InputFormat::Odp,
+                    &options,
+                    &services,
+                    &context(&options)
+                )),
+                Err(ConversionError::Malformed { .. })
+            ));
+        }
+    }
+    assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn jpeg_compatibility_preserves_limits_cancellation_and_timeout() {
+    let original = asset(&[0xa5; 17]);
+    for limit in ["max_pages", "image_chunks", "max_decompressed_bytes", "max_memory_bytes"] {
+        let mut options = ConversionOptions::default();
+        match limit {
+            "max_pages" => options.limits.max_pages = 0,
+            "image_chunks" => options.limits.max_archive_entries = 0,
+            "max_decompressed_bytes" => options.limits.max_decompressed_bytes = 1,
+            _ => options.limits.max_memory_bytes = 1,
+        }
+        assert!(
+            matches!(
+                normalize(&original, &options, &context(&options)),
+                Err(ConversionError::ResourceLimit { .. })
+            ),
+            "{limit}"
+        );
+    }
+    let options = ConversionOptions::default();
+    let cancellation = CancellationToken::new();
+    cancellation.cancel();
+    let cancelled = ExecutionContext::new(
+        ExecutionOptions { cancellation, ..ExecutionOptions::default() },
+        options.limits.clone(),
+    );
+    assert!(matches!(normalize(&original, &options, &cancelled), Err(ConversionError::Cancelled)));
+    let timed_out = ExecutionContext::new(
+        ExecutionOptions {
+            timeout: Some(std::time::Duration::ZERO),
+            ..ExecutionOptions::default()
+        },
+        options.limits.clone(),
+    );
+    assert!(matches!(normalize(&original, &options, &timed_out), Err(ConversionError::Timeout)));
+}
+
+#[test]
+fn jpeg_compatibility_diagnostic_survives_auto_provider_unavailability() {
+    let original = asset(&[0xa5; 17]);
+    let mut options = ConversionOptions::default();
+    options.ocr.policy = OcrPolicy::Auto;
+    let after = block_on(enrich(
+        source(&original),
+        InputFormat::Odp,
+        &options,
+        &Services::default(),
+        &context(&options),
+    ))
+    .unwrap();
+    assert_eq!(
+        after
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| { diagnostic.code == "embeddedVisualOcr.jpegTrailingData" })
+            .count(),
+        2
+    );
+}

--- a/crates/converters/src/image_converter/envelope/jpeg.rs
+++ b/crates/converters/src/image_converter/envelope/jpeg.rs
@@ -7,6 +7,19 @@ pub(super) fn validate(
     limits: &ResourceLimits,
     context: &ExecutionContext,
 ) -> Result<Summary, ConversionError> {
+    if codestream_end(bytes, limits, context)? != bytes.len() {
+        return Err(malformed("JPEG EOI must follow a frame and end exactly at EOF"));
+    }
+    Ok(Summary { frames: 1, animated: false })
+}
+
+/// Scan the first complete JPEG envelope; pixel validity still requires codec decoding.
+pub(crate) fn codestream_end(
+    bytes: &[u8],
+    limits: &ResourceLimits,
+    context: &ExecutionContext,
+) -> Result<usize, ConversionError> {
+    context.checkpoint()?;
     if !bytes.starts_with(&[0xff, 0xd8]) {
         return Err(malformed("JPEG SOI signature is invalid"));
     }
@@ -24,10 +37,10 @@ pub(super) fn validate(
         };
         match marker {
             0xd9 => {
-                if cursor != bytes.len() || !saw_frame {
+                if !saw_frame {
                     return Err(malformed("JPEG EOI must follow a frame and end exactly at EOF"));
                 }
-                return Ok(Summary { frames: 1, animated: false });
+                return Ok(cursor);
             }
             0xd8 | 0x00 => return Err(malformed("JPEG contains an invalid structural marker")),
             0x01 | 0xd0..=0xd7 => {}

--- a/crates/converters/src/image_converter/envelope/mod.rs
+++ b/crates/converters/src/image_converter/envelope/mod.rs
@@ -8,6 +8,8 @@ mod png;
 mod tiff;
 mod webp;
 
+pub(crate) use jpeg::codestream_end as jpeg_codestream_end;
+
 use super::format::RasterFormat;
 use into_markdown_core::{ConversionError, ExecutionContext, ResourceLimits};
 

--- a/docs/evidence/issue-324-embedded-jpeg.md
+++ b/docs/evidence/issue-324-embedded-jpeg.md
@@ -1,0 +1,27 @@
+# Issue #324: embedded JPEG OCR boundary
+
+The standalone JPEG wrapper continues to require its first structural EOI to
+end exactly at EOF, regardless of error policy. Embedded visual OCR uses the
+same marker scanner, but in best-effort mode may borrow the JPEG codestream
+through that EOI and exclude trailing bytes from the OCR input. Strict embedded
+mode rejects trailing bytes. There is no new public option or trusted-source
+marker, and no filename or trailing-byte-content exception.
+
+This adaptation is not pixel validation. The existing bounded image decoder
+must still decode the complete selected codestream before PNG normalization and
+OCR. Malformed structure, invalid pixels, resource limits, cancellation and
+timeouts continue to propagate. No original asset bytes or identities change.
+
+After successful complete decoding, `embeddedVisualOcr.jpegTrailingData` reports
+the excluded byte count and explicitly states that the original asset is
+unchanged. It receives the existing image-reference locator and remains present
+if automatic OCR has no available provider. No compatibility diagnostic is
+issued as a substitute for a failed pixel decode.
+
+Five targeted tests cover pixel/asset preservation and deduplicated OCR calls,
+strict/standalone rejection, marker-payload boundaries and malformed pixels,
+resource/cancellation/timeout propagation, and provider-unavailability diagnostics.
+They are implemented but not yet executed: the coordinating task is serializing
+local build and real-sample windows. Formatting and diff-whitespace checks pass.
+Real acceptance will compare OCR-off/auto for the reported ODP, including native
+content, original asset identities, OCR contribution and located diagnostics.

--- a/docs/evidence/issue-324-embedded-jpeg.md
+++ b/docs/evidence/issue-324-embedded-jpeg.md
@@ -21,7 +21,39 @@ issued as a substitute for a failed pixel decode.
 Five targeted tests cover pixel/asset preservation and deduplicated OCR calls,
 strict/standalone rejection, marker-payload boundaries and malformed pixels,
 resource/cancellation/timeout propagation, and provider-unavailability diagnostics.
-They are implemented but not yet executed: the coordinating task is serializing
-local build and real-sample windows. Formatting and diff-whitespace checks pass.
-Real acceptance will compare OCR-off/auto for the reported ODP, including native
-content, original asset identities, OCR contribution and located diagnostics.
+All five pass on implementation `0bf2adef2aef2cc6444054c0c85145c56190d2f6`.
+Formatting and diff-whitespace checks pass, as do all four existing PR CI jobs.
+
+## Real ODP acceptance
+
+The frozen manifest sample `8b16843138c57e6fd8163158` has source SHA-256
+`1fbb574d53faa5b7f5a9ddc139ce770441b321536d57ba03edb196ff9aed7de4`.
+Its original classification remains unchanged (`unclassified`). The debug CLI
+was built with `embedded-runtime`, borrowing the exact ten OCR payload files
+from the coordinating task's authenticated a6d4 candidate cache. Per-file SHA
+checks prove that provider, worker and model bytes were not replaced. The frozen
+OCR configuration and environment were reused, and capability inspection
+confirmed ready `core:ocr` 0.0.4 before conversion.
+
+Both serialized OCR-off and OCR-auto runs succeeded. With `asset-mode omit`,
+Markdown grew from 13,658 to 15,316 UTF-8 bytes. Result JSON retained original
+assets for verification: all seven are byte-identical between modes and their
+SHA-256 identities match their original source ZIP members. Removing only the
+154 newly added OCR nodes from auto reproduces the complete off Document exactly,
+including all 368 native nodes and their order/provenance. The added OCR text
+contains 1,308 characters, matching CLI contribution telemetry.
+
+Six compatibility diagnostics each report 17 trailing bytes and locate their
+images on slides 14, 16, 30, 32, 35 and 37. Existing layout and low-confidence
+diagnostics remain visible; successful conversion is not a claim of perfect OCR
+transcription. Strict rejection is covered by the targeted fixtures, not by an
+additional real-source run.
+
+Evidence is under `C:/im-bench-004/issue324-jpeg-20260831`: `tests.log`, `build.log`,
+`identity.json`, `payload-identity.json`, `capability.json`, `runs.json`, the two
+reports/result artifacts, `summary.json` and `ocr-text.txt`. `run.py` performs the
+two conversions; `verify.py` compares existing outputs without another run.
+The executable SHA-256 is
+`dc3b35ecb383bd65a9ec19ba01e88a1a49a19faed84c0b876fe57530d57e0040`.
+Observed debug process times were 1.657 s off and 12.502 s auto; these are
+correctness-run observations, not a release performance gate or regression score.


### PR DESCRIPTION
Closes #324

## Change

- Reuse the existing JPEG marker scanner to delimit the first complete codestream for embedded OCR.
- Only embedded best-effort mode may borrow that codestream without trailing bytes; strict embedded mode rejects the tail. The standalone/legacy JPEG wrapper still requires exact EOF under both policies.
- Require the existing bounded complete pixel decode and PNG normalization before OCR. No additional decode, trusted-source marker, public switch, filename/tail-content exception, or original-asset mutation.
- Emit located `embeddedVisualOcr.jpegTrailingData` after successful decoding, reporting the excluded byte count and unchanged original asset. Preserve that diagnostic if automatic OCR has no provider; malformed/resource/cancellation/timeout errors are not broadly swallowed.

Scope is JPEG envelope and embedded OCR adaptation only. No #322 lifecycle or #323 geometry changes, vendor edits, lint exemptions, or new Actions.

## Evidence / current validation status

- Started independently on main `a6d4b6f543be04755908f9181a722284cd44ef29`; rebased onto `cb53022c9bb6ff012c2e47adaed4a897397ba103` after #327 merged. The only conflict was adjacent module declarations in `embedded_visual_ocr.rs`: both `mod geometry;` and `mod jpeg_input;` are retained. Range-diff shows no other patch change, including #323 geometry/low-confidence behavior. No local tests were rerun after this context-only rebase; current-base validation is delegated to existing PR CI.
- Implementation `0bf2adef2aef2cc6444054c0c85145c56190d2f6` received coordinating-task independent static review: P0/P1/P2 = 0, including structural EOI, bounded codec, original asset, strict-mode boundary and no extra decode.
- Formatting and whitespace checks pass.
- Five targeted tests are implemented for compatibility/pixel/asset preservation and OCR deduplication; strict/standalone rejection; marker payload versus actual EOI and malformed pixels; resource/cancellation/timeout propagation; and provider-unavailability diagnostics.
- All five targeted local tests pass on the unchanged implementation; the CLI build with `--features embedded-runtime -j 2` passes. All four existing PR CI jobs passed on the implementation commit.
- Real source ID `8b16843138c57e6fd8163158`, SHA-256 `1fbb574d53faa5b7f5a9ddc139ce770441b321536d57ba03edb196ff9aed7de4`, is bound to the frozen manifest, without changing its `unclassified` label.
- Both serialized OCR-off/auto runs succeeded with the frozen profile/environment. Runtime inspection confirms ready `core:ocr` 0.0.4; the exact ten authenticated a6d4 provider/worker/model payload files are unchanged by SHA. No provider switch or runtime rebuild.
- All 368 native nodes are preserved: removing only the 154 new OCR nodes from auto reproduces the entire off Document exactly. All seven original assets are identical between modes and match their ZIP-member SHA. Actual OCR contribution is 154 regions / 1,308 characters; Markdown grows from 13,658 to 15,316 UTF-8 bytes with asset-mode omit. Result JSON retains the assets for identity checks.
- Exactly six located JPEG compatibility diagnostics report 17 bytes each, on slides 14, 16, 30, 32, 35 and 37. Layout/low-confidence warnings remain; this is not a perfect-transcription claim.
- Canonical evidence: `C:/im-bench-004/issue324-jpeg-20260831/{tests.log,build.log,identity.json,payload-identity.json,capability.json,runs.json,summary.json,ocr-text.txt}` and off/auto reports/results. CLI SHA-256 `dc3b35ecb383bd65a9ec19ba01e88a1a49a19faed84c0b876fe57530d57e0040`. Debug times 1.657 s off / 12.502 s auto are observations, not formal release performance acceptance.

See [boundary and evidence notes](docs/evidence/issue-324-embedded-jpeg.md). Product code did not change after independent review or local testing; the final update adds evidence documentation only. Local execution window is released to #322. Merge remains the coordinating task's decision.
