### PR TITLE
fix(release): validate effective OCR worker budget

### DIFF
--- a/tools/portable-release/ocr_smoke.py
+++ b/tools/portable-release/ocr_smoke.py
@@ -12,6 +12,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 FIXTURE_ID = "ocr-english-clear-1"
 MEMORY_BYTES = 2 * 1024**3
 SIGNED_WORKER_BYTES = 2048 * 1024**2
+MIN_EFFECTIVE_WORKER_BYTES = 1024 * 1024**2
 
 
 def fingerprint(path):
@@ -36,12 +37,13 @@ def verify_result(document, report, expected, error_type):
         raise error_type("installed OCR did not preserve the clear fixture's expected text")
     usage = report.get("resourceUsage", {})
     runtime = usage.get("ocrRuntime", {})
+    worker_min = runtime.get("workerBudgetMinBytes", 0)
+    worker_max = runtime.get("workerBudgetMaxBytes", 0)
     if (usage.get("sharedLeaseBudgetBytes") != MEMORY_BYTES
             or not 0 < usage.get("sharedLeasePeakBytes", 0) <= MEMORY_BYTES
             or runtime.get("requests") != 1
             or runtime.get("recognitionMemoryRefusals") != 0
-            or runtime.get("workerBudgetMinBytes") != SIGNED_WORKER_BYTES
-            or runtime.get("workerBudgetMaxBytes") != SIGNED_WORKER_BYTES
+            or not MIN_EFFECTIVE_WORKER_BYTES <= worker_min == worker_max <= SIGNED_WORKER_BYTES
             or usage.get("ocr", {}).get("recognizedChars", 0) < len(expected)):
         raise error_type("installed OCR budget or contribution evidence is incomplete")
     return usage

--- a/tools/portable-release/test_ocr_smoke.py
+++ b/tools/portable-release/test_ocr_smoke.py
@@ -13,15 +13,17 @@ SPEC.loader.exec_module(smoke)
 class OcrSmokeTests(unittest.TestCase):
     def test_signed_process_group_budget_matches_release_contract(self):
         self.assertEqual(smoke.SIGNED_WORKER_BYTES, 2048 * 1024**2)
+        self.assertEqual(smoke.MIN_EFFECTIVE_WORKER_BYTES, 1024 * 1024**2)
 
     def test_structured_ocr_survives_markdown_escaping_and_rejects_native_only_text(self):
+        effective_worker = smoke.MIN_EFFECTIVE_WORKER_BYTES + 128 * 1024**2
         document = {"markdown": "Clear scans\\.", "document": {"blocks": [{"type": "text",
             "data": {"value": "Clear scans.", "provenance": {"kind": "localOcr"}}}]}}
         report = {"failed": 0, "resourceUsage": {"sharedLeaseBudgetBytes": smoke.MEMORY_BYTES,
             "sharedLeasePeakBytes": 1024, "ocr": {"recognizedChars": 12},
             "ocrRuntime": {"requests": 1, "recognitionMemoryRefusals": 0,
-                "workerBudgetMinBytes": smoke.SIGNED_WORKER_BYTES,
-                "workerBudgetMaxBytes": smoke.SIGNED_WORKER_BYTES}}}
+                "workerBudgetMinBytes": effective_worker,
+                "workerBudgetMaxBytes": effective_worker}}}
         self.assertEqual(smoke.verify_result(document, report, "Clear scans.", ValueError),
                          report["resourceUsage"])
         native = copy.deepcopy(document)
@@ -29,6 +31,8 @@ class OcrSmokeTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "expected text"):
             smoke.verify_result(native, report, "Clear scans.", ValueError)
         for field, value in (("requests", 0), ("recognitionMemoryRefusals", 1),
+                             ("workerBudgetMinBytes", smoke.MIN_EFFECTIVE_WORKER_BYTES - 1),
+                             ("workerBudgetMaxBytes", effective_worker + 1),
                              ("workerBudgetMaxBytes", smoke.SIGNED_WORKER_BYTES + 1)):
             invalid = copy.deepcopy(report)
             invalid["resourceUsage"]["ocrRuntime"][field] = value


### PR DESCRIPTION
## 摘要

正式 OCR provider 的签名进程组硬上限是 2 GiB，但安装包黑盒使用固定 2 GiB 的请求预算；host IPC、wire 与 retained result 会占用同一请求 envelope，因此实际传给 worker 的有效额度应小于等于签名硬上限。

本补丁让 release smoke 验证真实契约：

- 单次 OCR 的 worker min/max 必须一致；
- 有效 worker 额度至少 1 GiB，确保高于旧的 768 MiB 路径并保留模型启动空间；
- 有效额度不得超过签名 2 GiB sandbox 上限；
- 仍要求 2 GiB 共享请求预算、非零且有限的 lease peak、一次请求、零 recognition memory refusal、真实 OCR provenance 和足够识别字符。

硬上限本身继续由 release manifest、renderer authority、process sandbox 和 release assembler 测试精确固定为 2 GiB。

## 验证

- `python3 -m unittest tools.portable-release.test_ocr_smoke tools.portable-release.test_native_acceptance tools.platform-release.test_release tools.platform-release.test_pr_fast_gate`
- `cargo test -p license-check release_tests::twelve_product_target_fixtures_generate_authoritative_metadata`
- `python3 tools/platform-release/pr_fast_gate.py --target aarch64-apple-darwin`
- structure gate：625 files，0 violations
- `git diff --check`

CI workflow、job、matrix 与触发方式未修改。