### PR TITLE
fix(ocr): keep embedded geometry in one coordinate space (#323)

### DIFF
--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -4,19 +4,23 @@ use crate::image_converter::{decode, encode, envelope, format};
 use image::{AnimationDecoder, ImageDecoder};
 use into_markdown_core::{
     AiMode, AssetId, Block, BlockNode, BoxFuture, ConversionError, ConversionOptions,
-    ConverterOutput, Diagnostic, DiagnosticSeverity, EnrichmentPlan, ExecutionContext, Inline,
-    InputFormat, NodeId, OcrInputIdentity, OcrPolicy, OutputEnricher, Provenance,
-    ResourceReservation, Services, SourceLocator, estimate_validation_working_set,
+    ConverterOutput, Diagnostic, DiagnosticSeverity, EnrichmentPlan, ExecutionContext, InputFormat,
+    NodeId, OcrInputIdentity, OcrPolicy, OutputEnricher, Provenance, ResourceReservation, Services,
+    SourceLocator, estimate_validation_working_set,
 };
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::io::Cursor;
 
 mod candidate_index;
+mod geometry;
 use candidate_index::{
     CandidateBuffer, OcrCandidate, ReferenceIndex, candidate_index_plan, group_candidates,
     validate_visual_references_without_index,
 };
+#[cfg(test)]
+use geometry::evidence_bounds;
+use geometry::{remap_ocr_node, remapped_locator};
 
 const PROVIDER: &str = "builtin.enricher.embedded-visual-ocr";
 const UNSUPPORTED_CODE: &str = "embeddedVisualOcr.unsupportedVisual";
@@ -1296,81 +1300,6 @@ fn fresh_ocr_node_id(
     }
 }
 
-fn remap_ocr_node(
-    mut node: BlockNode,
-    fresh_id: NodeId,
-    source: &Provenance,
-    context: &ExecutionContext,
-) -> Result<BlockNode, ConversionError> {
-    node.id = fresh_id;
-    let ocr_locator = node.provenance.locator.clone();
-    node.provenance.locator = remapped_ocr_locator(&source.locator, &ocr_locator);
-    if let Block::Paragraph(inlines) = &mut node.block {
-        for (inline_index, inline) in inlines.iter_mut().enumerate() {
-            if inline_index % 256 == 0 {
-                context.checkpoint()?;
-            }
-            if let Inline::OcrText { provenance, evidence, .. } = inline {
-                let inline_locator = provenance.locator.clone();
-                provenance.locator = remapped_ocr_locator(&source.locator, &inline_locator);
-                evidence.page = source.locator.page.or(source.locator.slide).unwrap_or(1);
-                if let Some((source_bounds, image_width, image_height)) =
-                    coordinate_frame(&source.locator, &inline_locator)
-                {
-                    for (region_index, region) in evidence.regions.iter_mut().enumerate() {
-                        if region_index % 256 == 0 {
-                            context.checkpoint()?;
-                        }
-                        for (point_index, point) in region.polygon.iter_mut().enumerate() {
-                            if point_index % 256 == 0 {
-                                context.checkpoint()?;
-                            }
-                            point.x = source_bounds.x + point.x * source_bounds.width / image_width;
-                            point.y =
-                                source_bounds.y + point.y * source_bounds.height / image_height;
-                        }
-                    }
-                }
-                provenance.locator.bounds = evidence_bounds(&evidence.regions);
-            }
-        }
-    }
-    Ok(node)
-}
-
-fn evidence_bounds(
-    regions: &[into_markdown_core::OcrSourceRegion],
-) -> Option<into_markdown_core::Rect> {
-    (!regions.is_empty()).then(|| {
-        let minimum_x = regions
-            .iter()
-            .flat_map(|region| region.polygon.iter())
-            .map(|point| point.x)
-            .fold(f32::INFINITY, f32::min);
-        let minimum_y = regions
-            .iter()
-            .flat_map(|region| region.polygon.iter())
-            .map(|point| point.y)
-            .fold(f32::INFINITY, f32::min);
-        let maximum_x = regions
-            .iter()
-            .flat_map(|region| region.polygon.iter())
-            .map(|point| point.x)
-            .fold(f32::NEG_INFINITY, f32::max);
-        let maximum_y = regions
-            .iter()
-            .flat_map(|region| region.polygon.iter())
-            .map(|point| point.y)
-            .fold(f32::NEG_INFINITY, f32::max);
-        into_markdown_core::Rect {
-            x: minimum_x,
-            y: minimum_y,
-            width: maximum_x - minimum_x,
-            height: maximum_y - minimum_y,
-        }
-    })
-}
-
 fn collect_node_ids(
     nodes: &[BlockNode],
     output: &mut BTreeSet<NodeId>,
@@ -1402,56 +1331,6 @@ fn collect_node_ids(
     Ok(())
 }
 
-fn coordinate_frame(
-    source: &SourceLocator,
-    ocr: &SourceLocator,
-) -> Option<(into_markdown_core::Rect, f32, f32)> {
-    let bounds = source.bounds?;
-    let width = ocr.page_width?;
-    let height = ocr.page_height?;
-    (bounds.x.is_finite()
-        && bounds.y.is_finite()
-        && bounds.width.is_finite()
-        && bounds.height.is_finite()
-        && bounds.width > 0.0
-        && bounds.height > 0.0
-        && width.is_finite()
-        && height.is_finite()
-        && width > 0.0
-        && height > 0.0)
-        .then_some((bounds, width, height))
-}
-
-fn remapped_ocr_locator(source: &SourceLocator, ocr: &SourceLocator) -> SourceLocator {
-    let mut locator = remapped_locator(source);
-    locator.page = source.page.or(source.slide).or(Some(1));
-    if let (Some((frame, width, height)), Some(bounds)) =
-        (coordinate_frame(source, ocr), ocr.bounds)
-    {
-        locator.page_width = source.page_width.or(ocr.page_width);
-        locator.page_height = source.page_height.or(ocr.page_height);
-        locator.bounds = Some(into_markdown_core::Rect {
-            x: frame.x + bounds.x * frame.width / width,
-            y: frame.y + bounds.y * frame.height / height,
-            width: bounds.width * frame.width / width,
-            height: bounds.height * frame.height / height,
-        });
-    } else {
-        locator.page_width = ocr.page_width;
-        locator.page_height = ocr.page_height;
-        locator.bounds = ocr.bounds;
-    }
-    locator
-}
-
-fn remapped_locator(source: &SourceLocator) -> SourceLocator {
-    let mut locator = source.clone();
-    locator.byte_start = None;
-    locator.byte_end = None;
-    locator.character_index = None;
-    locator
-}
-
 fn visual_diagnostic(locator: Option<SourceLocator>, detail: String) -> Diagnostic {
     Diagnostic {
         code: UNSUPPORTED_CODE.into(),
@@ -1470,7 +1349,7 @@ mod tests {
     use super::*;
     use image::{DynamicImage, Frame, ImageFormat, Rgba, RgbaImage, codecs::gif::GifEncoder};
     use into_markdown_core::{
-        Asset, BoundOcrResult, CancellationToken, Document, ExecutionOptions, OcrEngine,
+        Asset, BoundOcrResult, CancellationToken, Document, ExecutionOptions, Inline, OcrEngine,
         OcrEvidenceStage, OcrEvidenceStep, OcrOutputPlan, OcrRecognition, OcrRegion, OcrRequest,
         OcrResult, ProvenanceKind,
     };

--- a/crates/converters/src/embedded_visual_ocr/geometry.rs
+++ b/crates/converters/src/embedded_visual_ocr/geometry.rs
@@ -1,0 +1,149 @@
+//! Preserve one coordinate space for embedded OCR evidence and its locator.
+
+use into_markdown_core::{
+    Block, BlockNode, ConversionError, ExecutionContext, Inline, NodeId, Provenance, SourceLocator,
+};
+
+#[cfg(test)]
+#[path = "geometry_tests.rs"]
+mod tests;
+
+pub(super) fn remap_ocr_node(
+    mut node: BlockNode,
+    fresh_id: NodeId,
+    source: &Provenance,
+    context: &ExecutionContext,
+) -> Result<BlockNode, ConversionError> {
+    node.id = fresh_id;
+    let ocr_locator = node.provenance.locator.clone();
+    node.provenance.locator = remapped_ocr_locator(&source.locator, &ocr_locator);
+    if let Block::Paragraph(inlines) = &mut node.block {
+        for (inline_index, inline) in inlines.iter_mut().enumerate() {
+            if inline_index % 256 == 0 {
+                context.checkpoint()?;
+            }
+            if let Inline::OcrText { provenance, evidence, .. } = inline {
+                let inline_locator = provenance.locator.clone();
+                provenance.locator = remapped_ocr_locator(&source.locator, &inline_locator);
+                evidence.page = source.locator.page.or(source.locator.slide).unwrap_or(1);
+                if let Some((source_bounds, image_width, image_height)) =
+                    coordinate_frame(&source.locator, &inline_locator)
+                {
+                    for (region_index, region) in evidence.regions.iter_mut().enumerate() {
+                        if region_index % 256 == 0 {
+                            context.checkpoint()?;
+                        }
+                        for (point_index, point) in region.polygon.iter_mut().enumerate() {
+                            if point_index % 256 == 0 {
+                                context.checkpoint()?;
+                            }
+                            point.x = source_bounds.x + point.x * source_bounds.width / image_width;
+                            point.y =
+                                source_bounds.y + point.y * source_bounds.height / image_height;
+                        }
+                    }
+                }
+                provenance.locator.bounds = evidence_bounds(&evidence.regions);
+            }
+        }
+    }
+    Ok(node)
+}
+
+pub(super) fn evidence_bounds(
+    regions: &[into_markdown_core::OcrSourceRegion],
+) -> Option<into_markdown_core::Rect> {
+    (!regions.is_empty()).then(|| {
+        let minimum_x = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.x)
+            .fold(f32::INFINITY, f32::min);
+        let minimum_y = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.y)
+            .fold(f32::INFINITY, f32::min);
+        let maximum_x = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.x)
+            .fold(f32::NEG_INFINITY, f32::max);
+        let maximum_y = regions
+            .iter()
+            .flat_map(|region| region.polygon.iter())
+            .map(|point| point.y)
+            .fold(f32::NEG_INFINITY, f32::max);
+        into_markdown_core::Rect {
+            x: minimum_x,
+            y: minimum_y,
+            width: maximum_x - minimum_x,
+            height: maximum_y - minimum_y,
+        }
+    })
+}
+
+fn coordinate_frame(
+    source: &SourceLocator,
+    ocr: &SourceLocator,
+) -> Option<(into_markdown_core::Rect, f32, f32)> {
+    let bounds = source.bounds?;
+    let page_width = source.page_width?;
+    let page_height = source.page_height?;
+    let width = ocr.page_width?;
+    let height = ocr.page_height?;
+    // A container bounding box alone is not an image-to-page transform. In
+    // particular, do not mix ODF points or DrawingML EMUs with image pixels,
+    // or infer a rotated/cropped placement from its axis-aligned envelope.
+    (bounds.x.is_finite()
+        && bounds.y.is_finite()
+        && bounds.width.is_finite()
+        && bounds.height.is_finite()
+        && bounds.width > 0.0
+        && bounds.height > 0.0
+        && bounds.x >= 0.0
+        && bounds.y >= 0.0
+        && page_width.is_finite()
+        && page_height.is_finite()
+        && page_width > 0.0
+        && page_height > 0.0
+        && f64::from(bounds.x) + f64::from(bounds.width) <= f64::from(page_width)
+        && f64::from(bounds.y) + f64::from(bounds.height) <= f64::from(page_height)
+        && source.rotation_degrees.is_none_or(|rotation| rotation == 0.0)
+        && width.is_finite()
+        && height.is_finite()
+        && width > 0.0
+        && height > 0.0)
+        .then_some((bounds, width, height))
+}
+
+fn remapped_ocr_locator(source: &SourceLocator, ocr: &SourceLocator) -> SourceLocator {
+    let mut locator = remapped_locator(source);
+    locator.page = source.page.or(source.slide).or(Some(1));
+    if let (Some((frame, width, height)), Some(bounds)) =
+        (coordinate_frame(source, ocr), ocr.bounds)
+    {
+        locator.page_width = source.page_width;
+        locator.page_height = source.page_height;
+        locator.bounds = Some(into_markdown_core::Rect {
+            x: frame.x + bounds.x * frame.width / width,
+            y: frame.y + bounds.y * frame.height / height,
+            width: bounds.width * frame.width / width,
+            height: bounds.height * frame.height / height,
+        });
+    } else {
+        locator.page_width = ocr.page_width;
+        locator.page_height = ocr.page_height;
+        locator.bounds = ocr.bounds;
+        locator.rotation_degrees = ocr.rotation_degrees;
+    }
+    locator
+}
+
+pub(super) fn remapped_locator(source: &SourceLocator) -> SourceLocator {
+    let mut locator = source.clone();
+    locator.byte_start = None;
+    locator.byte_end = None;
+    locator.character_index = None;
+    locator
+}

--- a/crates/converters/src/embedded_visual_ocr/geometry_tests.rs
+++ b/crates/converters/src/embedded_visual_ocr/geometry_tests.rs
@@ -1,0 +1,170 @@
+use super::*;
+use into_markdown_core::{
+    Document, ExecutionOptions, OcrEvidence, OcrEvidenceStage, OcrEvidenceStep, OcrSourceRegion,
+    ProvenanceKind, Rect, ResourceLimits, SourcePoint,
+};
+
+fn image_locator() -> SourceLocator {
+    SourceLocator {
+        page: Some(1),
+        page_width: Some(1366.0),
+        page_height: Some(109.0),
+        bounds: Some(Rect { x: 10.0, y: 2.0, width: 1200.0, height: 100.0 }),
+        ..SourceLocator::default()
+    }
+}
+
+fn container_locator() -> SourceLocator {
+    SourceLocator {
+        slide: Some(4),
+        part: Some("Pictures/source.png".into()),
+        bounds: Some(Rect { x: 20.0, y: 311.811, width: 500.0, height: 40.0 }),
+        byte_start: Some(7),
+        byte_end: Some(12),
+        ..SourceLocator::default()
+    }
+}
+
+fn assert_image_local(source: &SourceLocator) {
+    let image = image_locator();
+    assert!(coordinate_frame(source, &image).is_none());
+    let actual = remapped_ocr_locator(source, &image);
+    assert_eq!(actual.page_width, image.page_width);
+    assert_eq!(actual.page_height, image.page_height);
+    assert_eq!(actual.bounds, image.bounds);
+    assert_eq!(actual.rotation_degrees, image.rotation_degrees);
+    assert_eq!(actual.slide, source.slide);
+    assert_eq!(actual.part, source.part);
+    assert_eq!(actual.page, Some(4));
+    assert_eq!(actual.byte_start, None);
+    assert_eq!(actual.byte_end, None);
+}
+
+#[test]
+fn incomplete_canvas_never_mixes_container_points_with_image_pixels() {
+    let mut source = container_locator();
+    assert_image_local(&source);
+    source.page_width = Some(800.0);
+    assert_image_local(&source);
+    source.page_width = None;
+    source.page_height = Some(600.0);
+    assert_image_local(&source);
+}
+
+#[test]
+fn off_canvas_and_unknown_rotation_keep_image_local_evidence() {
+    let mut source = container_locator();
+    source.page_width = Some(800.0);
+    source.page_height = Some(600.0);
+    for bounds in [
+        Rect { x: -2653.0, y: -8214.0, width: 100_000.0, height: 20_000.0 },
+        Rect { x: -0.0001, y: 20.0, width: 100.0, height: 30.0 },
+        Rect { x: 790.0, y: 20.0, width: 100.0, height: 30.0 },
+        Rect { x: 20.0, y: 590.0, width: 100.0, height: 30.0 },
+    ] {
+        source.bounds = Some(bounds);
+        assert_image_local(&source);
+    }
+    source.bounds = container_locator().bounds;
+    for rotation in [90.0, 180.0, 0.01, f32::NAN] {
+        source.rotation_degrees = Some(rotation);
+        assert_image_local(&source);
+    }
+}
+
+#[test]
+fn complete_axis_aligned_canvas_maps_pixels_into_source_units() {
+    let source = SourceLocator {
+        page_width: Some(800.0),
+        page_height: Some(600.0),
+        bounds: Some(Rect { x: 72.0, y: 144.0, width: 72.0, height: 36.0 }),
+        rotation_degrees: Some(0.0),
+        ..container_locator()
+    };
+    let image = SourceLocator {
+        page_width: Some(96.0),
+        page_height: Some(48.0),
+        bounds: Some(Rect { x: 8.0, y: 4.0, width: 80.0, height: 40.0 }),
+        ..image_locator()
+    };
+    let actual = remapped_ocr_locator(&source, &image);
+    assert_eq!(actual.page_width, Some(800.0));
+    assert_eq!(actual.page_height, Some(600.0));
+    assert_eq!(actual.bounds, Some(Rect { x: 78.0, y: 147.0, width: 60.0, height: 30.0 }));
+    assert_eq!(actual.slide, source.slide);
+    assert_eq!(actual.part, source.part);
+}
+
+#[test]
+fn fallback_preserves_polygon_bytes_and_passes_the_unchanged_ir_validator() {
+    let polygon = [
+        SourcePoint { x: 10.0, y: 2.0 },
+        SourcePoint { x: 1210.0, y: 2.0 },
+        SourcePoint { x: 1210.0, y: 102.0 },
+        SourcePoint { x: 10.0, y: 102.0 },
+    ];
+    let provenance = Provenance {
+        kind: ProvenanceKind::LocalOcr,
+        provider: "test.recognizer".into(),
+        locator: image_locator(),
+        confidence: Some(0.9),
+    };
+    let evidence = OcrEvidence {
+        page: 1,
+        regions: vec![OcrSourceRegion {
+            source_index: 7,
+            polygon,
+            detection_confidence: 0.9,
+            recognition_confidence: 0.9,
+        }],
+        chain: vec![
+            OcrEvidenceStep {
+                stage: OcrEvidenceStage::Detection,
+                provider: "test.detector".into(),
+                model: Some("detector".into()),
+            },
+            OcrEvidenceStep {
+                stage: OcrEvidenceStage::Recognition,
+                provider: "test.recognizer".into(),
+                model: Some("recognizer".into()),
+            },
+            OcrEvidenceStep {
+                stage: OcrEvidenceStage::Merge,
+                provider: "test.merge".into(),
+                model: None,
+            },
+        ],
+    };
+    let node = BlockNode {
+        id: NodeId("original".into()),
+        provenance: provenance.clone(),
+        block: Block::Paragraph(vec![Inline::OcrText {
+            value: "retained words".into(),
+            marks: Vec::new(),
+            provenance: Box::new(provenance),
+            evidence: Box::new(evidence),
+        }]),
+    };
+    let source = Provenance {
+        kind: ProvenanceKind::NativeParser,
+        provider: "test.container".into(),
+        locator: container_locator(),
+        confidence: None,
+    };
+    let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+    let mapped = remap_ocr_node(node, NodeId("mapped".into()), &source, &context).unwrap();
+    let Block::Paragraph(inlines) = &mapped.block else { panic!("paragraph") };
+    let Inline::OcrText { value, provenance, evidence, .. } = &inlines[0] else {
+        panic!("OCR text")
+    };
+    assert_eq!(value, "retained words");
+    assert_eq!(evidence.page, 4);
+    assert_eq!(evidence.regions[0].source_index, 7);
+    assert_eq!(evidence.regions[0].polygon, polygon);
+    assert_eq!(provenance.locator.page_width, Some(1366.0));
+    assert_eq!(provenance.locator.page_height, Some(109.0));
+    assert_eq!(provenance.locator.slide, Some(4));
+    assert_eq!(provenance.locator.part, source.locator.part);
+    Document { blocks: vec![mapped], ..Document::default() }.validate().unwrap();
+    assert_eq!(context.reserved_memory_bytes(), 0);
+}

--- a/crates/converters/src/image_converter/ocr.rs
+++ b/crates/converters/src/image_converter/ocr.rs
@@ -11,6 +11,9 @@ use into_markdown_core::{
 const MERGE_PROVIDER: &str = "builtin.converter.image.ocr-merge";
 const INSTALL_HINT: &str = "install the local OCR capability with `into-md setup ocr`";
 
+mod geometry;
+use geometry::{polygon_bounds, validate_region_bounds, validate_region_shape};
+
 #[derive(Debug)]
 pub(crate) struct OcrContribution {
     pub(crate) nodes: Vec<BlockNode>,
@@ -308,12 +311,7 @@ fn materialize_nodes(
         if index % 256 == 0 {
             materialize.execution.checkpoint()?;
         }
-        validate_region(
-            &region.polygon,
-            materialize.width,
-            materialize.height,
-            materialize.engine_id,
-        )?;
+        validate_region_bounds(&region.polygon, materialize)?;
         if !region.confidence.is_finite() || !(0.0..=1.0).contains(&region.confidence) {
             return Err(ConversionError::Ocr {
                 provider: materialize.engine_id.into(),
@@ -336,6 +334,9 @@ fn materialize_nodes(
             });
             continue;
         }
+        // Empty/low-confidence detector noise is already diagnosed above.
+        // Strict shape validation applies to evidence we actually publish.
+        validate_region_shape(&region.polygon, materialize.engine_id)?;
         let polygon = region.polygon.map(|(x, y)| SourcePoint { x, y });
         let bounds = polygon_bounds(&polygon);
         let locator =
@@ -495,54 +496,6 @@ fn preflight_unavailable(
         | ConversionError::ResourceLimit { .. } => Err(error),
         _ => Err(map_unavailable(provider, error)),
     }
-}
-
-fn validate_region(
-    polygon: &[(f32, f32); 4],
-    width: u32,
-    height: u32,
-    provider: &str,
-) -> Result<(), ConversionError> {
-    let width = dimension(width, provider)?;
-    let height = dimension(height, provider)?;
-    if polygon.iter().any(|(x, y)| {
-        !x.is_finite() || !y.is_finite() || *x < 0.0 || *y < 0.0 || *x > width || *y > height
-    }) {
-        return Err(ConversionError::Ocr {
-            provider: provider.into(),
-            detail: "OCR polygon lies outside the normalized image".into(),
-        });
-    }
-    let mut sign = 0_i8;
-    for index in 0..4 {
-        let a = polygon[index];
-        let b = polygon[(index + 1) % 4];
-        let c = polygon[(index + 2) % 4];
-        let cross = (b.0 - a.0) * (c.1 - b.1) - (b.1 - a.1) * (c.0 - b.0);
-        if cross == 0.0 {
-            return Err(ConversionError::Ocr {
-                provider: provider.into(),
-                detail: "OCR polygon must be a non-degenerate convex quadrilateral".into(),
-            });
-        }
-        let current = if cross > 0.0 { 1 } else { -1 };
-        if sign != 0 && sign != current {
-            return Err(ConversionError::Ocr {
-                provider: provider.into(),
-                detail: "OCR polygon must be convex and consistently ordered".into(),
-            });
-        }
-        sign = current;
-    }
-    Ok(())
-}
-
-fn polygon_bounds(points: &[SourcePoint; 4]) -> into_markdown_core::Rect {
-    let min_x = points.iter().map(|point| point.x).fold(f32::INFINITY, f32::min);
-    let max_x = points.iter().map(|point| point.x).fold(f32::NEG_INFINITY, f32::max);
-    let min_y = points.iter().map(|point| point.y).fold(f32::INFINITY, f32::min);
-    let max_y = points.iter().map(|point| point.y).fold(f32::NEG_INFINITY, f32::max);
-    into_markdown_core::Rect { x: min_x, y: min_y, width: max_x - min_x, height: max_y - min_y }
 }
 
 fn page_locator(

--- a/crates/converters/src/image_converter/ocr/geometry.rs
+++ b/crates/converters/src/image_converter/ocr/geometry.rs
@@ -1,0 +1,70 @@
+//! Admit only image-local evidence that satisfies the published IR geometry.
+
+use super::{MaterializeContext, dimension};
+use into_markdown_core::{ConversionError, Rect, SourcePoint};
+
+#[cfg(test)]
+#[path = "geometry_tests.rs"]
+mod tests;
+
+pub(super) fn validate_region_bounds(
+    polygon: &[(f32, f32); 4],
+    materialize: &MaterializeContext<'_>,
+) -> Result<(), ConversionError> {
+    let width = dimension(materialize.width, materialize.engine_id)?;
+    let height = dimension(materialize.height, materialize.engine_id)?;
+    if polygon.iter().any(|(x, y)| {
+        !x.is_finite() || !y.is_finite() || *x < 0.0 || *y < 0.0 || *x > width || *y > height
+    }) {
+        return Err(ConversionError::Ocr {
+            provider: materialize.engine_id.into(),
+            detail: "OCR polygon lies outside the normalized image".into(),
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn validate_region_shape(
+    polygon: &[(f32, f32); 4],
+    provider: &str,
+) -> Result<(), ConversionError> {
+    if strictly_convex(polygon) {
+        Ok(())
+    } else {
+        Err(ConversionError::Ocr {
+            provider: provider.into(),
+            detail: "OCR polygon must be a non-degenerate convex quadrilateral".into(),
+        })
+    }
+}
+
+fn strictly_convex(polygon: &[(f32, f32); 4]) -> bool {
+    let mut sign = 0_i8;
+    let mut twice_area = 0.0_f64;
+    for index in 0..4 {
+        let a = polygon[index];
+        let b = polygon[(index + 1) % 4];
+        let c = polygon[(index + 2) % 4];
+        twice_area += f64::from(a.0) * f64::from(b.1) - f64::from(a.1) * f64::from(b.0);
+        // Match IR validation's f32 differences and widened cross products.
+        let cross = f64::from(b.0 - a.0) * f64::from(c.1 - b.1)
+            - f64::from(b.1 - a.1) * f64::from(c.0 - b.0);
+        if cross.abs() <= f64::EPSILON {
+            return false;
+        }
+        let current = if cross.is_sign_positive() { 1 } else { -1 };
+        if sign != 0 && sign != current {
+            return false;
+        }
+        sign = current;
+    }
+    twice_area.is_finite() && twice_area.abs() > f64::EPSILON
+}
+
+pub(super) fn polygon_bounds(points: &[SourcePoint; 4]) -> Rect {
+    let min_x = points.iter().map(|point| point.x).fold(f32::INFINITY, f32::min);
+    let max_x = points.iter().map(|point| point.x).fold(f32::NEG_INFINITY, f32::max);
+    let min_y = points.iter().map(|point| point.y).fold(f32::INFINITY, f32::min);
+    let max_y = points.iter().map(|point| point.y).fold(f32::NEG_INFINITY, f32::max);
+    Rect { x: min_x, y: min_y, width: max_x - min_x, height: max_y - min_y }
+}

--- a/crates/converters/src/image_converter/ocr/geometry_tests.rs
+++ b/crates/converters/src/image_converter/ocr/geometry_tests.rs
@@ -1,0 +1,118 @@
+use super::super::materialize_nodes;
+use super::*;
+use into_markdown_core::{
+    Block, ConversionOptions, ExecutionContext, ExecutionOptions, Inline, OcrEvidenceStage,
+    OcrEvidenceStep, OcrRegion, OcrResult,
+};
+
+fn chain() -> Vec<OcrEvidenceStep> {
+    vec![
+        OcrEvidenceStep {
+            stage: OcrEvidenceStage::Detection,
+            provider: "test.detector".into(),
+            model: Some("detector".into()),
+        },
+        OcrEvidenceStep {
+            stage: OcrEvidenceStage::Recognition,
+            provider: "test.recognizer".into(),
+            model: Some("recognizer".into()),
+        },
+        OcrEvidenceStep {
+            stage: OcrEvidenceStage::Merge,
+            provider: "test.merge".into(),
+            model: None,
+        },
+    ]
+}
+
+fn region(text: &str, polygon: [(f32, f32); 4]) -> OcrRegion {
+    OcrRegion { text: text.into(), polygon, confidence: 0.95 }
+}
+
+const VALID: [(f32, f32); 4] = [(1.0, 1.0), (10.0, 1.0), (10.0, 10.0), (1.0, 10.0)];
+// Captured from ddb216474d903742140efad6, slide 5, 137x91 image,
+// region 11: empty text, recognition confidence 0, detector confidence .42518458.
+// Twice-area is 2, but the first three vertices are collinear.
+const COLLINEAR_NOISE: [(f32, f32); 4] = [(19.0, 74.0), (19.0, 75.0), (19.0, 76.0), (18.0, 75.0)];
+
+fn captured_noise() -> OcrRegion {
+    OcrRegion { text: String::new(), polygon: COLLINEAR_NOISE, confidence: 0.0 }
+}
+
+#[test]
+fn captured_empty_collinear_noise_is_diagnosed_before_publication_shape_validation() {
+    let options = ConversionOptions::default();
+    let execution = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    let chain = chain();
+    let materialize = MaterializeContext {
+        chain: &chain,
+        page: 1,
+        width: 137,
+        height: 91,
+        options: &options,
+        engine_id: "test.recognizer",
+        execution: &execution,
+    };
+    for regions in [
+        vec![region("first", VALID), captured_noise(), region("last", VALID)],
+        vec![captured_noise()],
+    ] {
+        let result = OcrResult { regions, provider: "test.recognizer".into() };
+        let count = result.regions.len();
+        let (document, diagnostics, accepted, _) =
+            materialize_nodes(result, vec![0.96; count], &materialize).unwrap();
+        document.validate().unwrap();
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "ocr.lowConfidence");
+        assert_eq!(accepted, u64::try_from(count - 1).unwrap());
+        let text: Vec<_> = document
+            .blocks
+            .iter()
+            .map(|node| {
+                let Block::Paragraph(inlines) = &node.block else { panic!("paragraph") };
+                let Inline::OcrText { value, evidence, .. } = &inlines[0] else {
+                    panic!("OCR text")
+                };
+                (value.as_str(), evidence.regions[0].source_index)
+            })
+            .collect();
+        if count == 3 {
+            assert_eq!(text, [("first", 0), ("last", 2)]);
+        } else {
+            assert!(text.is_empty());
+        }
+    }
+    let usable_text_with_invalid_shape = OcrResult {
+        regions: vec![region("must not silently disappear", COLLINEAR_NOISE)],
+        provider: "test.recognizer".into(),
+    };
+    assert!(matches!(
+        materialize_nodes(usable_text_with_invalid_shape, vec![0.96], &materialize),
+        Err(ConversionError::Ocr { .. })
+    ));
+    assert_eq!(execution.reserved_memory_bytes(), 0);
+}
+
+#[test]
+fn nonfinite_or_out_of_image_coordinates_remain_hard_errors() {
+    let options = ConversionOptions::default();
+    let execution = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+    let chain = chain();
+    let materialize = MaterializeContext {
+        chain: &chain,
+        page: 1,
+        width: 32,
+        height: 32,
+        options: &options,
+        engine_id: "test.recognizer",
+        execution: &execution,
+    };
+    for x in [f32::NAN, f32::INFINITY, -1.0, 33.0] {
+        let mut polygon = VALID;
+        polygon[0].0 = x;
+        assert!(matches!(
+            validate_region_bounds(&polygon, &materialize),
+            Err(ConversionError::Ocr { .. })
+        ));
+    }
+}


### PR DESCRIPTION
## Scope

Closes #323.

- Embedded OCR maps into a container frame only with a complete finite canvas, an in-canvas positive frame, and an axis-aligned rotation. Otherwise preserve image-local polygons/dimensions plus slide/part identity. Never substitute image-pixel dimensions for missing container dimensions or clamp legitimate off-canvas offsets into place.
- Extract remap helpers into a focused module; do not rewrite candidate scanning, normalization, OCR scheduling, or PDF page lifetimes.
- Keep coordinate validity checks before filtering, but apply strict convexity only to regions actually being published, after the existing empty/low-confidence diagnostic path. Published invalid shapes remain errors; no generic invalidGeometry recovery, fabricated quads, new public interface, model/budget change, validator relaxation, or workflow change.

## Captured cause, not a guessed quadrilateral

Real source `ddb216474d903742140efad6`, slide 5, `ppt/media/image4.png` (137×91, SHA-256 `133c3da805e35c3d9e2d0a15808b949d050cc3f6717cf2800e684574c1500758`), region index 11:

```
[(19,74), (19,75), (19,76), (18,75)]
text="", recognition confidence=0, detector confidence=0.42518458
```

Twice-area is 2, but the first three vertices are collinear. The area-only detection/crop checks accept this, whereas strict publication geometry rejects it. The existing empty/low-confidence diagnostic should run first: this region has no recognized text to preserve. The source asset is a small text-free illustration. All 12 regions of this image are below the existing confidence policy; 1/12 has the collinear shape. This was not introduced by #319's resolution change; the remap and acceptance-order boundaries predate it.

The captured quad is now a fixed regression. Valid surrounding text, order and source indices remain unchanged; an all-noise result still has an explicit diagnostic. Nonfinite/out-of-image coordinates and nonempty high-confidence invalid shapes remain hard errors.

## Validation / coordination

Geometry-directed tests: 18 passed, including six new tests for incomplete canvas, source units, negative/off-canvas locations, fallback polygon identity and unchanged IR validation, the real empty collinear quad, and hard coordinate errors.

Final validation on `ceef73a1c48b4a99d9961cd9135bc75393be56af`:

- `cargo fmt --all -- --check`, `git diff --check`: passed.
- `cargo clippy --locked -j 2 -p into-markdown-converters --all-targets -- -D warnings`: passed; no new lint exemptions.
- `cargo test --locked -j 2 -p into-markdown-converters`: **616 passed, 0 failed, 3 ignored**; the separate explicit PDF quality marker remains ignored. This does not claim that optional native PDF quality target was rerun here.
- Five actual documents and the #319 TIFF: all succeeded serially through the real converters + bound native OCR + embedded enricher, passed unchanged `Document::validate()`, and released all leases. This local driver is not a claim of full release-package acceptance.

| Source ID | Accepted OCR regions | Native text/order |
| --- | ---: | --- |
| ddb216474d903742140efad6 | 227 | exact |
| 859733d9a8dcc5ba3ccc399b | 89 | exact |
| cb4c06e72f71bbb0fa394005 | 67 | exact |
| ed89b2e345a96d7d1f7874fd | 104 | exact |
| f2e4991498d65036324edf52 | 600 | exact |
| 47a6533826cd5b9fb97168cc (TIFF) | 35 | full prior document exact |

The ddb run preserves every previously valid OCR inline (text, order, geometry and evidence) from the diagnostic run; its one affected noise diagnostic now uses the existing `ocr.lowConfidence` path. No valid text is newly discarded. TIFF's **entire document, all 35 OCR inlines and diagnostics exactly match** the frozen #319 `sheep-pipeline.json`; canonical document SHA-256 `8346786985d287dedf85407226b8fd10f5afc4eb04e72c8fbcaa1dd7b6ae9004`.

Evidence summary: `six-source-results.json`; final logs in `logs/`. Native driver SHA-256 `8706c844967f9771ab584d99bfced354fae88d56961b8acc5c68dae9d9b0eae1`; worker SHA-256 `47e78f2f57400cd11b3989d88164a6eb0dbbc69a43c35dfab128142c1fc44483`. Models/runtime are the unchanged authenticated snapshot used by #319. No speedup or global quality claim is made; this is a correctness repair.

The independent #322 page-lease change owns PDF full-page render production: its already-rendered bitmap has displayed-page bounds/dimensions and explicit rotation 0. Its new omit+OCR path does not send raw embedded PDF bitmaps into this enricher. No general affine API or unrelated PDF transform rewrite is included here. #324 independently owns JPEG-tail adaptation and does not overlap these geometry helpers.

Local evidence: `C:\im-bench-004\issue323-geometry-20260831`. Original raw capture: `logs/ddb-diagnostic.log`. Temporary diagnosis driver and binaries remain outside the PR. Root task performs independent review; no self-review, subagents, or merge from this task.
