### PR TITLE
fix(cli): stream typed batch reports within byte budgets (#328)

### DIFF
--- a/apps/cli/src/output.rs
+++ b/apps/cli/src/output.rs
@@ -3,6 +3,7 @@
 mod assets;
 mod bundle;
 mod commit;
+mod report;
 mod serialization;
 mod stdout;
 mod stream;
@@ -17,7 +18,8 @@ use assets::{plan_asset_writes, write_assets_with_hook};
 pub(crate) use bundle::write_bundle;
 #[cfg(test)]
 use commit::write_preflighted_file;
-pub(crate) use commit::{preflight_file, write_file, write_report, write_spooled_output_set_file};
+pub(crate) use commit::{preflight_file, write_file, write_spooled_output_set_file};
+pub(crate) use report::write_report;
 pub(crate) use serialization::encode_result;
 pub(crate) use stdout::publish as publish_stdout;
 pub(crate) use stream::StructuredSpool;

--- a/apps/cli/src/output/commit.rs
+++ b/apps/cli/src/output/commit.rs
@@ -1,12 +1,11 @@
 //! Atomic primary-artifact publication and conflict handling.
 
 use super::assets::plan_spooled_asset_writes;
-use super::serialization::report_json_with_newline;
 use super::stream::StructuredSpool;
 use crate::args::{AssetModeArg, ConflictPolicy};
 use crate::error::{CliError, ExitClass};
 use crate::transaction::{self, FileTarget, Target};
-use into_markdown::{BatchReportDto, ExecutionContext};
+use into_markdown::ExecutionContext;
 #[cfg(test)]
 use std::fs;
 #[cfg(test)]
@@ -79,15 +78,6 @@ pub(super) fn write_preflighted_file(
 ) -> Result<WriteOutcome, CliError> {
     write_exact_file(path, bytes, conflict == ConflictPolicy::Overwrite)?;
     Ok(WriteOutcome { path: path.to_path_buf(), renamed: false })
-}
-
-/// Write a versioned JSON report atomically.
-pub(crate) fn write_report(
-    path: &Path,
-    report: &BatchReportDto,
-    context: &ExecutionContext,
-) -> Result<WriteOutcome, CliError> {
-    write_file(path, &report_json_with_newline(report)?, ConflictPolicy::Overwrite, context)
 }
 
 fn resolve_conflict(

--- a/apps/cli/src/output/report.rs
+++ b/apps/cli/src/output/report.rs
@@ -1,0 +1,88 @@
+//! Bounded typed reports written directly to the existing file-backed transaction.
+
+use super::commit::WriteOutcome;
+use crate::error::{CliError, ExitClass};
+use crate::transaction::{self, FileTarget, PreparedTransaction};
+use into_markdown::{
+    BatchReportDto, ConversionError, DtoErrorCode, DtoJsonStyle, ExecutionContext, TemporaryFile,
+};
+use std::io::{self, BufWriter, Write};
+use std::path::Path;
+
+const BUFFER_BYTES: usize = 64 * 1024;
+
+pub(crate) fn write_report(
+    path: &Path,
+    report: &BatchReportDto,
+    context: &ExecutionContext,
+) -> Result<WriteOutcome, CliError> {
+    prepare_report(path, report, context)?.commit()?;
+    Ok(WriteOutcome { path: path.to_path_buf(), renamed: false })
+}
+
+fn prepare_report(
+    path: &Path,
+    report: &BatchReportDto,
+    context: &ExecutionContext,
+) -> Result<PreparedTransaction, CliError> {
+    let _buffer_memory = context.reserve_memory(BUFFER_BYTES as u64).map_err(CliError::from)?;
+    let mut stage = ReportFile {
+        file: context.temporary_file("into-md-report").map_err(CliError::from)?,
+        error: None,
+    };
+    let result = {
+        let mut buffered = BufWriter::with_capacity(BUFFER_BYTES, &mut stage);
+        let result = report
+            .write_json(DtoJsonStyle::Pretty, &mut buffered)
+            .map_err(|error| {
+                let (class, code) = if error.code == DtoErrorCode::ResourceLimit {
+                    (ExitClass::Policy, "resourceLimit")
+                } else {
+                    (ExitClass::Internal, "internal")
+                };
+                CliError::new(class, code, format!("write batch report DTO: {error}"))
+            })
+            .and_then(|()| buffered.write_all(b"\n").map_err(CliError::from))
+            .and_then(|()| buffered.flush().map_err(CliError::from));
+        // Do not retry flushing buffered prefixes during unwinding after a failure.
+        let _ = buffered.into_parts();
+        result
+    };
+    if let Some(error) = stage.error.take() {
+        return Err(error.into());
+    }
+    result?;
+    stage.file.sync_all().map_err(CliError::from)?;
+    transaction::recover_for_paths(&[path.to_path_buf()], context)?;
+    transaction::prepare_files(
+        &[FileTarget {
+            path: path.to_path_buf(),
+            file: stage.file.as_file().map_err(CliError::from)?,
+        }],
+        true,
+        context,
+    )
+}
+
+struct ReportFile {
+    file: TemporaryFile,
+    error: Option<ConversionError>,
+}
+
+impl Write for ReportFile {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if let Err(error) = self.file.write_all_checked(bytes) {
+            self.error = Some(error);
+            return Err(io::Error::other("batch report stage write failed"));
+        }
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "report_tests.rs"]
+mod tests;

--- a/apps/cli/src/output/report_tests.rs
+++ b/apps/cli/src/output/report_tests.rs
@@ -1,0 +1,134 @@
+use super::*;
+use into_markdown::{
+    BatchItemDto, BatchItemOutcome, BatchItemStatus, Diagnostic, DiagnosticDto,
+    DiagnosticSeverityDto, ExecutionOptions, ResourceLimits,
+};
+use std::fs;
+
+fn report(diagnostics: Vec<DiagnosticDto>) -> BatchReportDto {
+    BatchReportDto::try_new_with_wall_duration(
+        vec![BatchItemDto {
+            input: "diagnostics-replay".into(),
+            output: None,
+            format: None,
+            status: BatchItemStatus::Success,
+            outcome: BatchItemOutcome::Degraded,
+            diagnostics,
+            error_code: None,
+            reason_code: None,
+            component: None,
+            part: None,
+            limit: None,
+            message: None,
+            warnings: vec![],
+            duration_ms: Some(12.5),
+            processing_duration_ms: Some(8.25),
+        }],
+        Some(14.0),
+    )
+    .unwrap()
+}
+
+fn context(limits: ResourceLimits) -> ExecutionContext {
+    ExecutionContext::new(ExecutionOptions::default(), limits)
+}
+
+#[test]
+fn report_stage_preserves_bytes_and_rolls_back_commit_io_failure() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = temporary.path().canonicalize().unwrap();
+    let path = root.join("report.json");
+    fs::write(&path, b"previous").unwrap();
+    let report = report(vec![]);
+    let execution = context(ResourceLimits::default());
+    let error = prepare_report(&path, &report, &execution)
+        .unwrap()
+        .commit_with_hook(|phase, _| {
+            if phase == "targetInstalled" {
+                Err(io::Error::from(io::ErrorKind::StorageFull).into())
+            } else {
+                Ok(crate::transaction::HookDecision::Continue)
+            }
+        })
+        .unwrap_err();
+    assert_eq!(error.code(), "io");
+    assert_eq!(fs::read(&path).unwrap(), b"previous");
+    assert_eq!(fs::read_dir(&root).unwrap().count(), 1);
+    assert_eq!(execution.reserved_memory_bytes(), 0);
+    assert_eq!(execution.reserved_temporary_bytes(), 0);
+    write_report(&path, &report, &execution).unwrap();
+    assert_eq!(fs::read_to_string(&path).unwrap(), report.to_pretty_json().unwrap() + "\n");
+    assert_eq!(execution.reserved_memory_bytes(), 0);
+    assert_eq!(execution.reserved_temporary_bytes(), 0);
+}
+
+#[test]
+fn report_temporary_budget_failure_preserves_existing_destination() {
+    let temporary = tempfile::tempdir().unwrap();
+    let root = temporary.path().canonicalize().unwrap();
+    let path = root.join("report.json");
+    fs::write(&path, b"previous").unwrap();
+    let diagnostic = DiagnosticDto {
+        code: "ocr.lowConfidence".into(),
+        severity: DiagnosticSeverityDto::Warning,
+        message: "omitted region ".repeat(64),
+        locator: None,
+    };
+    let report = report(vec![diagnostic; 512]);
+    let encoded_bytes = u64::try_from(report.to_pretty_json().unwrap().len()).unwrap() + 1;
+    for max_temporary_bytes in [128 * 1024, encoded_bytes + 128 * 1024] {
+        let execution =
+            context(ResourceLimits { max_temporary_bytes, ..ResourceLimits::default() });
+        let error = write_report(&path, &report, &execution).unwrap_err();
+        assert_eq!(error.code(), "resourceLimit", "{error:?}");
+        assert_eq!(fs::read(&path).unwrap(), b"previous");
+        assert_eq!(fs::read_dir(&root).unwrap().count(), 1);
+        assert_eq!(execution.reserved_memory_bytes(), 0);
+        assert_eq!(execution.reserved_temporary_bytes(), 0);
+    }
+}
+
+#[test]
+#[ignore = "requires INTO_MD_REPORT_DIAGNOSTICS_FIXTURE and INTO_MD_REPORT_REPLAY_OUTPUT"]
+fn real_diagnostics_report_replay_without_reconversion() {
+    #[derive(serde::Deserialize)]
+    struct DiagnosticsOnly {
+        diagnostics: Vec<Diagnostic>,
+    }
+    #[derive(serde::Deserialize)]
+    struct ReportOnly {
+        items: Vec<DiagnosticsOnly>,
+    }
+    let fixture = std::env::var_os("INTO_MD_REPORT_DIAGNOSTICS_FIXTURE").unwrap();
+    let output =
+        std::path::PathBuf::from(std::env::var_os("INTO_MD_REPORT_REPLAY_OUTPUT").unwrap());
+    assert!(!output.exists(), "keep existing evidence unchanged");
+    let fixture: DiagnosticsOnly =
+        serde_json::from_reader(std::io::BufReader::new(fs::File::open(fixture).unwrap())).unwrap();
+    let report = report(fixture.diagnostics.into_iter().map(|value| (&value).into()).collect());
+    let legacy = report.to_pretty_json().unwrap_err();
+    assert_eq!(legacy.code, DtoErrorCode::ResourceLimit);
+    assert!(legacy.detail.contains("dtoValues"));
+    let execution =
+        context(ResourceLimits { max_memory_bytes: 4 * 1024 * 1024, ..ResourceLimits::default() });
+    write_report(&output, &report, &execution).unwrap();
+    let decoded: ReportOnly =
+        serde_json::from_reader(std::io::BufReader::new(fs::File::open(&output).unwrap())).unwrap();
+    let diagnostics: Vec<DiagnosticDto> = decoded
+        .items
+        .into_iter()
+        .next()
+        .unwrap()
+        .diagnostics
+        .into_iter()
+        .map(|value| (&value).into())
+        .collect();
+    assert_eq!(diagnostics, report.items[0].diagnostics);
+    assert_eq!(execution.reserved_memory_bytes(), 0);
+    assert_eq!(execution.reserved_temporary_bytes(), 0);
+    println!(
+        "replayed {} exact diagnostics into {} bytes; no OCR invoked",
+        diagnostics.len(),
+        fs::metadata(output).unwrap().len()
+    );
+}

--- a/apps/cli/src/output/serialization.rs
+++ b/apps/cli/src/output/serialization.rs
@@ -3,7 +3,7 @@
 use super::bundle;
 use crate::args::EmitKind;
 use crate::error::CliError;
-use into_markdown::{BatchReportDto, ConversionResult, DtoJsonStyle, ResultDto};
+use into_markdown::{ConversionResult, DtoJsonStyle, ResultDto};
 use std::io::{Cursor, Seek, Write};
 
 /// Serialize a conversion result into the selected primary artifact.
@@ -46,13 +46,4 @@ pub(crate) fn encode_result_into<W: Write + Seek>(
         EmitKind::Bundle => bundle::write_bundle(result, destination)?,
     }
     Ok(())
-}
-
-pub(super) fn report_json_with_newline(report: &BatchReportDto) -> Result<Vec<u8>, CliError> {
-    let json = report
-        .to_pretty_json()
-        .map_err(|error| CliError::internal(format!("serialize batch report DTO: {error}")))?;
-    let mut bytes = json.into_bytes();
-    bytes.push(b'\n');
-    Ok(bytes)
 }

--- a/crates/core/src/dto.rs
+++ b/crates/core/src/dto.rs
@@ -30,6 +30,8 @@ use std::fmt;
 use std::io::{self, Write};
 use thiserror::Error;
 
+mod batch_report;
+
 /// Schema version emitted and accepted by application DTOs.
 pub const DTO_SCHEMA_VERSION: u32 = 1;
 /// Current portable bundle manifest schema version.

--- a/crates/core/src/dto/batch_report.rs
+++ b/crates/core/src/dto/batch_report.rs
@@ -1,0 +1,209 @@
+//! Borrowed output for already typed reports; untrusted JSON decoding stays unchanged.
+
+use super::{
+    BatchItemDto, BatchItemOutcome, BatchItemStatus, BatchReportDto, DiagnosticDto,
+    DiagnosticSeverityDto, DtoError, DtoErrorCode, DtoJsonStyle, DtoLimits, InternalDiagnosticWire,
+    RawBatchItemOutcome, RawBatchItemStatus, RawBatchOcrUsageDto, RawBatchResourceUsageDto,
+    RawDiagnosticSeverityDto, WireAccounting, limit,
+};
+use serde::{Serialize, ser::SerializeSeq};
+use std::io::{self, Write};
+
+impl BatchReportDto {
+    /// Stream an internally constructed report without copying its items or diagnostics.
+    /// Semantic and encoded-byte limits still apply. Parser complexity limits are
+    /// reserved for untrusted JSON input, not this fixed, typed wire structure.
+    /// The destination may contain a prefix on failure; callers must stage publication.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invalid-report, encoded-byte-limit, or destination-write error.
+    #[doc(hidden)]
+    pub fn write_json<W: Write>(
+        &self,
+        style: DtoJsonStyle,
+        destination: W,
+    ) -> Result<(), DtoError> {
+        write_report(self, style, destination, &DtoLimits::default())
+    }
+}
+
+fn write_report<W: Write>(
+    report: &BatchReportDto,
+    style: DtoJsonStyle,
+    destination: W,
+    limits: &DtoLimits,
+) -> Result<(), DtoError> {
+    report.validate(limits)?;
+    let wire = ReportWire {
+        schema_version: report.schema_version,
+        succeeded: report.succeeded,
+        failed: report.failed,
+        items: Items(&report.items),
+        wall_duration_ms: report.wall_duration_ms,
+        resource_usage: report.resource_usage.as_ref().map(|usage| RawBatchResourceUsageDto {
+            shared_lease_budget_bytes: usage.shared_lease_budget_bytes,
+            shared_lease_peak_bytes: usage.shared_lease_peak_bytes,
+            ocr: usage.ocr.map(|ocr| RawBatchOcrUsageDto {
+                recognized_regions: ocr.recognized_regions,
+                recognized_chars: ocr.recognized_chars,
+            }),
+        }),
+    };
+    let mut writer =
+        ReportWriter { destination, accounting: WireAccounting::default(), limits, error: None };
+    let result = match style {
+        DtoJsonStyle::Compact => serde_json::to_writer(&mut writer, &wire),
+        DtoJsonStyle::Pretty => serde_json::to_writer_pretty(&mut writer, &wire),
+    };
+    if let Some(error) = writer.error {
+        return Err(error);
+    }
+    result.map_err(|error| {
+        DtoError::new(DtoErrorCode::InvalidJson, "$", format!("write batch report: {error}"))
+    })
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReportWire<'a> {
+    schema_version: u32,
+    succeeded: u64,
+    failed: u64,
+    items: Items<'a>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    wall_duration_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resource_usage: Option<RawBatchResourceUsageDto>,
+}
+
+struct Items<'a>(&'a [BatchItemDto]);
+
+impl Serialize for Items<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for item in self.0 {
+            sequence.serialize_element(&ItemWire {
+                input: &item.input,
+                output: item.output.as_deref(),
+                format: item.format.as_deref(),
+                status: match item.status {
+                    BatchItemStatus::Success => RawBatchItemStatus::Success,
+                    BatchItemStatus::Failed => RawBatchItemStatus::Failed,
+                },
+                outcome: match item.outcome {
+                    BatchItemOutcome::Complete => RawBatchItemOutcome::Complete,
+                    BatchItemOutcome::Degraded => RawBatchItemOutcome::Degraded,
+                    BatchItemOutcome::Failed => RawBatchItemOutcome::Failed,
+                },
+                diagnostics: Diagnostics(&item.diagnostics),
+                error_code: item.error_code.as_deref(),
+                reason_code: item.reason_code.as_deref(),
+                component: item.component.as_deref(),
+                part: item.part.as_deref(),
+                limit: item
+                    .limit
+                    .as_ref()
+                    .map(|value| LimitWire { name: &value.name, detail: value.detail.as_deref() }),
+                message: item.message.as_deref(),
+                warnings: &item.warnings,
+                duration_ms: item.duration_ms,
+                processing_duration_ms: item.processing_duration_ms,
+            })?;
+        }
+        sequence.end()
+    }
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ItemWire<'a> {
+    input: &'a str,
+    output: Option<&'a str>,
+    format: Option<&'a str>,
+    status: RawBatchItemStatus,
+    outcome: RawBatchItemOutcome,
+    diagnostics: Diagnostics<'a>,
+    error_code: Option<&'a str>,
+    reason_code: Option<&'a str>,
+    component: Option<&'a str>,
+    part: Option<&'a str>,
+    limit: Option<LimitWire<'a>>,
+    message: Option<&'a str>,
+    warnings: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    duration_ms: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    processing_duration_ms: Option<f64>,
+}
+
+#[derive(Serialize)]
+struct LimitWire<'a> {
+    name: &'a str,
+    detail: Option<&'a str>,
+}
+
+struct Diagnostics<'a>(&'a [DiagnosticDto]);
+
+impl Serialize for Diagnostics<'_> {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for diagnostic in self.0 {
+            sequence.serialize_element(&InternalDiagnosticWire {
+                code: &diagnostic.code,
+                severity: match diagnostic.severity {
+                    DiagnosticSeverityDto::Info => RawDiagnosticSeverityDto::Info,
+                    DiagnosticSeverityDto::Warning => RawDiagnosticSeverityDto::Warning,
+                    DiagnosticSeverityDto::Error => RawDiagnosticSeverityDto::Error,
+                },
+                message: &diagnostic.message,
+                locator: diagnostic.locator.as_ref(),
+            })?;
+        }
+        sequence.end()
+    }
+}
+
+struct ReportWriter<'a, W> {
+    destination: W,
+    accounting: WireAccounting,
+    limits: &'a DtoLimits,
+    error: Option<DtoError>,
+}
+
+impl<W: Write> ReportWriter<'_, W> {
+    fn check_bytes(&self) -> Result<(), DtoError> {
+        if self.accounting.json_bytes > self.limits.max_json_bytes {
+            return limit("$", "dtoJsonBytes", self.limits.max_json_bytes);
+        }
+        if self.accounting.max_string_bytes.max(self.accounting.string_bytes)
+            > self.limits.max_string_bytes
+        {
+            return limit("$", "dtoStringBytes", self.limits.max_string_bytes);
+        }
+        if self.accounting.total_string_bytes > self.limits.max_total_string_bytes {
+            return limit("$", "dtoTotalStringBytes", self.limits.max_total_string_bytes);
+        }
+        Ok(())
+    }
+}
+
+impl<W: Write> Write for ReportWriter<'_, W> {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        self.accounting.write_all(bytes)?;
+        if let Err(error) = self.check_bytes() {
+            self.error = Some(error);
+            return Err(io::Error::other("batch report exceeds encoded-byte budget"));
+        }
+        self.destination.write_all(bytes)?;
+        Ok(bytes.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.destination.flush()
+    }
+}
+
+#[cfg(test)]
+#[path = "batch_report_tests.rs"]
+mod tests;

--- a/crates/core/src/dto/batch_report_tests.rs
+++ b/crates/core/src/dto/batch_report_tests.rs
@@ -1,0 +1,143 @@
+use super::*;
+use crate::SourceLocator;
+use crate::dto::{BatchLimitDto, BatchOcrUsageDto, BatchResourceUsageDto};
+
+fn item() -> BatchItemDto {
+    BatchItemDto {
+        input: "C:/资料/\"report\".pdf".into(),
+        output: Some("out.md".into()),
+        format: Some("pdf".into()),
+        status: BatchItemStatus::Success,
+        outcome: BatchItemOutcome::Degraded,
+        diagnostics: vec![DiagnosticDto {
+            code: "ocr.lowConfidence".into(),
+            severity: DiagnosticSeverityDto::Warning,
+            message: "omitted region\nwith a \\ and 中文".into(),
+            locator: Some(SourceLocator {
+                page: Some(1),
+                bounds: Some(crate::Rect { x: 0.0, y: 0.0, width: 842.0, height: 667.0 }),
+                rotation_degrees: Some(0.0),
+                page_width: Some(842.0),
+                page_height: Some(667.0),
+                ..SourceLocator::default()
+            }),
+        }],
+        error_code: None,
+        reason_code: Some("ocr.lowConfidence".into()),
+        component: None,
+        part: None,
+        limit: None,
+        message: None,
+        warnings: vec!["warning".into()],
+        duration_ms: Some(12.5),
+        processing_duration_ms: Some(8.25),
+    }
+}
+
+#[test]
+fn typed_report_matches_existing_bytes_for_optional_fields_and_outcomes() {
+    let mut failed = item();
+    failed.status = BatchItemStatus::Failed;
+    failed.outcome = BatchItemOutcome::Failed;
+    failed.output = None;
+    failed.format = None;
+    failed.error_code = Some("resourceLimit".into());
+    failed.reason_code = Some("max_pages".into());
+    failed.component = Some("converter".into());
+    failed.part = Some("page".into());
+    failed.limit = Some(BatchLimitDto { name: "max_pages".into(), detail: Some("limit".into()) });
+    failed.message = Some("failed".into());
+    failed.processing_duration_ms = None;
+    let report = BatchReportDto::try_new_with_resource_usage(
+        vec![item(), failed],
+        Some(20.0),
+        Some(BatchResourceUsageDto {
+            shared_lease_budget_bytes: 1024,
+            shared_lease_peak_bytes: 512,
+            ocr: Some(BatchOcrUsageDto { recognized_regions: 1, recognized_chars: 2 }),
+        }),
+    )
+    .unwrap();
+    for report in [BatchReportDto::try_new(vec![]).unwrap(), report] {
+        for (style, expected) in [
+            (DtoJsonStyle::Compact, report.to_json().unwrap()),
+            (DtoJsonStyle::Pretty, report.to_pretty_json().unwrap()),
+        ] {
+            let mut bytes = Vec::new();
+            report.write_json(style, &mut bytes).unwrap();
+            assert_eq!(bytes, expected.as_bytes());
+            assert_eq!(BatchReportDto::from_json(&expected).unwrap(), report);
+        }
+    }
+}
+
+#[test]
+fn typed_report_streams_past_input_value_limit_without_weakening_decoder() {
+    let mut item = item();
+    item.diagnostics = vec![item.diagnostics[0].clone(); 56_000];
+    let report = BatchReportDto::try_new(vec![item]).unwrap();
+    let mut bytes = Vec::new();
+    report.write_json(DtoJsonStyle::Compact, &mut bytes).unwrap();
+    let json = String::from_utf8(bytes).unwrap();
+    let error = BatchReportDto::from_json(&json).unwrap_err();
+    assert_eq!(error.code, DtoErrorCode::ResourceLimit);
+    assert!(error.detail.contains("dtoValues"));
+    let decoded: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(decoded["items"][0]["diagnostics"].as_array().unwrap().len(), 56_000);
+    assert_eq!(decoded["items"][0]["processingDurationMs"], 8.25);
+    assert_eq!(DtoLimits::default().max_values, 2_000_000);
+}
+
+#[test]
+fn typed_report_keeps_semantics_and_encoded_byte_boundaries() {
+    let mut report = BatchReportDto::try_new(vec![item()]).unwrap();
+    for style in [DtoJsonStyle::Compact, DtoJsonStyle::Pretty] {
+        let mut bytes = Vec::new();
+        report.write_json(style, &mut bytes).unwrap();
+        let exact = DtoLimits { max_json_bytes: bytes.len(), ..DtoLimits::default() };
+        write_report(&report, style, io::sink(), &exact).unwrap();
+        let short = DtoLimits { max_json_bytes: bytes.len() - 1, ..exact };
+        let mut destination = Vec::new();
+        let error = write_report(&report, style, &mut destination, &short).unwrap_err();
+        assert_eq!(error.code, DtoErrorCode::ResourceLimit);
+        assert!(error.detail.contains("dtoJsonBytes"));
+        assert!(destination.len() <= short.max_json_bytes);
+    }
+    for limits in [
+        DtoLimits { max_string_bytes: 8, ..DtoLimits::default() },
+        DtoLimits { max_total_string_bytes: 32, ..DtoLimits::default() },
+    ] {
+        assert_eq!(
+            write_report(&report, DtoJsonStyle::Pretty, io::sink(), &limits).unwrap_err().code,
+            DtoErrorCode::ResourceLimit
+        );
+    }
+    report.succeeded = 0;
+    let mut destination = Vec::new();
+    assert_eq!(
+        report.write_json(DtoJsonStyle::Pretty, &mut destination).unwrap_err().code,
+        DtoErrorCode::InvalidField
+    );
+    assert!(destination.is_empty());
+}
+
+#[test]
+fn typed_report_propagates_partial_destination_failure() {
+    struct FailingWriter(usize);
+    impl Write for FailingWriter {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            if self.0 == 0 {
+                return Err(io::ErrorKind::StorageFull.into());
+            }
+            let written = bytes.len().min(self.0);
+            self.0 -= written;
+            Ok(written)
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    let report = BatchReportDto::try_new(vec![item()]).unwrap();
+    let error = report.write_json(DtoJsonStyle::Pretty, FailingWriter(31)).unwrap_err();
+    assert_eq!(error.code, DtoErrorCode::InvalidJson);
+}

--- a/docs/dto.md
+++ b/docs/dto.md
@@ -25,7 +25,11 @@ DTO 解码错误为 `invalidField`、`invalidBase64`、`duplicateId` 和 `resour
 `axum::Json<ResultDto>` 作为 extractor 或 response 均在类型层不可用；HTTP、SSE、CLI 和
 库调用方入站必须使用 `from_json` 或 `from_json_with_limits`；已有 owned DTO 出站使用
 `to_json` 或 `to_pretty_json`，内部 `ConversionResult` 出站使用
-`write_json_from_result`。这些入口通过私有 Raw/borrowed wire 类型编码或解码，并执行
+`write_json_from_result`；CLI 内部类型化批量报告使用 `BatchReportDto::write_json` 流式
+写入暂存事务，保留语义、JSON 总字节及字符串字节限制，不克隆整个 wire 报告或生成
+整串 JSON 后回读。该固定类型的出站路径不套用不可信输入的结构数量限制；入站
+`from_json` 的默认限额、重复键和深度检查不变。大报告消费者仍须显式选择适合自身
+信任边界的 `from_json_with_limits` 预算。这些入口通过私有 Raw/borrowed wire 类型编码或解码，并执行
 版本、预算和不变量检查，避免框架绕过稳定边界。字段公开用于读取已验证结果及应用代码
 显式构造，但不能直接进入通用 serde/Axum wire 边界。
 


### PR DESCRIPTION
## Summary

Closes #328.

- Add a small borrowed-wire writer for internally typed `BatchReportDto`, preserving the existing field order, omissions, diagnostics, timings and resource usage without cloning a complete wire report, allocating a full JSON string, or parsing the emitted JSON again.
- Preserve semantic validation and encoded JSON / single-string / total-string byte limits. Untrusted input decoding keeps its original value, depth and duplicate-key limits; the default 2,000,000-value input cap is unchanged.
- Route CLI report publication through a 64 KiB accounted buffer, accounted temporary file and the existing `prepare_files` transaction. This is bounded staging plus transaction-stage copying, **not zero-copy**. No transaction implementation changes, new lint exemptions, PDF special cases, dependencies or Actions.

## Regression evidence

- Compact/pretty bytes match the prior encoder for empty and populated reports, optional fields, failures, diagnostics, timings and resource usage.
- A valid 56,000-diagnostic typed report streams beyond the input value cap; the unchanged default decoder still rejects it at `dtoValues`.
- Exact/limit-minus-one JSON byte limits, string limits, invalid report semantics and partial destination failure are covered.
- CLI tests preserve the old destination on temporary-budget failures during both staging phases and on injected commit I/O failure; reservations and transaction artifacts are released.
- Existing real Result JSON from #322 was replayed **offline**, with no converter or OCR invocation: the prior report encoder reproduces `dtoValues`; the new path atomically emits **34,340,216 bytes** and preserves all **55,985 diagnostics**, compared entry-for-entry. The ignored replay test was explicitly run and passed in **6.30 s**, under a 4 MiB execution memory budget (excluding caller-owned fixture/DTO storage).

The replay uses synthetic report metadata/timings around the original diagnostics. It is not a reconstructed native #322 report or a new end-to-end OCR run, and 6.30 s is not a release performance comparison.

## Validation

Validation logs and SHA-256 receipts are archived externally at `C:/im-bench-004/issue328-batch-report-streaming/`; large fixture/output files are not committed.

- PASS: `cargo fmt --all -- --check`.
- PASS: `cargo test --locked -p into-markdown-core --lib -j2`: **116 passed**.
- PASS: targeted CLI report regressions (**2 passed**) and the separately invoked offline real-diagnostic replay (**1 passed**, 6.30 s).
- PASS: Core lib/tests strict clippy (`--no-deps -- -D warnings`) and final diff check against the base.
- BASELINE FAILURE: full CLI binary unit suite (`--test-threads=2`): **288 passed, 1 failed, 1 ignored**, 163.72 s. The sole failure is `web_tasks::tests::empty_result_tests::empty_source_and_empty_content_share_the_web_terminal_contract`, line 41 (`Succeeded` versus expected `Failed` for an altChunk-only DOCX). Isolated runs reproduce the identical failure on both this PR (0.25 s) and the clean `f1ad63e` base (0.29 s). No Web source/test is changed by this PR; the complete suite is not claimed green.
- BASELINE LINT: CLI production-bin strict clippy reports **45 diagnostics**, identical by message and source location to the clean `f1ad63e` base (**0 added, 0 removed**). Expanded CLI test-target strict clippy also fails. No report-writer diagnostic was emitted, no unrelated source was changed, and no CLI strict-clippy success is claimed.
- PASS: [PR fast gate run 33344956242](https://github.com/coolplayagent/into-markdown/actions/runs/33344956242), all four jobs: Linux x86_64/shared/Web, Linux ARM64 Core, Windows x86_64 Core and macOS ARM64 Core. This does not supersede the separately disclosed local full-suite/lint failures.

The broader CLI `clippy --tests` selection additionally includes unrelated integration targets; earlier runs also exposed failures in `plugin_lifecycle.rs` (`too_many_arguments`, `too_many_lines`) and `exit_contract.rs` (`needless_pass_by_value`). These files and lint policy are unchanged. All failing command logs remain archived rather than replacing them with successful filtered runs.

## Frozen evidence and scope

- Base: `f1ad63e3dbca0fe27c1d5253f50165e333bfe7d5`.
- PR head: `76c0a98431ed5fe4dff3fd09d3ae99865fb04855` (one isolated commit).
- #322 measured executable SHA-256 remains `eb914aab30e76eb93852d22c16947c36d4b377bd5a63bc8b287b03e492f99c5f`.
- Real diagnostic fixture: 59,146,797-byte Result JSON, SHA-256 `02b5ca5935d2fbdf3ba06bfd69b9df9eb3df99c323329ea54f0bae463bd66a0a`.
- Independent static review reported P0/P1/P2 = 0. This PR does not merge or publish a release, rerun OCR, or change OCR quality/ordering.
