### PR TITLE
fix(pdf): preserve native pages when optional OCR cannot contribute

### DIFF
--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -15,6 +15,7 @@ use std::io::Cursor;
 mod candidate_index;
 mod geometry;
 mod jpeg_input;
+mod pdf_placement;
 use candidate_index::{
     CandidateBuffer, OcrCandidate, ReferenceIndex, candidate_index_plan, group_candidates,
     validate_visual_references_without_index,
@@ -784,6 +785,15 @@ async fn enrich(
         }
     }
     let mut eligible_reference_count = 0_u32;
+    if input_format == InputFormat::Pdf {
+        pdf_placement::filter_references(
+            &mut references,
+            &eligible_assets,
+            &mut output.diagnostics,
+            options,
+            context,
+        )?;
+    }
     for (index, reference) in references.iter().enumerate() {
         if index % 256 == 0 {
             context.checkpoint()?;
@@ -805,6 +815,9 @@ async fn enrich(
                 "embedded visual references exceed the request limit",
             ));
         }
+    }
+    if eligible_reference_count == 0 {
+        return Ok(output);
     }
     let mut candidates = CandidateBuffer::new(eligible_assets.len(), context)?;
     let mut referenced_assets = BTreeSet::new();
@@ -955,6 +968,7 @@ async fn enrich(
         std::mem::take(&mut output.document.blocks),
         &contributions_by_asset,
         &mut occupied_ids,
+        input_format,
         context,
     )?;
     for (reference_index, reference) in references.iter().enumerate() {
@@ -1250,6 +1264,7 @@ fn rebuild_nodes(
     nodes: Vec<BlockNode>,
     cache: &BTreeMap<AssetId, CachedContribution>,
     occupied_ids: &mut BTreeSet<NodeId>,
+    input_format: InputFormat,
     context: &ExecutionContext,
 ) -> Result<Vec<BlockNode>, ConversionError> {
     let mut rebuilt = Vec::new();
@@ -1264,6 +1279,7 @@ fn rebuild_nodes(
                         std::mem::take(&mut item.blocks),
                         cache,
                         occupied_ids,
+                        input_format,
                         context,
                     )?;
                 }
@@ -1275,6 +1291,7 @@ fn rebuild_nodes(
                             std::mem::take(&mut cell.blocks),
                             cache,
                             occupied_ids,
+                            input_format,
                             context,
                         )?;
                     }
@@ -1284,12 +1301,23 @@ fn rebuild_nodes(
             | Block::Page { blocks, .. }
             | Block::Slide { blocks, .. }
             | Block::Sheet { blocks, .. } => {
-                *blocks = rebuild_nodes(std::mem::take(blocks), cache, occupied_ids, context)?;
+                *blocks = rebuild_nodes(
+                    std::mem::take(blocks),
+                    cache,
+                    occupied_ids,
+                    input_format,
+                    context,
+                )?;
             }
             _ => {}
         }
         let contribution = match &node.block {
-            Block::Image { asset, .. } => cache.get(asset).cloned(),
+            Block::Image { asset, .. }
+                if input_format != InputFormat::Pdf
+                    || geometry::source_coordinate_frame(&node.provenance.locator).is_some() =>
+            {
+                cache.get(asset).cloned()
+            }
             _ => None,
         };
         let source_id = node.id.clone();
@@ -1379,6 +1407,7 @@ fn resource(limit: &'static str, detail: impl Into<String>) -> ConversionError {
 #[cfg(test)]
 mod tests {
     mod jpeg;
+    mod pdf_placement;
 
     use super::*;
     use image::{DynamicImage, Frame, ImageFormat, Rgba, RgbaImage, codecs::gif::GifEncoder};

--- a/crates/converters/src/embedded_visual_ocr/geometry.rs
+++ b/crates/converters/src/embedded_visual_ocr/geometry.rs
@@ -87,11 +87,18 @@ fn coordinate_frame(
     source: &SourceLocator,
     ocr: &SourceLocator,
 ) -> Option<(into_markdown_core::Rect, f32, f32)> {
+    let bounds = source_coordinate_frame(source)?;
+    let width = ocr.page_width?;
+    let height = ocr.page_height?;
+    (width.is_finite() && height.is_finite() && width > 0.0 && height > 0.0)
+        .then_some((bounds, width, height))
+}
+
+/// A placement that can carry image-local OCR into the container's coordinates.
+pub(super) fn source_coordinate_frame(source: &SourceLocator) -> Option<into_markdown_core::Rect> {
     let bounds = source.bounds?;
     let page_width = source.page_width?;
     let page_height = source.page_height?;
-    let width = ocr.page_width?;
-    let height = ocr.page_height?;
     // A container bounding box alone is not an image-to-page transform. In
     // particular, do not mix ODF points or DrawingML EMUs with image pixels,
     // or infer a rotated/cropped placement from its axis-aligned envelope.
@@ -109,12 +116,8 @@ fn coordinate_frame(
         && page_height > 0.0
         && f64::from(bounds.x) + f64::from(bounds.width) <= f64::from(page_width)
         && f64::from(bounds.y) + f64::from(bounds.height) <= f64::from(page_height)
-        && source.rotation_degrees.is_none_or(|rotation| rotation == 0.0)
-        && width.is_finite()
-        && height.is_finite()
-        && width > 0.0
-        && height > 0.0)
-        .then_some((bounds, width, height))
+        && source.rotation_degrees.is_none_or(|rotation| rotation == 0.0))
+    .then_some(bounds)
 }
 
 fn remapped_ocr_locator(source: &SourceLocator, ocr: &SourceLocator) -> SourceLocator {

--- a/crates/converters/src/embedded_visual_ocr/pdf_placement.rs
+++ b/crates/converters/src/embedded_visual_ocr/pdf_placement.rs
@@ -1,0 +1,47 @@
+//! PDF layout needs page coordinates, unlike other containers' local OCR evidence.
+
+use super::{VisualRef, effective_ocr_policy, geometry};
+use into_markdown_core::{
+    AssetId, ConversionError, ConversionOptions, Diagnostic, DiagnosticSeverity, ErrorPolicy,
+    ExecutionContext, OcrPolicy,
+};
+use std::collections::BTreeSet;
+
+pub(super) fn filter_references(
+    references: &mut Vec<VisualRef>,
+    eligible_assets: &BTreeSet<AssetId>,
+    diagnostics: &mut Vec<Diagnostic>,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    // Filter placements, not assets: the same image may also have a usable
+    // placement on this page. Keep its recognition cached for that placement.
+    for reference in references.iter() {
+        context.checkpoint()?;
+        if !eligible_assets.contains(&reference.asset)
+            || geometry::source_coordinate_frame(&reference.provenance.locator).is_some()
+        {
+            continue;
+        }
+        let detail = "PDF image OCR omitted: its image-to-page coordinate transform is unavailable";
+        if options.error_policy != ErrorPolicy::BestEffort
+            || effective_ocr_policy(options) != OcrPolicy::Auto
+        {
+            return Err(ConversionError::Unsupported { detail: detail.into() });
+        }
+        diagnostics.try_reserve(1).map_err(|_| {
+            super::resource("max_memory_bytes", "PDF OCR placement diagnostic allocation failed")
+        })?;
+        diagnostics.push(Diagnostic {
+            code: "pdf.optionalOcrSkipped".into(),
+            severity: DiagnosticSeverity::Warning,
+            message: detail.into(),
+            locator: Some(geometry::remapped_locator(&reference.provenance.locator)),
+        });
+    }
+    references.retain(|reference| {
+        !eligible_assets.contains(&reference.asset)
+            || geometry::source_coordinate_frame(&reference.provenance.locator).is_some()
+    });
+    Ok(())
+}

--- a/crates/converters/src/embedded_visual_ocr/tests/pdf_placement.rs
+++ b/crates/converters/src/embedded_visual_ocr/tests/pdf_placement.rs
@@ -1,0 +1,166 @@
+use super::*;
+use into_markdown_core::{ErrorPolicy, Rect};
+
+fn with_native_text(mut source: ConverterOutput) -> ConverterOutput {
+    let Block::Page { blocks, .. } = &mut source.document.blocks[0].block else { panic!("page") };
+    blocks.insert(
+        0,
+        BlockNode {
+            id: NodeId("native-text".into()),
+            block: Block::Paragraph(
+                "native words retained"
+                    .chars()
+                    .enumerate()
+                    .map(|(index, value)| {
+                        let mut source = provenance("native");
+                        source.locator.bounds = Some(Rect {
+                            x: 10.0 + 8.0 * f32::from(u16::try_from(index).unwrap()),
+                            y: 120.0,
+                            width: 8.0,
+                            height: 12.0,
+                        });
+                        source.locator.font_size = Some(12.0);
+                        Inline::SourceText {
+                            value: value.to_string(),
+                            marks: Vec::new(),
+                            provenance: Box::new(source),
+                        }
+                    })
+                    .collect(),
+            ),
+            provenance: provenance("native"),
+        },
+    );
+    source
+}
+
+fn text(document: &Document) -> String {
+    fn visit(nodes: &[BlockNode], value: &mut String) {
+        for node in nodes {
+            match &node.block {
+                Block::Page { blocks, .. } => visit(blocks, value),
+                Block::Paragraph(inlines) => {
+                    for inline in inlines {
+                        if let Inline::SourceText { value: text, .. }
+                        | Inline::OcrText { value: text, .. } = inline
+                        {
+                            value.push_str(text);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    let mut value = String::new();
+    visit(&document.blocks, &mut value);
+    value
+}
+
+#[test]
+fn pdf_unmappable_placement_keeps_native_text_and_other_use_of_same_asset() {
+    for placement in [
+        Rect { x: -53.16, y: 20.0, width: 815.16, height: 60.0 },
+        Rect { x: 590.0, y: 20.0, width: 30.0, height: 20.0 },
+    ] {
+        let mut source = with_native_text(output());
+        let Block::Page { blocks, .. } = &mut source.document.blocks[0].block else {
+            panic!("page")
+        };
+        blocks[1].provenance.locator.bounds = Some(placement);
+        // Reusing the same ID must not either drop the good placement or
+        // accidentally attach its cached OCR to the rejected one.
+        let Block::Image { asset, .. } = &mut blocks[2].block else { panic!("image") };
+        *asset = AssetId("asset-a".into());
+        let ocr = source_bound_ocr(false);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let result =
+            block_on(enrich(source, InputFormat::Pdf, &options, &services, &context)).unwrap();
+        result.document.validate().unwrap();
+        let value = text(&result.document);
+        assert!(value.contains("native words retained"));
+        assert_eq!(value.matches("embedded words").count(), 1);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            result.diagnostics.iter().filter(|d| d.code == "pdf.optionalOcrSkipped").count(),
+            1
+        );
+        drop(result);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+}
+
+#[test]
+fn pdf_only_unmappable_images_skip_recognition_and_preserve_original_document() {
+    for rotation in [None, Some(90.0)] {
+        let mut source = with_native_text(output());
+        let Block::Page { blocks, .. } = &mut source.document.blocks[0].block else {
+            panic!("page")
+        };
+        for node in blocks.iter_mut().skip(1) {
+            if rotation.is_some() {
+                node.provenance.locator.rotation_degrees = rotation;
+            } else {
+                node.provenance.locator.page_width = None;
+            }
+        }
+        let expected = source.document.clone();
+        let ocr = source_bound_ocr(false);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let result =
+            block_on(enrich(source, InputFormat::Pdf, &options, &services, &context)).unwrap();
+        assert_eq!(result.document, expected);
+        assert_eq!(result.diagnostics.len(), 2);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+    }
+}
+
+#[test]
+fn pdf_unmappable_required_or_strict_ocr_is_not_silently_omitted() {
+    for (error_policy, policy) in
+        [(ErrorPolicy::Strict, OcrPolicy::Auto), (ErrorPolicy::BestEffort, OcrPolicy::Always)]
+    {
+        let mut source = output();
+        let Block::Page { blocks, .. } = &mut source.document.blocks[0].block else {
+            panic!("page")
+        };
+        blocks[0].provenance.locator.rotation_degrees = Some(90.0);
+        let mut options = ConversionOptions { error_policy, ..ConversionOptions::default() };
+        options.ocr.policy = policy;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let ocr = source_bound_ocr(false);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        assert!(matches!(
+            block_on(enrich(source, InputFormat::Pdf, &options, &services, &context)),
+            Err(ConversionError::Unsupported { .. })
+        ));
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+    }
+}
+
+#[test]
+fn pdf_empty_ocr_contributions_keep_native_text_without_geometry_error() {
+    for missing_provider in [false, true] {
+        let source = with_native_text(output());
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Auto;
+        options.ocr.minimum_confidence = 0.999;
+        let services = if missing_provider {
+            Services::default()
+        } else {
+            Services { ocr: Some(source_bound_ocr(false)), ..Services::default() }
+        };
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let result =
+            block_on(enrich(source, InputFormat::Pdf, &options, &services, &context)).unwrap();
+        result.document.validate().unwrap();
+        assert!(text(&result.document).contains("native words retained"));
+        assert!(!text(&result.document).contains("embedded words"));
+    }
+}

--- a/crates/engine/src/page_enrichment.rs
+++ b/crates/engine/src/page_enrichment.rs
@@ -1,5 +1,6 @@
 //! Enrich transient PDF pages without changing aggregate stream ownership.
 
+use crate::{optional_embedded_ocr, push_optional_ocr_skipped};
 use into_markdown_core::{
     Asset, ConversionError, ConversionOptions, ConverterEventSink, ConverterOutput, Document,
     EnrichmentPlan, ExecutionContext, InputFormat, LocalBoxFuture, OutputEnricher, Services,
@@ -37,35 +38,52 @@ impl ConverterEventSink for PageEnrichmentSink<'_> {
 
     fn enrich_page(
         &mut self,
-        output: ConverterOutput,
+        mut output: ConverterOutput,
     ) -> LocalBoxFuture<'_, Result<ConverterOutput, ConversionError>> {
         Box::pin(async move {
             self.context.checkpoint()?;
             let enricher = self.enricher.ok_or_else(|| ConversionError::Internal {
                 detail: "page enrichment was not negotiated".into(),
             })?;
-            let plan = enricher.planned_enrichment_bytes(
-                &output,
-                self.converter_id,
-                self.format,
-                self.options,
-                self.services,
-                self.context,
-            )?;
-            let EnrichmentPlan::Reserve(bytes) = plan else { return Ok(output) };
             // As in nested conversion, the enclosing native invocation already
             // holds the global admission. Child credits cannot back new credits.
-            // Check the incremental peak before entry and use the same context
-            // for all actual OCR working-set and retained-output reservations.
-            if bytes > self.context.available_memory_bytes() {
-                return Err(ConversionError::ResourceLimit {
-                    limit: "max_memory_bytes",
-                    detail: format!(
-                        "page OCR planned {bytes} bytes but only {} remain",
-                        self.context.available_memory_bytes()
-                    ),
+            // Apply the aggregate path's optional preflight policy before the
+            // enricher consumes the page; runtime errors remain terminal.
+            let plan = enricher
+                .planned_enrichment_bytes(
+                    &output,
+                    self.converter_id,
+                    self.format,
+                    self.options,
+                    self.services,
+                    self.context,
+                )
+                .and_then(|plan| {
+                    if let EnrichmentPlan::Reserve(bytes) = plan {
+                        let available = self.context.available_memory_bytes();
+                        if bytes > available {
+                            return Err(ConversionError::ResourceLimit {
+                                limit: "max_memory_bytes",
+                                detail: format!(
+                                    "page OCR planned {bytes} bytes but only {available} remain"
+                                ),
+                            });
+                        }
+                    }
+                    Ok(plan)
                 });
-            }
+            let plan = match plan {
+                Ok(plan) => plan,
+                Err(error)
+                    if optional_embedded_ocr(self.options, enricher)
+                        && matches!(error, ConversionError::ResourceLimit { .. }) =>
+                {
+                    push_optional_ocr_skipped(&mut output, &error)?;
+                    return Ok(output);
+                }
+                Err(error) => return Err(error),
+            };
+            let EnrichmentPlan::Reserve(_) = plan else { return Ok(output) };
             let output = self
                 .context
                 .run(enricher.enrich(
@@ -90,3 +108,7 @@ impl ConverterEventSink for PageEnrichmentSink<'_> {
         })
     }
 }
+
+#[cfg(test)]
+#[path = "page_enrichment_tests.rs"]
+mod tests;

--- a/crates/engine/src/page_enrichment_tests.rs
+++ b/crates/engine/src/page_enrichment_tests.rs
@@ -1,0 +1,239 @@
+use super::*;
+use into_markdown_core::{
+    Block, BlockNode, BoxFuture, DiagnosticSeverity, ErrorPolicy, ExecutionOptions, Inline,
+    IrErrorCode, MAX_DOCUMENT_NODES, NodeId, OcrPolicy, Provenance, ProvenanceKind, ResourceLimits,
+    SourceLocator,
+};
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+struct Fixture {
+    plan: Result<EnrichmentPlan, ConversionError>,
+    runtime_error: Option<ConversionError>,
+    calls: AtomicUsize,
+}
+
+impl OutputEnricher for Fixture {
+    fn id(&self) -> &'static str {
+        EMBEDDED_OCR
+    }
+
+    fn planned_enrichment_bytes(
+        &self,
+        _: &ConverterOutput,
+        _: &str,
+        _: InputFormat,
+        _: &ConversionOptions,
+        _: &Services,
+        _: &ExecutionContext,
+    ) -> Result<EnrichmentPlan, ConversionError> {
+        self.plan.clone()
+    }
+
+    fn enrich<'a>(
+        &'a self,
+        output: ConverterOutput,
+        _: &'a str,
+        _: InputFormat,
+        _: &'a ConversionOptions,
+        _: &'a Services,
+        _: &'a ExecutionContext,
+    ) -> BoxFuture<'a, Result<ConverterOutput, ConversionError>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move { self.runtime_error.clone().map_or(Ok(output), Err) })
+    }
+}
+
+fn fixture(plan: Result<EnrichmentPlan, ConversionError>) -> Fixture {
+    Fixture { plan, runtime_error: None, calls: AtomicUsize::new(0) }
+}
+
+fn resource(limit: &'static str) -> ConversionError {
+    ConversionError::ResourceLimit { limit, detail: "preflight fixture".into() }
+}
+
+fn options() -> ConversionOptions {
+    let mut options =
+        ConversionOptions { error_policy: ErrorPolicy::BestEffort, ..ConversionOptions::default() };
+    options.ocr.policy = OcrPolicy::Auto;
+    options
+}
+
+fn node(id: String, block: Block) -> BlockNode {
+    BlockNode {
+        id: NodeId(id),
+        block,
+        provenance: Provenance {
+            kind: ProvenanceKind::NativeParser,
+            provider: "builtin.converter.pdfium".into(),
+            locator: SourceLocator::default(),
+            confidence: None,
+        },
+    }
+}
+
+fn source() -> ConverterOutput {
+    ConverterOutput::new(
+        Document {
+            blocks: vec![node(
+                "native".into(),
+                Block::Paragraph(vec![Inline::Text { value: "native body".into(), marks: vec![] }]),
+            )],
+            ..Document::default()
+        },
+        vec![],
+        vec![],
+    )
+}
+
+fn enrich(
+    fixture: &Fixture,
+    options: &ConversionOptions,
+    context: &ExecutionContext,
+    output: ConverterOutput,
+) -> Result<ConverterOutput, ConversionError> {
+    let services = Services::default();
+    let mut destination = crate::collecting::CollectingArtifactSink::new(context);
+    let mut sink = PageEnrichmentSink {
+        destination: &mut destination,
+        enricher: Some(fixture),
+        converter_id: "builtin.converter.pdfium",
+        format: InputFormat::Pdf,
+        options,
+        services: &services,
+        context,
+    };
+    let mut future = std::pin::pin!(sink.enrich_page(output));
+    let mut task = std::task::Context::from_waker(std::task::Waker::noop());
+    loop {
+        match future.as_mut().poll(&mut task) {
+            std::task::Poll::Ready(result) => return result,
+            std::task::Poll::Pending => std::thread::yield_now(),
+        }
+    }
+}
+
+#[test]
+fn auto_preflight_resource_failures_preserve_native_page_without_running_ocr() {
+    let options = options();
+    for plan in [
+        Err(resource("documentNodes")),
+        Err(resource("max_memory_bytes")),
+        Ok(EnrichmentPlan::Reserve(4097)),
+    ] {
+        let fixture = fixture(plan);
+        let context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            ResourceLimits { max_memory_bytes: 4096, ..ResourceLimits::default() },
+        );
+        let input = source();
+        let expected = input.document.clone();
+        let output = enrich(&fixture, &options, &context, input).unwrap();
+        assert_eq!(output.document, expected);
+        assert_eq!(output.diagnostics.len(), 1);
+        assert_eq!(output.diagnostics[0].code, "presentation.optionalOcrSkipped");
+        assert_eq!(output.diagnostics[0].severity, DiagnosticSeverity::Warning);
+        assert!(output.diagnostics[0].message.contains("resource limit exceeded"));
+        assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+        drop(output);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+}
+
+#[test]
+fn strict_or_required_ocr_keeps_preflight_resource_errors() {
+    for (policy, ocr) in
+        [(ErrorPolicy::Strict, OcrPolicy::Auto), (ErrorPolicy::BestEffort, OcrPolicy::Always)]
+    {
+        let mut options = options();
+        options.error_policy = policy;
+        options.ocr.policy = ocr;
+        let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+        for plan in [Err(resource("documentNodes")), Ok(EnrichmentPlan::Reserve(u64::MAX))] {
+            let fixture = fixture(plan);
+            assert!(matches!(
+                enrich(&fixture, &options, &context, source()),
+                Err(ConversionError::ResourceLimit { .. })
+            ));
+            assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+        }
+    }
+}
+
+#[test]
+fn non_resource_preflight_and_all_runtime_errors_remain_terminal() {
+    let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+    let options = options();
+    for error in [
+        ConversionError::Cancelled,
+        ConversionError::Timeout,
+        ConversionError::Malformed { part: None, detail: "fixture".into() },
+        ConversionError::ComponentUnavailable { component: "ocr".into(), detail: "fixture".into() },
+    ] {
+        let fixture = fixture(Err(error.clone()));
+        let actual = enrich(&fixture, &options, &context, source()).unwrap_err();
+        assert_eq!(actual.to_string(), error.to_string());
+        assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+    }
+    for error in [resource("documentNodes"), ConversionError::Cancelled, ConversionError::Timeout] {
+        let mut fixture = fixture(Ok(EnrichmentPlan::Reserve(1)));
+        fixture.runtime_error = Some(error.clone());
+        let actual = enrich(&fixture, &options, &context, source()).unwrap_err();
+        assert_eq!(actual.to_string(), error.to_string());
+        assert_eq!(fixture.calls.load(Ordering::SeqCst), 1);
+    }
+    assert_eq!(context.reserved_memory_bytes(), 0);
+}
+
+#[test]
+fn skipped_or_empty_ocr_contribution_keeps_the_original_page() {
+    let options = options();
+    let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+    for (plan, calls) in [(EnrichmentPlan::Skip, 0), (EnrichmentPlan::Reserve(1), 1)] {
+        let fixture = fixture(Ok(plan));
+        let input = source();
+        let expected = input.document.clone();
+        let output = enrich(&fixture, &options, &context, input).unwrap();
+        assert_eq!(output.document, expected);
+        assert!(output.diagnostics.is_empty());
+        assert_eq!(fixture.calls.load(Ordering::SeqCst), calls);
+        drop(output);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+}
+
+#[test]
+fn final_validation_budget_counts_nodes_across_enriched_pages() {
+    let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+    let options = options();
+    let fixture = fixture(Ok(EnrichmentPlan::Skip));
+    let mut combined = Document::default();
+    for number in 1..=2 {
+        let blocks = (0..MAX_DOCUMENT_NODES / 2 - 1)
+            .map(|index| node(format!("page-{number}-rule-{index}"), Block::Rule))
+            .collect();
+        let page = ConverterOutput::new(
+            Document {
+                blocks: vec![node(format!("page-{number}"), Block::Page { number, blocks })],
+                ..Document::default()
+            },
+            vec![],
+            vec![],
+        );
+        let mut page = enrich(&fixture, &options, &context, page).unwrap();
+        estimate_validation_working_set(&page.document, &[], &[]).unwrap();
+        combined.blocks.append(&mut page.document.blocks);
+    }
+    // invoke_native applies this same guard to the complete output, not once
+    // per page. The two page containers count toward the exact 100,000 nodes.
+    estimate_validation_working_set(&combined, &[], &[]).unwrap();
+    combined.validate().unwrap();
+    combined.blocks.push(node("one-too-many".into(), Block::Rule));
+    assert!(matches!(
+        estimate_validation_working_set(&combined, &[], &[]),
+        Err(ConversionError::ResourceLimit { limit: "documentNodes", .. })
+    ));
+    assert_eq!(combined.validate().unwrap_err().code, IrErrorCode::ResourceLimit);
+    assert_eq!(fixture.calls.load(Ordering::SeqCst), 0);
+    assert_eq!(context.reserved_memory_bytes(), 0);
+}

--- a/crates/pdf-layout/src/ids.rs
+++ b/crates/pdf-layout/src/ids.rs
@@ -1,0 +1,98 @@
+//! Preserve retained identities when another layout pass produces new blocks.
+
+use crate::{budget::LayoutBudget, model::RebuiltBlock};
+use into_markdown_core::{Block, BlockNode, ConversionError};
+use std::collections::BTreeSet;
+
+pub(crate) fn avoid_retained_collisions(
+    rebuilt: &mut [RebuiltBlock],
+    retained: &[BlockNode],
+    budget: &mut LayoutBudget<'_>,
+) -> Result<(), ConversionError> {
+    if retained.is_empty() {
+        return Ok(());
+    }
+    let mut occupied = BTreeSet::new();
+    for node in retained {
+        collect(node, &mut occupied, budget)?;
+    }
+    for block in rebuilt {
+        assign(&mut block.node, &mut occupied, budget)?;
+    }
+    Ok(())
+}
+
+fn collect(
+    node: &BlockNode,
+    occupied: &mut BTreeSet<String>,
+    budget: &mut LayoutBudget<'_>,
+) -> Result<(), ConversionError> {
+    budget.checkpoint_item()?;
+    occupied.insert(node.id.0.clone());
+    match &node.block {
+        Block::List { items, .. } => {
+            for child in items.iter().flat_map(|item| &item.blocks) {
+                collect(child, occupied, budget)?;
+            }
+        }
+        Block::Table { rows, .. } => {
+            for child in rows.iter().flat_map(|row| &row.cells).flat_map(|cell| &cell.blocks) {
+                collect(child, occupied, budget)?;
+            }
+        }
+        Block::Footnote { blocks, .. }
+        | Block::Page { blocks, .. }
+        | Block::Slide { blocks, .. }
+        | Block::Sheet { blocks, .. } => {
+            for child in blocks {
+                collect(child, occupied, budget)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn assign(
+    node: &mut BlockNode,
+    occupied: &mut BTreeSet<String>,
+    budget: &mut LayoutBudget<'_>,
+) -> Result<(), ConversionError> {
+    budget.checkpoint_item()?;
+    if !occupied.insert(node.id.0.clone()) {
+        let mut suffix = 1_usize;
+        loop {
+            budget.checkpoint_item()?;
+            let candidate = format!("{}-reflow-{suffix}", node.id.0);
+            if occupied.insert(candidate.clone()) {
+                node.id.0 = candidate;
+                break;
+            }
+            suffix += 1;
+        }
+    }
+    match &mut node.block {
+        Block::List { items, .. } => {
+            for child in items.iter_mut().flat_map(|item| &mut item.blocks) {
+                assign(child, occupied, budget)?;
+            }
+        }
+        Block::Table { rows, .. } => {
+            for child in
+                rows.iter_mut().flat_map(|row| &mut row.cells).flat_map(|cell| &mut cell.blocks)
+            {
+                assign(child, occupied, budget)?;
+            }
+        }
+        Block::Footnote { blocks, .. }
+        | Block::Page { blocks, .. }
+        | Block::Slide { blocks, .. }
+        | Block::Sheet { blocks, .. } => {
+            for child in blocks {
+                assign(child, occupied, budget)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/crates/pdf-layout/src/lib.rs
+++ b/crates/pdf-layout/src/lib.rs
@@ -12,6 +12,7 @@ mod dedup;
 mod footnotes;
 mod geometry;
 mod gutters;
+mod ids;
 mod lines;
 mod materialize;
 mod model;

--- a/crates/pdf-layout/src/materialize.rs
+++ b/crates/pdf-layout/src/materialize.rs
@@ -53,6 +53,7 @@ pub(crate) fn reconstruct_page(
         .try_reserve_exact(table_blocks.len() + content.passthrough.len())
         .map_err(|_| memory("layout rebuilt page"))?;
     rebuilt.append(&mut table_blocks);
+    crate::ids::avoid_retained_collisions(&mut rebuilt, &content.passthrough, budget)?;
     for (index, node) in content.passthrough.into_iter().enumerate() {
         rebuilt.push(RebuiltBlock {
             bounds: node.provenance.locator.bounds,

--- a/crates/pdf-layout/src/tests.rs
+++ b/crates/pdf-layout/src/tests.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::cast_precision_loss, reason = "small bounded fixture coordinates")]
 
 use super::*;
+
+mod relayout_ids;
 use into_markdown_core::{
     AssetId, Block, BlockNode, CancellationToken, ExecutionOptions, Inline, NodeId, OcrEvidence,
     OcrEvidenceStage, OcrEvidenceStep, OcrSourceRegion, Provenance, ProvenanceKind, Rect,

--- a/crates/pdf-layout/src/tests/relayout_ids.rs
+++ b/crates/pdf-layout/src/tests/relayout_ids.rs
@@ -1,0 +1,87 @@
+use super::*;
+
+#[test]
+fn new_ocr_table_preserves_existing_table_and_uses_distinct_nested_ids() {
+    let mut native = Vec::new();
+    for row in 0..3 {
+        for column in 0..3 {
+            native.extend(source_text(
+                ["A", "B", "C"][column],
+                Rect {
+                    x: 40.0 + column as f32 * 210.0,
+                    y: 80.0 + row as f32 * 25.0,
+                    width: 40.0,
+                    height: 12.0,
+                },
+                12.0,
+            ));
+        }
+    }
+    let mut input = rebuild(document(native));
+    let original = page_blocks(&input)[0].clone();
+    assert!(matches!(original.block, Block::Table { .. }));
+    let mut additions = Vec::new();
+    for row in 0..3 {
+        for column in 0..3 {
+            additions.push(ocr(
+                ["D", "E", "F"][column],
+                Rect {
+                    x: 40.0 + column as f32 * 210.0,
+                    y: 380.0 + row as f32 * 25.0,
+                    width: 40.0,
+                    height: 12.0,
+                },
+            ));
+        }
+    }
+    let Block::Page { blocks, .. } = &mut input.blocks[0].block else { panic!("page") };
+    blocks.push(BlockNode {
+        id: NodeId("new-ocr".into()),
+        block: Block::Paragraph(additions),
+        provenance: provenance(1, None, 12.0, 0.0),
+    });
+    let actual = rebuild(input.clone());
+    actual.validate().unwrap();
+    let blocks = page_blocks(&actual);
+    assert_eq!(blocks.len(), 2);
+    assert_eq!(blocks[0], original);
+    let Block::Table { rows, .. } = &blocks[1].block else { panic!("new table") };
+    let text = rows
+        .iter()
+        .flat_map(|row| &row.cells)
+        .flat_map(|cell| &cell.blocks)
+        .map(|node| block_text(&node.block))
+        .collect::<Vec<_>>()
+        .join(" ");
+    assert_eq!(text, "D E F D E F D E F");
+    assert_eq!(actual, rebuild(input));
+    assert_eq!(actual, rebuild(actual.clone()));
+}
+
+#[test]
+fn retained_link_paragraph_does_not_collide_with_new_paragraph() {
+    let mut input =
+        document(source_text("new", Rect { x: 40.0, y: 80.0, width: 30.0, height: 12.0 }, 12.0));
+    let retained = BlockNode {
+        id: NodeId("pdf-page-1-layout-paragraph-0".into()),
+        block: Block::Paragraph(vec![Inline::Link {
+            target: "https://example.com".into(),
+            content: vec![Inline::Text { value: "original link".into(), marks: Vec::new() }],
+        }]),
+        provenance: provenance(
+            1,
+            Some(Rect { x: 40.0, y: 380.0, width: 100.0, height: 12.0 }),
+            12.0,
+            0.0,
+        ),
+    };
+    let Block::Page { blocks, .. } = &mut input.blocks[0].block else { panic!("page") };
+    blocks.push(retained.clone());
+    let actual = rebuild(input);
+    actual.validate().unwrap();
+    assert!(page_blocks(&actual).iter().any(|node| node == &retained));
+    assert_eq!(
+        page_blocks(&actual).iter().filter(|node| block_text(&node.block) == "new").count(),
+        1
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #332. This restores seven previously successful PDF OCR-auto conversions exposed by the complete 2edf717 release-candidate corpus run. The real-file verification is in progress; publication remains blocked until it finishes.

- Reuse the existing automatic/best-effort OCR policy for page-local **preflight** resource failures. Keep native pages unchanged; runtime errors and final whole-document limits still fail.
- Do not submit image-local OCR pixels to PDF page layout. Skip and diagnose only unmappable image **placements** under optional OCR, retain native content, and still recognize other valid placements of the same cached image. Required/strict OCR is not silently dropped.
- Preserve non-PDF local-coordinate fallback and existing page bitmap lifetime. No new public SPI, memory-limit increase, workflow or GitHub Action.

## Validation

- 9 focused regression tests: page preflight resource policy, required/strict failures, runtime errors, full-document node boundary, native text preservation, same-asset placement isolation, empty OCR contributions.
- `cargo test --locked -p into-markdown-engine -p into-markdown-converters --lib`: passed (engine 50; converters 626 passed / 9 previously ignored).
- `cargo clippy --locked -p into-markdown-engine -p into-markdown-converters --all-targets -- -D warnings`: passed.
- Independent root-owned read-only code review: PASS, no P0/P1/P2 findings. Reviewer did not author this patch or run self-review agents.
- Exact complete pre-fix evidence remains retained: 2,289 OCR-auto terminal records; 1,820 nonempty + 11 empty outputs; 458 failures. Compared with a6d4: 14 gained, 7 lost, 25 changed and 1,792 byte-identical outputs. The seven losses are the regression gate, not reclassified damaged samples.

Real-file and final-package receipts will be appended before merge/publication as appropriate. Debug timing is not used as release performance data.
