### PR TITLE
Keep PDF OCR page renders out of published assets

### DIFF
--- a/crates/api/src/embedded_visual_ocr_tests.rs
+++ b/crates/api/src/embedded_visual_ocr_tests.rs
@@ -217,20 +217,17 @@ impl OcrEngine for PdfGeometryOcr {
             context.checkpoint()?;
             let (width, height) = dimensions?;
             let is_page_render = width > 10 && height > 10;
-            let regions = (!is_page_render)
-                .then(|| OcrRegion {
-                    text: "embedded second".into(),
-                    polygon: [
-                        (0.0, 0.0),
-                        (width as f32, 0.0),
-                        (width as f32, height as f32),
-                        (0.0, height as f32),
-                    ],
-                    confidence: 0.99,
-                })
-                .into_iter()
-                .collect();
-            let confidences = if is_page_render { Vec::new() } else { vec![0.99] };
+            let regions = vec![OcrRegion {
+                text: if is_page_render { "page recognized" } else { "embedded second" }.into(),
+                polygon: [
+                    (0.0, 0.0),
+                    (width as f32, 0.0),
+                    (width as f32, height as f32),
+                    (0.0, height as f32),
+                ],
+                confidence: 0.99,
+            }];
+            let confidences = vec![0.99];
             let identity = OcrInputIdentity::try_new(digest, width, height, 0);
             Ok(OcrRecognition::Bound(BoundOcrResult::try_new_for_input(
                 OcrResult { regions, provider: "test.api.pdf-geometry-ocr".into() },
@@ -510,21 +507,34 @@ fn dynamically_created_pdf_merges_native_and_embedded_ocr_geometry_and_deduplica
     let ocr = Arc::new(PdfGeometryOcr(AtomicUsize::new(0)));
     let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
     let engine = default_engine_with_services(services).unwrap();
-    let mut request = ConversionRequest::new(InputRef::bytes(
-        pdf_with_native_text_and_two_images(),
-        Some("dynamic-embedded.pdf"),
-    ));
-    request.options.ocr.policy = OcrPolicy::Always;
-    let result = block_on(engine.convert(request)).unwrap();
-    // One request is the PDF page OCR pass. The embedded stage makes one request
-    // for red and one for green; the second green drawing reuses that result.
-    assert_eq!(ocr.0.load(Ordering::SeqCst), 3);
-    assert_eq!(result.markdown.matches("native words").count(), 1);
-    assert_eq!(result.markdown.matches("embedded second").count(), 3);
-    assert!(
-        result.markdown.find("native words").unwrap()
-            < result.markdown.find("embedded second").unwrap()
-    );
+    for mode in [AssetMode::Extract, AssetMode::Embed] {
+        let input = pdf_with_native_text_and_two_images();
+        let mut baseline =
+            ConversionRequest::new(InputRef::bytes(input.clone(), Some("dynamic-embedded.pdf")));
+        baseline.options.ocr.policy = OcrPolicy::Off;
+        baseline.options.output.asset_mode = mode;
+        let baseline = block_on(engine.convert(baseline)).unwrap();
+
+        let mut request =
+            ConversionRequest::new(InputRef::bytes(input, Some("dynamic-embedded.pdf")));
+        request.options.ocr.policy = OcrPolicy::Always;
+        request.options.output.asset_mode = mode;
+        let result = block_on(engine.convert(request)).unwrap();
+
+        assert_eq!(ocr.0.load(Ordering::SeqCst), usize::from(mode == AssetMode::Embed) + 1);
+        assert_eq!(result.markdown.matches("native words").count(), 1);
+        assert_eq!(result.markdown.matches("page recognized").count(), 1);
+        assert!(!result.markdown.contains("embedded second"));
+        assert_eq!(result.assets.len(), 2);
+        assert_eq!(
+            result.assets.iter().map(|asset| (&asset.id, &asset.bytes)).collect::<Vec<_>>(),
+            baseline.assets.iter().map(|asset| (&asset.id, &asset.bytes)).collect::<Vec<_>>()
+        );
+        let serialized = serde_json::to_string(&result.document).unwrap();
+        assert!(!serialized.contains("pdf-page-render-"));
+        assert!(!serialized.contains("ocr-render"));
+        assert!(!serialized.contains("page render for OCR"));
+    }
 }
 
 fn pdf_with_native_text_and_two_images() -> Vec<u8> {
@@ -593,6 +603,10 @@ fn assert_dynamic_file_ocr_references(
     let ocr = Arc::new(SourceBoundOcr(AtomicUsize::new(0)));
     let services = Services { ocr: Some(ocr.clone()), ..Services::default() };
     let engine = default_engine_with_services(services).unwrap();
+    let mut baseline_request = ConversionRequest::new(InputRef::Path(file.path().to_path_buf()));
+    baseline_request.options.ocr.policy = OcrPolicy::Off;
+    baseline_request.options.output.asset_mode = AssetMode::Extract;
+    let baseline = block_on(engine.convert(baseline_request)).unwrap();
     let mut request = ConversionRequest::new(InputRef::Path(file.path().to_path_buf()));
     request.options.ocr.policy = OcrPolicy::Always;
     request.options.output.asset_mode = AssetMode::Extract;
@@ -622,6 +636,11 @@ fn assert_dynamic_file_ocr_references(
         );
     }
     assert_eq!(ocr.0.load(Ordering::SeqCst), recognized_assets, "{suffix}");
+    assert_eq!(
+        result.assets.iter().map(|asset| (&asset.id, &asset.bytes)).collect::<Vec<_>>(),
+        baseline.assets.iter().map(|asset| (&asset.id, &asset.bytes)).collect::<Vec<_>>(),
+        "{suffix}: OCR working bytes must not change the published asset inventory"
+    );
     let mut ocr_nodes = Vec::new();
     collect_ocr_nodes(&result.document.blocks, &mut ocr_nodes);
     assert_eq!(ocr_nodes.len(), references, "{suffix}: OCR IR reference count");

--- a/crates/converters/src/embedded_visual_ocr.rs
+++ b/crates/converters/src/embedded_visual_ocr.rs
@@ -2,10 +2,12 @@
 
 use crate::image_converter::{decode, encode, envelope, format};
 use image::{AnimationDecoder, ImageDecoder};
+#[cfg(test)]
+use into_markdown_core::Provenance;
 use into_markdown_core::{
     AiMode, AssetId, Block, BlockNode, BoxFuture, ConversionError, ConversionOptions,
     ConverterOutput, Diagnostic, DiagnosticSeverity, EnrichmentPlan, ExecutionContext, InputFormat,
-    NodeId, OcrInputIdentity, OcrPolicy, OutputEnricher, Provenance, ResourceReservation, Services,
+    NodeId, OcrInputIdentity, OcrPolicy, OutputEnricher, ResourceReservation, Services,
     SourceLocator, estimate_validation_working_set,
 };
 use sha2::{Digest, Sha256};
@@ -20,6 +22,7 @@ mod node_budget;
 mod pdf_placement;
 mod resource_lifecycle;
 mod runtime;
+mod visual_refs;
 use candidate_index::{
     CandidateBuffer, OcrCandidate, ReferenceIndex, candidate_index_plan, group_candidates,
     validate_visual_references_without_index,
@@ -28,6 +31,7 @@ use candidate_index::{
 use geometry::evidence_bounds;
 use geometry::{remap_ocr_node, remapped_locator};
 use resource_lifecycle::{attach_optional_memory, discard_group_payloads};
+use visual_refs::VisualRef;
 
 const PROVIDER: &str = "builtin.enricher.embedded-visual-ocr";
 const UNSUPPORTED_CODE: &str = "embeddedVisualOcr.unsupportedVisual";
@@ -245,8 +249,22 @@ fn plan_enrichment(
     if reference_count == 0 {
         return Ok(EnrichmentPlan::Skip);
     }
+    let selection =
+        match visual_refs::plan(output, reference_count, reference_id_bytes, input_format, context)
+        {
+            Ok(selection) => selection,
+            Err(error @ ConversionError::ResourceLimit { limit: "max_memory_bytes", .. }) => {
+                validate_visual_references_without_index(output, context)?;
+                return Err(error);
+            }
+            Err(error) => return Err(error),
+        };
+    if selection.references.is_empty() {
+        return Ok(EnrichmentPlan::Skip);
+    }
     let mut reference_counts =
-        match ReferenceIndex::new(reference_count, reference_id_bytes, context) {
+        match ReferenceIndex::new(selection.references.len(), selection.selected_id_bytes, context)
+        {
             Ok(index) => index,
             Err(error @ ConversionError::ResourceLimit { limit: "max_memory_bytes", .. }) => {
                 validate_visual_references_without_index(output, context)?;
@@ -254,37 +272,27 @@ fn plan_enrichment(
             }
             Err(error) => return Err(error),
         };
-    for_each_visual_reference(&output.document.blocks, context, &mut |asset_id| {
-        reference_counts.record(asset_id)
-    })?;
+    for reference in &selection.references {
+        context.checkpoint()?;
+        reference_counts.record(&reference.asset)?;
+    }
+    let working_assets = selection.working_assets;
+    let reference_vector_bytes = selection.planned_bytes;
+    drop(selection.memory);
     reference_counts.validate_assets(&output.assets, context)?;
     if effective_ocr_policy(options) == OcrPolicy::Always {
-        let mut supported_references = 0_u64;
-        for asset in &output.assets {
-            if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
-                continue;
-            }
-            supported_references = supported_references
-                .checked_add(reference_counts.count(&asset.id).unwrap_or(0))
-                .ok_or_else(|| {
-                    resource(
-                        "max_archive_entries",
-                        "embedded visual reference count is not representable",
-                    )
-                })?;
-        }
-        if supported_references > u64::from(options.limits.max_archive_entries) {
-            return Err(resource(
-                "max_archive_entries",
-                "embedded visual references exceed the request limit",
-            ));
-        }
+        visual_refs::enforce_supported_reference_limit(
+            &output.assets,
+            &reference_counts,
+            options.limits.max_archive_entries,
+        )?;
     }
 
     let mut candidates = CandidateBuffer::new(reference_counts.unique_len(), context)?;
     let mut references = 0_u64;
     let mut candidate_bytes = 0_u64;
     let mut total = reference_counts.planned_bytes();
+    checked_add(&mut total, reference_vector_bytes, "OCR reference retained plan overflow")?;
     checked_add(
         &mut total,
         candidates.planned_bytes(),
@@ -329,17 +337,12 @@ fn plan_enrichment(
             })?,
             "embedded OCR reference plan overflow",
         )?;
-        candidate_bytes = candidate_bytes
-            .checked_add(u64::try_from(asset.bytes.len()).map_err(|_| {
-                resource("max_total_asset_bytes", "embedded visual byte count is not representable")
-            })?)
-            .ok_or_else(|| resource("max_total_asset_bytes", "embedded visual bytes overflow"))?;
-        if candidate_bytes > options.limits.max_total_asset_bytes {
-            return Err(resource(
-                "max_total_asset_bytes",
-                "embedded visual bytes exceed the request limit",
-            ));
-        }
+        visual_refs::account_published_bytes(
+            &mut candidate_bytes,
+            asset,
+            &working_assets,
+            options,
+        )?;
         candidates.push(OcrCandidate {
             asset_index: index,
             reference_count,
@@ -694,13 +697,6 @@ fn for_each_visual_reference(
     Ok(())
 }
 
-#[derive(Clone)]
-struct VisualRef {
-    optional: bool,
-    asset: AssetId,
-    provenance: Provenance,
-}
-
 #[derive(Clone, Default)]
 struct CachedContribution {
     nodes: Vec<BlockNode>,
@@ -730,8 +726,7 @@ async fn enrich(
     {
         return Ok(output);
     }
-    let mut references = Vec::new();
-    collect_references(&output.document.blocks, &mut references, input_format, context)?;
+    let (mut references, working_assets) = visual_refs::select(&output, input_format, context)?;
     runtime::require_scanned_pages(&mut references, &output.diagnostics, input_format, context)?;
     if references.is_empty() {
         return Ok(output);
@@ -783,7 +778,7 @@ async fn enrich(
         context,
     )?;
     if reference_counts.is_empty() {
-        return Ok(output);
+        return visual_refs::discard_working(output, input_format, context);
     }
     let mut candidates = CandidateBuffer::new(eligible_assets.len(), context)?;
     let mut referenced_assets = BTreeSet::new();
@@ -804,17 +799,12 @@ async fn enrich(
         if !referenced_assets.insert(reference.asset.clone()) {
             continue;
         }
-        compressed_bytes = compressed_bytes
-            .checked_add(u64::try_from(asset.bytes.len()).map_err(|_| {
-                resource("max_total_asset_bytes", "embedded visual byte count is not representable")
-            })?)
-            .ok_or_else(|| resource("max_total_asset_bytes", "embedded visual bytes overflow"))?;
-        if compressed_bytes > options.limits.max_total_asset_bytes {
-            return Err(resource(
-                "max_total_asset_bytes",
-                "embedded visual bytes exceed the request limit",
-            ));
-        }
+        visual_refs::account_published_bytes(
+            &mut compressed_bytes,
+            asset,
+            &working_assets,
+            options,
+        )?;
         let digest = checkpointed_sha256(&asset.bytes, context)?;
         candidates.push(OcrCandidate {
             asset_index: *asset_index,
@@ -910,8 +900,11 @@ async fn enrich(
             }
         }
     }
-    if input_format == InputFormat::Pdf && !contributions_by_asset.is_empty() {
-        output = crate::pdf_ocr::reconstruct_enriched_pdf(output, options, context)?;
+    if input_format == InputFormat::Pdf {
+        output = crate::pdf::working_visual::remove_assets(output, &working_assets, context)?;
+        if !contributions_by_asset.is_empty() {
+            output = crate::pdf_ocr::reconstruct_enriched_pdf(output, options, context)?;
+        }
     }
     if let Some(engine) = &services.ocr {
         for contribution in cache.into_iter().flatten() {
@@ -933,7 +926,7 @@ fn embedded_visual_ocr_enabled(input_format: InputFormat, options: &ConversionOp
             && matches!(input_format, InputFormat::Doc | InputFormat::Ppt | InputFormat::Xls))
 }
 
-fn effective_ocr_policy(options: &ConversionOptions) -> OcrPolicy {
+pub(crate) fn effective_ocr_policy(options: &ConversionOptions) -> OcrPolicy {
     match options.ai.vision_ocr {
         AiMode::Only => OcrPolicy::Always,
         AiMode::Fallback | AiMode::Prefer if options.ocr.policy == OcrPolicy::Off => {
@@ -1149,53 +1142,6 @@ fn checkpointed_sha256(
     Ok(digest.finalize().into())
 }
 
-fn collect_references(
-    nodes: &[BlockNode],
-    output: &mut Vec<VisualRef>,
-    input_format: InputFormat,
-    context: &ExecutionContext,
-) -> Result<(), ConversionError> {
-    for (index, node) in nodes.iter().enumerate() {
-        if index % 256 == 0 {
-            context.checkpoint()?;
-        }
-        match &node.block {
-            Block::Image { asset, .. } => {
-                output.push(VisualRef {
-                    optional: runtime::has_native_body(
-                        nodes,
-                        &node.provenance,
-                        input_format,
-                        context,
-                    )?,
-                    asset: asset.clone(),
-                    provenance: node.provenance.clone(),
-                });
-            }
-            Block::List { items, .. } => {
-                for item in items {
-                    collect_references(&item.blocks, output, input_format, context)?;
-                }
-            }
-            Block::Table { rows, .. } => {
-                for row in rows {
-                    for cell in &row.cells {
-                        collect_references(&cell.blocks, output, input_format, context)?;
-                    }
-                }
-            }
-            Block::Footnote { blocks, .. }
-            | Block::Page { blocks, .. }
-            | Block::Slide { blocks, .. }
-            | Block::Sheet { blocks, .. } => {
-                collect_references(blocks, output, input_format, context)?;
-            }
-            _ => {}
-        }
-    }
-    Ok(())
-}
-
 fn rebuild_nodes(
     nodes: Vec<BlockNode>,
     cache: &BTreeMap<AssetId, CachedContribution>,
@@ -1247,6 +1193,11 @@ fn rebuild_nodes(
             }
             _ => {}
         }
+        let role = if input_format == InputFormat::Pdf {
+            crate::pdf::working_visual::classify(&node)?
+        } else {
+            crate::pdf::working_visual::VisualRole::Published
+        };
         let contribution = match &node.block {
             Block::Image { asset, .. }
                 if input_format != InputFormat::Pdf
@@ -1258,7 +1209,9 @@ fn rebuild_nodes(
         };
         let source_id = node.id.clone();
         let source_provenance = node.provenance.clone();
-        rebuilt.push(node);
+        if role == crate::pdf::working_visual::VisualRole::Published {
+            rebuilt.push(node);
+        }
         if let Some(contribution) = contribution {
             for (ocr_index, template) in contribution.nodes.into_iter().enumerate() {
                 if ocr_index % 256 == 0 {

--- a/crates/converters/src/embedded_visual_ocr/pdf_placement.rs
+++ b/crates/converters/src/embedded_visual_ocr/pdf_placement.rs
@@ -1,11 +1,34 @@
 //! PDF layout needs page coordinates, unlike other containers' local OCR evidence.
 
-use super::{VisualRef, effective_ocr_policy, geometry};
+use super::{VisualRef, geometry};
+use crate::pdf::working_visual::VisualRole;
 use into_markdown_core::{
     AssetId, ConversionError, ConversionOptions, Diagnostic, DiagnosticSeverity, ErrorPolicy,
     ExecutionContext, OcrPolicy,
 };
 use std::collections::BTreeSet;
+
+pub(super) fn select_page_sources(
+    references: &mut Vec<VisualRef>,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    let mut rendered_pages = BTreeSet::new();
+    for reference in references.iter() {
+        context.checkpoint()?;
+        if reference.role == VisualRole::OcrPageRender {
+            let page =
+                reference.provenance.locator.page.ok_or_else(|| ConversionError::Internal {
+                    detail: "PDF OCR page render has no page locator".into(),
+                })?;
+            rendered_pages.insert(page);
+        }
+    }
+    references.retain(|reference| {
+        reference.role == VisualRole::OcrPageRender
+            || reference.provenance.locator.page.is_none_or(|page| !rendered_pages.contains(&page))
+    });
+    Ok(())
+}
 
 pub(super) fn filter_references(
     references: &mut Vec<VisualRef>,
@@ -25,7 +48,7 @@ pub(super) fn filter_references(
         }
         let detail = "PDF image OCR omitted: its image-to-page coordinate transform is unavailable";
         if options.error_policy != ErrorPolicy::BestEffort
-            || effective_ocr_policy(options) != OcrPolicy::Auto
+            || super::effective_ocr_policy(options) != OcrPolicy::Auto
         {
             return Err(ConversionError::Unsupported { detail: detail.into() });
         }

--- a/crates/converters/src/embedded_visual_ocr/runtime.rs
+++ b/crates/converters/src/embedded_visual_ocr/runtime.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use into_markdown_core::{
-    ErrorPolicy, Inline, ProvenanceKind, ResourceFailureScope, ResourceLimitSource,
+    ErrorPolicy, Inline, Provenance, ProvenanceKind, ResourceFailureScope, ResourceLimitSource,
     ResourceRecoveryAction, ResourceRecoveryBoundary, ResourceUnitKind, classify_resource_recovery,
     recovery_diagnostic,
 };
@@ -198,7 +198,7 @@ pub(super) async fn recognize(
     let normalized = match normalize(asset, options, context) {
         Ok(value) => value,
         Err(error)
-            if effective_ocr_policy(options) == OcrPolicy::Auto
+            if super::effective_ocr_policy(options) == OcrPolicy::Auto
                 && options.error_policy == ErrorPolicy::BestEffort
                 && auto_degradable_normalization(&error) =>
         {
@@ -236,7 +236,7 @@ pub(super) async fn recognize(
             )
         });
     if let Err(error) = plan {
-        if effective_ocr_policy(options) == OcrPolicy::Auto
+        if super::effective_ocr_policy(options) == OcrPolicy::Auto
             && options.error_policy == ErrorPolicy::BestEffort
             && matches!(error, ConversionError::ComponentUnavailable { .. })
         {

--- a/crates/converters/src/embedded_visual_ocr/visual_refs.rs
+++ b/crates/converters/src/embedded_visual_ocr/visual_refs.rs
@@ -1,0 +1,190 @@
+//! Source-bound visual selection and published-asset accounting.
+
+use super::{pdf_placement, resource, runtime, supported_raster};
+use into_markdown_core::{
+    Asset, AssetId, Block, BlockNode, ConversionError, ConversionOptions, ConverterOutput,
+    ExecutionContext, InputFormat, Provenance, ResourceReservation,
+};
+use std::collections::BTreeSet;
+
+#[derive(Clone)]
+pub(super) struct VisualRef {
+    pub(super) optional: bool,
+    pub(super) asset: AssetId,
+    pub(super) provenance: Provenance,
+    pub(super) role: crate::pdf::working_visual::VisualRole,
+}
+
+pub(super) struct PlanSelection {
+    pub(super) references: Vec<VisualRef>,
+    pub(super) working_assets: BTreeSet<AssetId>,
+    pub(super) memory: ResourceReservation,
+    pub(super) planned_bytes: u64,
+    pub(super) selected_id_bytes: u64,
+}
+
+pub(super) fn plan(
+    output: &ConverterOutput,
+    expected_count: usize,
+    expected_id_bytes: u64,
+    input_format: InputFormat,
+    context: &ExecutionContext,
+) -> Result<PlanSelection, ConversionError> {
+    let planned_bytes = u64::try_from(expected_count)
+        .unwrap_or(u64::MAX)
+        .checked_mul(u64::try_from(std::mem::size_of::<VisualRef>()).unwrap_or(u64::MAX) + 512)
+        .and_then(|bytes| bytes.checked_add(expected_id_bytes))
+        .ok_or_else(|| resource("max_memory_bytes", "OCR reference plan overflow"))?;
+    let memory = context.reserve_memory(planned_bytes)?;
+    let mut references = Vec::new();
+    references.try_reserve_exact(expected_count).map_err(|error| {
+        resource("max_memory_bytes", format!("cannot reserve OCR references: {error}"))
+    })?;
+    collect(&output.document.blocks, &mut references, input_format, context)?;
+    let working_assets = select_pdf_sources(output, &mut references, input_format, context)?;
+    let selected_id_bytes = references.iter().try_fold(0_u64, |total, reference| {
+        total
+            .checked_add(u64::try_from(reference.asset.0.len()).map_err(|_| {
+                resource(
+                    "max_memory_bytes",
+                    "selected OCR reference ID length is not representable",
+                )
+            })?)
+            .ok_or_else(|| resource("max_memory_bytes", "selected OCR reference IDs overflow"))
+    })?;
+    Ok(PlanSelection { references, working_assets, memory, planned_bytes, selected_id_bytes })
+}
+
+pub(super) fn select(
+    output: &ConverterOutput,
+    input_format: InputFormat,
+    context: &ExecutionContext,
+) -> Result<(Vec<VisualRef>, BTreeSet<AssetId>), ConversionError> {
+    let mut references = Vec::new();
+    collect(&output.document.blocks, &mut references, input_format, context)?;
+    let working_assets = select_pdf_sources(output, &mut references, input_format, context)?;
+    Ok((references, working_assets))
+}
+
+pub(super) fn discard_working(
+    output: ConverterOutput,
+    input_format: InputFormat,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    if input_format == InputFormat::Pdf {
+        crate::pdf::working_visual::discard(output, context)
+    } else {
+        Ok(output)
+    }
+}
+
+fn select_pdf_sources(
+    output: &ConverterOutput,
+    references: &mut Vec<VisualRef>,
+    input_format: InputFormat,
+    context: &ExecutionContext,
+) -> Result<BTreeSet<AssetId>, ConversionError> {
+    if input_format != InputFormat::Pdf {
+        return Ok(BTreeSet::new());
+    }
+    let working_assets =
+        crate::pdf::working_visual::validate(&output.document, &output.assets, context)?;
+    pdf_placement::select_page_sources(references, context)?;
+    Ok(working_assets)
+}
+
+pub(super) fn account_published_bytes(
+    total: &mut u64,
+    asset: &Asset,
+    working_assets: &BTreeSet<AssetId>,
+    options: &ConversionOptions,
+) -> Result<(), ConversionError> {
+    if working_assets.contains(&asset.id) {
+        return Ok(());
+    }
+    *total = total
+        .checked_add(u64::try_from(asset.bytes.len()).map_err(|_| {
+            resource("max_total_asset_bytes", "embedded visual byte count is not representable")
+        })?)
+        .ok_or_else(|| resource("max_total_asset_bytes", "embedded visual bytes overflow"))?;
+    if *total > options.limits.max_total_asset_bytes {
+        return Err(resource(
+            "max_total_asset_bytes",
+            "embedded visual bytes exceed the request limit",
+        ));
+    }
+    Ok(())
+}
+
+fn collect(
+    nodes: &[BlockNode],
+    output: &mut Vec<VisualRef>,
+    input_format: InputFormat,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    for (index, node) in nodes.iter().enumerate() {
+        if index % 256 == 0 {
+            context.checkpoint()?;
+        }
+        match &node.block {
+            Block::Image { asset, .. } => {
+                let role = if input_format == InputFormat::Pdf {
+                    crate::pdf::working_visual::classify(node)?
+                } else {
+                    crate::pdf::working_visual::VisualRole::Published
+                };
+                output.push(VisualRef {
+                    optional: runtime::has_native_body(
+                        nodes,
+                        &node.provenance,
+                        input_format,
+                        context,
+                    )?,
+                    asset: asset.clone(),
+                    provenance: node.provenance.clone(),
+                    role,
+                });
+            }
+            Block::List { items, .. } => {
+                for item in items {
+                    collect(&item.blocks, output, input_format, context)?;
+                }
+            }
+            Block::Table { rows, .. } => {
+                for row in rows {
+                    for cell in &row.cells {
+                        collect(&cell.blocks, output, input_format, context)?;
+                    }
+                }
+            }
+            Block::Footnote { blocks, .. }
+            | Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. } => collect(blocks, output, input_format, context)?,
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+pub(super) fn enforce_supported_reference_limit(
+    assets: &[Asset],
+    reference_counts: &super::ReferenceIndex,
+    limit: u32,
+) -> Result<(), ConversionError> {
+    let count = assets.iter().try_fold(0_u64, |total, asset| {
+        if asset.bytes.is_empty() || asset.external_uri.is_some() || !supported_raster(asset) {
+            return Ok(total);
+        }
+        total.checked_add(reference_counts.count(&asset.id).unwrap_or(0)).ok_or_else(|| {
+            resource("max_archive_entries", "embedded visual reference count is not representable")
+        })
+    })?;
+    if count > u64::from(limit) {
+        return Err(resource(
+            "max_archive_entries",
+            "embedded visual references exceed the request limit",
+        ));
+    }
+    Ok(())
+}

--- a/crates/converters/src/image_converter/ocr.rs
+++ b/crates/converters/src/image_converter/ocr.rs
@@ -1,11 +1,11 @@
 //! Policy-bound OCR routing and evidence-preserving IR construction.
 
 use into_markdown_core::{
-    AiMode, Asset, Block, BlockNode, ConversionError, ConversionOptions, Diagnostic,
-    DiagnosticSeverity, Document, ExecutionContext, Inline, NodeId, OcrEvidence, OcrEvidenceStage,
-    OcrEvidenceStep, OcrInputIdentity, OcrOutputPlan, OcrPolicy, OcrRecognition, OcrRequest,
-    OcrResult, OcrSourceRegion, Provenance, ProvenanceKind, ResourceReservation, Services,
-    SourceLocator, SourcePoint, estimate_retained_output,
+    Asset, Block, BlockNode, ConversionError, ConversionOptions, Diagnostic, DiagnosticSeverity,
+    Document, ExecutionContext, Inline, NodeId, OcrEvidence, OcrEvidenceStage, OcrEvidenceStep,
+    OcrInputIdentity, OcrOutputPlan, OcrPolicy, OcrRecognition, OcrRequest, OcrResult,
+    OcrSourceRegion, Provenance, ProvenanceKind, ResourceReservation, Services, SourceLocator,
+    SourcePoint, estimate_retained_output,
 };
 
 const MERGE_PROVIDER: &str = "builtin.converter.image.ocr-merge";
@@ -61,7 +61,7 @@ async fn recognize_inner(
     services: &Services,
     context: &ExecutionContext,
 ) -> Result<OcrContribution, ConversionError> {
-    let policy = effective_ocr_policy(options);
+    let policy = crate::embedded_visual_ocr::effective_ocr_policy(options);
     if policy == OcrPolicy::Off {
         return Ok(empty());
     }
@@ -202,16 +202,6 @@ async fn recognize_inner(
         recognized_regions,
         recognized_chars,
     })
-}
-
-fn effective_ocr_policy(options: &ConversionOptions) -> OcrPolicy {
-    match options.ai.vision_ocr {
-        AiMode::Only => OcrPolicy::Always,
-        AiMode::Fallback | AiMode::Prefer if options.ocr.policy == OcrPolicy::Off => {
-            OcrPolicy::Auto
-        }
-        _ => options.ocr.policy,
-    }
 }
 
 fn materialize_remote_unbound(

--- a/crates/converters/src/pdf/mod.rs
+++ b/crates/converters/src/pdf/mod.rs
@@ -11,6 +11,7 @@ mod links;
 mod pages;
 mod runtime;
 mod stream;
+pub(crate) mod working_visual;
 
 #[cfg(test)]
 mod tests;

--- a/crates/converters/src/pdf/page_lifetime_tests.rs
+++ b/crates/converters/src/pdf/page_lifetime_tests.rs
@@ -4,7 +4,7 @@ use futures::executor::block_on;
 use into_markdown_core::{
     ArtifactSink, AssetStreamInfo, Block, BoundOcrResult, BoxFuture, CancellationToken,
     ConversionError, ConversionOptions, ConversionRequest, ConverterOutput, EnrichmentPlan,
-    ExecutionContext, ExecutionOptions, FormatHint, InputFormat, InputRef, OcrEngine,
+    ErrorPolicy, ExecutionContext, ExecutionOptions, FormatHint, InputFormat, InputRef, OcrEngine,
     OcrEvidenceStage, OcrEvidenceStep, OcrInputIdentity, OcrOutputPlan, OcrRecognition, OcrRegion,
     OcrRequest, OcrResult, OutputEnricher, Services,
 };
@@ -13,8 +13,16 @@ use sha2::{Digest, Sha256};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
+#[derive(Clone, Copy, Default)]
+enum FirstFailure {
+    #[default]
+    None,
+    ComponentUnavailable,
+    RecognitionMemory,
+}
+
 #[derive(Default)]
-struct Recognizer(AtomicUsize, bool);
+struct Recognizer(AtomicUsize, FirstFailure);
 
 impl OcrEngine for Recognizer {
     fn id(&self) -> &'static str {
@@ -61,11 +69,22 @@ impl OcrEngine for Recognizer {
             })
             .await;
             let ordinal = self.0.fetch_add(1, Ordering::SeqCst) + 1;
-            if self.1 && ordinal == 1 {
-                return Err(ConversionError::ComponentUnavailable {
-                    component: "ocr".into(),
-                    detail: "test provider temporarily unavailable".into(),
-                });
+            if ordinal == 1 {
+                match self.1 {
+                    FirstFailure::ComponentUnavailable => {
+                        return Err(ConversionError::ComponentUnavailable {
+                            component: "ocr".into(),
+                            detail: "test provider temporarily unavailable".into(),
+                        });
+                    }
+                    FirstFailure::RecognitionMemory => {
+                        return Err(ConversionError::OcrRecognitionMemory {
+                            provider: "test.page-ocr".into(),
+                            detail: "test worker reached its fixed allowance".into(),
+                        });
+                    }
+                    FirstFailure::None => {}
+                }
             }
             let image = image::load_from_memory(request.image).unwrap();
             let identity = OcrInputIdentity::try_new(
@@ -286,6 +305,35 @@ fn collecting_consumes_ocr_pixels_per_page_and_releases_leases() {
     }
 }
 
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn thousand_page_scan_never_retains_more_than_one_page_render() {
+    let pages = Arc::new(ObservedPages::default());
+    let ocr = Arc::new(Recognizer::default());
+    let engine = engine(pages.clone(), ocr.clone());
+    let mut conversion = request(1);
+    conversion.input = InputRef::Bytes {
+        data: Arc::from(scanned_page_variants(1_000, true)),
+        name: Some("thousand-pages.pdf".into()),
+    };
+    conversion.options.limits.max_pages = 1_000;
+    let context =
+        ExecutionContext::new(ExecutionOptions::default(), conversion.options.limits.clone());
+    let result = block_on(engine.convert_with_context(conversion, context.clone())).unwrap();
+    assert_eq!(result.document.blocks.len(), 1_000);
+    assert!(result.assets.is_empty());
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 1, "identical pages reuse recognition");
+    let entries = pages.entries.lock().unwrap();
+    assert_eq!(entries.len(), 1_000);
+    assert!(entries.iter().all(|(_, live_page_pixels, _)| *live_page_pixels < 400_000));
+    assert!(entries.iter().map(|(_, pixels, _)| pixels).sum::<usize>() > 100_000_000);
+    assert!(!serde_json::to_string(&result.document).unwrap().contains("ocr-render"));
+    drop(entries);
+    drop(result);
+    assert_eq!(context.reserved_memory_bytes(), 0);
+    assert_eq!(context.reserved_temporary_bytes(), 0);
+}
+
 #[derive(Default)]
 struct MarkdownSink(Vec<u8>);
 impl ArtifactSink for MarkdownSink {
@@ -367,19 +415,35 @@ fn prepared_path_is_single_execution_and_keeps_body_in_page_order() {
 
 #[test]
 #[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
-fn permanent_assets_still_obey_document_total_budget() {
+fn permanent_assets_keep_originals_without_charging_ocr_page_renders() {
     for mode in [into_markdown_core::AssetMode::Extract, into_markdown_core::AssetMode::Embed] {
-        let mut request = request(3);
-        request.options.output.asset_mode = mode;
+        let mut conversion = request(3);
+        conversion.options.output.asset_mode = mode;
         let pages = Arc::new(ObservedPages::default());
-        let engine = engine(pages.clone(), Arc::new(Recognizer::default()));
+        let ocr = Arc::new(Recognizer::default());
+        let engine = engine(pages.clone(), ocr.clone());
         let context =
-            ExecutionContext::new(ExecutionOptions::default(), request.options.limits.clone());
+            ExecutionContext::new(ExecutionOptions::default(), conversion.options.limits.clone());
+        let result = block_on(engine.convert_with_context(conversion, context.clone())).unwrap();
+        assert_eq!(result.assets.len(), 3);
+        assert!(result.assets.iter().all(|asset| asset.id.0.starts_with("pdf-image-")));
+        assert!(!serde_json::to_string(&result.document).unwrap().contains("ocr-render"));
+        assert!(!result.markdown.contains("page render for OCR"));
+        assert_eq!(result.markdown.matches("recognized body").count(), 3);
+        assert_eq!(ocr.0.load(Ordering::SeqCst), 3);
+        assert_eq!(pages.entries.lock().unwrap().len(), 3);
+        drop(result);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+
+        let mut limited = request(3);
+        limited.options.output.asset_mode = mode;
+        limited.options.limits.max_total_asset_bytes = 100;
+        let context =
+            ExecutionContext::new(ExecutionOptions::default(), limited.options.limits.clone());
         assert!(matches!(
-            block_on(engine.convert_with_context(request, context.clone())),
+            block_on(engine.convert_with_context(limited, context.clone())),
             Err(ConversionError::ResourceLimit { limit: "max_total_asset_bytes", .. })
         ));
-        assert!(pages.entries.lock().unwrap().is_empty());
         assert_eq!(context.reserved_memory_bytes(), 0);
     }
 }
@@ -438,8 +502,11 @@ fn identical_scanned_pages_reuse_recognition_without_retaining_pixels() {
 
 fn check_repeated_pages(unavailable_first: bool) {
     let pages = Arc::new(ObservedPages::default());
-    let ocr = Arc::new(Recognizer(AtomicUsize::new(0), unavailable_first));
-    let engine = engine(pages.clone(), ocr.clone());
+    let ocr = Arc::new(Recognizer(
+        AtomicUsize::new(0),
+        if unavailable_first { FirstFailure::ComponentUnavailable } else { FirstFailure::None },
+    ));
+    let conversion_engine = engine(pages.clone(), ocr.clone());
     let mut request = request(4);
     request.input = InputRef::Bytes {
         data: Arc::from(scanned_page_variants(4, true)),
@@ -447,7 +514,8 @@ fn check_repeated_pages(unavailable_first: bool) {
     };
     let context =
         ExecutionContext::new(ExecutionOptions::default(), request.options.limits.clone());
-    let result = block_on(engine.convert_with_context(request, context.clone())).unwrap();
+    let result =
+        block_on(conversion_engine.convert_with_context(request, context.clone())).unwrap();
     let unavailable = usize::from(unavailable_first);
     let body = format!("recognized body {}", 1 + unavailable);
     assert_eq!(ocr.0.load(Ordering::SeqCst), 1 + unavailable);
@@ -478,4 +546,54 @@ fn check_repeated_pages(unavailable_first: bool) {
     drop(result);
     assert_eq!(context.reserved_memory_bytes(), 0);
     assert_eq!(context.reserved_temporary_bytes(), 0);
+}
+
+#[test]
+#[ignore = "requires PDFIUM_LIBRARY pointing to the pinned current-target runtime"]
+fn best_effort_permanent_assets_survive_page_ocr_memory_failure_without_working_renders() {
+    let pages = Arc::new(ObservedPages::default());
+    let ocr = Arc::new(Recognizer(AtomicUsize::new(0), FirstFailure::RecognitionMemory));
+    let conversion_engine = engine(pages.clone(), ocr.clone());
+    let mut conversion = request(3);
+    conversion.options.output.asset_mode = into_markdown_core::AssetMode::Extract;
+    conversion.options.ocr.policy = into_markdown_core::OcrPolicy::Always;
+    conversion.options.error_policy = ErrorPolicy::BestEffort;
+    let context =
+        ExecutionContext::new(ExecutionOptions::default(), conversion.options.limits.clone());
+    let result =
+        block_on(conversion_engine.convert_with_context(conversion, context.clone())).unwrap();
+    assert_eq!(result.assets.len(), 3);
+    assert!(result.assets.iter().all(|asset| asset.id.0.starts_with("pdf-image-")));
+    assert_eq!(result.markdown.matches("recognized body").count(), 2);
+    assert_eq!(ocr.0.load(Ordering::SeqCst), 3);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "ocr.optionalRecognitionMemorySkipped")
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "resource.ocrRecognitionMemory.unitOmitted")
+    );
+    let serialized = serde_json::to_string(&result.document).unwrap();
+    assert!(!serialized.contains("pdf-page-render-"));
+    assert!(!serialized.contains("ocr-render"));
+    assert_eq!(pages.entries.lock().unwrap().len(), 3);
+    drop(result);
+    assert_eq!(context.reserved_memory_bytes(), 0);
+
+    let pages = Arc::new(ObservedPages::default());
+    let engine =
+        engine(pages, Arc::new(Recognizer(AtomicUsize::new(0), FirstFailure::RecognitionMemory)));
+    let mut strict = request(1);
+    strict.options.output.asset_mode = into_markdown_core::AssetMode::Extract;
+    strict.options.ocr.policy = into_markdown_core::OcrPolicy::Always;
+    strict.options.error_policy = ErrorPolicy::Strict;
+    assert!(matches!(
+        block_on(engine.convert(strict)),
+        Err(ConversionError::OcrRecognitionMemory { .. })
+    ));
 }

--- a/crates/converters/src/pdf/pages.rs
+++ b/crates/converters/src/pdf/pages.rs
@@ -271,8 +271,9 @@ impl PdfOutput {
             .count();
         let scanned =
             printable < MIN_NATIVE_TEXT_CHARS && coverage.ratio() >= MIN_SCAN_IMAGE_COVERAGE;
-        let render_requested = options.ocr.policy == OcrPolicy::Always
-            || (options.ocr.policy == OcrPolicy::Auto && scanned);
+        let ocr_policy = crate::embedded_visual_ocr::effective_ocr_policy(options);
+        let render_requested =
+            ocr_policy == OcrPolicy::Always || (ocr_policy == OcrPolicy::Auto && scanned);
         for image in images {
             context.checkpoint()?;
             // A full displayed-page render already includes every embedded
@@ -351,9 +352,8 @@ impl PdfOutput {
             let (encoded, encoded_memory) = rendered_bitmap_to_bmp(&bitmap, options, context)?;
             drop(bitmap);
             drop(bitmap_memory);
-            account_asset(&encoded, &mut counts.asset_bytes, options)?;
             retain_output_bytes(context, &mut retained_memory, asset_record_overhead()?)?;
-            let id = content_asset_id("pdf-page-render", &encoded)?;
+            let id = content_asset_id(super::working_visual::ASSET_KIND, &encoded)?;
             counts
                 .asset_ids
                 .try_reserve(1)
@@ -392,7 +392,7 @@ impl PdfOutput {
             rendered_provenance.locator.rotation_degrees = Some(0.0);
             blocks.push(BlockNode {
                 id: NodeId(format!("pdf-page-{page_number}-ocr-render")),
-                block: Block::Image { asset: AssetId(id), alt: Some("page render for OCR".into()) },
+                block: super::working_visual::image_block(id),
                 provenance: rendered_provenance,
             });
         }

--- a/crates/converters/src/pdf/stream.rs
+++ b/crates/converters/src/pdf/stream.rs
@@ -1,27 +1,18 @@
-//! Page-bounded OCR-only pixel lifetime; final semantic ownership moves once.
+//! Page-bounded PDF OCR working pixels; only publishable source assets survive.
 
 use super::{
-    PdfConverter, convert_pdf_admitted, image_pixels_required, open_document, pages,
-    runtime::acquire_pdf_conversion,
+    PdfConverter, convert_pdf_admitted, open_document, pages, runtime::acquire_pdf_conversion,
 };
 use into_markdown_core::{
-    AiMode, AssetMode, Block, BlockNode, ConversionError, ConversionOptions, ConverterEventSink,
-    ConverterOutput, ConverterStream, ConverterStreamCompletion, ConverterStreamMode, Diagnostic,
-    ExecutionContext, FormatCandidate, LocalBoxFuture, ResolvedInput, Services, StreamConsumerKind,
-    estimate_retained_output, stream_converter_output,
+    Asset, AssetId, AssetMode, Block, BlockNode, ConversionError, ConversionOptions,
+    ConverterEventSink, ConverterOutput, ConverterStream, ConverterStreamCompletion,
+    ConverterStreamMode, Diagnostic, ExecutionContext, FormatCandidate, LocalBoxFuture, OcrPolicy,
+    ResolvedInput, Services, StreamConsumerKind, stream_converter_output,
 };
+use std::collections::HashSet;
 
-fn ocr_only_pixels(options: &ConversionOptions) -> bool {
-    options.output.asset_mode == AssetMode::Omit
-        && image_pixels_required(options)
-        && [
-            options.ai.image_description,
-            options.ai.layout_repair,
-            options.ai.table_repair,
-            options.ai.formula_repair,
-        ]
-        .iter()
-        .all(|mode| *mode == AiMode::Off)
+fn page_ocr_requested(options: &ConversionOptions) -> bool {
+    crate::embedded_visual_ocr::effective_ocr_policy(options) != OcrPolicy::Off
 }
 
 impl ConverterStream for PdfConverter {
@@ -32,7 +23,7 @@ impl ConverterStream for PdfConverter {
         options: &ConversionOptions,
         _: StreamConsumerKind,
     ) -> ConverterStreamMode {
-        if ocr_only_pixels(options) {
+        if page_ocr_requested(options) {
             ConverterStreamMode::Native
         } else {
             ConverterStreamMode::AggregateAdapter
@@ -51,11 +42,16 @@ impl ConverterStream for PdfConverter {
         Box::pin(async move {
             let path = self.runtime_path()?;
             let _permit = acquire_pdf_conversion(context).await?;
-            if !ocr_only_pixels(options) || !sink.supports_page_enrichment() {
+            if !page_ocr_requested(options) {
                 return stream_converter_output(
                     convert_pdf_admitted(&path, input, options, context)?,
                     sink,
                 );
+            }
+            if !sink.supports_page_enrichment() {
+                let output = convert_pdf_admitted(&path, input, options, context)?;
+                let output = super::working_visual::discard(output, context)?;
+                return stream_converter_output(output, sink);
             }
             let runtime = pages::load_runtime(&path, options)?;
             let pdf = open_document(&runtime, input, context)?;
@@ -63,6 +59,7 @@ impl ConverterStream for PdfConverter {
             let selected_pages = observed_pages.min(options.limits.max_pages);
             let mut counts = pages::Counts::default();
             let mut output = ConverterOutput::default();
+            let mut published_asset_ids = HashSet::new();
             if observed_pages > selected_pages {
                 output
                     .diagnostics
@@ -72,15 +69,30 @@ impl ConverterStream for PdfConverter {
                 context.checkpoint()?;
                 sink.checkpoint()?;
                 let page = pages::PdfOutput::new(1, context)?
-                    .extract_page(&pdf, page_index, options, context, &mut counts, true)?
+                    .extract_page(
+                        &pdf,
+                        page_index,
+                        options,
+                        context,
+                        &mut counts,
+                        options.output.asset_mode == AssetMode::Omit,
+                    )?
                     .finish(options, context)?;
                 let page = sink.enrich_page(page).await?;
-                append_consumed_page(&mut output, page, context)?;
-                // Reset only after the page's actual bitmap allocations AND
-                // their leases were destroyed. Permanent asset modes never use
-                // this branch and keep document-wide byte/dedup accounting.
-                counts.asset_bytes = 0;
+                append_page(
+                    &mut output,
+                    page,
+                    options.output.asset_mode,
+                    &mut published_asset_ids,
+                    context,
+                )?;
+                // Every page must carry the payloads needed by its own OCR
+                // transaction. The final collector performs document-wide
+                // content-ID deduplication after those working bytes are gone.
                 counts.asset_ids.clear();
+                if options.output.asset_mode == AssetMode::Omit {
+                    counts.asset_bytes = 0;
+                }
             }
             // Keep document-wide native/OCR layout and running-matter policy,
             // now over semantic text only, without retaining page pixels.
@@ -90,19 +102,22 @@ impl ConverterStream for PdfConverter {
     }
 }
 
-fn append_consumed_page(
+fn append_page(
     output: &mut ConverterOutput,
-    mut page: ConverterOutput,
+    page: ConverterOutput,
+    asset_mode: AssetMode,
+    published_asset_ids: &mut HashSet<AssetId>,
     context: &ExecutionContext,
 ) -> Result<(), ConversionError> {
     context.checkpoint()?;
-    remove_images(&mut page.document.blocks, context)?;
-    page.assets = Vec::new();
-    let retained = estimate_retained_output(&page.document, &page.assets, &page.diagnostics)?;
-    let compact = context.reserve_memory(retained)?;
-    // Replace the now-freed pixel/codec/layout peak leases with only the live
-    // semantic output. Ownership is covered throughout the transition.
-    let mut page = page.certify_preflight_reservation(context, compact)?;
+    let mut page = super::working_visual::discard(page, context)?;
+    if asset_mode == AssetMode::Omit {
+        remove_images(&mut page.document.blocks, context)?;
+        page.assets.clear();
+    } else {
+        page.assets.retain(|asset| published_asset_ids.insert(asset.id.clone()));
+    }
+    let mut page = page.reconcile_retained_output(context)?;
     let growth = page
         .document
         .blocks
@@ -111,6 +126,7 @@ fn append_consumed_page(
         .and_then(|bytes| {
             bytes.checked_add(page.diagnostics.len().checked_mul(size_of::<Diagnostic>())?)
         })
+        .and_then(|bytes| bytes.checked_add(page.assets.len().checked_mul(size_of::<Asset>())?))
         .and_then(|bytes| bytes.checked_mul(2))
         .and_then(|bytes| u64::try_from(bytes).ok())
         .ok_or_else(|| super::resource("max_memory_bytes", "PDF page collector growth overflow"))?;
@@ -123,8 +139,12 @@ fn append_consumed_page(
     output.diagnostics.try_reserve(page.diagnostics.len()).map_err(|_| {
         super::resource("max_memory_bytes", "PDF diagnostic collector allocation failed")
     })?;
+    output.assets.try_reserve(page.assets.len()).map_err(|_| {
+        super::resource("max_memory_bytes", "PDF asset collector allocation failed")
+    })?;
     output.document.blocks.append(&mut page.document.blocks);
     output.diagnostics.append(&mut page.diagnostics);
+    output.assets.append(&mut page.assets);
     output.absorb_memory_lease(&mut page, context)?;
     output.attach_memory_reservation(context, growth)
 }
@@ -162,18 +182,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn only_ocr_only_omitted_pixels_use_page_consumption() {
+    fn every_pdf_ocr_mode_uses_page_consumption() {
         let mut options = ConversionOptions::default();
         options.output.asset_mode = AssetMode::Omit;
-        assert!(ocr_only_pixels(&options));
+        assert!(page_ocr_requested(&options));
         options.ocr.policy = into_markdown_core::OcrPolicy::Off;
-        assert!(!ocr_only_pixels(&options));
-        options.ai.vision_ocr = AiMode::Only;
-        assert!(ocr_only_pixels(&options));
-        options.ai.image_description = AiMode::Prefer;
-        assert!(!ocr_only_pixels(&options));
-        options.ai.image_description = AiMode::Off;
+        assert!(!page_ocr_requested(&options));
+        options.ai.vision_ocr = into_markdown_core::AiMode::Only;
+        assert!(page_ocr_requested(&options));
         options.output.asset_mode = AssetMode::Extract;
-        assert!(!ocr_only_pixels(&options));
+        assert!(page_ocr_requested(&options));
+        options.output.asset_mode = AssetMode::Embed;
+        assert!(page_ocr_requested(&options));
     }
 }

--- a/crates/converters/src/pdf/working_visual.rs
+++ b/crates/converters/src/pdf/working_visual.rs
@@ -1,0 +1,300 @@
+//! Internal ownership contract for full-page bitmaps created only for PDF OCR.
+
+use into_markdown_core::{
+    Asset, AssetId, Block, BlockNode, ConversionError, ConverterOutput, Document, ExecutionContext,
+    ProvenanceKind,
+};
+use std::collections::BTreeSet;
+
+pub(crate) const ASSET_KIND: &str = "pdf-page-render";
+pub(crate) const ASSET_PREFIX: &str = "pdf-page-render-";
+const NODE_PREFIX: &str = "pdf-page-";
+const NODE_SUFFIX: &str = "-ocr-render";
+pub(crate) const ALT: &str = "page render for OCR";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum VisualRole {
+    Published,
+    OcrPageRender,
+}
+
+pub(crate) fn image_block(id: String) -> Block {
+    Block::Image { asset: AssetId(id), alt: Some(ALT.into()) }
+}
+
+pub(crate) fn classify(node: &BlockNode) -> Result<VisualRole, ConversionError> {
+    let Block::Image { asset, alt } = &node.block else { return Ok(VisualRole::Published) };
+    let id_marked = node.id.0.starts_with(NODE_PREFIX) && node.id.0.ends_with(NODE_SUFFIX);
+    let asset_marked = asset.0.starts_with(ASSET_PREFIX);
+    let alt_marked = alt.as_deref() == Some(ALT);
+    if !id_marked && !asset_marked && !alt_marked {
+        return Ok(VisualRole::Published);
+    }
+    let page = node
+        .id
+        .0
+        .strip_prefix(NODE_PREFIX)
+        .and_then(|value| value.strip_suffix(NODE_SUFFIX))
+        .and_then(|value| value.parse::<u32>().ok())
+        .filter(|page| *page > 0)
+        .ok_or_else(|| invalid_marker(node, "node ID"))?;
+    let locator = &node.provenance.locator;
+    let bounds = locator.bounds.ok_or_else(|| invalid_marker(node, "bounds"))?;
+    let page_width = locator.page_width.ok_or_else(|| invalid_marker(node, "page width"))?;
+    let page_height = locator.page_height.ok_or_else(|| invalid_marker(node, "page height"))?;
+    if !asset_marked
+        || !alt_marked
+        || locator.page != Some(page)
+        || node.provenance.kind != ProvenanceKind::NativeParser
+        || node.provenance.provider != super::PROVIDER_ID
+        || locator.rotation_degrees != Some(0.0)
+        || bounds.x != 0.0
+        || bounds.y != 0.0
+        || bounds.width.to_bits() != page_width.to_bits()
+        || bounds.height.to_bits() != page_height.to_bits()
+    {
+        return Err(invalid_marker(node, "coherent page-render provenance"));
+    }
+    Ok(VisualRole::OcrPageRender)
+}
+
+pub(crate) fn validate(
+    document: &Document,
+    assets: &[Asset],
+    context: &ExecutionContext,
+) -> Result<BTreeSet<AssetId>, ConversionError> {
+    let mut working = BTreeSet::new();
+    visit_nodes(&document.blocks, context, &mut |node| {
+        if classify(node)? == VisualRole::OcrPageRender
+            && let Block::Image { asset, .. } = &node.block
+        {
+            working.insert(asset.clone());
+        }
+        Ok(())
+    })?;
+    for asset in assets {
+        context.checkpoint()?;
+        if !asset.id.0.starts_with(ASSET_PREFIX) {
+            continue;
+        }
+        if !working.contains(&asset.id)
+            || asset.filename.as_deref().and_then(|filename| filename.strip_suffix(".bmp"))
+                != Some(asset.id.0.as_str())
+            || asset.media_type != "image/bmp"
+            || asset.external_uri.is_some()
+            || !asset.bytes.starts_with(b"BM")
+        {
+            return Err(ConversionError::Internal {
+                detail: format!("invalid PDF OCR working asset {}", asset.id.0),
+            });
+        }
+    }
+    for id in &working {
+        if !assets.iter().any(|asset| asset.id == *id) {
+            return Err(ConversionError::Internal {
+                detail: format!("PDF OCR working node references missing asset {}", id.0),
+            });
+        }
+    }
+    Ok(working)
+}
+
+pub(crate) fn discard(
+    mut output: ConverterOutput,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    let working = validate(&output.document, &output.assets, context)?;
+    remove_nodes(&mut output.document.blocks, context)?;
+    remove_assets(output, &working, context)
+}
+
+pub(crate) fn remove_assets(
+    mut output: ConverterOutput,
+    working: &BTreeSet<AssetId>,
+    context: &ExecutionContext,
+) -> Result<ConverterOutput, ConversionError> {
+    if working.is_empty() {
+        return Ok(output);
+    }
+    visit_nodes(&output.document.blocks, context, &mut |node| {
+        if let Block::Image { asset, .. } = &node.block
+            && working.contains(asset)
+        {
+            return Err(ConversionError::Internal {
+                detail: format!(
+                    "published node still references PDF OCR working asset {}",
+                    asset.0
+                ),
+            });
+        }
+        Ok(())
+    })?;
+    output.assets.retain(|asset| !working.contains(&asset.id));
+    output.reconcile_retained_output(context)
+}
+
+fn remove_nodes(
+    nodes: &mut Vec<BlockNode>,
+    context: &ExecutionContext,
+) -> Result<(), ConversionError> {
+    let mut index = 0;
+    while index < nodes.len() {
+        context.checkpoint()?;
+        match &mut nodes[index].block {
+            Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. }
+            | Block::Footnote { blocks, .. } => remove_nodes(blocks, context)?,
+            Block::List { items, .. } => {
+                for item in items {
+                    remove_nodes(&mut item.blocks, context)?;
+                }
+            }
+            Block::Table { rows, .. } => {
+                for cell in rows.iter_mut().flat_map(|row| &mut row.cells) {
+                    remove_nodes(&mut cell.blocks, context)?;
+                }
+            }
+            _ => {}
+        }
+        if classify(&nodes[index])? == VisualRole::OcrPageRender {
+            nodes.remove(index);
+        } else {
+            index += 1;
+        }
+    }
+    Ok(())
+}
+
+fn visit_nodes(
+    nodes: &[BlockNode],
+    context: &ExecutionContext,
+    visit: &mut impl FnMut(&BlockNode) -> Result<(), ConversionError>,
+) -> Result<(), ConversionError> {
+    for node in nodes {
+        context.checkpoint()?;
+        visit(node)?;
+        match &node.block {
+            Block::Page { blocks, .. }
+            | Block::Slide { blocks, .. }
+            | Block::Sheet { blocks, .. }
+            | Block::Footnote { blocks, .. } => visit_nodes(blocks, context, visit)?,
+            Block::List { items, .. } => {
+                for item in items {
+                    visit_nodes(&item.blocks, context, visit)?;
+                }
+            }
+            Block::Table { rows, .. } => {
+                for cell in rows.iter().flat_map(|row| &row.cells) {
+                    visit_nodes(&cell.blocks, context, visit)?;
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn invalid_marker(node: &BlockNode, detail: &str) -> ConversionError {
+    ConversionError::Internal {
+        detail: format!("PDF OCR working node {} lacks {detail}", node.id.0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use into_markdown_core::{
+        Document, ExecutionOptions, NodeId, Provenance, Rect, ResourceLimits, SourceLocator,
+    };
+
+    fn provenance(bounds: Rect) -> Provenance {
+        Provenance {
+            kind: ProvenanceKind::NativeParser,
+            provider: super::super::PROVIDER_ID.into(),
+            locator: SourceLocator {
+                page: Some(1),
+                bounds: Some(bounds),
+                rotation_degrees: Some(0.0),
+                page_width: Some(100.0),
+                page_height: Some(200.0),
+                ..Default::default()
+            },
+            confidence: None,
+        }
+    }
+
+    fn working_node(alt: Option<&str>) -> BlockNode {
+        BlockNode {
+            id: NodeId("pdf-page-1-ocr-render".into()),
+            block: Block::Image {
+                asset: AssetId(format!("{ASSET_PREFIX}fixture")),
+                alt: alt.map(str::to_owned),
+            },
+            provenance: provenance(Rect { x: 0.0, y: 0.0, width: 100.0, height: 200.0 }),
+        }
+    }
+
+    #[test]
+    fn discard_removes_only_the_validated_working_visual_and_reconciles_memory() {
+        let original = AssetId("pdf-image-original".into());
+        let working = AssetId(format!("{ASSET_PREFIX}fixture"));
+        let document = Document {
+            blocks: vec![BlockNode {
+                id: NodeId("pdf-page-1".into()),
+                block: Block::Page {
+                    number: 1,
+                    blocks: vec![
+                        BlockNode {
+                            id: NodeId("pdf-page-1-image-1".into()),
+                            block: Block::Image { asset: original.clone(), alt: None },
+                            provenance: provenance(Rect {
+                                x: 10.0,
+                                y: 20.0,
+                                width: 30.0,
+                                height: 40.0,
+                            }),
+                        },
+                        working_node(Some(ALT)),
+                    ],
+                },
+                provenance: provenance(Rect { x: 0.0, y: 0.0, width: 100.0, height: 200.0 }),
+            }],
+            ..Default::default()
+        };
+        let output = ConverterOutput::new(
+            document,
+            vec![
+                Asset {
+                    id: original.clone(),
+                    filename: Some("original.bmp".into()),
+                    media_type: "image/bmp".into(),
+                    bytes: b"BM-original".to_vec(),
+                    external_uri: None,
+                },
+                Asset {
+                    id: working.clone(),
+                    filename: Some(format!("{}.bmp", working.0)),
+                    media_type: "image/bmp".into(),
+                    bytes: b"BM-working".to_vec(),
+                    external_uri: None,
+                },
+            ],
+            vec![],
+        );
+        let context = ExecutionContext::new(ExecutionOptions::default(), ResourceLimits::default());
+        let output = output.account_retained(&context).unwrap();
+        let output = discard(output, &context).unwrap();
+        assert_eq!(output.assets.len(), 1);
+        assert_eq!(output.assets[0].id, original);
+        assert!(!serde_json::to_string(&output.document).unwrap().contains(ASSET_PREFIX));
+        drop(output);
+        assert_eq!(context.reserved_memory_bytes(), 0);
+    }
+
+    #[test]
+    fn partial_working_markers_fail_closed() {
+        let node = working_node(None);
+        assert!(matches!(classify(&node), Err(ConversionError::Internal { .. })));
+    }
+}

--- a/crates/engine/src/artifact_execution.rs
+++ b/crates/engine/src/artifact_execution.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Engine, PreparedArtifactConversion, artifact_output, invoke_converter_preflighted,
-    invoke_enrichers, rendering, stream_execution,
+    invoke_enrichers_skipping, rendering, stream_execution,
 };
 use into_markdown_core::{
     ArtifactSink, ConversionError, ConversionSummary, ConverterStreamMode, ExecutionStage,
@@ -37,8 +37,8 @@ pub(crate) async fn execute(
             StreamConsumerKind::Immediate,
         ) == ConverterStreamMode::Native
     });
-    let output = if let Some(stream) = native {
-        stream_execution::invoke_native_immediate(
+    let (output, completed_page_ocr) = if let Some(stream) = native {
+        let native = stream_execution::invoke_native_immediate(
             stream,
             source.input(),
             &attempt.candidate,
@@ -47,27 +47,34 @@ pub(crate) async fn execute(
             &engine.enrichers,
             &context,
         )
-        .await?
+        .await?;
+        (native.output, native.completed_page_ocr)
     } else {
-        invoke_converter_preflighted(
-            attempt.converter.as_ref(),
-            source.input(),
-            &attempt.candidate,
+        (
+            invoke_converter_preflighted(
+                attempt.converter.as_ref(),
+                source.input(),
+                &attempt.candidate,
+                &request.options,
+                &engine.services,
+                &context,
+                |_| Ok(()),
+            )
+            .await?,
+            false,
+        )
+    };
+    let output = invoke_enrichers_skipping(
+        &engine.enrichers,
+        output,
+        crate::EnricherInvocation::after_page_enrichment(
+            attempt.converter.id(),
+            attempt.candidate.format,
             &request.options,
             &engine.services,
             &context,
-            |_| Ok(()),
-        )
-        .await?
-    };
-    let output = invoke_enrichers(
-        &engine.enrichers,
-        output,
-        attempt.converter.id(),
-        attempt.candidate.format,
-        &request.options,
-        &engine.services,
-        &context,
+            completed_page_ocr.then_some(crate::page_enrichment::EMBEDDED_OCR),
+        ),
     )
     .await?;
     let output = if request.options.output.asset_mode == into_markdown_core::AssetMode::Omit {

--- a/crates/engine/src/collecting/integration_tests.rs
+++ b/crates/engine/src/collecting/integration_tests.rs
@@ -380,7 +380,7 @@ fn native_admission_has_stable_exact_minus_one_and_releases_on_drop() {
     ))
     .unwrap();
     assert_eq!(calls.load(Ordering::SeqCst), 1);
-    assert_eq!(output.document.blocks.len(), 8);
+    assert_eq!(output.output.document.blocks.len(), 8);
     drop(output);
     assert_eq!(exact.available_memory_bytes(), plan);
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -399,8 +399,8 @@ impl Engine {
                 StreamConsumerKind::Collecting,
             ) == ConverterStreamMode::Native
         });
-        let output = if let Some(stream) = native_stream {
-            stream_execution::invoke_native_collecting(
+        let (output, completed_page_ocr) = if let Some(stream) = native_stream {
+            let native = stream_execution::invoke_native_collecting(
                 stream,
                 source.input(),
                 &attempt.candidate,
@@ -409,27 +409,34 @@ impl Engine {
                 &self.enrichers,
                 &context,
             )
-            .await?
+            .await?;
+            (native.output, native.completed_page_ocr)
         } else {
-            invoke_converter_preflighted(
-                attempt.converter.as_ref(),
-                source.input(),
-                &attempt.candidate,
+            (
+                invoke_converter_preflighted(
+                    attempt.converter.as_ref(),
+                    source.input(),
+                    &attempt.candidate,
+                    &request.options,
+                    &self.services,
+                    &context,
+                    |_| Ok(()),
+                )
+                .await?,
+                false,
+            )
+        };
+        let output = invoke_enrichers_skipping(
+            &self.enrichers,
+            output,
+            EnricherInvocation::after_page_enrichment(
+                attempt.converter.id(),
+                attempt.candidate.format,
                 &request.options,
                 &self.services,
                 &context,
-                |_| Ok(()),
-            )
-            .await?
-        };
-        let output = invoke_enrichers(
-            &self.enrichers,
-            output,
-            attempt.converter.id(),
-            attempt.candidate.format,
-            &request.options,
-            &self.services,
-            &context,
+                completed_page_ocr.then_some(page_enrichment::EMBEDDED_OCR),
+            ),
         )
         .await?;
         let output = if request.options.output.asset_mode == into_markdown_core::AssetMode::Omit {
@@ -514,15 +521,55 @@ fn preserve_utf8_markdown(
 
 pub(crate) async fn invoke_enrichers(
     enrichers: &[Arc<dyn OutputEnricher>],
-    mut output: ConverterOutput,
+    output: ConverterOutput,
     converter_id: &str,
     format: into_markdown_core::InputFormat,
     options: &ConversionOptions,
     services: &Services,
     context: &ExecutionContext,
 ) -> Result<ConverterOutput, ConversionError> {
+    invoke_enrichers_skipping(
+        enrichers,
+        output,
+        EnricherInvocation { converter_id, format, options, services, context, completed: None },
+    )
+    .await
+}
+
+pub(crate) struct EnricherInvocation<'a> {
+    converter_id: &'a str,
+    format: into_markdown_core::InputFormat,
+    options: &'a ConversionOptions,
+    services: &'a Services,
+    context: &'a ExecutionContext,
+    completed: Option<&'a str>,
+}
+
+impl<'a> EnricherInvocation<'a> {
+    pub(crate) fn after_page_enrichment(
+        converter_id: &'a str,
+        format: into_markdown_core::InputFormat,
+        options: &'a ConversionOptions,
+        services: &'a Services,
+        context: &'a ExecutionContext,
+        completed: Option<&'a str>,
+    ) -> Self {
+        Self { converter_id, format, options, services, context, completed }
+    }
+}
+
+pub(crate) async fn invoke_enrichers_skipping(
+    enrichers: &[Arc<dyn OutputEnricher>],
+    mut output: ConverterOutput,
+    invocation: EnricherInvocation<'_>,
+) -> Result<ConverterOutput, ConversionError> {
+    let EnricherInvocation { converter_id, format, options, services, context, completed } =
+        invocation;
     for enricher in enrichers {
         context.checkpoint()?;
+        if completed == Some(enricher.id()) {
+            continue;
+        }
         let plan = enricher.planned_enrichment_bytes(
             &output,
             converter_id,

--- a/crates/engine/src/page_enrichment.rs
+++ b/crates/engine/src/page_enrichment.rs
@@ -17,6 +17,7 @@ pub(crate) struct PageEnrichmentSink<'a> {
     pub(crate) options: &'a ConversionOptions,
     pub(crate) services: &'a Services,
     pub(crate) context: &'a ExecutionContext,
+    pub(crate) enrichment_attempted: bool,
 }
 
 impl ConverterEventSink for PageEnrichmentSink<'_> {
@@ -40,6 +41,7 @@ impl ConverterEventSink for PageEnrichmentSink<'_> {
         &mut self,
         mut output: ConverterOutput,
     ) -> LocalBoxFuture<'_, Result<ConverterOutput, ConversionError>> {
+        self.enrichment_attempted = true;
         Box::pin(async move {
             self.context.checkpoint()?;
             let enricher = self.enricher.ok_or_else(|| ConversionError::Internal {

--- a/crates/engine/src/page_enrichment/policy.rs
+++ b/crates/engine/src/page_enrichment/policy.rs
@@ -1,6 +1,6 @@
 //! Recovery policy for one transactional native PDF page.
 
-use super::*;
+use super::{ConversionError, ConverterOutput, InputFormat, OutputEnricher, PageEnrichmentSink};
 use into_markdown_core::{
     Diagnostic, DiagnosticSeverity, ResourceFailureScope, ResourceLimitSource,
     ResourceRecoveryAction, ResourceRecoveryBoundary, ResourceUnitKind, classify_resource_recovery,

--- a/crates/engine/src/page_enrichment_tests.rs
+++ b/crates/engine/src/page_enrichment_tests.rs
@@ -103,6 +103,7 @@ fn enrich(
         options,
         services: &services,
         context,
+        enrichment_attempted: false,
     };
     let mut future = std::pin::pin!(sink.enrich_page(output));
     let mut task = std::task::Context::from_waker(std::task::Waker::noop());

--- a/crates/engine/src/stream_execution.rs
+++ b/crates/engine/src/stream_execution.rs
@@ -20,7 +20,7 @@ pub(crate) async fn invoke_native_collecting(
     services: &Services,
     enrichers: &[Arc<dyn OutputEnricher>],
     context: &ExecutionContext,
-) -> Result<ConverterOutput, ConversionError> {
+) -> Result<NativeExecution, ConversionError> {
     invoke_native(NativeRequest {
         converter,
         input,
@@ -42,7 +42,7 @@ pub(crate) async fn invoke_native_immediate(
     services: &Services,
     enrichers: &[Arc<dyn OutputEnricher>],
     context: &ExecutionContext,
-) -> Result<ConverterOutput, ConversionError> {
+) -> Result<NativeExecution, ConversionError> {
     invoke_native(NativeRequest {
         converter,
         input,
@@ -67,7 +67,12 @@ struct NativeRequest<'a> {
     consumer: StreamConsumerKind,
 }
 
-async fn invoke_native(request: NativeRequest<'_>) -> Result<ConverterOutput, ConversionError> {
+pub(crate) struct NativeExecution {
+    pub(crate) output: ConverterOutput,
+    pub(crate) completed_page_ocr: bool,
+}
+
+async fn invoke_native(request: NativeRequest<'_>) -> Result<NativeExecution, ConversionError> {
     let NativeRequest {
         converter,
         input,
@@ -82,7 +87,9 @@ async fn invoke_native(request: NativeRequest<'_>) -> Result<ConverterOutput, Co
     let mut admission = context.reserve_memory(plan)?;
     let credited = context.with_memory_credit(&mut admission)?;
     let mut sink = CollectingArtifactSink::new(&credited);
-    let completion = {
+    let page_enricher =
+        enrichers.iter().find(|enricher| enricher.id() == EMBEDDED_OCR).map(AsRef::as_ref);
+    let (completion, completed_page_ocr) = {
         let mut page_services = services.clone();
         if candidate.format == into_markdown_core::InputFormat::Pdf {
             page_services.ocr = services.ocr.as_ref().map(|provider| {
@@ -92,22 +99,21 @@ async fn invoke_native(request: NativeRequest<'_>) -> Result<ConverterOutput, Co
         }
         let mut pages = PageEnrichmentSink {
             destination: &mut sink,
-            enricher: enrichers
-                .iter()
-                .find(|enricher| enricher.id() == EMBEDDED_OCR)
-                .map(AsRef::as_ref),
+            enricher: page_enricher,
             converter_id: converter.id(),
             format: candidate.format,
             options,
             services: &page_services,
             context: &credited,
+            enrichment_attempted: false,
         };
-        context
+        let completion = context
             .run(
                 converter
                     .convert_stream(input, candidate, options, services, &credited, &mut pages),
             )
-            .await??
+            .await??;
+        (completion, pages.enrichment_attempted)
     };
     let output = sink.finish(completion)?;
     let retained = estimate_retained_output(&output.document, &output.assets, &output.diagnostics)?;
@@ -128,5 +134,8 @@ async fn invoke_native(request: NativeRequest<'_>) -> Result<ConverterOutput, Co
     drop(validation_guard);
     drop(retained_guard);
     drop(credited);
-    output.certify_preflight_reservation(context, admission)
+    Ok(NativeExecution {
+        output: output.certify_preflight_reservation(context, admission)?,
+        completed_page_ocr,
+    })
 }

--- a/tools/structure_gate/baseline.json
+++ b/tools/structure_gate/baseline.json
@@ -460,15 +460,15 @@
     },
     {
       "path": "crates/converters/src/embedded_visual_ocr.rs",
-      "lines": 1273,
+      "lines": 1226,
       "functions": [
         {
           "symbol": "enrich",
-          "lines": 199
+          "lines": 196
         },
         {
           "symbol": "plan_enrichment",
-          "lines": 206
+          "lines": 205
         }
       ],
       "allowances": [


### PR DESCRIPTION
Fixes #365. References #354 and #361.

## What changed

- assign full-page PDF OCR renders an internal, fail-closed working-visual role
- use one page render as the sole OCR source when present while retaining original embedded images
- run PDF OCR page-by-page for extract, embed, omit, auto, always, and vision OCR
- remove working nodes and payloads after success, empty output, cache hits, and best-effort rollback
- deduplicate published source assets without charging working renders to final asset totals
- skip only the already-completed page OCR enricher while preserving later enrichers
- enforce the same OCR-on/off published-asset invariant for EPUB and other containers

## Verification

- cargo fmt --all -- --check
- cargo test --locked -p into-markdown-engine -p into-markdown-converters -p into-markdown --lib -j2: 851 passed, 21 runtime-dependent ignored
- pinned PDFium page-lifetime suite: 8 passed, including 1000 pages
- pinned PDFium dynamic API test: passed
- cargo clippy for converters, engine, and API: passed (repository-existing warnings remain)
- Web typecheck and committed bundle verification: passed
- structure gate: 0 violations
- python3 -m unittest tools.platform-release.test_pr_fast_gate: 14 passed

## Real samples

- User PDF OCR-off baseline: 305-page conversion succeeded; current installed pre-refresh OCR plugin still declares the old 768 MiB process-group limit, so its strict run is intentionally deferred to the refreshed release artifact.
- Wikimedia Commons Alice PDF (77 pages, 2,270,965 bytes, SHA-256 73fc3e86cd5f037c69eddf675f6bec923c5a029db78f7da977f025ea8471beaf): OCR off/on both publish the exact same 42 assets and hashes; all working-render markers are absent.
- Project Gutenberg Pride and Prejudice illustrated EPUB (24,835,578 bytes, SHA-256 bbd82efa5e3e8d8a302a39c5e20d7d6d250804c7003c63378946d85f1176ccb6): OCR off/on both publish the exact same 39 assets and hashes; normalization images are absent. Two visuals degrade locally under the installed old worker limit while the rest complete.

No sample files are committed. `normal_assets/` remains untouched.