### PR TITLE
fix(pdf): bound OCR-only bitmap lifetime to each page

### DIFF
--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -723,6 +723,7 @@ struct VisualRef {
 struct CachedContribution {
     nodes: Vec<BlockNode>,
     diagnostics: Vec<Diagnostic>,
+    telemetry: Option<(OcrInputIdentity, u64, u64)>,
 }
 
 struct NormalizedImage {
@@ -856,8 +857,6 @@ async fn enrich(
         resource("max_memory_bytes", format!("allocate OCR contribution cache: {error}"))
     })?;
     cache.resize_with(grouping.groups.len(), || None);
-    let mut recognized_regions = 0_u64;
-    let mut recognized_chars = 0_u64;
     for (ordinal, group_index) in grouping.digest_order.iter().copied().enumerate() {
         context.checkpoint()?;
         let candidate = &candidates[grouping.groups[group_index].representative];
@@ -871,6 +870,7 @@ async fn enrich(
                 cache[group_index] = Some(CachedContribution {
                     nodes: Vec::new(),
                     diagnostics: vec![visual_diagnostic(None, error.to_string())],
+                    telemetry: None,
                 });
                 continue;
             }
@@ -903,7 +903,11 @@ async fn enrich(
                     && matches!(error, ConversionError::ComponentUnavailable { .. }) =>
             {
                 diagnostics.push(visual_diagnostic(None, error.to_string()));
-                cache[group_index] = Some(CachedContribution { nodes: Vec::new(), diagnostics });
+                cache[group_index] = Some(CachedContribution {
+                    nodes: Vec::new(),
+                    diagnostics,
+                    telemetry: None,
+                });
                 continue;
             }
             Err(error) => return Err(error),
@@ -923,14 +927,16 @@ async fn enrich(
         if let Some(memory) = contribution.memory.take() {
             output.attach_memory_reservation(context, memory)?;
         }
-        recognized_regions = recognized_regions
-            .checked_add(contribution.recognized_regions)
-            .ok_or_else(|| resource("max_archive_entries", "OCR region telemetry overflow"))?;
-        recognized_chars = recognized_chars
-            .checked_add(contribution.recognized_chars)
-            .ok_or_else(|| resource("max_field_bytes", "OCR character telemetry overflow"))?;
         diagnostics.append(&mut contribution.diagnostics);
-        cache[group_index] = Some(CachedContribution { nodes: contribution.nodes, diagnostics });
+        cache[group_index] = Some(CachedContribution {
+            nodes: contribution.nodes,
+            diagnostics,
+            telemetry: Some((
+                identity,
+                contribution.recognized_regions,
+                contribution.recognized_chars,
+            )),
+        });
     }
 
     let mut contributions_by_asset = BTreeMap::new();
@@ -972,7 +978,13 @@ async fn enrich(
     if input_format == InputFormat::Pdf && !contributions_by_asset.is_empty() {
         output = crate::pdf_ocr::reconstruct_enriched_pdf(output, options, context)?;
     }
-    context.record_ocr_contribution(recognized_regions, recognized_chars)?;
+    if let Some(engine) = &services.ocr {
+        for contribution in cache.into_iter().flatten() {
+            if let Some((identity, regions, characters)) = contribution.telemetry {
+                engine.record_contribution(identity, regions, characters, context)?;
+            }
+        }
+    }
     Ok(output)
 }
 

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -903,11 +903,8 @@ async fn enrich(
                     && matches!(error, ConversionError::ComponentUnavailable { .. }) =>
             {
                 diagnostics.push(visual_diagnostic(None, error.to_string()));
-                cache[group_index] = Some(CachedContribution {
-                    nodes: Vec::new(),
-                    diagnostics,
-                    telemetry: None,
-                });
+                cache[group_index] =
+                    Some(CachedContribution { nodes: Vec::new(), diagnostics, telemetry: None });
                 continue;
             }
             Err(error) => return Err(error),

--- a/crates/converters/src/pdf/mod.rs
+++ b/crates/converters/src/pdf/mod.rs
@@ -7,7 +7,9 @@ mod coverage;
 mod error;
 mod geometry;
 mod ir;
+mod pages;
 mod runtime;
+mod stream;
 
 #[cfg(test)]
 mod tests;
@@ -47,8 +49,7 @@ use std::collections::HashSet;
 #[cfg(target_os = "windows")]
 use std::os::windows::fs::MetadataExt as _;
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, MutexGuard, OnceLock, TryLockError};
-use std::time::Duration;
+use std::sync::OnceLock;
 
 const PROVIDER_ID: &str = "builtin.converter.pdfium";
 const FORMATS: &[InputFormat] = &[InputFormat::Pdf];
@@ -56,7 +57,6 @@ const MIN_NATIVE_TEXT_CHARS: usize = 8;
 const MIN_SCAN_IMAGE_COVERAGE: f64 = 0.50;
 const MAX_RENDER_DIMENSION: u32 = 16_384;
 const MAX_PAGE_RENDER_DIMENSION: u32 = 4096;
-static PDF_CONVERSION_GATE: OnceLock<Mutex<()>> = OnceLock::new();
 type PdfiumRuntimeResolver = fn() -> Result<PathBuf, ConversionError>;
 static PDFIUM_RUNTIME_RESOLVER: OnceLock<PdfiumRuntimeResolver> = OnceLock::new();
 
@@ -293,6 +293,10 @@ impl Converter for PdfConverter {
         FORMATS
     }
 
+    fn stream_support(&self) -> Option<&dyn into_markdown_core::ConverterStream> {
+        Some(self)
+    }
+
     fn probe<'a>(
         &'a self,
         input: &'a ResolvedInput,
@@ -337,7 +341,6 @@ impl Converter for PdfConverter {
     }
 }
 
-#[allow(clippy::too_many_lines)]
 fn convert_pdf(
     runtime_path: &Path,
     input: &ResolvedInput,
@@ -346,426 +349,22 @@ fn convert_pdf(
 ) -> Result<ConverterOutput, ConversionError> {
     context.checkpoint()?;
     let _conversion_guard = lock_pdf_conversion(context)?;
-    let bitmap_limit =
-        options.limits.max_asset_bytes.min(options.limits.max_memory_bytes).min(400_000_000);
-    let limits = Limits {
-        max_document_bytes: options.limits.max_input_bytes.min(1024 * 1024 * 1024),
-        max_pages: options.limits.max_pages,
-        max_text_units_per_page: u32::try_from(into_markdown_core::MAX_DOCUMENT_INLINES)
-            .unwrap_or(u32::MAX),
-        max_render_dimension: MAX_RENDER_DIMENSION,
-        max_render_pixels: bitmap_limit / 4,
-        max_images_per_page: 10_000,
-        max_page_objects: u32::try_from(into_markdown_core::MAX_DOCUMENT_NODES).unwrap_or(u32::MAX),
-        max_password_bytes: 1024,
-        max_bitmap_bytes: bitmap_limit,
-        max_links_per_page: 10_000,
-        max_link_bytes: 8 * 1024,
-        max_font_name_bytes: 4 * 1024,
-    };
-    let runtime = Pdfium::load_pinned(runtime_path, limits).map_err(map_pdfium_error)?;
-    let open_plan = runtime.plan_open(input.bytes.clone(), None).map_err(map_pdfium_error)?;
-    let open_memory = context.reserve_memory(open_plan.allocation_bytes())?;
-    let pdf = open_plan.materialize().map_err(map_pdfium_error)?;
-    // The plan covers only the exact temporary password copy. PDFium has
-    // consumed it before `materialize` returns; the input Arc remains owned by
-    // the Engine input lease and the native parser allocation is documented
-    // residual risk.
-    drop(open_memory);
-    let mut document = Document::default();
-    let mut assets = Vec::new();
-    let mut asset_ids = HashSet::new();
-    let mut diagnostics = Vec::new();
-    let mut total_asset_bytes = 0_u64;
-    let mut total_nodes = 0_usize;
-    let mut total_inlines = 0_usize;
-    let mut total_page_objects = 0_usize;
-    let mut retained_memory = Vec::new();
-    let retain_image_pixels = image_pixels_required(options);
-    let path_page_capacity =
-        allocation_capacity_bound(usize::try_from(pdf.page_count()).unwrap_or(usize::MAX))?;
-    let path_page_bytes = path_page_capacity
-        .checked_mul(std::mem::size_of::<into_markdown_pdf_layout::PagePathEvidence>())
-        .and_then(|bytes| u64::try_from(bytes).ok())
-        .ok_or_else(|| resource("max_memory_bytes", "PDF path page inventory overflow"))?;
-    let path_page_memory = context.reserve_memory(path_page_bytes)?;
-    let mut path_evidence = Vec::new();
-    path_evidence
-        .try_reserve_exact(path_page_capacity)
-        .map_err(|_| resource("max_memory_bytes", "PDF path page inventory allocation failed"))?;
-    if path_evidence.capacity() > path_page_capacity {
-        return Err(resource(
-            "max_memory_bytes",
-            "PDF path page inventory capacity exceeded its plan",
-        ));
-    }
-    let mut path_memory = Vec::new();
-    retain_existing_reservation(context, &mut path_memory, path_page_memory)?;
-
+    let runtime = pages::load_runtime(runtime_path, options)?;
+    let pdf = open_document(&runtime, input, context)?;
+    let mut output = pages::PdfOutput::new(pdf.page_count(), context)?;
+    let mut counts = pages::Counts::default();
     for page_index in 0..pdf.page_count() {
-        context.checkpoint()?;
-        let page_number = page_index + 1;
-        let page = pdf.page(page_index).map_err(map_pdfium_error)?;
-        total_page_objects = checked_count(
-            total_page_objects,
-            usize::try_from(page.object_count().map_err(map_pdfium_error)?).unwrap_or(usize::MAX),
-            into_markdown_core::MAX_DOCUMENT_NODES,
-            "pdfPageObjects",
-        )?;
-        let info = page.info().map_err(map_pdfium_error)?;
-        let path_plan = request_path_scan(context, |checkpoint| {
-            page.plan_path_bounds_with_checkpoint(checkpoint)
-        })?;
-        let path_allocation_bytes = path_plan.allocation_bytes();
-        let (raw_path_bounds, raw_path_memory) =
-            materialize_after_reserve(context, path_allocation_bytes, || {
-                request_path_scan(context, |checkpoint| {
-                    path_plan.materialize_with_checkpoint(checkpoint)
-                })
-            })?;
-        let path_capacity = allocation_capacity_bound(raw_path_bounds.len())?;
-        let normalized_path_bytes = path_capacity
-            .checked_mul(std::mem::size_of::<Rect>())
-            .and_then(|bytes| u64::try_from(bytes).ok())
-            .ok_or_else(|| resource("max_memory_bytes", "PDF path bounds allocation overflow"))?;
-        let normalized_path_memory = context.reserve_memory(normalized_path_bytes)?;
-        let mut normalized_paths = Vec::new();
-        normalized_paths
-            .try_reserve_exact(path_capacity)
-            .map_err(|_| resource("max_memory_bytes", "PDF path bounds allocation failed"))?;
-        if normalized_paths.capacity() > path_capacity {
-            return Err(resource("max_memory_bytes", "PDF path bounds capacity exceeded its plan"));
-        }
-        for bounds in raw_path_bounds {
-            context.checkpoint()?;
-            normalized_paths.push(normalize_rect(bounds, &info)?);
-        }
-        drop(raw_path_memory);
-        if normalized_paths.is_empty() {
-            drop(normalized_path_memory);
-        } else {
-            retain_existing_reservation(context, &mut path_memory, normalized_path_memory)?;
-            path_evidence.push(into_markdown_pdf_layout::PagePathEvidence {
-                page: page_number,
-                bounds: normalized_paths,
-            });
-        }
-        let text_page = page.text_page().map_err(map_pdfium_error)?;
-        let character_plan = text_page.plan_characters().map_err(map_pdfium_error)?;
-        let character_count = character_plan.count();
-        let character_budget = character_working_set_bytes(
-            character_plan.allocation_bytes(),
-            character_plan.retained_font_bytes(),
-            character_count,
-        )?;
-        let (characters, character_memory) =
-            materialize_after_reserve(context, character_budget, || {
-                character_plan.materialize().map_err(map_pdfium_error)
-            })?;
-        retain_existing_reservation(context, &mut retained_memory, character_memory)?;
-        total_inlines = checked_count(
-            total_inlines,
-            characters.len(),
-            into_markdown_core::MAX_DOCUMENT_INLINES,
-            "documentInlines",
-        )?;
-        let mut blocks = Vec::new();
-        if !characters.is_empty() {
-            total_nodes = checked_count(
-                total_nodes,
-                1,
-                into_markdown_core::MAX_DOCUMENT_NODES,
-                "documentNodes",
-            )?;
-            blocks
-                .try_reserve(1)
-                .map_err(|_| resource("max_memory_bytes", "PDF block allocation failed"))?;
-            blocks.push(text_block(page_number, &info, &characters)?);
-        }
-        let link_plan = text_page.plan_links().map_err(map_pdfium_error)?;
-        let link_plan_bytes = link_plan.allocation_bytes();
-        let (links, link_memory) = materialize_after_reserve(context, link_plan_bytes, || {
-            link_plan.materialize().map_err(map_pdfium_error)
-        })?;
-        for (link_index, link) in links.into_iter().enumerate() {
-            total_nodes = checked_count(
-                total_nodes,
-                1,
-                into_markdown_core::MAX_DOCUMENT_NODES,
-                "documentNodes",
-            )?;
-            total_inlines = checked_count(
-                total_inlines,
-                2,
-                into_markdown_core::MAX_DOCUMENT_INLINES,
-                "documentInlines",
-            )?;
-            let target_length = match &link.target {
-                LinkTarget::ExternalUri(value) => value.len(),
-                LinkTarget::InternalPage { .. } => 32,
-            };
-            let link_ir_bytes = u64::try_from(target_length)
-                .unwrap_or(u64::MAX)
-                .checked_mul(2)
-                .and_then(|bytes| bytes.checked_add(output_block_overhead(2).ok()?))
-                .ok_or_else(|| resource("max_memory_bytes", "link IR memory overflow"))?;
-            retain_output_bytes(context, &mut retained_memory, link_ir_bytes)?;
-            let display_text = match &link.target {
-                LinkTarget::ExternalUri(value) => Some(value.clone()),
-                LinkTarget::InternalPage { .. } => None,
-            };
-            let target = match safe_link_target(link.target, pdf.page_count()) {
-                Ok(target) => target,
-                Err(error) if options.error_policy == ErrorPolicy::Strict => return Err(error),
-                Err(error) => {
-                    diagnostics.push(Diagnostic {
-                        code: "pdf.linkOmitted".into(),
-                        severity: DiagnosticSeverity::Warning,
-                        message: error.to_string(),
-                        locator: Some(page_locator(page_number, &info)),
-                    });
-                    if let Some(value) = display_text {
-                        blocks.try_reserve(1).map_err(|_| {
-                            resource("max_memory_bytes", "PDF block allocation failed")
-                        })?;
-                        blocks.push(BlockNode {
-                            id: NodeId(format!("pdf-page-{page_number}-link-{link_index}")),
-                            block: Block::Paragraph(vec![Inline::Text {
-                                value,
-                                marks: Vec::new(),
-                            }]),
-                            provenance: provenance(
-                                page_number,
-                                Some(normalize_rect(link.bounds, &info)?),
-                                None,
-                                &info,
-                            )?,
-                        });
-                    }
-                    continue;
-                }
-            };
-            blocks
-                .try_reserve(1)
-                .map_err(|_| resource("max_memory_bytes", "PDF block allocation failed"))?;
-            blocks.push(BlockNode {
-                id: NodeId(format!("pdf-page-{page_number}-link-{link_index}")),
-                block: Block::Paragraph(vec![Inline::Link {
-                    target: target.clone(),
-                    content: vec![Inline::Text { value: target, marks: Vec::new() }],
-                }]),
-                provenance: provenance(
-                    page_number,
-                    Some(normalize_rect(link.bounds, &info)?),
-                    None,
-                    &info,
-                )?,
-            });
-        }
-        drop(link_memory);
+        output = output.extract_page(&pdf, page_index, options, context, &mut counts, false)?;
+    }
+    output.finish(options, context)
+}
 
-        let mut coverage = PageCoverage::default();
-        let image_plan = page.plan_images().map_err(map_pdfium_error)?;
-        let image_plan_bytes = image_plan.allocation_bytes();
-        let (images, image_metadata_memory) =
-            materialize_after_reserve(context, image_plan_bytes, || {
-                image_plan.materialize().map_err(map_pdfium_error)
-            })?;
-        for image in images {
-            context.checkpoint()?;
-            let bounds = normalize_rect(image.bounds(), &info)?;
-            coverage.add(bounds, &info);
-            let id = if retain_image_pixels {
-                #[cfg(test)]
-                IMAGE_BITMAP_MATERIALIZATIONS.set(IMAGE_BITMAP_MATERIALIZATIONS.get() + 1);
-                let bitmap_plan = image.plan_bitmap().map_err(map_pdfium_error)?;
-                let bitmap_plan_bytes = bitmap_plan.allocation_bytes();
-                let (bitmap, bitmap_memory) =
-                    materialize_after_reserve(context, bitmap_plan_bytes, || {
-                        bitmap_plan.materialize().map_err(map_pdfium_error)
-                    })?;
-                let (encoded, encoded_memory) = image_bitmap_to_bmp(&bitmap, options, context)?;
-                drop(bitmap);
-                drop(bitmap_memory);
-                account_asset(&encoded, &mut total_asset_bytes, options)?;
-                retain_output_bytes(context, &mut retained_memory, asset_record_overhead()?)?;
-                let id = content_asset_id("pdf-image", &encoded)?;
-                asset_ids
-                    .try_reserve(1)
-                    .map_err(|_| resource("max_memory_bytes", "asset ID allocation failed"))?;
-                if asset_ids.insert(id.clone()) {
-                    retain_existing_reservation(context, &mut retained_memory, encoded_memory)?;
-                    assets.try_reserve(1).map_err(|_| {
-                        resource("max_memory_bytes", "asset inventory allocation failed")
-                    })?;
-                    assets.push(Asset {
-                        id: AssetId(id.clone()),
-                        filename: Some(format!("{id}.bmp")),
-                        media_type: "image/bmp".into(),
-                        bytes: encoded,
-                        external_uri: None,
-                    });
-                }
-                id
-            } else {
-                // Preserve image geometry through reading-order reconstruction.
-                // This transient reference is removed before publishing the IR.
-                "pdf-omitted-image".into()
-            };
-            total_nodes = checked_count(
-                total_nodes,
-                1,
-                into_markdown_core::MAX_DOCUMENT_NODES,
-                "documentNodes",
-            )?;
-            retain_output_bytes(context, &mut retained_memory, output_block_overhead(0)?)?;
-            blocks
-                .try_reserve(1)
-                .map_err(|_| resource("max_memory_bytes", "PDF block allocation failed"))?;
-            blocks.push(BlockNode {
-                id: NodeId(format!("pdf-page-{page_number}-image-{}", image.index())),
-                block: Block::Image { asset: AssetId(id), alt: None },
-                provenance: provenance(page_number, Some(bounds), None, &info)?,
-            });
-        }
-        drop(image_metadata_memory);
-
-        let printable = characters
-            .iter()
-            .filter(|character| !character.value.is_control() && !character.value.is_whitespace())
-            .count();
-        let scanned =
-            printable < MIN_NATIVE_TEXT_CHARS && coverage.ratio() >= MIN_SCAN_IMAGE_COVERAGE;
-        let render_requested = options.ocr.policy == OcrPolicy::Always
-            || (options.ocr.policy == OcrPolicy::Auto && scanned);
-        if render_requested {
-            let (width, height) = render_dimensions(&info)?;
-            let (page_width, page_height) = displayed_dimensions(&info);
-            let render_bytes = u64::from(width)
-                .checked_mul(u64::from(height))
-                .and_then(|pixels| pixels.checked_mul(4))
-                .and_then(|bytes| bytes.checked_mul(2))
-                .ok_or_else(|| resource("max_memory_bytes", "render working set overflow"))?;
-            let bitmap_memory = context.reserve_memory(render_bytes)?;
-            let bitmap = page.render_bgra(width, height).map_err(map_pdfium_error)?;
-            let (encoded, encoded_memory) = rendered_bitmap_to_bmp(&bitmap, options, context)?;
-            drop(bitmap);
-            drop(bitmap_memory);
-            account_asset(&encoded, &mut total_asset_bytes, options)?;
-            retain_output_bytes(context, &mut retained_memory, asset_record_overhead()?)?;
-            let id = content_asset_id("pdf-page-render", &encoded)?;
-            asset_ids
-                .try_reserve(1)
-                .map_err(|_| resource("max_memory_bytes", "asset ID allocation failed"))?;
-            if asset_ids.insert(id.clone()) {
-                retain_existing_reservation(context, &mut retained_memory, encoded_memory)?;
-                assets.try_reserve(1).map_err(|_| {
-                    resource("max_memory_bytes", "asset inventory allocation failed")
-                })?;
-                assets.push(Asset {
-                    id: AssetId(id.clone()),
-                    filename: Some(format!("{id}.bmp")),
-                    media_type: "image/bmp".into(),
-                    bytes: encoded,
-                    external_uri: None,
-                });
-            }
-            total_nodes = checked_count(
-                total_nodes,
-                1,
-                into_markdown_core::MAX_DOCUMENT_NODES,
-                "documentNodes",
-            )?;
-            retain_output_bytes(context, &mut retained_memory, output_block_overhead(0)?)?;
-            blocks
-                .try_reserve(1)
-                .map_err(|_| resource("max_memory_bytes", "PDF block allocation failed"))?;
-            blocks.push(BlockNode {
-                id: NodeId(format!("pdf-page-{page_number}-ocr-render")),
-                block: Block::Image { asset: AssetId(id), alt: Some("page render for OCR".into()) },
-                provenance: provenance(
-                    page_number,
-                    Some(Rect { x: 0.0, y: 0.0, width: page_width, height: page_height }),
-                    None,
-                    &info,
-                )?,
-            });
-        }
-        if scanned {
-            retain_output_bytes(context, &mut retained_memory, diagnostic_overhead()?)?;
-            diagnostics
-                .try_reserve(1)
-                .map_err(|_| resource("max_memory_bytes", "diagnostic allocation failed"))?;
-            diagnostics.push(Diagnostic {
-                code: "pdf.scannedPage".into(),
-                severity: DiagnosticSeverity::Info,
-                message: format!(
-                    "page {page_number} has fewer than {MIN_NATIVE_TEXT_CHARS} printable native characters and image coverage of at least 50%"
-                ),
-                locator: Some(page_locator(page_number, &info)),
-            });
-        }
-        total_nodes =
-            checked_count(total_nodes, 1, into_markdown_core::MAX_DOCUMENT_NODES, "documentNodes")?;
-        retain_output_bytes(context, &mut retained_memory, output_block_overhead(0)?)?;
-        document
-            .blocks
-            .try_reserve(1)
-            .map_err(|_| resource("max_memory_bytes", "page allocation failed"))?;
-        document.blocks.push(BlockNode {
-            id: NodeId(format!("pdf-page-{page_number}")),
-            block: Block::Page { number: page_number, blocks },
-            provenance: provenance(page_number, None, None, &info)?,
-        });
-    }
-    let layout_config = into_markdown_pdf_layout::LayoutConfig {
-        limits: into_markdown_pdf_layout::LayoutLimits {
-            max_atoms: into_markdown_core::MAX_DOCUMENT_INLINES,
-            max_lines: into_markdown_core::MAX_DOCUMENT_NODES,
-            max_comparisons: 12_000_000,
-            max_table_columns: usize::try_from(options.limits.max_table_columns)
-                .unwrap_or(usize::MAX)
-                .min(into_markdown_core::MAX_TABLE_COLUMNS),
-            max_table_cells: usize::try_from(options.limits.max_table_cells)
-                .unwrap_or(usize::MAX)
-                .min(into_markdown_core::MAX_DOCUMENT_NODES),
-        },
-    };
-    let layout = into_markdown_pdf_layout::reconstruct_document_with_path_evidence(
-        document,
-        &layout_config,
-        &path_evidence,
-        context,
-    )?;
-    let (rebuilt_document, layout_reservation) = layout.into_parts();
-    drop(path_evidence);
-    drop(path_memory);
-    document = rebuilt_document;
-    if !retain_image_pixels {
-        for page in &mut document.blocks {
-            if let Block::Page { blocks, .. } = &mut page.block {
-                blocks.retain(|node| !matches!(node.block, Block::Image { .. }));
-            }
-        }
-    }
-    if let Some(reservation) = layout_reservation {
-        retain_existing_reservation(context, &mut retained_memory, reservation)?;
-    }
-    let validation_bytes = total_nodes
-        .checked_add(total_inlines)
-        .and_then(|value| value.checked_mul(256))
-        .and_then(|value| u64::try_from(value).ok())
-        .ok_or_else(|| resource("max_memory_bytes", "document validation memory overflow"))?;
-    let validation_memory = context.reserve_memory(validation_bytes)?;
-    document.validate().map_err(|error| ConversionError::Internal {
-        detail: format!("PDF converter emitted invalid IR at {}: {}", error.path, error.detail),
-    })?;
-    drop(validation_memory);
-    let output = ConverterOutput::new_with_memory_reservations(
-        document,
-        assets,
-        diagnostics,
-        retained_memory,
-    );
-    output.account_retained(context)
+fn open_document<'a>(
+    runtime: &'a Pdfium,
+    input: &ResolvedInput,
+    context: &ExecutionContext,
+) -> Result<into_markdown_pdfium::Document<'a>, ConversionError> {
+    let plan = runtime.plan_open(input.bytes.clone(), None).map_err(map_pdfium_error)?;
+    let _memory = context.reserve_memory(plan.allocation_bytes())?;
+    plan.materialize().map_err(map_pdfium_error)
 }

--- a/crates/converters/src/pdf/mod.rs
+++ b/crates/converters/src/pdf/mod.rs
@@ -26,6 +26,7 @@ use geometry::{
     displayed_dimensions, normalize_rect, page_locator, render_dimensions, safe_link_target,
 };
 use ir::{allocation_capacity_bound, character_working_set_bytes, provenance, text_block};
+#[cfg(test)]
 use runtime::lock_pdf_conversion;
 
 #[cfg(test)]
@@ -336,11 +337,13 @@ impl Converter for PdfConverter {
     ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
         Box::pin(async move {
             let path = self.runtime_path()?;
-            convert_pdf(&path, input, options, context)
+            let _permit = runtime::acquire_pdf_conversion(context).await?;
+            convert_pdf_admitted(&path, input, options, context)
         })
     }
 }
 
+#[cfg(test)]
 fn convert_pdf(
     runtime_path: &Path,
     input: &ResolvedInput,
@@ -349,6 +352,16 @@ fn convert_pdf(
 ) -> Result<ConverterOutput, ConversionError> {
     context.checkpoint()?;
     let _conversion_guard = lock_pdf_conversion(context)?;
+    convert_pdf_admitted(runtime_path, input, options, context)
+}
+
+fn convert_pdf_admitted(
+    runtime_path: &Path,
+    input: &ResolvedInput,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    context.checkpoint()?;
     let runtime = pages::load_runtime(runtime_path, options)?;
     let pdf = open_document(&runtime, input, context)?;
     let mut output = pages::PdfOutput::new(pdf.page_count(), context)?;

--- a/crates/converters/src/pdf/page_lifetime_tests.rs
+++ b/crates/converters/src/pdf/page_lifetime_tests.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 #[derive(Default)]
-struct Recognizer(AtomicUsize);
+struct Recognizer(AtomicUsize, bool);
 
 impl OcrEngine for Recognizer {
     fn id(&self) -> &'static str {
@@ -61,6 +61,12 @@ impl OcrEngine for Recognizer {
             })
             .await;
             let ordinal = self.0.fetch_add(1, Ordering::SeqCst) + 1;
+            if self.1 && ordinal == 1 {
+                return Err(ConversionError::ComponentUnavailable {
+                    component: "ocr".into(),
+                    detail: "test provider temporarily unavailable".into(),
+                });
+            }
             let image = image::load_from_memory(request.image).unwrap();
             let identity = OcrInputIdentity::try_new(
                 Sha256::digest(request.image).into(),
@@ -425,8 +431,14 @@ fn mixed_pdf_modes_yield_runtime_admission_on_one_executor() {
 #[test]
 #[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
 fn identical_scanned_pages_reuse_recognition_without_retaining_pixels() {
+    for unavailable_first in [false, true] {
+        check_repeated_pages(unavailable_first);
+    }
+}
+
+fn check_repeated_pages(unavailable_first: bool) {
     let pages = Arc::new(ObservedPages::default());
-    let ocr = Arc::new(Recognizer::default());
+    let ocr = Arc::new(Recognizer(AtomicUsize::new(0), unavailable_first));
     let engine = engine(pages.clone(), ocr.clone());
     let mut request = request(4);
     request.input = InputRef::Bytes {
@@ -436,8 +448,14 @@ fn identical_scanned_pages_reuse_recognition_without_retaining_pixels() {
     let context =
         ExecutionContext::new(ExecutionOptions::default(), request.options.limits.clone());
     let result = block_on(engine.convert_with_context(request, context.clone())).unwrap();
-    assert_eq!(ocr.0.load(Ordering::SeqCst), 1);
-    assert_eq!(result.markdown.matches("recognized body 1").count(), 4);
+    let unavailable = usize::from(unavailable_first);
+    let body = format!("recognized body {}", 1 + unavailable);
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 1 + unavailable);
+    assert_eq!(result.markdown.matches(&body).count(), 4 - unavailable);
+    assert_eq!(
+        result.diagnostics.iter().filter(|value| value.code == "image.ocrUnavailable").count(),
+        unavailable
+    );
     assert_eq!(context.resource_usage().ocr_recognized_regions, 1);
     assert_eq!(context.resource_usage().ocr_recognized_chars, 17);
     assert_eq!(result.document.blocks.len(), 4);
@@ -446,7 +464,10 @@ fn identical_scanned_pages_reuse_recognition_without_retaining_pixels() {
         assert!(
             matches!(node.block, Block::Page { number, .. } if usize::try_from(number).unwrap() == index + 1)
         );
-        assert!(serde_json::to_string(node).unwrap().contains("recognized body 1"));
+        assert_eq!(
+            serde_json::to_string(node).unwrap().contains(&body),
+            !unavailable_first || index > 0
+        );
     }
     let entries = pages.entries.lock().unwrap();
     assert_eq!(entries.len(), 4);

--- a/crates/converters/src/pdf/page_lifetime_tests.rs
+++ b/crates/converters/src/pdf/page_lifetime_tests.rs
@@ -1,0 +1,363 @@
+use super::{assemble_pdf, stream_object};
+use crate::{EmbeddedVisualOcrEnricher, HintFormatDetector, MemorySourceResolver, PdfConverter};
+use futures::executor::block_on;
+use into_markdown_core::{
+    ArtifactSink, AssetStreamInfo, Block, BoundOcrResult, BoxFuture, CancellationToken,
+    ConversionError, ConversionOptions, ConversionRequest, ConverterOutput, EnrichmentPlan,
+    ExecutionContext, ExecutionOptions, FormatHint, InputFormat, InputRef, OcrEngine,
+    OcrEvidenceStage, OcrEvidenceStep, OcrInputIdentity, OcrOutputPlan, OcrRecognition, OcrRegion,
+    OcrRequest, OcrResult, OutputEnricher, Services,
+};
+use into_markdown_engine::{Engine, EngineBuilder};
+use sha2::{Digest, Sha256};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+#[derive(Default)]
+struct Recognizer(AtomicUsize);
+
+impl OcrEngine for Recognizer {
+    fn id(&self) -> &'static str {
+        "test.page-ocr"
+    }
+    fn recognize<'a>(
+        &'a self,
+        _: OcrRequest<'a>,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+        Box::pin(async { unreachable!("bound OCR path is required") })
+    }
+    fn planned_bound_output(
+        &self,
+        _: OcrRequest<'_>,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new(16 * 1024, 1, 128)
+    }
+    fn planned_normalized_png_output(
+        &self,
+        _: u32,
+        _: u32,
+        _: &ConversionOptions,
+        _: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        OcrOutputPlan::try_new(16 * 1024, 1, 128)
+    }
+    fn recognize_bound<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+        Box::pin(async move {
+            let ordinal = self.0.fetch_add(1, Ordering::SeqCst) + 1;
+            let image = image::load_from_memory(request.image).unwrap();
+            let identity = OcrInputIdentity::try_new(
+                Sha256::digest(request.image).into(),
+                image.width(),
+                image.height(),
+                0,
+            )?;
+            Ok(OcrRecognition::Bound(BoundOcrResult::try_new_for_input(
+                OcrResult {
+                    provider: self.id().into(),
+                    regions: vec![OcrRegion {
+                        text: format!("recognized body {ordinal}"),
+                        polygon: [(0.0, 0.0), (0.8, 0.0), (0.8, 0.8), (0.0, 0.8)],
+                        confidence: 0.99,
+                    }],
+                },
+                vec![0.99],
+                vec![
+                    OcrEvidenceStep {
+                        stage: OcrEvidenceStage::Detection,
+                        provider: self.id().into(),
+                        model: None,
+                    },
+                    OcrEvidenceStep {
+                        stage: OcrEvidenceStage::Recognition,
+                        provider: self.id().into(),
+                        model: None,
+                    },
+                ],
+                identity,
+            )?))
+        })
+    }
+}
+
+#[derive(Default)]
+struct ObservedPages {
+    // page number, live source pixels, all converter-credit bytes at entry
+    entries: Mutex<Vec<(u32, usize, u64)>>,
+    stop_at: Option<u32>,
+    cancel: Option<CancellationToken>,
+}
+
+impl OutputEnricher for ObservedPages {
+    fn id(&self) -> &'static str {
+        "builtin.enricher.embedded-visual-ocr"
+    }
+    fn planned_enrichment_bytes(
+        &self,
+        output: &ConverterOutput,
+        converter: &str,
+        format: InputFormat,
+        options: &ConversionOptions,
+        services: &Services,
+        context: &ExecutionContext,
+    ) -> Result<EnrichmentPlan, ConversionError> {
+        EmbeddedVisualOcrEnricher
+            .planned_enrichment_bytes(output, converter, format, options, services, context)
+    }
+    fn enrich<'a>(
+        &'a self,
+        output: ConverterOutput,
+        converter: &'a str,
+        format: InputFormat,
+        options: &'a ConversionOptions,
+        services: &'a Services,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        Box::pin(async move {
+            assert_eq!(
+                output.document.blocks.len(),
+                1,
+                "must consume one page before extracting another"
+            );
+            let Block::Page { number, .. } = output.document.blocks[0].block else {
+                panic!("page")
+            };
+            if let Block::Page { blocks, .. } = &output.document.blocks[0].block {
+                for node in blocks.iter().filter(|node| node.id.0.ends_with("ocr-render")) {
+                    let locator = &node.provenance.locator;
+                    let bounds = locator.bounds.unwrap();
+                    assert_eq!(locator.rotation_degrees, Some(0.0));
+                    assert_eq!((bounds.x, bounds.y), (0.0, 0.0));
+                    assert_eq!(Some(bounds.width), locator.page_width);
+                    assert_eq!(Some(bounds.height), locator.page_height);
+                }
+            }
+            self.entries.lock().unwrap().push((
+                number,
+                output.assets.iter().map(|asset| asset.bytes.len()).sum(),
+                context.reserved_memory_bytes(),
+            ));
+            if self.stop_at == Some(number) {
+                if let Some(cancel) = &self.cancel {
+                    cancel.cancel();
+                    context.checkpoint()?;
+                }
+                return Err(ConversionError::Malformed {
+                    part: Some("page OCR".into()),
+                    detail: "test page failure".into(),
+                });
+            }
+            EmbeddedVisualOcrEnricher
+                .enrich(output, converter, format, options, services, context)
+                .await
+        })
+    }
+}
+
+fn engine(pages: Arc<ObservedPages>, ocr: Arc<Recognizer>) -> Engine {
+    let mut builder = EngineBuilder::new()
+        .services(Services { ocr: Some(ocr), ..Services::default() })
+        .enricher(pages)
+        .renderer(Arc::new(into_markdown_render_markdown::GfmRenderer));
+    builder.registry_mut().register_source_resolver(Arc::new(MemorySourceResolver));
+    builder.registry_mut().register_format_detector(Arc::new(HintFormatDetector));
+    builder.registry_mut().register_converter(Arc::new(PdfConverter::with_runtime_path(
+        std::env::var_os("PDFIUM_LIBRARY").expect("PDFIUM_LIBRARY"),
+    )));
+    builder.build().unwrap()
+}
+
+fn request(page_count: u32) -> ConversionRequest {
+    let mut options = ConversionOptions::default();
+    options.output.asset_mode = into_markdown_core::AssetMode::Omit;
+    options.limits.max_total_asset_bytes = 400_000;
+    options.limits.max_memory_bytes = 128 * 1024 * 1024;
+    ConversionRequest {
+        input: InputRef::Bytes {
+            data: Arc::from(scanned_pages(page_count)),
+            name: Some("pages.pdf".into()),
+        },
+        hint: FormatHint { format: Some(InputFormat::Pdf), ..FormatHint::default() },
+        options,
+    }
+}
+
+fn scanned_pages(count: u32) -> Vec<u8> {
+    let kids =
+        (0..count).map(|index| format!("{} 0 R", 3 + index * 3)).collect::<Vec<_>>().join(" ");
+    let mut objects = vec![
+        b"<< /Type /Catalog /Pages 2 0 R >>".to_vec(),
+        format!("<< /Type /Pages /Kids [{kids}] /Count {count} >>").into_bytes(),
+    ];
+    for index in 0..count {
+        let page = 3 + index * 3;
+        let rotation = if index % 2 == 0 { 0 } else { 90 };
+        objects.push(format!("<< /Type /Page /Parent 2 0 R /Rotate {rotation} /MediaBox [0 0 100 200] /Resources << /XObject << /Im1 {} 0 R >> >> /Contents {} 0 R >>", page + 2, page + 1).into_bytes());
+        objects.push(stream_object("", b"q 100 0 0 200 0 0 cm /Im1 Do Q\n"));
+        objects.push(stream_object("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[u8::try_from(index + 1).unwrap(), 0, 0]));
+    }
+    assemble_pdf(&objects)
+}
+
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn collecting_consumes_ocr_pixels_per_page_and_releases_leases() {
+    for count in [2, 8] {
+        let pages = Arc::new(ObservedPages::default());
+        let ocr = Arc::new(Recognizer::default());
+        let engine = engine(pages.clone(), ocr.clone());
+        let request = request(count);
+        let context =
+            ExecutionContext::new(ExecutionOptions::default(), request.options.limits.clone());
+        super::IMAGE_BITMAP_MATERIALIZATIONS.set(0);
+        let result = block_on(engine.convert_with_context(request, context.clone())).unwrap();
+        assert_eq!(
+            super::IMAGE_BITMAP_MATERIALIZATIONS.get(),
+            0,
+            "whole-page OCR must not decode embedded images too"
+        );
+        assert_eq!(result.document.blocks.len(), usize::try_from(count).unwrap());
+        for (index, node) in result.document.blocks.iter().enumerate() {
+            assert!(
+                matches!(node.block, Block::Page { number, .. } if usize::try_from(number).unwrap() == index + 1)
+            );
+            assert!(
+                serde_json::to_string(node).unwrap().contains("recognized body"),
+                "each page needs recognized body"
+            );
+        }
+        assert!(result.assets.is_empty());
+        assert_eq!(
+            result.markdown.matches("recognized body").count(),
+            usize::try_from(count).unwrap()
+        );
+        assert!(
+            result.markdown.contains("recognized body"),
+            "must retain OCR body, not just page headings"
+        );
+        assert_eq!(
+            result
+                .diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "pdf.scannedPage")
+                .count(),
+            usize::try_from(count).unwrap()
+        );
+        let entries = pages.entries.lock().unwrap();
+        assert_eq!(entries.len(), usize::try_from(count).unwrap());
+        assert!(entries.iter().all(|(_, pixels, _)| *pixels < 400_000));
+        assert!(entries.iter().map(|(_, pixels, _)| pixels).sum::<usize>() > 400_000);
+        assert!(
+            entries.last().unwrap().2 < entries[0].2 + 512 * 1024,
+            "pixel leases must not accumulate: {entries:?}"
+        );
+        assert_eq!(ocr.0.load(Ordering::SeqCst), usize::try_from(count).unwrap());
+        drop(result);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+    }
+}
+
+#[derive(Default)]
+struct MarkdownSink(Vec<u8>);
+impl ArtifactSink for MarkdownSink {
+    fn write_markdown(&mut self, bytes: &[u8]) -> Result<(), ConversionError> {
+        self.0.extend_from_slice(bytes);
+        Ok(())
+    }
+    fn begin_asset(&mut self, _: &AssetStreamInfo) -> Result<(), ConversionError> {
+        panic!("OCR-only assets must be released")
+    }
+    fn write_asset(&mut self, _: &[u8]) -> Result<(), ConversionError> {
+        panic!("OCR-only assets must be released")
+    }
+    fn end_asset(&mut self) -> Result<(), ConversionError> {
+        panic!("OCR-only assets must be released")
+    }
+}
+
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn prepared_page_failure_and_cancellation_do_not_publish_partial_output() {
+    for cancel in [false, true] {
+        let token = CancellationToken::new();
+        let pages = Arc::new(ObservedPages {
+            stop_at: Some(2),
+            cancel: cancel.then(|| token.clone()),
+            ..Default::default()
+        });
+        let engine = engine(pages.clone(), Arc::new(Recognizer::default()));
+        let request = request(3);
+        let context = ExecutionContext::new(
+            ExecutionOptions { cancellation: token, ..ExecutionOptions::default() },
+            request.options.limits.clone(),
+        );
+        let mut sink = MarkdownSink::default();
+        let prepared = block_on(engine.prepare_into_with_context(
+            request,
+            context.clone(),
+            sink.capabilities(),
+        ))
+        .unwrap();
+        assert!(pages.entries.lock().unwrap().is_empty());
+        let error = block_on(engine.execute_prepared_into(prepared, &mut sink)).unwrap_err();
+        assert!(if cancel {
+            matches!(error, ConversionError::Cancelled)
+        } else {
+            matches!(error, ConversionError::Malformed { .. })
+        });
+        assert_eq!(pages.entries.lock().unwrap().len(), 2);
+        assert!(sink.0.is_empty());
+        assert_eq!(context.reserved_memory_bytes(), 0);
+        assert_eq!(context.reserved_temporary_bytes(), 0);
+    }
+}
+
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn prepared_path_is_single_execution_and_keeps_body_in_page_order() {
+    let pages = Arc::new(ObservedPages::default());
+    let engine = engine(pages.clone(), Arc::new(Recognizer::default()));
+    let request = request(3);
+    let context =
+        ExecutionContext::new(ExecutionOptions::default(), request.options.limits.clone());
+    let mut sink = MarkdownSink::default();
+    let prepared =
+        block_on(engine.prepare_into_with_context(request, context.clone(), sink.capabilities()))
+            .unwrap();
+    assert!(pages.entries.lock().unwrap().is_empty());
+    let summary = block_on(engine.execute_prepared_into(prepared, &mut sink)).unwrap();
+    assert_eq!(
+        pages.entries.lock().unwrap().iter().map(|entry| entry.0).collect::<Vec<_>>(),
+        [1, 2, 3]
+    );
+    assert!(String::from_utf8(sink.0).unwrap().contains("recognized body"));
+    assert_eq!(summary.assets, 0);
+    drop(summary);
+    assert_eq!(context.reserved_memory_bytes(), 0);
+}
+
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn permanent_assets_still_obey_document_total_budget() {
+    for mode in [into_markdown_core::AssetMode::Extract, into_markdown_core::AssetMode::Embed] {
+        let mut request = request(3);
+        request.options.output.asset_mode = mode;
+        let pages = Arc::new(ObservedPages::default());
+        let engine = engine(pages.clone(), Arc::new(Recognizer::default()));
+        let context =
+            ExecutionContext::new(ExecutionOptions::default(), request.options.limits.clone());
+        assert!(matches!(
+            block_on(engine.convert_with_context(request, context.clone())),
+            Err(ConversionError::ResourceLimit { limit: "max_total_asset_bytes", .. })
+        ));
+        assert!(pages.entries.lock().unwrap().is_empty());
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+}

--- a/crates/converters/src/pdf/page_lifetime_tests.rs
+++ b/crates/converters/src/pdf/page_lifetime_tests.rs
@@ -82,12 +82,12 @@ impl OcrEngine for Recognizer {
                     OcrEvidenceStep {
                         stage: OcrEvidenceStage::Detection,
                         provider: self.id().into(),
-                        model: None,
+                        model: Some("test-detector".into()),
                     },
                     OcrEvidenceStep {
                         stage: OcrEvidenceStage::Recognition,
                         provider: self.id().into(),
-                        model: None,
+                        model: Some("test-recognizer".into()),
                     },
                 ],
                 identity,
@@ -438,6 +438,8 @@ fn identical_scanned_pages_reuse_recognition_without_retaining_pixels() {
     let result = block_on(engine.convert_with_context(request, context.clone())).unwrap();
     assert_eq!(ocr.0.load(Ordering::SeqCst), 1);
     assert_eq!(result.markdown.matches("recognized body 1").count(), 4);
+    assert_eq!(context.resource_usage().ocr_recognized_regions, 1);
+    assert_eq!(context.resource_usage().ocr_recognized_chars, 17);
     assert_eq!(result.document.blocks.len(), 4);
     assert!(result.assets.is_empty());
     for (index, node) in result.document.blocks.iter().enumerate() {

--- a/crates/converters/src/pdf/page_lifetime_tests.rs
+++ b/crates/converters/src/pdf/page_lifetime_tests.rs
@@ -50,6 +50,16 @@ impl OcrEngine for Recognizer {
         _: &'a ExecutionContext,
     ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
         Box::pin(async move {
+            let mut yielded = false;
+            std::future::poll_fn(|task| {
+                if std::mem::replace(&mut yielded, true) {
+                    std::task::Poll::Ready(())
+                } else {
+                    task.waker().wake_by_ref();
+                    std::task::Poll::Pending
+                }
+            })
+            .await;
             let ordinal = self.0.fetch_add(1, Ordering::SeqCst) + 1;
             let image = image::load_from_memory(request.image).unwrap();
             let identity = OcrInputIdentity::try_new(
@@ -185,10 +195,15 @@ fn request(page_count: u32) -> ConversionRequest {
         },
         hint: FormatHint { format: Some(InputFormat::Pdf), ..FormatHint::default() },
         options,
+        execution: ExecutionOptions::default(),
     }
 }
 
 fn scanned_pages(count: u32) -> Vec<u8> {
+    scanned_page_variants(count, false)
+}
+
+fn scanned_page_variants(count: u32, repeated: bool) -> Vec<u8> {
     let kids =
         (0..count).map(|index| format!("{} 0 R", 3 + index * 3)).collect::<Vec<_>>().join(" ");
     let mut objects = vec![
@@ -197,10 +212,11 @@ fn scanned_pages(count: u32) -> Vec<u8> {
     ];
     for index in 0..count {
         let page = 3 + index * 3;
-        let rotation = if index % 2 == 0 { 0 } else { 90 };
+        let variant = if repeated { 0 } else { index };
+        let rotation = if variant % 2 == 0 { 0 } else { 90 };
         objects.push(format!("<< /Type /Page /Parent 2 0 R /Rotate {rotation} /MediaBox [0 0 100 200] /Resources << /XObject << /Im1 {} 0 R >> >> /Contents {} 0 R >>", page + 2, page + 1).into_bytes());
         objects.push(stream_object("", b"q 100 0 0 200 0 0 cm /Im1 Do Q\n"));
-        objects.push(stream_object("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[u8::try_from(index + 1).unwrap(), 0, 0]));
+        objects.push(stream_object("/Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8", &[u8::try_from(variant + 1).unwrap(), 0, 0]));
     }
     assemble_pdf(&objects)
 }
@@ -360,4 +376,83 @@ fn permanent_assets_still_obey_document_total_budget() {
         assert!(pages.entries.lock().unwrap().is_empty());
         assert_eq!(context.reserved_memory_bytes(), 0);
     }
+}
+
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn mixed_pdf_modes_yield_runtime_admission_on_one_executor() {
+    for mode in [into_markdown_core::AssetMode::Omit, into_markdown_core::AssetMode::Extract] {
+        let pages = Arc::new(ObservedPages::default());
+        let ocr = Arc::new(Recognizer::default());
+        let engine = engine(pages, ocr.clone());
+        let scanning = request(1);
+        let mut aggregate = request(1);
+        aggregate.options.ocr.policy = into_markdown_core::OcrPolicy::Off;
+        aggregate.options.output.asset_mode = mode;
+        let scanning_context = ExecutionContext::new(
+            ExecutionOptions {
+                timeout: Some(std::time::Duration::from_secs(5)),
+                ..ExecutionOptions::default()
+            },
+            scanning.options.limits.clone(),
+        );
+        let aggregate_context = ExecutionContext::new(
+            ExecutionOptions {
+                timeout: Some(std::time::Duration::from_secs(5)),
+                ..ExecutionOptions::default()
+            },
+            aggregate.options.limits.clone(),
+        );
+        // Recognizer yields while owning PDFium. A synchronous permit wait in
+        // the aggregate future would prevent the first future from resuming.
+        let (scan, plain) = block_on(async {
+            futures::join!(
+                engine.convert_with_context(scanning, scanning_context.clone()),
+                engine.convert_with_context(aggregate, aggregate_context.clone()),
+            )
+        });
+        let scan = scan.unwrap();
+        let plain = plain.unwrap();
+        assert!(scan.markdown.contains("recognized body"));
+        assert_eq!(plain.document.blocks.len(), 1);
+        assert_eq!(ocr.0.load(Ordering::SeqCst), 1);
+        drop((scan, plain));
+        assert_eq!(scanning_context.reserved_memory_bytes(), 0);
+        assert_eq!(aggregate_context.reserved_memory_bytes(), 0);
+    }
+}
+
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn identical_scanned_pages_reuse_recognition_without_retaining_pixels() {
+    let pages = Arc::new(ObservedPages::default());
+    let ocr = Arc::new(Recognizer::default());
+    let engine = engine(pages.clone(), ocr.clone());
+    let mut request = request(4);
+    request.input = InputRef::Bytes {
+        data: Arc::from(scanned_page_variants(4, true)),
+        name: Some("repeated.pdf".into()),
+    };
+    let context =
+        ExecutionContext::new(ExecutionOptions::default(), request.options.limits.clone());
+    let result = block_on(engine.convert_with_context(request, context.clone())).unwrap();
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 1);
+    assert_eq!(result.markdown.matches("recognized body 1").count(), 4);
+    assert_eq!(result.document.blocks.len(), 4);
+    assert!(result.assets.is_empty());
+    for (index, node) in result.document.blocks.iter().enumerate() {
+        assert!(
+            matches!(node.block, Block::Page { number, .. } if usize::try_from(number).unwrap() == index + 1)
+        );
+        assert!(serde_json::to_string(node).unwrap().contains("recognized body 1"));
+    }
+    let entries = pages.entries.lock().unwrap();
+    assert_eq!(entries.len(), 4);
+    assert!(
+        entries.last().unwrap().2 < entries[0].2 + 512 * 1024,
+        "cached contributions must not retain source pixels: {entries:?}"
+    );
+    drop(result);
+    assert_eq!(context.reserved_memory_bytes(), 0);
+    assert_eq!(context.reserved_temporary_bytes(), 0);
 }

--- a/crates/converters/src/pdf/pages.rs
+++ b/crates/converters/src/pdf/pages.rs
@@ -1,0 +1,508 @@
+//! Shared page extraction and layout for aggregate and OCR-only PDF execution.
+
+#[cfg(test)]
+use super::IMAGE_BITMAP_MATERIALIZATIONS;
+use super::{
+    Asset, AssetId, Block, BlockNode, ConversionError, ConversionOptions, ConverterOutput,
+    Diagnostic, DiagnosticSeverity, Document, ErrorPolicy, ExecutionContext, HashSet, Inline,
+    Limits, MAX_RENDER_DIMENSION, MIN_NATIVE_TEXT_CHARS, MIN_SCAN_IMAGE_COVERAGE, NodeId,
+    OcrPolicy, PageCoverage, Path, Pdfium, Rect, ResourceReservation, account_asset,
+    allocation_capacity_bound, asset_record_overhead, character_working_set_bytes, checked_count,
+    content_asset_id, diagnostic_overhead, displayed_dimensions, image_bitmap_to_bmp,
+    image_pixels_required, map_pdfium_error, materialize_after_reserve, normalize_rect,
+    output_block_overhead, page_locator, provenance, render_dimensions, rendered_bitmap_to_bmp,
+    request_path_scan, resource, retain_existing_reservation, retain_output_bytes,
+    safe_link_target, text_block,
+};
+
+#[derive(Default)]
+pub(super) struct Counts {
+    pub(super) asset_bytes: u64,
+    pub(super) asset_ids: HashSet<String>,
+    nodes: usize,
+    inlines: usize,
+    page_objects: usize,
+}
+
+pub(super) struct PdfOutput {
+    document: Document,
+    assets: Vec<Asset>,
+    diagnostics: Vec<Diagnostic>,
+    retained_memory: Vec<ResourceReservation>,
+    path_evidence: Vec<into_markdown_pdf_layout::PagePathEvidence>,
+    path_memory: Vec<ResourceReservation>,
+}
+
+pub(super) fn load_runtime(
+    runtime_path: &Path,
+    options: &ConversionOptions,
+) -> Result<Pdfium, ConversionError> {
+    let bitmap_limit =
+        options.limits.max_asset_bytes.min(options.limits.max_memory_bytes).min(400_000_000);
+    let limits = Limits {
+        max_document_bytes: options.limits.max_input_bytes.min(1024 * 1024 * 1024),
+        max_pages: options.limits.max_pages,
+        max_text_units_per_page: u32::try_from(into_markdown_core::MAX_DOCUMENT_INLINES)
+            .unwrap_or(u32::MAX),
+        max_render_dimension: MAX_RENDER_DIMENSION,
+        max_render_pixels: bitmap_limit / 4,
+        max_images_per_page: 10_000,
+        max_page_objects: u32::try_from(into_markdown_core::MAX_DOCUMENT_NODES).unwrap_or(u32::MAX),
+        max_password_bytes: 1024,
+        max_bitmap_bytes: bitmap_limit,
+        max_links_per_page: 10_000,
+        max_link_bytes: 8 * 1024,
+        max_font_name_bytes: 4 * 1024,
+    };
+    Pdfium::load_pinned(runtime_path, limits).map_err(map_pdfium_error)
+}
+
+impl PdfOutput {
+    pub(super) fn new(pages: u32, context: &ExecutionContext) -> Result<Self, ConversionError> {
+        let path_page_capacity =
+            allocation_capacity_bound(usize::try_from(pages).unwrap_or(usize::MAX))?;
+        let path_page_bytes = path_page_capacity
+            .checked_mul(std::mem::size_of::<into_markdown_pdf_layout::PagePathEvidence>())
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .ok_or_else(|| resource("max_memory_bytes", "PDF path page inventory overflow"))?;
+        let path_page_memory = context.reserve_memory(path_page_bytes)?;
+        let mut path_evidence = Vec::new();
+        path_evidence.try_reserve_exact(path_page_capacity).map_err(|_| {
+            resource("max_memory_bytes", "PDF path page inventory allocation failed")
+        })?;
+        if path_evidence.capacity() > path_page_capacity {
+            return Err(resource(
+                "max_memory_bytes",
+                "PDF path page inventory capacity exceeded its plan",
+            ));
+        }
+        let mut path_memory = Vec::new();
+        retain_existing_reservation(context, &mut path_memory, path_page_memory)?;
+        Ok(Self {
+            document: Document::default(),
+            assets: Vec::new(),
+            diagnostics: Vec::new(),
+            retained_memory: Vec::new(),
+            path_evidence,
+            path_memory,
+        })
+    }
+
+    #[allow(clippy::too_many_lines)]
+    pub(super) fn extract_page(
+        self,
+        pdf: &into_markdown_pdfium::Document<'_>,
+        page_index: u32,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+        counts: &mut Counts,
+        ocr_only: bool,
+    ) -> Result<Self, ConversionError> {
+        let Self {
+            mut document,
+            mut assets,
+            mut diagnostics,
+            mut retained_memory,
+            mut path_evidence,
+            mut path_memory,
+        } = self;
+        let retain_image_pixels = image_pixels_required(options);
+        context.checkpoint()?;
+        let page_number = page_index + 1;
+        let page = pdf.page(page_index).map_err(map_pdfium_error)?;
+        counts.page_objects = checked_count(
+            counts.page_objects,
+            usize::try_from(page.object_count().map_err(map_pdfium_error)?).unwrap_or(usize::MAX),
+            into_markdown_core::MAX_DOCUMENT_NODES,
+            "pdfPageObjects",
+        )?;
+        let info = page.info().map_err(map_pdfium_error)?;
+        let path_plan = request_path_scan(context, |checkpoint| {
+            page.plan_path_bounds_with_checkpoint(checkpoint)
+        })?;
+        let path_allocation_bytes = path_plan.allocation_bytes();
+        let (raw_path_bounds, raw_path_memory) =
+            materialize_after_reserve(context, path_allocation_bytes, || {
+                request_path_scan(context, |checkpoint| {
+                    path_plan.materialize_with_checkpoint(checkpoint)
+                })
+            })?;
+        let path_capacity = allocation_capacity_bound(raw_path_bounds.len())?;
+        let normalized_path_bytes = path_capacity
+            .checked_mul(std::mem::size_of::<Rect>())
+            .and_then(|bytes| u64::try_from(bytes).ok())
+            .ok_or_else(|| resource("max_memory_bytes", "PDF path bounds allocation overflow"))?;
+        let normalized_path_memory = context.reserve_memory(normalized_path_bytes)?;
+        let mut normalized_paths = Vec::new();
+        normalized_paths
+            .try_reserve_exact(path_capacity)
+            .map_err(|_| resource("max_memory_bytes", "PDF path bounds allocation failed"))?;
+        if normalized_paths.capacity() > path_capacity {
+            return Err(resource("max_memory_bytes", "PDF path bounds capacity exceeded its plan"));
+        }
+        for bounds in raw_path_bounds {
+            context.checkpoint()?;
+            normalized_paths.push(normalize_rect(bounds, &info)?);
+        }
+        drop(raw_path_memory);
+        if normalized_paths.is_empty() {
+            drop(normalized_path_memory);
+        } else {
+            retain_existing_reservation(context, &mut path_memory, normalized_path_memory)?;
+            path_evidence.push(into_markdown_pdf_layout::PagePathEvidence {
+                page: page_number,
+                bounds: normalized_paths,
+            });
+        }
+        let text_page = page.text_page().map_err(map_pdfium_error)?;
+        let character_plan = text_page.plan_characters().map_err(map_pdfium_error)?;
+        let character_count = character_plan.count();
+        let character_budget = character_working_set_bytes(
+            character_plan.allocation_bytes(),
+            character_plan.retained_font_bytes(),
+            character_count,
+        )?;
+        let (characters, character_memory) =
+            materialize_after_reserve(context, character_budget, || {
+                character_plan.materialize().map_err(map_pdfium_error)
+            })?;
+        retain_existing_reservation(context, &mut retained_memory, character_memory)?;
+        counts.inlines = checked_count(
+            counts.inlines,
+            characters.len(),
+            into_markdown_core::MAX_DOCUMENT_INLINES,
+            "documentInlines",
+        )?;
+        let mut blocks = Vec::new();
+        if !characters.is_empty() {
+            counts.nodes = checked_count(
+                counts.nodes,
+                1,
+                into_markdown_core::MAX_DOCUMENT_NODES,
+                "documentNodes",
+            )?;
+            blocks
+                .try_reserve(1)
+                .map_err(|_| resource("max_memory_bytes", "PDF block allocation failed"))?;
+            blocks.push(text_block(page_number, &info, &characters)?);
+        }
+        let link_plan = text_page.plan_links().map_err(map_pdfium_error)?;
+        let link_plan_bytes = link_plan.allocation_bytes();
+        let (links, link_memory) = materialize_after_reserve(context, link_plan_bytes, || {
+            link_plan.materialize().map_err(map_pdfium_error)
+        })?;
+        for (link_index, link) in links.into_iter().enumerate() {
+            counts.nodes = checked_count(
+                counts.nodes,
+                1,
+                into_markdown_core::MAX_DOCUMENT_NODES,
+                "documentNodes",
+            )?;
+            counts.inlines = checked_count(
+                counts.inlines,
+                2,
+                into_markdown_core::MAX_DOCUMENT_INLINES,
+                "documentInlines",
+            )?;
+            let target_length = match &link.target {
+                LinkTarget::ExternalUri(value) => value.len(),
+                LinkTarget::InternalPage { .. } => 32,
+            };
+            let link_ir_bytes = u64::try_from(target_length)
+                .unwrap_or(u64::MAX)
+                .checked_mul(2)
+                .and_then(|bytes| bytes.checked_add(output_block_overhead(2).ok()?))
+                .ok_or_else(|| resource("max_memory_bytes", "link IR memory overflow"))?;
+            retain_output_bytes(context, &mut retained_memory, link_ir_bytes)?;
+            let display_text = match &link.target {
+                LinkTarget::ExternalUri(value) => Some(value.clone()),
+                LinkTarget::InternalPage { .. } => None,
+            };
+            let target = match safe_link_target(link.target, pdf.page_count()) {
+                Ok(target) => target,
+                Err(error) if options.error_policy == ErrorPolicy::Strict => return Err(error),
+                Err(error) => {
+                    diagnostics.push(Diagnostic {
+                        code: "pdf.linkOmitted".into(),
+                        severity: DiagnosticSeverity::Warning,
+                        message: error.to_string(),
+                        locator: Some(page_locator(page_number, &info)),
+                    });
+                    if let Some(value) = display_text {
+                        blocks.try_reserve(1).map_err(|_| {
+                            resource("max_memory_bytes", "PDF block allocation failed")
+                        })?;
+                        blocks.push(BlockNode {
+                            id: NodeId(format!("pdf-page-{page_number}-link-{link_index}")),
+                            block: Block::Paragraph(vec![Inline::Text {
+                                value,
+                                marks: Vec::new(),
+                            }]),
+                            provenance: provenance(
+                                page_number,
+                                Some(normalize_rect(link.bounds, &info)?),
+                                None,
+                                &info,
+                            )?,
+                        });
+                    }
+                    continue;
+                }
+            };
+            blocks
+                .try_reserve(1)
+                .map_err(|_| resource("max_memory_bytes", "PDF block allocation failed"))?;
+            blocks.push(BlockNode {
+                id: NodeId(format!("pdf-page-{page_number}-link-{link_index}")),
+                block: Block::Paragraph(vec![Inline::Link {
+                    target: target.clone(),
+                    content: vec![Inline::Text { value: target, marks: Vec::new() }],
+                }]),
+                provenance: provenance(
+                    page_number,
+                    Some(normalize_rect(link.bounds, &info)?),
+                    None,
+                    &info,
+                )?,
+            });
+        }
+        drop(link_memory);
+
+        let mut coverage = PageCoverage::default();
+        let image_plan = page.plan_images().map_err(map_pdfium_error)?;
+        let image_plan_bytes = image_plan.allocation_bytes();
+        let (images, image_metadata_memory) =
+            materialize_after_reserve(context, image_plan_bytes, || {
+                image_plan.materialize().map_err(map_pdfium_error)
+            })?;
+        for image in &images {
+            context.checkpoint()?;
+            coverage.add(normalize_rect(image.bounds(), &info)?, &info);
+        }
+        let printable = characters
+            .iter()
+            .filter(|character| !character.value.is_control() && !character.value.is_whitespace())
+            .count();
+        let scanned =
+            printable < MIN_NATIVE_TEXT_CHARS && coverage.ratio() >= MIN_SCAN_IMAGE_COVERAGE;
+        let render_requested = options.ocr.policy == OcrPolicy::Always
+            || (options.ocr.policy == OcrPolicy::Auto && scanned);
+        for image in images {
+            context.checkpoint()?;
+            // A full displayed-page render already includes every embedded
+            // image. Do not decode or recognize that same page a second time
+            // when no permanent image output was requested.
+            if ocr_only && render_requested {
+                continue;
+            }
+            let bounds = normalize_rect(image.bounds(), &info)?;
+            let id = if retain_image_pixels {
+                #[cfg(test)]
+                IMAGE_BITMAP_MATERIALIZATIONS.set(IMAGE_BITMAP_MATERIALIZATIONS.get() + 1);
+                let bitmap_plan = image.plan_bitmap().map_err(map_pdfium_error)?;
+                let bitmap_plan_bytes = bitmap_plan.allocation_bytes();
+                let (bitmap, bitmap_memory) =
+                    materialize_after_reserve(context, bitmap_plan_bytes, || {
+                        bitmap_plan.materialize().map_err(map_pdfium_error)
+                    })?;
+                let (encoded, encoded_memory) = image_bitmap_to_bmp(&bitmap, options, context)?;
+                drop(bitmap);
+                drop(bitmap_memory);
+                account_asset(&encoded, &mut counts.asset_bytes, options)?;
+                retain_output_bytes(context, &mut retained_memory, asset_record_overhead()?)?;
+                let id = content_asset_id("pdf-image", &encoded)?;
+                counts
+                    .asset_ids
+                    .try_reserve(1)
+                    .map_err(|_| resource("max_memory_bytes", "asset ID allocation failed"))?;
+                if counts.asset_ids.insert(id.clone()) {
+                    retain_existing_reservation(context, &mut retained_memory, encoded_memory)?;
+                    assets.try_reserve(1).map_err(|_| {
+                        resource("max_memory_bytes", "asset inventory allocation failed")
+                    })?;
+                    assets.push(Asset {
+                        id: AssetId(id.clone()),
+                        filename: Some(format!("{id}.bmp")),
+                        media_type: "image/bmp".into(),
+                        bytes: encoded,
+                        external_uri: None,
+                    });
+                }
+                id
+            } else {
+                // Preserve image geometry through reading-order reconstruction.
+                // This transient reference is removed before publishing the IR.
+                "pdf-omitted-image".into()
+            };
+            counts.nodes = checked_count(
+                counts.nodes,
+                1,
+                into_markdown_core::MAX_DOCUMENT_NODES,
+                "documentNodes",
+            )?;
+            retain_output_bytes(context, &mut retained_memory, output_block_overhead(0)?)?;
+            blocks
+                .try_reserve(1)
+                .map_err(|_| resource("max_memory_bytes", "PDF block allocation failed"))?;
+            blocks.push(BlockNode {
+                id: NodeId(format!("pdf-page-{page_number}-image-{}", image.index())),
+                block: Block::Image { asset: AssetId(id), alt: None },
+                provenance: provenance(page_number, Some(bounds), None, &info)?,
+            });
+        }
+        drop(image_metadata_memory);
+
+        if render_requested {
+            let (width, height) = render_dimensions(&info)?;
+            let (page_width, page_height) = displayed_dimensions(&info);
+            let render_bytes = u64::from(width)
+                .checked_mul(u64::from(height))
+                .and_then(|pixels| pixels.checked_mul(4))
+                .and_then(|bytes| bytes.checked_mul(2))
+                .ok_or_else(|| resource("max_memory_bytes", "render working set overflow"))?;
+            let bitmap_memory = context.reserve_memory(render_bytes)?;
+            let bitmap = page.render_bgra(width, height).map_err(map_pdfium_error)?;
+            let (encoded, encoded_memory) = rendered_bitmap_to_bmp(&bitmap, options, context)?;
+            drop(bitmap);
+            drop(bitmap_memory);
+            account_asset(&encoded, &mut counts.asset_bytes, options)?;
+            retain_output_bytes(context, &mut retained_memory, asset_record_overhead()?)?;
+            let id = content_asset_id("pdf-page-render", &encoded)?;
+            counts
+                .asset_ids
+                .try_reserve(1)
+                .map_err(|_| resource("max_memory_bytes", "asset ID allocation failed"))?;
+            if counts.asset_ids.insert(id.clone()) {
+                retain_existing_reservation(context, &mut retained_memory, encoded_memory)?;
+                assets.try_reserve(1).map_err(|_| {
+                    resource("max_memory_bytes", "asset inventory allocation failed")
+                })?;
+                assets.push(Asset {
+                    id: AssetId(id.clone()),
+                    filename: Some(format!("{id}.bmp")),
+                    media_type: "image/bmp".into(),
+                    bytes: encoded,
+                    external_uri: None,
+                });
+            }
+            counts.nodes = checked_count(
+                counts.nodes,
+                1,
+                into_markdown_core::MAX_DOCUMENT_NODES,
+                "documentNodes",
+            )?;
+            retain_output_bytes(context, &mut retained_memory, output_block_overhead(0)?)?;
+            blocks
+                .try_reserve(1)
+                .map_err(|_| resource("max_memory_bytes", "PDF block allocation failed"))?;
+            let mut rendered_provenance = provenance(
+                page_number,
+                Some(Rect { x: 0.0, y: 0.0, width: page_width, height: page_height }),
+                None,
+                &info,
+            )?;
+            // PDFium already applied page rotation to this displayed-page
+            // bitmap. The OCR frame must not rotate its polygons a second time.
+            rendered_provenance.locator.rotation_degrees = Some(0.0);
+            blocks.push(BlockNode {
+                id: NodeId(format!("pdf-page-{page_number}-ocr-render")),
+                block: Block::Image { asset: AssetId(id), alt: Some("page render for OCR".into()) },
+                provenance: rendered_provenance,
+            });
+        }
+        if scanned {
+            retain_output_bytes(context, &mut retained_memory, diagnostic_overhead()?)?;
+            diagnostics
+                .try_reserve(1)
+                .map_err(|_| resource("max_memory_bytes", "diagnostic allocation failed"))?;
+            diagnostics.push(Diagnostic {
+                code: "pdf.scannedPage".into(),
+                severity: DiagnosticSeverity::Info,
+                message: format!(
+                    "page {page_number} has fewer than {MIN_NATIVE_TEXT_CHARS} printable native characters and image coverage of at least 50%"
+                ),
+                locator: Some(page_locator(page_number, &info)),
+            });
+        }
+        counts.nodes = checked_count(
+            counts.nodes,
+            1,
+            into_markdown_core::MAX_DOCUMENT_NODES,
+            "documentNodes",
+        )?;
+        retain_output_bytes(context, &mut retained_memory, output_block_overhead(0)?)?;
+        document
+            .blocks
+            .try_reserve(1)
+            .map_err(|_| resource("max_memory_bytes", "page allocation failed"))?;
+        document.blocks.push(BlockNode {
+            id: NodeId(format!("pdf-page-{page_number}")),
+            block: Block::Page { number: page_number, blocks },
+            provenance: provenance(page_number, None, None, &info)?,
+        });
+        Ok(Self { document, assets, diagnostics, retained_memory, path_evidence, path_memory })
+    }
+
+    pub(super) fn finish(
+        self,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<ConverterOutput, ConversionError> {
+        let Self {
+            mut document,
+            assets,
+            diagnostics,
+            mut retained_memory,
+            path_evidence,
+            path_memory,
+        } = self;
+        let retain_image_pixels = image_pixels_required(options);
+        let layout_config = into_markdown_pdf_layout::LayoutConfig {
+            limits: into_markdown_pdf_layout::LayoutLimits {
+                max_atoms: into_markdown_core::MAX_DOCUMENT_INLINES,
+                max_lines: into_markdown_core::MAX_DOCUMENT_NODES,
+                max_comparisons: 12_000_000,
+                max_table_columns: usize::try_from(options.limits.max_table_columns)
+                    .unwrap_or(usize::MAX)
+                    .min(into_markdown_core::MAX_TABLE_COLUMNS),
+                max_table_cells: usize::try_from(options.limits.max_table_cells)
+                    .unwrap_or(usize::MAX)
+                    .min(into_markdown_core::MAX_DOCUMENT_NODES),
+            },
+        };
+        let layout = into_markdown_pdf_layout::reconstruct_document_with_path_evidence(
+            document,
+            &layout_config,
+            &path_evidence,
+            context,
+        )?;
+        let (rebuilt_document, layout_reservation) = layout.into_parts();
+        drop(path_evidence);
+        drop(path_memory);
+        document = rebuilt_document;
+        if !retain_image_pixels {
+            for page in &mut document.blocks {
+                if let Block::Page { blocks, .. } = &mut page.block {
+                    blocks.retain(|node| !matches!(node.block, Block::Image { .. }));
+                }
+            }
+        }
+        if let Some(reservation) = layout_reservation {
+            retain_existing_reservation(context, &mut retained_memory, reservation)?;
+        }
+        let validation_bytes =
+            into_markdown_core::estimate_validation_working_set(&document, &assets, &diagnostics)?;
+        let validation_memory = context.reserve_memory(validation_bytes)?;
+        document.validate().map_err(|error| ConversionError::Internal {
+            detail: format!("PDF converter emitted invalid IR at {}: {}", error.path, error.detail),
+        })?;
+        drop(validation_memory);
+        let output = ConverterOutput::new_with_memory_reservations(
+            document,
+            assets,
+            diagnostics,
+            retained_memory,
+        );
+        output.account_retained(context)
+    }
+}

--- a/crates/converters/src/pdf/pages.rs
+++ b/crates/converters/src/pdf/pages.rs
@@ -5,8 +5,8 @@ use super::IMAGE_BITMAP_MATERIALIZATIONS;
 use super::{
     Asset, AssetId, Block, BlockNode, ConversionError, ConversionOptions, ConverterOutput,
     Diagnostic, DiagnosticSeverity, Document, ErrorPolicy, ExecutionContext, HashSet, Inline,
-    Limits, MAX_RENDER_DIMENSION, MIN_NATIVE_TEXT_CHARS, MIN_SCAN_IMAGE_COVERAGE, NodeId,
-    OcrPolicy, PageCoverage, Path, Pdfium, Rect, ResourceReservation, account_asset,
+    Limits, LinkTarget, MAX_RENDER_DIMENSION, MIN_NATIVE_TEXT_CHARS, MIN_SCAN_IMAGE_COVERAGE,
+    NodeId, OcrPolicy, PageCoverage, Path, Pdfium, Rect, ResourceReservation, account_asset,
     allocation_capacity_bound, asset_record_overhead, character_working_set_bytes, checked_count,
     content_asset_id, diagnostic_overhead, displayed_dimensions, image_bitmap_to_bmp,
     image_pixels_required, map_pdfium_error, materialize_after_reserve, normalize_rect,

--- a/crates/converters/src/pdf/runtime.rs
+++ b/crates/converters/src/pdf/runtime.rs
@@ -1,22 +1,61 @@
-use super::{
-    ConversionError, Duration, ExecutionContext, Mutex, MutexGuard, PDF_CONVERSION_GATE,
-    TryLockError,
-};
+use super::{ConversionError, ExecutionContext};
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Poll, Waker};
+use std::time::Duration;
+
+static PDF_CONVERSION_ACTIVE: AtomicBool = AtomicBool::new(false);
+static WAITERS: Mutex<Vec<Waker>> = Mutex::new(Vec::new());
+
+// PDFium admits only one live runtime. This permit owns that lifetime, not a
+// thread-bound mutex guard: OCR may await while the document stays open.
+pub(super) struct PdfConversionPermit;
+
+impl Drop for PdfConversionPermit {
+    fn drop(&mut self) {
+        let mut waiters = WAITERS.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        PDF_CONVERSION_ACTIVE.store(false, Ordering::Release);
+        let ready = std::mem::take(&mut *waiters);
+        drop(waiters);
+        for waker in ready {
+            waker.wake();
+        }
+    }
+}
+
+pub(super) async fn acquire_pdf_conversion(
+    context: &ExecutionContext,
+) -> Result<PdfConversionPermit, ConversionError> {
+    std::future::poll_fn(|task| {
+        context.checkpoint()?;
+        // Serialize registration with release so no wakeup can be lost.
+        let mut waiters = WAITERS.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if PDF_CONVERSION_ACTIVE
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+        {
+            Poll::Ready(Ok(PdfConversionPermit))
+        } else {
+            if !waiters.iter().any(|waker| waker.will_wake(task.waker())) {
+                waiters.push(task.waker().clone());
+            }
+            Poll::Pending
+        }
+    })
+    .await
+}
 
 pub(super) fn lock_pdf_conversion(
     context: &ExecutionContext,
-) -> Result<MutexGuard<'static, ()>, ConversionError> {
-    let gate = PDF_CONVERSION_GATE.get_or_init(|| Mutex::new(()));
+) -> Result<PdfConversionPermit, ConversionError> {
     loop {
         context.checkpoint()?;
-        match gate.try_lock() {
-            Ok(guard) => return Ok(guard),
-            Err(TryLockError::WouldBlock) => std::thread::sleep(Duration::from_millis(2)),
-            Err(TryLockError::Poisoned(_)) => {
-                return Err(ConversionError::Internal {
-                    detail: "PDF conversion gate is poisoned".into(),
-                });
-            }
+        if PDF_CONVERSION_ACTIVE
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_ok()
+        {
+            return Ok(PdfConversionPermit);
         }
+        std::thread::sleep(Duration::from_millis(2));
     }
 }

--- a/crates/converters/src/pdf/runtime.rs
+++ b/crates/converters/src/pdf/runtime.rs
@@ -2,6 +2,7 @@ use super::{ConversionError, ExecutionContext};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::task::{Poll, Waker};
+#[cfg(test)]
 use std::time::Duration;
 
 static PDF_CONVERSION_ACTIVE: AtomicBool = AtomicBool::new(false);
@@ -45,6 +46,7 @@ pub(super) async fn acquire_pdf_conversion(
     .await
 }
 
+#[cfg(test)]
 pub(super) fn lock_pdf_conversion(
     context: &ExecutionContext,
 ) -> Result<PdfConversionPermit, ConversionError> {

--- a/crates/converters/src/pdf/stream.rs
+++ b/crates/converters/src/pdf/stream.rs
@@ -1,0 +1,169 @@
+//! Page-bounded OCR-only pixel lifetime; final semantic ownership moves once.
+
+use super::{
+    PdfConverter, convert_pdf, image_pixels_required, open_document, pages,
+    runtime::acquire_pdf_conversion,
+};
+use into_markdown_core::{
+    AiMode, AssetMode, Block, BlockNode, ConversionError, ConversionOptions, ConverterEventSink,
+    ConverterOutput, ConverterStream, ConverterStreamCompletion, ConverterStreamMode, Diagnostic,
+    ExecutionContext, FormatCandidate, LocalBoxFuture, ResolvedInput, Services, StreamConsumerKind,
+    estimate_retained_output, stream_converter_output,
+};
+
+fn ocr_only_pixels(options: &ConversionOptions) -> bool {
+    options.output.asset_mode == AssetMode::Omit
+        && image_pixels_required(options)
+        && [
+            options.ai.image_description,
+            options.ai.layout_repair,
+            options.ai.table_repair,
+            options.ai.formula_repair,
+        ]
+        .iter()
+        .all(|mode| *mode == AiMode::Off)
+}
+
+impl ConverterStream for PdfConverter {
+    fn stream_mode_for(
+        &self,
+        _: &ResolvedInput,
+        _: &FormatCandidate,
+        options: &ConversionOptions,
+        _: StreamConsumerKind,
+    ) -> ConverterStreamMode {
+        if ocr_only_pixels(options) {
+            ConverterStreamMode::Native
+        } else {
+            ConverterStreamMode::AggregateAdapter
+        }
+    }
+
+    fn convert_stream<'a>(
+        &'a self,
+        input: &'a ResolvedInput,
+        _: &'a FormatCandidate,
+        options: &'a ConversionOptions,
+        _: &'a Services,
+        context: &'a ExecutionContext,
+        sink: &'a mut dyn ConverterEventSink,
+    ) -> LocalBoxFuture<'a, Result<ConverterStreamCompletion, ConversionError>> {
+        Box::pin(async move {
+            let path = self.runtime_path()?;
+            if !ocr_only_pixels(options) || !sink.supports_page_enrichment() {
+                return stream_converter_output(convert_pdf(&path, input, options, context)?, sink);
+            }
+            let _permit = acquire_pdf_conversion(context).await?;
+            let runtime = pages::load_runtime(&path, options)?;
+            let pdf = open_document(&runtime, input, context)?;
+            let mut counts = pages::Counts::default();
+            let mut output = ConverterOutput::default();
+            for page_index in 0..pdf.page_count() {
+                context.checkpoint()?;
+                sink.checkpoint()?;
+                let page = pages::PdfOutput::new(1, context)?
+                    .extract_page(&pdf, page_index, options, context, &mut counts, true)?
+                    .finish(options, context)?;
+                let page = sink.enrich_page(page).await?;
+                append_consumed_page(&mut output, page, context)?;
+                // Reset only after the page's actual bitmap allocations AND
+                // their leases were destroyed. Permanent asset modes never use
+                // this branch and keep document-wide byte/dedup accounting.
+                counts.asset_bytes = 0;
+                counts.asset_ids.clear();
+            }
+            // Keep document-wide native/OCR layout and running-matter policy,
+            // now over semantic text only, without retaining page pixels.
+            let output = crate::pdf_ocr::reconstruct_enriched_pdf(output, options, context)?;
+            stream_converter_output(output.account_retained(context)?, sink)
+        })
+    }
+}
+
+fn append_consumed_page(
+    output: &mut ConverterOutput,
+    mut page: ConverterOutput,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    context.checkpoint()?;
+    remove_images(&mut page.document.blocks, context)?;
+    page.assets = Vec::new();
+    let retained = estimate_retained_output(&page.document, &page.assets, &page.diagnostics)?;
+    let compact = context.reserve_memory(retained)?;
+    // Replace the now-freed pixel/codec/layout peak leases with only the live
+    // semantic output. Ownership is covered throughout the transition.
+    let mut page = page.certify_preflight_reservation(context, compact)?;
+    let growth = page
+        .document
+        .blocks
+        .len()
+        .checked_mul(size_of::<BlockNode>())
+        .and_then(|bytes| {
+            bytes.checked_add(page.diagnostics.len().checked_mul(size_of::<Diagnostic>())?)
+        })
+        .and_then(|bytes| bytes.checked_mul(2))
+        .and_then(|bytes| u64::try_from(bytes).ok())
+        .ok_or_else(|| super::resource("max_memory_bytes", "PDF page collector growth overflow"))?;
+    let growth = context.reserve_memory(growth)?;
+    output
+        .document
+        .blocks
+        .try_reserve(page.document.blocks.len())
+        .map_err(|_| super::resource("max_memory_bytes", "PDF page collector allocation failed"))?;
+    output.diagnostics.try_reserve(page.diagnostics.len()).map_err(|_| {
+        super::resource("max_memory_bytes", "PDF diagnostic collector allocation failed")
+    })?;
+    output.document.blocks.append(&mut page.document.blocks);
+    output.diagnostics.append(&mut page.diagnostics);
+    output.absorb_memory_lease(&mut page, context)?;
+    output.attach_memory_reservation(context, growth)
+}
+
+fn remove_images(
+    nodes: &mut Vec<BlockNode>,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    for node in nodes.iter_mut() {
+        context.checkpoint()?;
+        match &mut node.block {
+            Block::Page { blocks, .. }
+            | Block::Footnote { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => remove_images(blocks, context)?,
+            Block::List { items, .. } => {
+                for item in items {
+                    remove_images(&mut item.blocks, context)?;
+                }
+            }
+            Block::Table { rows, .. } => {
+                for cell in rows.iter_mut().flat_map(|row| &mut row.cells) {
+                    remove_images(&mut cell.blocks, context)?;
+                }
+            }
+            _ => {}
+        }
+    }
+    nodes.retain(|node| !matches!(node.block, Block::Image { .. }));
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_ocr_only_omitted_pixels_use_page_consumption() {
+        let mut options = ConversionOptions::default();
+        options.output.asset_mode = AssetMode::Omit;
+        assert!(ocr_only_pixels(&options));
+        options.ocr.policy = into_markdown_core::OcrPolicy::Off;
+        assert!(!ocr_only_pixels(&options));
+        options.ai.vision_ocr = AiMode::Only;
+        assert!(ocr_only_pixels(&options));
+        options.ai.image_description = AiMode::Prefer;
+        assert!(!ocr_only_pixels(&options));
+        options.ai.image_description = AiMode::Off;
+        options.output.asset_mode = AssetMode::Extract;
+        assert!(!ocr_only_pixels(&options));
+    }
+}

--- a/crates/converters/src/pdf/stream.rs
+++ b/crates/converters/src/pdf/stream.rs
@@ -1,7 +1,7 @@
 //! Page-bounded OCR-only pixel lifetime; final semantic ownership moves once.
 
 use super::{
-    PdfConverter, convert_pdf, image_pixels_required, open_document, pages,
+    PdfConverter, convert_pdf_admitted, image_pixels_required, open_document, pages,
     runtime::acquire_pdf_conversion,
 };
 use into_markdown_core::{
@@ -50,10 +50,13 @@ impl ConverterStream for PdfConverter {
     ) -> LocalBoxFuture<'a, Result<ConverterStreamCompletion, ConversionError>> {
         Box::pin(async move {
             let path = self.runtime_path()?;
-            if !ocr_only_pixels(options) || !sink.supports_page_enrichment() {
-                return stream_converter_output(convert_pdf(&path, input, options, context)?, sink);
-            }
             let _permit = acquire_pdf_conversion(context).await?;
+            if !ocr_only_pixels(options) || !sink.supports_page_enrichment() {
+                return stream_converter_output(
+                    convert_pdf_admitted(&path, input, options, context)?,
+                    sink,
+                );
+            }
             let runtime = pages::load_runtime(&path, options)?;
             let pdf = open_document(&runtime, input, context)?;
             let mut counts = pages::Counts::default();

--- a/crates/converters/src/pdf/tests.rs
+++ b/crates/converters/src/pdf/tests.rs
@@ -678,7 +678,11 @@ fn scan_coverage_is_union_based_and_blank_or_overlapping_small_images_do_not_qua
 
 #[test]
 fn conversion_gate_wait_honors_cancellation() {
-    let held = PDF_CONVERSION_GATE.get_or_init(|| Mutex::new(())).lock().unwrap();
+    let admission = ExecutionContext::new(
+        into_markdown_core::ExecutionOptions::default(),
+        into_markdown_core::ResourceLimits::default(),
+    );
+    let held = lock_pdf_conversion(&admission).unwrap();
     let cancellation = into_markdown_core::CancellationToken::new();
     cancellation.cancel();
     let context = ExecutionContext::new(

--- a/crates/converters/src/pdf/tests.rs
+++ b/crates/converters/src/pdf/tests.rs
@@ -6,6 +6,9 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 static TEMPORARY_SEQUENCE: AtomicUsize = AtomicUsize::new(1);
 
+#[path = "page_lifetime_tests.rs"]
+mod page_lifetime;
+
 #[test]
 fn direct_pdf_probe_accepts_only_the_header_or_one_utf8_bom() {
     let context = ExecutionContext::new(

--- a/crates/core/src/spi.rs
+++ b/crates/core/src/spi.rs
@@ -1504,6 +1504,23 @@ pub trait OcrEngine: Send + Sync {
     fn provenance_kind(&self) -> crate::ProvenanceKind {
         crate::ProvenanceKind::LocalOcr
     }
+    /// Record accepted text after merge. Request-local replay adapters may
+    /// suppress recounting the same normalized input, without changing its IR.
+    ///
+    /// # Errors
+    ///
+    /// Returns the existing request telemetry accounting error.
+    #[doc(hidden)]
+    fn record_contribution(
+        &self,
+        input: crate::OcrInputIdentity,
+        regions: u64,
+        characters: u64,
+        context: &ExecutionContext,
+    ) -> Result<(), ConversionError> {
+        let _ = input;
+        context.record_ocr_contribution(regions, characters)
+    }
     /// Recognize text and geometry.
     fn recognize<'a>(
         &'a self,

--- a/crates/core/src/stream.rs
+++ b/crates/core/src/stream.rs
@@ -90,6 +90,27 @@ pub trait ConverterStream: Converter {
 
 /// Synchronous destination for owned converter events.
 pub trait ConverterEventSink {
+    /// Whether this sink can enrich an owned transient page before its pixels
+    /// are released. This does not change the single `write_output` contract.
+    fn supports_page_enrichment(&self) -> bool {
+        false
+    }
+
+    /// Enrich one unpublished page using the enclosing converter's memory credit.
+    /// The returned output owns its diagnostics and authenticated leases; the
+    /// producer must consume it before extracting the next transient page.
+    fn enrich_page<'a>(
+        &'a mut self,
+        output: ConverterOutput,
+    ) -> LocalBoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        Box::pin(async move {
+            drop(output);
+            Err(ConversionError::Unsupported {
+                detail: "semantic sink does not support page enrichment".into(),
+            })
+        })
+    }
+
     /// Observe cancellation or timeout before the next allocation or callback.
     ///
     /// # Errors

--- a/crates/core/src/stream.rs
+++ b/crates/core/src/stream.rs
@@ -99,10 +99,10 @@ pub trait ConverterEventSink {
     /// Enrich one unpublished page using the enclosing converter's memory credit.
     /// The returned output owns its diagnostics and authenticated leases; the
     /// producer must consume it before extracting the next transient page.
-    fn enrich_page<'a>(
-        &'a mut self,
+    fn enrich_page(
+        &mut self,
         output: ConverterOutput,
-    ) -> LocalBoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+    ) -> LocalBoxFuture<'_, Result<ConverterOutput, ConversionError>> {
         Box::pin(async move {
             drop(output);
             Err(ConversionError::Unsupported {

--- a/crates/engine/src/artifact_execution.rs
+++ b/crates/engine/src/artifact_execution.rs
@@ -44,6 +44,7 @@ pub(crate) async fn execute(
             &attempt.candidate,
             &request.options,
             &engine.services,
+            &engine.enrichers,
             &context,
         )
         .await?

--- a/crates/engine/src/collecting/integration_tests.rs
+++ b/crates/engine/src/collecting/integration_tests.rs
@@ -356,6 +356,7 @@ fn native_admission_has_stable_exact_minus_one_and_releases_on_drop() {
             &candidate,
             &options,
             &Services::default(),
+            &[],
             &low,
         )),
         Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
@@ -374,6 +375,7 @@ fn native_admission_has_stable_exact_minus_one_and_releases_on_drop() {
         &candidate,
         &options,
         &Services::default(),
+        &[],
         &exact,
     ))
     .unwrap();

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -5,6 +5,7 @@ mod artifact_output;
 mod collecting;
 mod fixed_alloc;
 mod nested;
+mod page_enrichment;
 mod preparation;
 mod recovery;
 mod rendering;
@@ -403,6 +404,7 @@ impl Engine {
                 &attempt.candidate,
                 &request.options,
                 &self.services,
+                &self.enrichers,
                 &context,
             )
             .await?

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -6,6 +6,7 @@ mod collecting;
 mod fixed_alloc;
 mod nested;
 mod page_enrichment;
+mod page_ocr_cache;
 mod preparation;
 mod recovery;
 mod rendering;

--- a/crates/engine/src/page_enrichment.rs
+++ b/crates/engine/src/page_enrichment.rs
@@ -1,0 +1,92 @@
+//! Enrich transient PDF pages without changing aggregate stream ownership.
+
+use into_markdown_core::{
+    Asset, ConversionError, ConversionOptions, ConverterEventSink, ConverterOutput, Document,
+    EnrichmentPlan, ExecutionContext, InputFormat, LocalBoxFuture, OutputEnricher, Services,
+    estimate_validation_working_set,
+};
+
+pub(crate) const EMBEDDED_OCR: &str = "builtin.enricher.embedded-visual-ocr";
+
+pub(crate) struct PageEnrichmentSink<'a> {
+    pub(crate) destination: &'a mut dyn ConverterEventSink,
+    pub(crate) enricher: Option<&'a dyn OutputEnricher>,
+    pub(crate) converter_id: &'a str,
+    pub(crate) format: InputFormat,
+    pub(crate) options: &'a ConversionOptions,
+    pub(crate) services: &'a Services,
+    pub(crate) context: &'a ExecutionContext,
+}
+
+impl ConverterEventSink for PageEnrichmentSink<'_> {
+    fn checkpoint(&mut self) -> Result<(), ConversionError> {
+        self.destination.checkpoint()
+    }
+
+    fn write_output(
+        &mut self,
+        document: Document,
+        assets: Vec<Asset>,
+    ) -> Result<(), ConversionError> {
+        self.destination.write_output(document, assets)
+    }
+
+    fn supports_page_enrichment(&self) -> bool {
+        self.enricher.is_some() && self.format == InputFormat::Pdf
+    }
+
+    fn enrich_page<'a>(
+        &'a mut self,
+        output: ConverterOutput,
+    ) -> LocalBoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        Box::pin(async move {
+            self.context.checkpoint()?;
+            let enricher = self.enricher.ok_or_else(|| ConversionError::Internal {
+                detail: "page enrichment was not negotiated".into(),
+            })?;
+            let plan = enricher.planned_enrichment_bytes(
+                &output,
+                self.converter_id,
+                self.format,
+                self.options,
+                self.services,
+                self.context,
+            )?;
+            let EnrichmentPlan::Reserve(bytes) = plan else { return Ok(output) };
+            // As in nested conversion, the enclosing native invocation already
+            // holds the global admission. Child credits cannot back new credits.
+            // Check the incremental peak before entry and use the same context
+            // for all actual OCR working-set and retained-output reservations.
+            if bytes > self.context.available_memory_bytes() {
+                return Err(ConversionError::ResourceLimit {
+                    limit: "max_memory_bytes",
+                    detail: format!(
+                        "page OCR planned {bytes} bytes but only {} remain",
+                        self.context.available_memory_bytes()
+                    ),
+                });
+            }
+            let output = self
+                .context
+                .run(enricher.enrich(
+                    output,
+                    self.converter_id,
+                    self.format,
+                    self.options,
+                    self.services,
+                    self.context,
+                ))
+                .await??;
+            let validation = estimate_validation_working_set(
+                &output.document,
+                &output.assets,
+                &output.diagnostics,
+            )?;
+            let _validation = self.context.reserve_memory(validation)?;
+            output.document.validate().map_err(|error| ConversionError::Internal {
+                detail: format!("page OCR returned invalid IR at {}: {}", error.path, error.detail),
+            })?;
+            output.account_retained(self.context)
+        })
+    }
+}

--- a/crates/engine/src/page_enrichment.rs
+++ b/crates/engine/src/page_enrichment.rs
@@ -35,10 +35,10 @@ impl ConverterEventSink for PageEnrichmentSink<'_> {
         self.enricher.is_some() && self.format == InputFormat::Pdf
     }
 
-    fn enrich_page<'a>(
-        &'a mut self,
+    fn enrich_page(
+        &mut self,
         output: ConverterOutput,
-    ) -> LocalBoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+    ) -> LocalBoxFuture<'_, Result<ConverterOutput, ConversionError>> {
         Box::pin(async move {
             self.context.checkpoint()?;
             let enricher = self.enricher.ok_or_else(|| ConversionError::Internal {

--- a/crates/engine/src/page_ocr_cache.rs
+++ b/crates/engine/src/page_ocr_cache.rs
@@ -1,0 +1,176 @@
+//! Request-local OCR contributions shared by transient PDF pages, never pixels.
+
+use into_markdown_core::{
+    BoxFuture, ConversionError, ConversionOptions, ExecutionContext, OcrEngine, OcrEvidenceStep,
+    OcrOutputPlan, OcrRecognition, OcrRegion, OcrRequest, OcrResult, ProvenanceKind,
+    ResourceReservation,
+};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+struct Entry {
+    contribution: OcrRecognition,
+    _memory: ResourceReservation,
+}
+
+pub(crate) struct PageOcrCache {
+    provider: Arc<dyn OcrEngine>,
+    entries: Mutex<BTreeMap<[u8; 32], Entry>>,
+}
+
+impl PageOcrCache {
+    pub(crate) fn new(provider: Arc<dyn OcrEngine>) -> Self {
+        Self { provider, entries: Mutex::new(BTreeMap::new()) }
+    }
+}
+
+impl OcrEngine for PageOcrCache {
+    fn id(&self) -> &str {
+        self.provider.id()
+    }
+
+    fn provenance_kind(&self) -> ProvenanceKind {
+        self.provider.provenance_kind()
+    }
+
+    fn recognize<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrResult, ConversionError>> {
+        self.provider.recognize(request, context)
+    }
+
+    fn planned_bound_output(
+        &self,
+        request: OcrRequest<'_>,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        cache_plan(self.provider.planned_bound_output(request, options, context)?)
+    }
+
+    fn planned_normalized_png_output(
+        &self,
+        width: u32,
+        height: u32,
+        options: &ConversionOptions,
+        context: &ExecutionContext,
+    ) -> Result<OcrOutputPlan, ConversionError> {
+        cache_plan(self.provider.planned_normalized_png_output(width, height, options, context)?)
+    }
+
+    fn recognize_bound<'a>(
+        &'a self,
+        request: OcrRequest<'a>,
+        context: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<OcrRecognition, ConversionError>> {
+        Box::pin(async move {
+            let digest = request_digest(request, context)?;
+            {
+                let entries = self
+                    .entries
+                    .lock()
+                    .map_err(|_| cache_error("OCR contribution cache lock poisoned"))?;
+                if let Some(entry) = entries.get(&digest) {
+                    // The caller's normal provider-output allowance covers this
+                    // clone; the cache keeps its own independently held lease.
+                    return Ok(entry.contribution.clone());
+                }
+                if entries.len()
+                    >= usize::try_from(context.resource_limits().max_pages).unwrap_or(usize::MAX)
+                {
+                    return Err(ConversionError::ResourceLimit {
+                        limit: "max_pages",
+                        detail: "request-wide PDF OCR candidate count exceeded".into(),
+                    });
+                }
+            }
+            let contribution = self.provider.recognize_bound(request, context).await?;
+            context.checkpoint()?;
+            let bytes = clone_bytes(&contribution)?
+                .checked_add(entry_overhead())
+                .ok_or_else(|| cache_error("OCR contribution cache size overflow"))?;
+            let memory = context.reserve_memory(bytes)?;
+            let cached = Entry { contribution: contribution.clone(), _memory: memory };
+            self.entries
+                .lock()
+                .map_err(|_| cache_error("OCR contribution cache lock poisoned"))?
+                .insert(digest, cached);
+            Ok(contribution)
+        })
+    }
+}
+
+fn cache_plan(plan: OcrOutputPlan) -> Result<OcrOutputPlan, ConversionError> {
+    let working = plan
+        .max_working_bytes()
+        .checked_add(plan.max_retained_bytes())
+        .and_then(|bytes| bytes.checked_add(entry_overhead()))
+        .ok_or_else(|| cache_error("OCR contribution cache plan overflow"))?;
+    OcrOutputPlan::try_new_with_working(
+        plan.max_retained_bytes(),
+        working,
+        plan.max_regions(),
+        plan.max_text_bytes(),
+    )
+}
+
+fn entry_overhead() -> u64 {
+    // One complete high-water B-tree node per entry, including sparse nodes.
+    ((size_of::<[u8; 32]>() + size_of::<Entry>()) * 11 + size_of::<usize>() * 12 + 256) as u64
+}
+
+fn request_digest(
+    request: OcrRequest<'_>,
+    context: &ExecutionContext,
+) -> Result<[u8; 32], ConversionError> {
+    let mut hash = Sha256::new();
+    hash.update((request.media_type.len() as u64).to_le_bytes());
+    hash.update(request.media_type.as_bytes());
+    hash.update((request.languages.len() as u64).to_le_bytes());
+    for language in request.languages {
+        hash.update((language.len() as u64).to_le_bytes());
+        hash.update(language.as_bytes());
+    }
+    for chunk in request.image.chunks(64 * 1024) {
+        context.checkpoint()?;
+        hash.update(chunk);
+    }
+    Ok(hash.finalize().into())
+}
+
+fn clone_bytes(value: &OcrRecognition) -> Result<u64, ConversionError> {
+    let mut bytes = size_of::<OcrRecognition>() as u64;
+    let result = match value {
+        OcrRecognition::Bound(bound) => {
+            add(&mut bytes, bound.detection_confidences().len() * size_of::<f32>())?;
+            add(&mut bytes, bound.evidence_chain().len() * size_of::<OcrEvidenceStep>())?;
+            for step in bound.evidence_chain() {
+                add(&mut bytes, step.provider.len())?;
+                add(&mut bytes, step.model.as_ref().map_or(0, String::len))?;
+            }
+            bound.result()
+        }
+        OcrRecognition::Unbound(result) | OcrRecognition::Remote(result) => result,
+        _ => return Err(cache_error("unsupported OCR contribution kind")),
+    };
+    add(&mut bytes, result.provider.len())?;
+    add(&mut bytes, result.regions.len() * size_of::<OcrRegion>())?;
+    for region in &result.regions {
+        add(&mut bytes, region.text.len())?;
+    }
+    Ok(bytes)
+}
+
+fn add(bytes: &mut u64, extra: usize) -> Result<(), ConversionError> {
+    *bytes = bytes
+        .checked_add(u64::try_from(extra).map_err(|_| cache_error("OCR cache length overflow"))?)
+        .ok_or_else(|| cache_error("OCR cache size overflow"))?;
+    Ok(())
+}
+
+fn cache_error(detail: &str) -> ConversionError {
+    ConversionError::ResourceLimit { limit: "max_memory_bytes", detail: detail.into() }
+}

--- a/crates/engine/src/page_ocr_cache.rs
+++ b/crates/engine/src/page_ocr_cache.rs
@@ -45,10 +45,11 @@ impl OcrEngine for PageOcrCache {
     ) -> Result<(), ConversionError> {
         let mut entries =
             self.entries.lock().map_err(|_| cache_error("OCR contribution cache lock poisoned"))?;
-        let entry = entries
-            .values_mut()
-            .find(|entry| entry.normalized_sha256 == input.sha256())
-            .ok_or_else(|| cache_error("OCR contribution has no cached input identity"))?;
+        let Some(entry) =
+            entries.values_mut().find(|entry| entry.normalized_sha256 == input.sha256())
+        else {
+            return context.record_ocr_contribution(regions, characters);
+        };
         if !entry.counted {
             self.provider.record_contribution(input, regions, characters, context)?;
             entry.counted = true;

--- a/crates/engine/src/page_ocr_cache.rs
+++ b/crates/engine/src/page_ocr_cache.rs
@@ -1,7 +1,7 @@
 //! Request-local OCR contributions shared by transient PDF pages, never pixels.
 
 use into_markdown_core::{
-    BoxFuture, ConversionError, ConversionOptions, ExecutionContext, OcrEngine, OcrEvidenceStep,
+    BoxFuture, ConversionError, ConversionOptions, ExecutionContext, OcrEngine, OcrInputIdentity,
     OcrOutputPlan, OcrRecognition, OcrRegion, OcrRequest, OcrResult, ProvenanceKind,
     ResourceReservation,
 };
@@ -11,6 +11,8 @@ use std::sync::{Arc, Mutex};
 
 struct Entry {
     contribution: OcrRecognition,
+    normalized_sha256: [u8; 32],
+    counted: bool,
     _memory: ResourceReservation,
 }
 
@@ -32,6 +34,26 @@ impl OcrEngine for PageOcrCache {
 
     fn provenance_kind(&self) -> ProvenanceKind {
         self.provider.provenance_kind()
+    }
+
+    fn record_contribution(
+        &self,
+        input: OcrInputIdentity,
+        regions: u64,
+        characters: u64,
+        context: &ExecutionContext,
+    ) -> Result<(), ConversionError> {
+        let mut entries =
+            self.entries.lock().map_err(|_| cache_error("OCR contribution cache lock poisoned"))?;
+        let entry = entries
+            .values_mut()
+            .find(|entry| entry.normalized_sha256 == input.sha256())
+            .ok_or_else(|| cache_error("OCR contribution has no cached input identity"))?;
+        if !entry.counted {
+            self.provider.record_contribution(input, regions, characters, context)?;
+            entry.counted = true;
+        }
+        Ok(())
     }
 
     fn recognize<'a>(
@@ -93,7 +115,12 @@ impl OcrEngine for PageOcrCache {
                 .checked_add(entry_overhead())
                 .ok_or_else(|| cache_error("OCR contribution cache size overflow"))?;
             let memory = context.reserve_memory(bytes)?;
-            let cached = Entry { contribution: contribution.clone(), _memory: memory };
+            let cached = Entry {
+                contribution: contribution.clone(),
+                normalized_sha256: Sha256::digest(request.image).into(),
+                counted: false,
+                _memory: memory,
+            };
             self.entries
                 .lock()
                 .map_err(|_| cache_error("OCR contribution cache lock poisoned"))?
@@ -145,8 +172,8 @@ fn clone_bytes(value: &OcrRecognition) -> Result<u64, ConversionError> {
     let mut bytes = size_of::<OcrRecognition>() as u64;
     let result = match value {
         OcrRecognition::Bound(bound) => {
-            add(&mut bytes, bound.detection_confidences().len() * size_of::<f32>())?;
-            add(&mut bytes, bound.evidence_chain().len() * size_of::<OcrEvidenceStep>())?;
+            add(&mut bytes, size_of_val(bound.detection_confidences()))?;
+            add(&mut bytes, size_of_val(bound.evidence_chain()))?;
             for step in bound.evidence_chain() {
                 add(&mut bytes, step.provider.len())?;
                 add(&mut bytes, step.model.as_ref().map_or(0, String::len))?;

--- a/crates/engine/src/stream_execution.rs
+++ b/crates/engine/src/stream_execution.rs
@@ -4,11 +4,13 @@
 //! and collector admission boundaries independently reviewable.
 
 use crate::collecting::CollectingArtifactSink;
+use crate::page_enrichment::{EMBEDDED_OCR, PageEnrichmentSink};
 use into_markdown_core::{
     ConversionError, ConversionOptions, ConverterOutput, ConverterStream, ExecutionContext,
-    FormatCandidate, ResolvedInput, Services, StreamConsumerKind, estimate_retained_output,
-    estimate_validation_working_set,
+    FormatCandidate, OutputEnricher, ResolvedInput, Services, StreamConsumerKind,
+    estimate_retained_output, estimate_validation_working_set,
 };
+use std::sync::Arc;
 
 pub(crate) async fn invoke_native_collecting(
     converter: &dyn ConverterStream,
@@ -16,17 +18,19 @@ pub(crate) async fn invoke_native_collecting(
     candidate: &FormatCandidate,
     options: &ConversionOptions,
     services: &Services,
+    enrichers: &[Arc<dyn OutputEnricher>],
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
-    invoke_native(
+    invoke_native(NativeRequest {
         converter,
         input,
         candidate,
         options,
         services,
+        enrichers,
         context,
-        StreamConsumerKind::Collecting,
-    )
+        consumer: StreamConsumerKind::Collecting,
+    })
     .await
 }
 
@@ -36,36 +40,68 @@ pub(crate) async fn invoke_native_immediate(
     candidate: &FormatCandidate,
     options: &ConversionOptions,
     services: &Services,
+    enrichers: &[Arc<dyn OutputEnricher>],
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
-    invoke_native(
+    invoke_native(NativeRequest {
         converter,
         input,
         candidate,
         options,
         services,
+        enrichers,
         context,
-        StreamConsumerKind::Immediate,
-    )
+        consumer: StreamConsumerKind::Immediate,
+    })
     .await
 }
 
-async fn invoke_native(
-    converter: &dyn ConverterStream,
-    input: &ResolvedInput,
-    candidate: &FormatCandidate,
-    options: &ConversionOptions,
-    services: &Services,
-    context: &ExecutionContext,
+struct NativeRequest<'a> {
+    converter: &'a dyn ConverterStream,
+    input: &'a ResolvedInput,
+    candidate: &'a FormatCandidate,
+    options: &'a ConversionOptions,
+    services: &'a Services,
+    enrichers: &'a [Arc<dyn OutputEnricher>],
+    context: &'a ExecutionContext,
     consumer: StreamConsumerKind,
-) -> Result<ConverterOutput, ConversionError> {
+}
+
+async fn invoke_native(request: NativeRequest<'_>) -> Result<ConverterOutput, ConversionError> {
+    let NativeRequest {
+        converter,
+        input,
+        candidate,
+        options,
+        services,
+        enrichers,
+        context,
+        consumer,
+    } = request;
     let plan = converter.planned_stream_bytes(input, candidate, options, context, consumer)?;
     let mut admission = context.reserve_memory(plan)?;
     let credited = context.with_memory_credit(&mut admission)?;
     let mut sink = CollectingArtifactSink::new(&credited);
-    let completion = context
-        .run(converter.convert_stream(input, candidate, options, services, &credited, &mut sink))
-        .await??;
+    let completion = {
+        let mut pages = PageEnrichmentSink {
+            destination: &mut sink,
+            enricher: enrichers
+                .iter()
+                .find(|enricher| enricher.id() == EMBEDDED_OCR)
+                .map(AsRef::as_ref),
+            converter_id: converter.id(),
+            format: candidate.format,
+            options,
+            services,
+            context: &credited,
+        };
+        context
+            .run(
+                converter
+                    .convert_stream(input, candidate, options, services, &credited, &mut pages),
+            )
+            .await??
+    };
     let output = sink.finish(completion)?;
     let retained = estimate_retained_output(&output.document, &output.assets, &output.diagnostics)?;
     let validation =

--- a/crates/engine/src/stream_execution.rs
+++ b/crates/engine/src/stream_execution.rs
@@ -83,6 +83,13 @@ async fn invoke_native(request: NativeRequest<'_>) -> Result<ConverterOutput, Co
     let credited = context.with_memory_credit(&mut admission)?;
     let mut sink = CollectingArtifactSink::new(&credited);
     let completion = {
+        let mut page_services = services.clone();
+        if candidate.format == into_markdown_core::InputFormat::Pdf {
+            page_services.ocr = services.ocr.as_ref().map(|provider| {
+                Arc::new(crate::page_ocr_cache::PageOcrCache::new(Arc::clone(provider)))
+                    as Arc<dyn into_markdown_core::OcrEngine>
+            });
+        }
         let mut pages = PageEnrichmentSink {
             destination: &mut sink,
             enricher: enrichers
@@ -92,7 +99,7 @@ async fn invoke_native(request: NativeRequest<'_>) -> Result<ConverterOutput, Co
             converter_id: converter.id(),
             format: candidate.format,
             options,
-            services,
+            services: &page_services,
             context: &credited,
         };
         context


### PR DESCRIPTION
## Scope

Closes #322.

Fix PDF OCR-only page-pixel lifetime under `--asset-mode omit` without increasing limits, reducing render quality, disabling OCR, or changing output transactions. Based on main `a6d4b6f543be04755908f9181a722284cd44ef29`; independent of the completed ODF work.

## Changes

- Reuse PDFium's single document open and page access; extract the existing PDF page parser into `pdf/pages.rs`, shared with the unchanged aggregate entry point.
- Add an optional, awaitable page-enrichment callback to the existing native semantic stream. `write_output` retains its single owned-output meaning; collecting and prepared artifact paths use the same callback.
- Reuse the registered embedded visual OCR enricher and the existing nested-conversion memory-credit pattern. Enrich, consume, and release each page's OCR-only bitmap allocations and leases before extracting the next page; retain semantic text and diagnostics in source page order.
- Select the full-page render from image geometry before decoding embedded image pixels. In the OCR-only rendered-page path, do not decode or OCR the original embedded images a second time. Permanent asset modes retain their original assets and document-wide limits.
- Keep displayed-page render coordinates explicit: page rotation has already been applied to the bitmap, so its OCR frame has rotation zero. No affine API or coordinate-frame rewrite; #323 owns the separate coordinate helper fix.
- Keep PDFium's single-live-runtime admission while allowing OCR to await without a thread-bound mutex guard.

## Final validation evidence

- Frozen code HEAD: `0b31e3e2c9fedb7ee9e2a3765c2bb48da24a2d82`, rebased onto main containing #327 and #325. Four-platform CI passed. No evidence-only code commits.
- `cargo fmt --all -- --check`, `git diff --check`, and Core/Engine/Converters strict `clippy --lib --tests --no-deps -- -D warnings` passed.
- Existing library tests: Converters 622 passed/9 ignored; Core 112 passed; Engine 45 passed.
- All six #322 native lifecycle regressions passed: bounded pixel lifetime, repeated-page request/telemetry reuse, optional provider recovery, mixed-mode async admission, cancellation/failure, one-shot preparation/execution and permanent asset limits.
- Explicit full native PDF set: **8 passed, 1 failed**. Existing `native_production_converter_is_serialized_and_emits_unified_ir` fails at `pdf/tests.rs:886` (`blocks[0]` Paragraph assumption). This is reported without claiming its cause or changing frozen code.
- No new Actions or lint exemptions were added; the existing long-parser exemption moved with the extracted parser.

## Single real 434-page verification: reporting failure, not an end-to-end pass

Authority: frozen manifest SHA256 `7f82792dca7d1011d8a1bbcdfe7de5b4f0c463515be347405d0c88a6b866cacc`; fixture `d9bd5f48586b687712c71836`, 51,000,310 bytes, source SHA256 `29f7275520694ef490508aafee341d8b264f8b90d22c2ac86d0ff8262dbfcc21`.

The debug CLI used OCR auto, assets omit, the frozen OCR profile, and 2 GiB memory without raising asset limits. It committed a **59,146,797-byte Result JSON**, then exited **70** while serializing the batch report: `dtoValues exceeds limit 2000000`. No native report was created or synthesized. Independent follow-up: #328.

The committed artifact parses completely: **434 pages in exact 1..434 order, 432 pages with OCR, 54,971 OCR characters, 53,784 Han characters**, no retained assets. Pages 3/4 have no OCR text. Diagnostics: 434 `pdf.scannedPage` plus 55,551 `ocr.lowConfidence`. The diagnostics subtree alone has 2,067,973 structural values, exceeding the report decoder-style limit despite being below the diagnostic-count limit. The failure is after primary output commit, not the previous OCR-only asset accumulation failure.

Source spot checks prove body content beyond page headings, but only 2/9 preselected anchors matched and the source has no independent text oracle. **Do not claim satisfactory full-body recall or an overall quality pass.**

Native stderr timings: processing 2,185,168.9743 ms; per-file 2,267,228.0354 ms; batch wall 2,267,242.7091 ms. External wall 2,268.1098575 s. Root OS peak RSS 259,104,768 B; sampled simultaneous process-tree peak 534,532,096 B; sampled temp peak 173,516,361 B; final temporary/transaction residue 0. Debug observations are not release performance rankings.

Evidence root: `C:/im-bench-004/issue322-pdf-page-lifetime/README.md` with native logs, exact command, hashes, Result JSON, extracted Markdown, page-by-page text, wire accounting, and regression/clippy logs. Executable SHA256 `eb914aab30e76eb93852d22c16947c36d4b377bd5a63bc8b287b03e492f99c5f`; Result SHA256 `02b5ca5935d2fbdf3ba06bfd69b9df9eb3df99c323329ea54f0bae463bd66a0a`. Source, code HEAD, and measured executable remain unchanged.
