### PR TITLE
fix(skill): 为技能添加与产品同步的版本头 (#335)

### DIFF
--- a/.agents/skills/into-markdown/SKILL.md
+++ b/.agents/skills/into-markdown/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: into-markdown
 description: Convert documents, images, audio or video, standard input, directories, and explicitly authorized remote sources into Markdown or structured artifacts with the bundled into-md CLI. Use when the user asks to run Into Markdown or convert source files; do not use for editing existing Markdown, generic summarization, Web UI administration, plugin management, or provider configuration.
+metadata:
+  version: "0.0.4"
 ---
 
 # Into Markdown

--- a/.github/workflows/pr-fast-gate.yml
+++ b/.github/workflows/pr-fast-gate.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
+          components: clippy, rustfmt
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
@@ -82,6 +83,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
+          components: clippy, rustfmt
       - uses: actions/cache@v4
         with:
           path: |
@@ -106,6 +108,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
+          components: clippy, rustfmt
       - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
@@ -133,6 +136,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.97.1
+          components: clippy, rustfmt
       - uses: actions/cache@v4
         with:
           path: |

--- a/docs/agent-skill.md
+++ b/docs/agent-skill.md
@@ -64,7 +64,13 @@ python3 tools/skill-release/skill_release_main.py verify \
 
 发布 CI 连续生成两次并逐字节比较 ZIP，然后重新读取所有条目、权限和 canonical 字节。三平台
 Core 装配器复用同一 materializer；安装后 smoke 还会检查 skill 的精确文件集合、入口、元数据和
-许可证。skill 随产品发布同步演进，不维护独立版本号。
+许可证。skill 随产品发布同步演进。
+
+`SKILL.md` 的 YAML 头部通过 `metadata.version` 标识产品版本，使用两空格缩进的
+`version` 字段和双引号字符串。根 `Cargo.toml` 的 `workspace.package.version` 是版本权威；
+升级产品版本时同步更新该字段。仓库校验器与现有 PR 门禁会拒绝版本缺失、重复字段、结构错误
+或版本不一致。复制与打包保留 canonical 字节，发布 ZIP 的 `archive-manifest.json` 同时绑定
+包含版本头的完整 `SKILL.md`。
 
 ## English summary
 
@@ -73,3 +79,7 @@ directory in every Core package. Users explicitly install either copy into an ag
 directory. The skill runs the installed CLI for conversion and read-only diagnostics; the CLI and
 Web workflows handle product installation, plugins, providers, models, configuration, and Web UI
 administration.
+
+The skill's YAML frontmatter declares `metadata.version` as a double-quoted string matching
+`workspace.package.version` in the root `Cargo.toml`. Update both together when bumping the product
+version; release validation and the PR gate reject missing, malformed, or mismatched skill versions.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -619,6 +619,11 @@ fail closed；官方插件目录与安装 transport 固定 HTTPS 来源、完整
 `quick_validate.py`，再执行仓库校验器，检查 frontmatter、路由描述、OpenAI 元数据、引用关系、
 精确允许文件集合和许可证。任何符号链接、额外文件、非 UTF-8 内容或元数据依赖都会失败关闭。
 
+版本契约要求 `metadata.version` 与根 `Cargo.toml` 的 `workspace.package.version` 一致。
+测试覆盖缺失、空值、重复字段、错误嵌套、版本漂移，以及产品升级后同步更新技能头的恢复路径。
+materialize 与 ZIP 必须保留完整版本头；即使重算归档 manifest，版本头篡改仍须被 canonical
+字节校验拒绝。现有 PR fast gate 执行这些技能发布测试。
+
 发布工作流在两个独立目录生成同名 `into-markdown-skill.zip`，逐字节比较 ZIP 和 SHA-256
 sidecar，再解包复验固定根目录、排序、时间戳、目录 `0755`、文件 `0644` 和 canonical 字节。
 Core 装配只调用同一 materializer；`archive-manifest.json` 必须逐文件绑定

--- a/tools/platform-release/test_pr_fast_gate.py
+++ b/tools/platform-release/test_pr_fast_gate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pathlib
 import sys
+import tomllib
 import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -13,6 +14,25 @@ from pr_fast_gate import ContractError, SUPPORTED, validate  # noqa: E402
 
 
 class PrFastGateTests(unittest.TestCase):
+    def test_ci_installs_repository_toolchain_components_up_front(self) -> None:
+        root = pathlib.Path(__file__).resolve().parents[2]
+        toolchain = tomllib.loads((root / "rust-toolchain.toml").read_text())["toolchain"]
+        workflow = (root / ".github/workflows/pr-fast-gate.yml").read_text()
+        setups = workflow.split("- uses: dtolnay/rust-toolchain@stable")[1:]
+        self.assertTrue(setups, "PR gate must initialize its Rust toolchains")
+        for index, setup in enumerate(setups):
+            with self.subTest(setup=index):
+                settings = dict(
+                    line.strip().split(": ", 1)
+                    for line in setup.split("      - ", 1)[0].splitlines()
+                    if ": " in line
+                )
+                self.assertEqual(settings.get("toolchain"), toolchain["channel"])
+                self.assertEqual(
+                    {value.strip() for value in settings.get("components", "").split(",")},
+                    set(toolchain["components"]),
+                )
+
     def test_every_supported_native_host_preserves_release_authority(self) -> None:
         for target, (system, machines) in SUPPORTED.items():
             with self.subTest(target=target):

--- a/tools/skill-release/BUILD.bazel
+++ b/tools/skill-release/BUILD.bazel
@@ -6,6 +6,7 @@ py_library(
     name = "library",
     srcs = ["skill_release.py"],
     data = [
+        "//:Cargo.toml",
         "//:agent_skill_files",
         "//:release_license_files",
         "//third_party/pdfium:manifest.json",

--- a/tools/skill-release/skill_release.py
+++ b/tools/skill-release/skill_release.py
@@ -9,6 +9,7 @@ import shutil
 import stat
 import struct
 import sys
+import tomllib
 import zipfile
 from dataclasses import dataclass
 from typing import Mapping
@@ -220,6 +221,17 @@ def validate(source: pathlib.Path = SKILL_SOURCE) -> tuple[pathlib.Path, ...]:
     return tuple(source / relative for relative in CANONICAL_FILES)
 
 
+def _workspace_version() -> str:
+    try:
+        manifest = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))
+        version = manifest["workspace"]["package"]["version"]
+    except (OSError, UnicodeDecodeError, ValueError, KeyError, TypeError) as error:
+        raise SkillReleaseError("cannot read Cargo.toml workspace.package.version") from error
+    if not isinstance(version, str) or not version.strip():
+        raise SkillReleaseError("Cargo.toml workspace.package.version must be a non-empty string")
+    return version
+
+
 def _validate_skill_markdown(text: str) -> None:
     lines = text.splitlines()
     if not lines or lines[0] != "---":
@@ -229,13 +241,37 @@ def _validate_skill_markdown(text: str) -> None:
     except ValueError as error:
         raise SkillReleaseError("SKILL.md frontmatter is not closed") from error
     fields = {}
-    for line in lines[1:end]:
+    frontmatter = iter(lines[1:end])
+    # Parse the reviewed block layout; version uses a double-quoted YAML string.
+    for line in frontmatter:
         key, separator, value = line.partition(":")
-        if not separator or not key or not value.strip():
+        if not separator or key not in {"name", "description", "metadata"}:
             raise SkillReleaseError("SKILL.md frontmatter contains an invalid field")
-        fields[key] = value.strip().strip('"')
-    if set(fields) != {"name", "description"} or fields["name"] != SKILL_NAME:
-        raise SkillReleaseError("SKILL.md must declare the reviewed name and description only")
+        if key in fields:
+            raise SkillReleaseError(f"SKILL.md frontmatter contains a duplicate field: {key}")
+        if key == "metadata":
+            version_key, version_separator, version_value = next(frontmatter, "").partition(":")
+            if value.strip() or version_key != "  version" or not version_separator:
+                raise SkillReleaseError("SKILL.md metadata must contain an indented version field")
+            try:
+                version = json.loads(version_value.strip())
+            except json.JSONDecodeError as error:
+                raise SkillReleaseError("SKILL.md metadata.version must be a double-quoted string") from error
+            if not isinstance(version, str) or not version.strip():
+                raise SkillReleaseError("SKILL.md metadata.version must be a non-empty string")
+            fields[key] = version
+        else:
+            if not value.strip():
+                raise SkillReleaseError("SKILL.md frontmatter contains an invalid field")
+            fields[key] = value.strip().strip('"')
+    if set(fields) != {"name", "description", "metadata"} or fields["name"] != SKILL_NAME:
+        raise SkillReleaseError("SKILL.md must declare the reviewed name, description, and metadata.version")
+    expected_version = _workspace_version()
+    if fields["metadata"] != expected_version:
+        raise SkillReleaseError(
+            f"SKILL.md metadata.version {fields['metadata']!r} differs from "
+            f"Cargo.toml workspace.package.version {expected_version!r}"
+        )
     description = fields["description"].lower()
     positive = [
         "documents",

--- a/tools/skill-release/test_skill_release.py
+++ b/tools/skill-release/test_skill_release.py
@@ -10,6 +10,7 @@ import stat
 import struct
 import sys
 import tempfile
+import tomllib
 import unittest
 import zipfile
 from unittest import mock
@@ -224,6 +225,9 @@ def replace_material_and_recompute_manifest(
 
 class SkillReleaseTests(unittest.TestCase):
     def setUp(self) -> None:
+        self.product_version = tomllib.loads(
+            (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+        )["workspace"]["package"]["version"]
         self.pdfium_authority = mock.patch(
             "skill_release.WINDOWS_PDFIUM_AUTHORITY",
             {
@@ -243,9 +247,91 @@ class SkillReleaseTests(unittest.TestCase):
             [path.as_posix() for path in ALLOWED_FILES],
         )
         text = (SKILL_SOURCE / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn(f'metadata:\n  version: "{self.product_version}"\n', text)
         self.assertIn("Do not search `PATH`", text)
         for spec in ASSET_SPECS:
             self.assertIn(spec.relative.as_posix(), text)
+
+    def test_invalid_version_frontmatter_fails_closed(self) -> None:
+        text = (SKILL_SOURCE / "SKILL.md").read_text(encoding="utf-8")
+        _opening, header, body = text.split("---", 2)
+        fields, version_field = header.split("metadata:\n", 1)
+        metadata_block = "metadata:\n" + version_field
+        invalid_metadata = {
+            "missing metadata": "",
+            "missing version": "metadata:\n",
+            "empty value": "metadata:\n  version:\n",
+            "empty string": 'metadata:\n  version: ""\n',
+            "blank string": 'metadata:\n  version: " "\n',
+            "null": "metadata:\n  version: null\n",
+            "boolean": "metadata:\n  version: true\n",
+            "number": "metadata:\n  version: 4\n",
+            "list": 'metadata:\n  version: ["0.0.4"]\n',
+            "mapping": 'metadata:\n  version: {"value": "0.0.4"}\n',
+            "unquoted": "metadata:\n  version: 0.0.4\n",
+            "unclosed string": 'metadata:\n  version: "0.0.4\n',
+            "top-level version": 'version: "0.0.4"\n',
+            "unindented version": 'metadata:\nversion: "0.0.4"\n',
+            "wrong indentation": 'metadata:\n    version: "0.0.4"\n',
+            "scalar metadata": 'metadata: "0.0.4"\n',
+            "flow metadata": 'metadata: {version: "0.0.4"}\n',
+            "duplicate metadata": metadata_block * 2,
+            "duplicate version": metadata_block + version_field,
+            "duplicate name": metadata_block + "name: into-markdown\n",
+            "duplicate description": metadata_block + "description: duplicate\n",
+            "extra metadata field": metadata_block + '  author: "extra"\n',
+            "version drift": 'metadata:\n  version: "999.999.999"\n',
+        }
+        with tempfile.TemporaryDirectory() as name:
+            source = materialize(pathlib.Path(name) / SKILL_NAME)
+            for label, metadata in invalid_metadata.items():
+                with self.subTest(case=label):
+                    (source / "SKILL.md").write_text(
+                        "---" + fields + metadata + "---" + body, encoding="utf-8"
+                    )
+                    with self.assertRaisesRegex(SkillReleaseError, "SKILL.md"):
+                        validate(source)
+
+    def test_product_version_bump_requires_matching_skill_version(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = pathlib.Path(name)
+            source = materialize(root / SKILL_NAME)
+            (root / "LICENSE").write_bytes((ROOT / "LICENSE").read_bytes())
+            cargo = root / "Cargo.toml"
+            text = (source / "SKILL.md").read_text(encoding="utf-8")
+            # Exercise the actual manifest reader, including prerelease/build metadata.
+            with mock.patch("skill_release.ROOT", root):
+                for version in ("999.999.999", "999.999.999-rc.1+build.2"):
+                    with self.subTest(version=version):
+                        cargo.write_text(
+                            f'[workspace.package]\nversion = "{version}"\n', encoding="utf-8"
+                        )
+                        (source / "SKILL.md").write_text(text, encoding="utf-8")
+                        with self.assertRaisesRegex(SkillReleaseError, "differs from.*workspace.package.version"):
+                            validate(source)
+                        (source / "SKILL.md").write_text(
+                            text.replace(f'  version: "{self.product_version}"', f'  version: "{version}"'),
+                            encoding="utf-8",
+                        )
+                        validate(source)
+
+    def test_unavailable_or_invalid_product_version_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = pathlib.Path(name)
+            source = materialize(root / SKILL_NAME)
+            with mock.patch("skill_release.ROOT", root):
+                with self.assertRaisesRegex(SkillReleaseError, "Cargo.toml workspace.package.version"):
+                    validate(source)
+                for manifest in (
+                    "invalid TOML",
+                    "[workspace.package]\n",
+                    "[workspace.package]\nversion = 4\n",
+                    '[workspace.package]\nversion = ""\n',
+                ):
+                    with self.subTest(manifest=manifest):
+                        (root / "Cargo.toml").write_text(manifest, encoding="utf-8")
+                        with self.assertRaisesRegex(SkillReleaseError, "Cargo.toml workspace.package.version"):
+                            validate(source)
 
     def test_archive_is_deterministic_and_has_exact_assets_and_modes(self) -> None:
         with tempfile.TemporaryDirectory() as name:
@@ -281,6 +367,14 @@ class SkillReleaseTests(unittest.TestCase):
                 )
                 manifest = archive.getinfo(f"{SKILL_NAME}/{ARCHIVE_MANIFEST.as_posix()}")
                 self.assertIn(b'"schemaVersion": 1', archive.read(manifest))
+                skill_bytes = (SKILL_SOURCE / "SKILL.md").read_bytes()
+                self.assertEqual(archive.read(f"{SKILL_NAME}/SKILL.md"), skill_bytes)
+                skill_record = next(
+                    record for record in json.loads(archive.read(manifest))["files"]
+                    if record["path"] == "SKILL.md"
+                )
+                self.assertEqual(skill_record["bytes"], len(skill_bytes))
+                self.assertEqual(skill_record["sha256"], hashlib.sha256(skill_bytes).hexdigest())
                 for target, _asset in TARGET_LAYOUTS:
                     for member in AUTHORITY_MATERIALS:
                         relative = evidence_relative(target, member)
@@ -289,6 +383,23 @@ class SkillReleaseTests(unittest.TestCase):
                             cores[relative].read_bytes(),
                         )
                 self.assertFalse(any("whisper" in name.lower() or "ffmpeg" in name.lower() for name in names))
+
+    def test_changed_skill_version_fails_even_with_recomputed_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as name:
+            root = pathlib.Path(name)
+            valid = create_archive(root / "valid.zip", write_cores(root))
+            contents = (SKILL_SOURCE / "SKILL.md").read_bytes().replace(
+                f'  version: "{self.product_version}"'.encode(), b'  version: "999.999.999"'
+            )
+            rewrite_entry(valid, root / "tampered.zip", f"{SKILL_NAME}/SKILL.md", contents=contents)
+            replace_material_and_recompute_manifest(
+                valid, root / "recomputed.zip", "SKILL.md", contents
+            )
+            for archive in (root / "tampered.zip", root / "recomputed.zip"):
+                with self.subTest(archive=archive.name), self.assertRaisesRegex(
+                    SkillReleaseError, "instruction metadata or bytes"
+                ):
+                    verify_release(archive)
 
     def test_three_target_materials_and_matching_binaries_are_authority_bound(self) -> None:
         with tempfile.TemporaryDirectory() as name:


### PR DESCRIPTION
## 概要

Closes #335

- 在 canonical SKILL.md 中添加 `metadata.version: "0.0.4"`，保留技能正文、调用策略和现有分发结构。
- 发布校验从根 Cargo.toml 读取产品版本，拒绝缺失、空值、重复字段、错误嵌套和版本不一致；补齐 Bazel 数据依赖。
- 增加产品版本升级、归档版本篡改和 manifest 绑定回归，更新版本同步与测试说明。

## 本地验证

- `python3 tools/skill-release/skill_release_main.py validate`：通过。
- 现有 PR fast gate 的发布相关 Python 测试组合：113 项通过，包含 16 项技能发布测试。
- `bazel test --lockfile_mode=off //tools/skill-release:skill_release_test`：通过。
- `skill-creator/scripts/quick_validate.py`：通过；PyYAML 仅用于临时 uv 校验环境，产品依赖保持不变。
- `uv run --no-project --with-requirements tools/structure_gate/requirements.txt python -m tools.structure_gate check --base-ref origin/main`：541 个生产文件，0 项违规。
- `git diff --check`：通过。

## 范围与基线

基于 main 提交 `7c53c43`，包含 #335 的 6 个功能文件改动及 2 个 CI 修复文件。产品版本保持 0.0.4；无 CLI、转换行为或分发结构变更。以上是本地验证结果，GitHub CI 由本 PR 触发。

## CI 工具链修复

Linux x86_64 的初始化步骤原先只安装 minimal 工具链，后续 cargo fmt 按仓库声明补装 rustfmt 时发生 bin/cargo-fmt 冲突；失败作业重跑仍复现。提交 `3b328ad` 在四个平台初始化时显式安装 clippy、rustfmt，并添加与 rust-toolchain.toml 对齐的回归检查。本地 113 项发布相关测试、cargo fmt 和工作流 YAML 检查通过。
