### PR TITLE
fix(ocr): bound serial normalization workspace before 0.0.5

### DIFF
--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -15,6 +15,7 @@ use std::io::Cursor;
 mod candidate_index;
 mod geometry;
 mod jpeg_input;
+mod memory_plan;
 mod node_budget;
 mod pdf_placement;
 mod runtime;
@@ -369,22 +370,17 @@ fn plan_enrichment(
     }
 
     node_budget::NodeBudget::new(count_document_nodes(&output.document.blocks, context)?)?;
-    let mut provider_working_peak = 0_u64;
+    let mut recognition_working_peak = 0_u64;
     // Only consult provider plans after every knowable input count and envelope
     // bound has passed, so a provider cannot observe a request that preflight
     // must reject.
-    // Account hash/map work once per eligible AssetId, but normalization and
-    // provider output once per unique byte identity.
+    // Retained outputs accumulate across byte identities. Normalization stays
+    // alive during recognition, then drops before the next serial image.
     for group in &grouping.groups {
         context.checkpoint()?;
         let candidate = &candidates[group.representative];
         let (width, height) = candidate.dimensions;
-        let normalized_peak = u64::from(width)
-            .checked_mul(u64::from(height))
-            .and_then(|pixels| pixels.checked_mul(32))
-            .and_then(|bytes| bytes.checked_add(64 * 1024))
-            .ok_or_else(|| resource("max_memory_bytes", "normalization plan overflow"))?;
-        checked_add(&mut total, normalized_peak, "normalization working-set plan overflow")?;
+        let normalized_peak = memory_plan::normalization_working_set(width, height)?;
         let (provider_bound, provider_working) = match services.ocr.as_deref() {
             Some(engine) => {
                 match engine.planned_normalized_png_output(width, height, options, context) {
@@ -405,7 +401,8 @@ fn plan_enrichment(
                 });
             }
         };
-        provider_working_peak = provider_working_peak.max(provider_working);
+        recognition_working_peak = recognition_working_peak
+            .max(memory_plan::recognition_working_set(normalized_peak, provider_working)?);
         // Provider ceilings bound retained memory, not the number of nodes a
         // picture will actually produce. Recognition admits its real nodes,
         // including every reference copy, before retaining or cloning them.
@@ -422,7 +419,7 @@ fn plan_enrichment(
             "OCR output plan overflow",
         )?;
     }
-    checked_add(&mut total, provider_working_peak, "OCR provider working-set plan overflow")?;
+    checked_add(&mut total, recognition_working_peak, "OCR recognition working-set plan overflow")?;
     let (occupied_id_bytes, collision_scratch) =
         planned_node_id_working_set(&output.document.blocks, context)?;
     checked_add(&mut total, occupied_id_bytes, "occupied OCR node ID plan overflow")?;
@@ -2049,6 +2046,62 @@ mod tests {
         assert_eq!(blocks.len(), 128);
         drop(enriched);
         assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn serial_images_reserve_peak_normalization_plus_overlapping_provider_work() {
+        let working = 32 * 1024 * 1024;
+        let ocr = source_bound_ocr_with_working_plan(false, 64 * 1024, working);
+        let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
+        let mut source = output();
+        for (index, asset) in source.assets.iter_mut().enumerate() {
+            let pixels = RgbaImage::from_pixel(1024, 1024, Rgba([index as u8, 2, 3, 255]));
+            let mut encoded = Cursor::new(Vec::new());
+            DynamicImage::ImageRgba8(pixels).write_to(&mut encoded, ImageFormat::Png).unwrap();
+            asset.bytes = encoded.into_inner();
+        }
+        let mut options = ConversionOptions::default();
+        options.ocr.policy = OcrPolicy::Always;
+        options.limits.max_memory_bytes = 80 * 1024 * 1024;
+        let context = ExecutionContext::new(ExecutionOptions::default(), options.limits.clone());
+        let EnrichmentPlan::Reserve(plan) =
+            plan_enrichment(&source, InputFormat::Docx, &options, &services, &context).unwrap()
+        else {
+            panic!("active plan expected")
+        };
+        // Each image needs about 32 MiB for normalization while the provider's
+        // 32 MiB workspace coexists. Serial images must not require 96 MiB.
+        assert!(plan >= 64 * 1024 * 1024);
+        let reservation = context.reserve_memory(plan).unwrap();
+        assert_eq!(ocr.plans.load(Ordering::SeqCst), 2);
+        assert_eq!(ocr.calls.load(Ordering::SeqCst), 0);
+        drop(reservation);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let low_context = ExecutionContext::new(
+            ExecutionOptions::default(),
+            into_markdown_core::ResourceLimits {
+                max_memory_bytes: plan - 1,
+                ..options.limits.clone()
+            },
+        );
+        assert!(matches!(
+            low_context.reserve_memory(plan),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
+        assert_eq!(low_context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn normalization_and_provider_working_sum_overflow_is_rejected() {
+        assert!(matches!(
+            memory_plan::recognition_working_set(64 * 1024, u64::MAX),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
+        assert!(matches!(
+            memory_plan::normalization_working_set(u32::MAX, u32::MAX),
+            Err(ConversionError::ResourceLimit { limit: "max_memory_bytes", .. })
+        ));
     }
 
     #[test]

--- a/crates/converters/src/embedded_visual_ocr/memory_plan.rs
+++ b/crates/converters/src/embedded_visual_ocr/memory_plan.rs
@@ -1,0 +1,21 @@
+//! Temporary normalization and provider work coexist for one image at a time.
+
+use super::resource;
+use into_markdown_core::ConversionError;
+
+pub(super) fn normalization_working_set(width: u32, height: u32) -> Result<u64, ConversionError> {
+    u64::from(width)
+        .checked_mul(u64::from(height))
+        .and_then(|pixels| pixels.checked_mul(32))
+        .and_then(|bytes| bytes.checked_add(64 * 1024))
+        .ok_or_else(|| resource("max_memory_bytes", "normalization plan overflow"))
+}
+
+pub(super) fn recognition_working_set(
+    normalization: u64,
+    provider: u64,
+) -> Result<u64, ConversionError> {
+    normalization.checked_add(provider).ok_or_else(|| {
+        resource("max_memory_bytes", "normalization and OCR working-set plan overflow")
+    })
+}

--- a/tools/structure_gate/baseline.json
+++ b/tools/structure_gate/baseline.json
@@ -460,7 +460,7 @@
     },
     {
       "path": "crates/converters/src/embedded_visual_ocr.rs",
-      "lines": 1288,
+      "lines": 1285,
       "functions": [
         {
           "symbol": "enrich",
@@ -468,7 +468,7 @@
         },
         {
           "symbol": "plan_enrichment",
-          "lines": 216
+          "lines": 212
         }
       ],
       "allowances": [


### PR DESCRIPTION
## 问题

0.0.5 全量复测确认 #351 已让前两个 EPUB 恢复转换，但《绿野仙踪》仍在进入 OCR 前被内存预检拒绝：122,906,731 + 24,649,394,852 超过当时的 17,052,164,096 字节预算。其 155 张不同图片的归一化临时空间被累加为约 13.995 GiB，单张最大仅约 0.241 GiB。

`runtime::recognize` 的 normalized 图像只在当前调用中存活，返回后释放，外层逐图片串行 await；缓存保存识别贡献而不保存归一化像素。把所有图片的临时空间相加与实际生命周期不一致，在新版本将全局资源错误作为终止错误后造成了明显兼容性回退。

## 修改

按每张图片的“归一化临时空间 + 同时存在的 OCR 提供方工作空间”计算峰值，并只预留一次该峰值。继续累计所有保留输出、每个引用/资产副本、哈希索引、原文及验证空间；不提高预算，不吞掉全局错误，也不改变 #351 的实际文档节点硬上限。

算术单独放入小模块，保留 checked 运算，并降低既有大函数/文件的结构债务。没有更改 CI workflow、job、平台或发布入口。

## 验证

- 新增两个不同 1024×1024 PNG 的串行预算测试：两张图各需约 32 MiB 归一化空间，与 32 MiB 提供方空间重叠；80 MiB 预算可以预留正确的约 64 MiB 峰值，不应被错误的约 96 MiB 累加值拒绝。
- 验证实际预算少一字节仍拒绝、lease 释放和归一化/提供方相加溢出拒绝。
- converters、engine、API 完整库测试通过；结构门禁、格式检查及 CI 工作流策略 14 项测试通过。
- 此次中断的候选测试另存证据，不计入最终成绩。合并后再次使用正式构建的最终二进制完成全部 2,285 个输入的 OCR off/auto 比较。
