### PR TITLE
Bind release SPDX authority to refreshed Web bundle

### DIFF
--- a/third_party/licenses/npm-release.spdx.json
+++ b/third_party/licenses/npm-release.spdx.json
@@ -2,8 +2,8 @@
   "spdxVersion": "SPDX-2.3",
   "dataLicense": "CC0-1.0",
   "SPDXID": "SPDXRef-DOCUMENT",
-  "name": "into-markdown-web-console-ff87db1fce4c67c3",
-  "documentNamespace": "https://github.com/coolplayagent/into-markdown/spdx/web-console/sha256-ff87db1fce4c67c3656eb765273785048960a4a394b9edbafb53e9b9f5117cdd",
+  "name": "into-markdown-web-console-ea7b34ab5ca6c3aa",
+  "documentNamespace": "https://github.com/coolplayagent/into-markdown/spdx/web-console/sha256-ea7b34ab5ca6c3aaf23f651fca9b601e4cd30de9bbae17a0cacdcb1369731e05",
   "creationInfo": {
     "created": "2026-08-13T00:00:00Z",
     "creators": ["Organization: into-markdown contributors"]

--- a/tools/platform-release/test_release.py
+++ b/tools/platform-release/test_release.py
@@ -155,6 +155,12 @@ class PlatformReleaseTests(unittest.TestCase):
             if item["algorithm"] == "SHA256"
         )
         self.assertEqual(expected, hashlib.sha256(app.read_bytes()).hexdigest())
+        self.assertEqual(value["name"], f"into-markdown-web-console-{expected[:16]}")
+        self.assertEqual(
+            value["documentNamespace"],
+            "https://github.com/coolplayagent/into-markdown/spdx/"
+            f"web-console/sha256-{expected}",
+        )
 
     def test_release_version_matches_workspace_and_bazel_module(self) -> None:
         workspace = tomllib.loads((ROOT / "Cargo.toml").read_text(encoding="utf-8"))


### PR DESCRIPTION
Closes #363

Updates the deterministic npm release SPDX document name and namespace alongside the refreshed Web app checksum. Extends the release contract test to bind all three fields to the production bundle digest.

Validated with the offline license audit, all 124 release contract tests, and the 14 CI workflow policy tests.