### PR TITLE
fix(release): bind OCR resource renderer authority

### DIFF
--- a/third_party/licenses/release-material-authority.json
+++ b/third_party/licenses/release-material-authority.json
@@ -23,13 +23,13 @@
     },
     {
       "path": "tools/macos-release/release.py",
-      "bytes": 33896,
-      "sha256": "8ec30b741fcc466ee0315a2add28d40775052ede6e23f73c69bc82646dc63abc"
+      "bytes": 34122,
+      "sha256": "ccad8dc2976f5634040c1d736c3480e82834f55af6bf2f79085a12606e805034"
     },
     {
       "path": "tools/platform-release/release.py",
-      "bytes": 41506,
-      "sha256": "538e7db8efd82e3be6dc8215ef3c63db2a5b81fe287f1d6d88eec60245432a86"
+      "bytes": 41883,
+      "sha256": "8eccdf548fa12c8eda5335099ae08ab39ee46b5e202fce72538bb35cbbac35d7"
     }
   ],
   "licenses": [

--- a/tools/license-check/src/release_authority.rs
+++ b/tools/license-check/src/release_authority.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 const AUTHORITY_PATH: &str = "third_party/licenses/release-material-authority.json";
 const REVIEWED_AUTHORITY_SHA256: &str =
-    "cc948c7646859c31d35757220208943317b59c284ff0d564d6ceb81233f83eca";
+    "e78e255d851b0d87a1a41bdcbd3f4a6da4477b2a69062350f7d9c109f1f61e56";
 const GENERATED_PATHS: [&str; 5] =
     ["NOTICE", "THIRD_PARTY_NOTICES.md", "SBOM.spdx.json", "SOURCES.json", "core-catalog.json"];
 const PROFILE_PATHS: [&str; 12] = [


### PR DESCRIPTION
## 摘要

PR #358 调整了 macOS 与跨平台 release renderer 中正式 OCR provider 的有限进程组额度。发布 fail-closed 门禁正确检测到 renderer authority 漂移；本补丁重新绑定两个已审核文件的 byte count 和 SHA-256，并更新 authority 文件自身的 reviewed hash。

## 审核结果

- 显式运行 `export_release_material_profile_candidate`，12 个 release profile 与现有 authority 逐项完全一致。
- 许可结论、组件集合、NOTICE、SBOM、SOURCES 和 core catalog 均未变化。
- `release-projection generate` 对 Linux ARM64 OCR plugin profile 通过。

## 验证

- `cargo test -p license-check`：94 passed，2 ignored；ignored candidate 已单独显式运行并通过。
- `cargo clippy -p license-check --all-targets --no-deps -- -D warnings`
- `python3 -m unittest tools.platform-release.test_release tools.platform-release.test_pr_fast_gate`
- `python3 tools/platform-release/pr_fast_gate.py --target aarch64-apple-darwin`
- structure gate：625 files，0 violations
- `git diff --check`

CI workflow、job、matrix 与触发方式未修改。